### PR TITLE
bugfix - preserve checked C resource borrows (#941)

### DIFF
--- a/src/backend/ir/expr.rs
+++ b/src/backend/ir/expr.rs
@@ -516,6 +516,8 @@ pub enum VarAccess {
     Read,
     /// Borrow immutably (&)
     Borrow,
+    /// Borrow immutably for a checked C resource call, even when its lowered wrapper parameter is an owned carrier.
+    CAbiBorrow,
     /// Borrow mutably (&mut)
     BorrowMut,
     /// Copy the value (for Copy types)

--- a/src/backend/ir/lower/expr/mod.rs
+++ b/src/backend/ir/lower/expr/mod.rs
@@ -105,7 +105,7 @@ impl AstLowering {
             };
             let variable_access = match access {
                 crate::frontend::typechecker::CResourceAccess::Owned => VarAccess::Move,
-                crate::frontend::typechecker::CResourceAccess::Borrowed => VarAccess::Borrow,
+                crate::frontend::typechecker::CResourceAccess::Borrowed => VarAccess::CAbiBorrow,
                 crate::frontend::typechecker::CResourceAccess::BorrowedMut => VarAccess::BorrowMut,
             };
             Self::set_checked_c_argument_access(&mut argument.expr, variable_access);

--- a/src/backend/ir/ownership.rs
+++ b/src/backend/ir/ownership.rs
@@ -328,6 +328,10 @@ impl ArgumentPassingPlan {
                     passing = ArgumentPassingMode::MutableBorrow;
                     value = ArgumentValuePlan::Ownership(OwnershipPlan::None);
                 }
+                VarAccess::CAbiBorrow => {
+                    passing = ArgumentPassingMode::SharedBorrow;
+                    value = ArgumentValuePlan::Ownership(OwnershipPlan::None);
+                }
                 VarAccess::Borrow if value_use_site_target_ty(site).is_none() => {
                     passing = ArgumentPassingMode::SharedBorrow;
                     value = ArgumentValuePlan::Ownership(OwnershipPlan::None);
@@ -993,6 +997,29 @@ mod tests {
         );
         assert_eq!(render(plan.apply_full(quote! { thing })), "&thing");
         assert_eq!(render(plan.apply_after_value_plan(quote! { &thing })), "&thing");
+    }
+
+    #[test]
+    fn argument_plan_checked_c_borrow_skips_owned_value_materialization() {
+        let resource = IrType::Struct("__incan_c_resource::Binding::Handle".to_string());
+        let expr = IrExpr::new(
+            IrExprKind::Var {
+                name: "handle".to_string(),
+                access: VarAccess::CAbiBorrow,
+                ref_kind: VarRefKind::Value,
+            },
+            resource.clone(),
+        );
+        let plan = ArgumentPassingPlan::for_use_site(
+            &expr,
+            ValueUseSite::IncanCallArg {
+                target_ty: Some(&resource),
+                callee_param: None,
+                in_return: false,
+            },
+        );
+
+        assert_eq!(render(plan.apply_full(quote! { handle })), "&handle");
     }
 
     #[test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -17878,6 +17878,104 @@ def main() -> Result[None, SessionError]:
     }
 
     #[test]
+    fn consumer_check_hides_owned_c_resources_behind_an_incan_facade() -> Result<(), Box<dyn std::error::Error>> {
+        let tmp = tempfile::tempdir()?;
+        let fixture_header = tmp.path().join("fixture.h");
+        std::fs::write(
+            &fixture_header,
+            r#"typedef struct fixture_file FILE;
+int fclose(FILE *);
+FILE *tmpfile(void);
+int fflush(FILE *);
+int fileno(FILE *);
+int close(int);
+"#,
+        )?;
+        let source = format!(
+            r#"from std.interop import c
+
+binding CFile:
+    header = "{}"
+    link = c.system_library("c")
+
+    resource File:
+        native = "FILE"
+        release = close
+
+    symbol close(file: c.Owned[File]) -> c.i32:
+        native = "fclose"
+
+    symbol open() -> Option[c.Owned[File]]:
+        native = "tmpfile"
+
+    symbol flush(file: c.BorrowedMut[File]) -> c.i32:
+        native = "fflush"
+
+    symbol descriptor(file: c.Borrowed[File]) -> c.i32:
+        native = "fileno"
+
+    symbol close_descriptor(descriptor: c.i32) -> c.i32:
+        native = "close"
+
+def temporary_descriptor() -> int:
+    unsafe:
+        if let Some(open_file) = CFile.open():
+            mut file = open_file
+            if CFile.flush(file) != 0:
+                return -1
+            return CFile.descriptor(file)
+        return -1
+
+def temporary_file_is_released() -> bool:
+    descriptor = temporary_descriptor()
+    if descriptor < 0:
+        return False
+    unsafe:
+        return CFile.close_descriptor(descriptor) == -1
+
+def main() -> None:
+    assert temporary_file_is_released()
+"#,
+            fixture_header.display()
+        );
+        let main_path = write_project_files(
+            tmp.path(),
+            "[project]\nname = \"checked_c_resource_facade\"\n\n[sdk]\nprofile = \"minimal\"\n",
+            &source,
+        )?;
+        let generated_cargo_target = tmp.path().join("generated-cargo-target");
+
+        let output = run_check_against_checkout_sdk(&main_path, &generated_cargo_target)?;
+        assert!(
+            output.status.success(),
+            "expected a same-module Incan façade to hide an owned C resource.\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let checkout = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let run_output = super::incan_command()
+            .env("INCAN_SOURCE_ROOT", checkout)
+            .env("INCAN_STDLIB", checkout.join("crates/incan_stdlib/stdlib"))
+            .env_remove("INCAN_STDLIB_DIR")
+            .env("INCAN_TOOLCHAIN_CRATES_DIR", checkout.join("crates"))
+            .env("INCAN_GENERATED_CARGO_TARGET_DIR", &generated_cargo_target)
+            .env("INCAN_LOCK_PREHEAT", "0")
+            .env("CARGO_NET_OFFLINE", "true")
+            .args(["run", main_path.to_string_lossy().as_ref()])
+            .output()?;
+        assert!(
+            run_output.status.success(),
+            concat!(
+                "expected the Incan façade to borrow, flush, and release its encapsulated C resource.\n",
+                "stdout:\n{}\nstderr:\n{}",
+            ),
+            String::from_utf8_lossy(&run_output.stdout),
+            String::from_utf8_lossy(&run_output.stderr)
+        );
+        Ok(())
+    }
+
+    #[test]
     fn consumer_check_reports_checked_c_signature_mismatch_at_the_binding() -> Result<(), Box<dyn std::error::Error>> {
         let tmp = tempfile::tempdir()?;
         let fixture_header = tmp.path().join("fixture.h");

--- a/workspaces/docs-site/docs/language/explanation/checked_c_interop.md
+++ b/workspaces/docs-site/docs/language/explanation/checked_c_interop.md
@@ -24,12 +24,10 @@ The probe is syntax-only. It checks free-function signatures, folds declared enu
 
 The declaration projection deliberately does not absorb facts with different lifecycles:
 
-| Surface | Question it answers |
-| --- | --- |
-| Binding inspection | What ABI, ownership, output, enum, and layout contract did the compiler accept from this source graph? |
-| `[oven.interop]` and `incan.lock` | What target requirements and package-owned physical inputs did the author declare and lock? |
-| Future Oven receipt and store | Which concrete toolchain, SDK, artifacts, commands, and shim outputs satisfied those requirements? |
-| Future editor and codegraph projections | Where are raw declarations, private bridges, and public façades related in source? |
+- Binding inspection answers which ABI, ownership, output, enum, and layout contract the compiler accepted from the source graph.
+- `[oven.interop]` and `incan.lock` answer which target requirements and package-owned physical inputs the author declared and locked.
+- A future Oven receipt and store will answer which concrete toolchain, SDK, artifacts, commands, and shim outputs satisfied those requirements.
+- Future editor and codegraph projections will answer where raw declarations, private bridges, and public façades are related in source.
 
 Keeping these projections separate prevents a source inspection from being mistaken for evidence that an artifact was resolved, a shim was built, or a mobile package is ready. They can still share stable binding identities as the tooling vertical grows.
 
@@ -39,15 +37,15 @@ C is an ABI, not a complete ownership model. A header can expose an integer func
 
 The current surface adds one narrow ownership model without widening into general pointers. A binding may declare an opaque resource, one matching release operation, and whether each call consumes, shares, or mutably borrows that resource. It may also declare scalar and owned-resource output positions. These are compiler-owned call facts: the source does not expose raw addresses, and generated Rust does not infer ownership from its own requirements. The façade above the binding remains responsible for input validation, native status interpretation, error models, retries, and cancellation.
 
+A binding and its façade can live in the same Incan module. The raw calls stay inside a small `unsafe:` region, while the package publishes only the façade's ordinary values and domain operations. A compiler-managed owned resource carries a last-resort release guard, so a façade can borrow it for one checked call and return normally without inventing a separate context-manager API. An explicit release call remains available when the domain needs an earlier release point.
+
 ## C interop and Rust interop solve different problems
 
 Neither choice is universally better:
 
-| Choose | When it is the better fit today |
-| --- | --- |
-| Checked C binding | The supported foreign boundary is a small, stable C ABI whose scalar calls, opaque handles, and output positions can be declared and verified exactly. |
-| Rust interop | A maintained Rust crate already exposes the safe API you need, especially for resources, callbacks, async work, collections, or richer types. |
-| A future checked shim | The underlying C API is real but needs an adapter for callbacks, variadics, function tables, bitfields, unions, or lifetime relationships. |
+- Choose a checked C binding when the supported foreign boundary is a small, stable C ABI whose scalar calls, opaque handles, and output positions can be declared and verified exactly.
+- Choose Rust interop when a maintained Rust crate already exposes the safe API you need, especially for resources, callbacks, async work, collections, or richer types.
+- Choose a future checked shim when the underlying C API is real but needs an adapter for callbacks, variadics, function tables, bitfields, unions, or lifetime relationships.
 
 The language in which a library happens to be implemented is not decisive. A C++ engine, a Python extension, or a Rust library may intentionally publish a C ABI; a Rust wrapper can still be preferable when it owns difficult safety and build concerns well. Conversely, a small C ABI can be clearer and more durable than a wrapper when it is the producer's published contract.
 

--- a/workspaces/docs-site/docs/language/how-to/checked_c_bindings.md
+++ b/workspaces/docs-site/docs/language/how-to/checked_c_bindings.md
@@ -27,17 +27,13 @@ The `binding` vocabulary desugars to a `@c.binding(...)` declaration class exten
 
 Use the C namespace in the raw declaration, even when a type looks similar to Incan `int`:
 
-| C declaration need | Binding type |
-| --- | --- |
-| Exact signed or unsigned width | `c.i8` through `c.i64`, or `c.u8` through `c.u64` |
-| C `int` | `c.c_int` |
-| C `char` | `c.c_char` |
-| Target-sized byte count | `c.Size` |
-| Required immutable or mutable pointer | `c.ConstPtr[T]` or `c.MutPtr[T]` |
-| Nullable pointer | `Option[c.ConstPtr[T]]` or `Option[c.MutPtr[T]]` |
-| Opaque resource consumed by the native call | `c.Owned[Handle]` |
-| Call-scoped shared or exclusive resource access | `c.Borrowed[Handle]` or `c.BorrowedMut[Handle]` |
-| Native-written or caller-initialized output storage | `c.Out[T]` or `c.InOut[T]` |
+- Use `c.i8` through `c.i64`, or `c.u8` through `c.u64`, for an exact signed or unsigned width.
+- Use `c.c_int` for C `int` and `c.c_char` for C `char`.
+- Use `c.Size` for a target-sized byte count.
+- Use `c.ConstPtr[T]` or `c.MutPtr[T]` for a required immutable or mutable pointer; wrap either in `Option[...]` for a nullable pointer.
+- Use `c.Owned[Handle]` for an opaque resource consumed by the native call.
+- Use `c.Borrowed[Handle]` or `c.BorrowedMut[Handle]` for call-scoped shared or exclusive resource access.
+- Use `c.Out[T]` or `c.InOut[T]` for native-written or caller-initialized output storage.
 
 The executable subset admits scalar calls, opaque resource calls, and scalar or owned-resource output positions. Pointer and by-value structure declarations are still useful because the compiler verifies their declared shape, but calls that would require pointer arithmetic, arbitrary dereference, or unimplemented view rules remain rejected.
 
@@ -62,6 +58,12 @@ binding Fixture:
 ```
 
 `c.Owned[Handle]` moves into `close`, so use after that call is a type error and generated Rust disarms the last-resort guard before invoking the native release function. `c.Borrowed[Handle]` and `c.BorrowedMut[Handle]` are selected from the parameter declaration at the call site; wrapper authors do not write Rust-shaped borrow calls. A mutable local is required for `c.BorrowedMut[Handle]`.
+
+## Keep the raw bridge inside an ordinary Incan façade
+
+The binding and its façade may be authored in the same module. Put the `unsafe:` region around the small set of raw calls, then publish only functions, models, or errors built from ordinary Incan values. Do not return `c.Owned[...]`, `c.Out[...]`, raw status values, or a foreign pointer from that façade.
+
+An owned resource may pass through any number of declared `c.Borrowed[...]` or `c.BorrowedMut[...]` calls while it stays in the façade. The compiler emits the matching Rust borrow for each call and retains the release guard. If a façade needs deterministic early release, pass the resource to its declared `c.Owned[...]` release symbol; otherwise the guard releases it once on normal scope exit or an early return. No separate `with`-style cleanup surface is required for this compiler-managed lifetime.
 
 ## Use output positions only through compiler-managed storage
 
@@ -163,15 +165,13 @@ This declaration and lock slice deliberately does not download artifacts, discov
 
 ## Interpret common failures
 
-| Failure | What to check |
-| --- | --- |
-| `@c.binding requires from std.interop import c` | Import `c` in the declaring module. An alias is allowed; a global activation is not. |
-| C symbol has an unsupported parameter or return type | Use the current scalar, opaque-resource, or output forms. Do not weaken an unsupported pointer or view contract into an integer. |
-| Clang rejects the signature or layout | Compare the header's exact spelling, calling shape, field order, and scalar category with the binding. Do not change the declaration to make generated Rust compile. |
-| Native enum carrier mismatch | Keep one declared `c.*` carrier for all variants and verify what the header exposes after macro expansion. |
-| `take()` is rejected | For `Out`, guard the read with the binding outcome that names the initialized parameter. For `InOut`, ensure the selected outcome has not invalidated the slot. |
-| C resource was transferred or requires a mutable borrow | Do not reuse a resource passed as `c.Owned[...]`; bind it as `mut` before a call declared `c.BorrowedMut[...]`. |
-| Missing system library at final link | `c.system_library("name")` records a logical system capability; this slice does not download, vendor, or lock a library for you. |
+- If `@c.binding requires from std.interop import c`, import `c` in the declaring module. An alias is allowed; global activation is not.
+- If a C symbol has an unsupported parameter or return type, use the current scalar, opaque-resource, or output forms. Do not weaken an unsupported pointer or view contract into an integer.
+- If Clang rejects a signature or layout, compare the header's exact spelling, calling shape, field order, and scalar category with the binding. Do not change the declaration merely to make generated Rust compile.
+- If an enum carrier mismatches, keep one declared `c.*` carrier for all variants and verify the header's macro-expanded value.
+- If `take()` is rejected for `Out`, guard the read with the binding outcome that initializes the parameter. For `InOut`, ensure the selected outcome has not invalidated the slot.
+- If a C resource was transferred or requires a mutable borrow, do not reuse a resource passed as `c.Owned[...]`; bind it as `mut` before a call declared `c.BorrowedMut[...]`.
+- If the final link misses a system library, remember that `c.system_library("name")` records a logical system capability; this slice does not download, vendor, or lock a library for you.
 
 ## Review the checked declaration
 

--- a/workspaces/docs-site/docs/language/reference/stdlib/interop.md
+++ b/workspaces/docs-site/docs/language/reference/stdlib/interop.md
@@ -70,9 +70,10 @@ The current surface accepts these declaration forms:
 - Plain `struct` declarations with an explicit native C type name and listed fields.
 - `resource` declarations that associate an opaque native type with one `c.Owned[...]` release symbol.
 - `c.Owned[T]`, `c.Borrowed[T]`, and `c.BorrowedMut[T]` resource parameters and owned or nullable-owned resource results.
+- `Option[c.Owned[T]]` for a factory whose native resource pointer may be null; use `if let Some(handle) = factory():` before passing the handle to a resource call.
 - `c.Out[T]` and `c.InOut[T]` parameters for scalar values and owned resources, plus an `outcome` declaration that makes output initialization explicit.
 
-For the executable subset, Incan carries scalar values as `int`, releases owned resources through their declared native operation, and keeps output storage in compiler-generated private slots. Generated wrappers range-check every scalar conversion; a value that cannot be represented by Incan `int` is not silently truncated. A verified enum constant is available as an ordinary integer expression such as `LibC.Status.OK`. `c.Out[...]` is readable only after its declared outcome, while a consumed `c.Owned[...]` resource cannot be used again. Pointer and by-value structure contracts are verified declarations in this slice, but calls using them stay rejected until the later view design is implemented.
+For the executable subset, Incan carries scalar values as `int`, releases owned resources through their declared native operation, and keeps output storage in compiler-generated private slots. Generated wrappers range-check every scalar conversion; a value that cannot be represented by Incan `int` is not silently truncated. A verified enum constant is available as an ordinary integer expression such as `LibC.Status.OK`. `c.Out[...]` is readable only after its declared outcome, while a consumed `c.Owned[...]` resource cannot be used again. A live owned resource can enter checked shared or mutable borrow calls without losing ownership; its compiler-generated release guard performs the declared release once when it remains live at scope exit. Pointer and by-value structure contracts are verified declarations in this slice, but calls using them stay rejected until the later view design is implemented.
 
 ## Verification and diagnostics
 

--- a/workspaces/docs-site/docs/language/tutorials/checked_c_binding.md
+++ b/workspaces/docs-site/docs/language/tutorials/checked_c_binding.md
@@ -84,6 +84,9 @@ binding Fixture:
     symbol close(handle: c.Owned[Handle]) -> None:
         native = "fixture_close"
 
+    symbol inspect(handle: c.Borrowed[Handle]) -> c.i32:
+        native = "fixture_inspect"
+
     enum Status:
         OK: c.i32 = FIXTURE_OK
 
@@ -94,18 +97,27 @@ binding Fixture:
             initializes = [output]
 ```
 
-`c.Owned[Handle]` is a non-copyable private bridge value. Passing it to `close` transfers the resource to the declared release operation. If ordinary control flow leaves a still-owned handle unconsumed, the generated release guard performs the same release once. `c.Out[...]` is compiler-managed storage, not a general-purpose container: call it with `c.out[...]()`, and call `take()` only on the outcome path that declares the slot initialized.
+`c.Owned[Handle]` is a non-copyable compiler-managed bridge value. Passing it to `close` transfers the resource to the declared release operation. If ordinary control flow leaves a still-owned handle unconsumed, the generated release guard performs the same release once. `c.Out[...]` is compiler-managed storage, not a general-purpose container: call it with `c.out[...]()`, and call `take()` only on the outcome path that declares the slot initialized.
+
+## Put the safe façade beside the binding
+
+The binding and its ordinary Incan façade can live in the same module. Keep `unsafe:` entirely inside the façade and publish only the façade from a library. The application below receives one ordinary `bool`; it never receives a raw handle, output slot, or native status integer.
 
 ```incan
-def open_handle() -> int:
+def handle_is_ready() -> bool:
     unsafe:
         output = c.out[c.Owned[Handle]]()
         status = Fixture.open(output)
-        if status == Fixture.Status.OK:
-            handle = output.take()
-            Fixture.close(handle)
-        return status
+        if status != Fixture.Status.OK:
+            return False
+        handle = output.take()
+        return Fixture.inspect(handle) == 0
+
+def main() -> None:
+    assert handle_is_ready()
 ```
+
+`inspect` receives a call-scoped shared borrow, so `handle` remains owned by the façade. It is released automatically when the function returns; use `Fixture.close(handle)` only when the façade needs an earlier, explicit release point. This lifecycle does not need a `with` statement because the compiler-owned resource guard already covers normal scope exit and early return.
 
 Use `c.InOut[c.i32]` for a scalar pointer whose initial value is supplied by the caller and may be updated by the native call. Create it with `c.inout(value)` and consume its post-call value with `take()`. A binding outcome can state that an `Out` slot is initialized and that an `InOut` slot is updated; the compiler will reject an unguarded `Out.take()`.
 


### PR DESCRIPTION
## Summary

Part of #941. This fixes checked C resource lowering so a resource can move through a declared `c.BorrowedMut[T]` call and then a declared `c.Borrowed[T]` call without generated Rust trying to clone the non-copyable resource. It adds an end-to-end same-module façade proof: the application receives an ordinary Incan `bool`, while the façade owns the resource, performs the raw calls in `unsafe:`, and the compiler guard releases it on return.

This is a completed #941 vertical, not the whole issue. Checked C strings, spans and caller-owned buffers, additional diagnostics, and the full SQLite façade remain tracked by #941 and its review slices.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [x] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: A same-module façade may keep an owned opaque resource through checked mutable and shared borrow calls, then return an ordinary Incan result without exposing the resource, raw status, or output carrier.
- **Internals**: Adds a checked-C-specific shared-borrow access plan so the ordinary ownership planner emits `&resource` rather than applying its generic non-copy clone materialization rule. The plan remains distinct from ordinary `self` borrowing behavior.
- **Risks**: The change is deliberately limited to compiler-recorded checked C resource borrows. The acceptance test compiles and runs a real libc-backed temporary-file façade and proves the release guard closes its descriptor.

## Testing / verification

- [x] `cargo test` focused ownership-planner unit test
- [x] `cargo test --test integration_tests consumer_check_hides_owned_c_resources_behind_an_incan_facade -- --nocapture --test-threads=1`
- [x] `cargo test --test integration_tests consumer_check_verifies_checked_c_resource_and_output_contracts -- --nocapture --test-threads=1`
- [x] `make pre-commit-fast`
- [x] `make docs-build`
- [x] Changed-page Markdown lint

Manual verification notes:

- The generated program successfully performs a mutable C borrow followed by a shared C borrow and confirms that the implicit release guard has closed the temporary file descriptor.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- [Checked C tutorial](workspaces/docs-site/docs/language/tutorials/checked_c_binding.md), [how-to](workspaces/docs-site/docs/language/how-to/checked_c_bindings.md), [architecture explanation](workspaces/docs-site/docs/language/explanation/checked_c_interop.md), and [reference](workspaces/docs-site/docs/language/reference/stdlib/interop.md) now describe same-module façades, nullable owned factories, checked borrow sequencing, and guard-based cleanup.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Part of #941; it intentionally does not close the remaining resource/buffer/SQLite acceptance work.