### PR TITLE
docs - define Loaf and Oven RFC contracts

### DIFF
--- a/workspaces/docs-site/docs/RFCs/034_incan_pub_registry.md
+++ b/workspaces/docs-site/docs/RFCs/034_incan_pub_registry.md
@@ -3,15 +3,15 @@
 - **Status:** Draft
 - **Created:** 2026-03-06
 - **Author(s):** Danny Meijer (@dannymeijer)
-- **Related:** RFC 031 (library system phase 1), RFC 027 (incan-vocab)
+- **Related:** RFC 027 (incan-vocab), RFC 031 (library system phase 1), RFC 117 (`Loaf.toml` and Oven's language-neutral project model), RFC 118 (Incan and Oven command-line surfaces)
 - **Issue:** [#168](https://github.com/encero-systems/incan/issues/168)
 - **RFC PR:** —
-- **Written against:** v0.2
+- **Written against:** ~~v0.2~~ v0.5
 - **Shipped in:** —
 
 ## Summary
 
-Define the `incan.pub` package registry: the protocols, guarantees, and CLI commands that allow Incan library authors to publish packages and consumers to resolve them. The registry must be EU-hosted, integrity-verified, signature-aware, and operationally cheap enough to run with predictable capped spend. Exact vendor choice and launch-era cost numbers are implementation details, not the core contract.
+Define the `incan.pub` package registry: the protocols, guarantees, and Oven lifecycle operations that allow Incan library authors to publish packages and consumers to resolve them. The registry must be EU-hosted, integrity-verified, signature-aware, and operationally cheap enough to run with predictable capped spend. Exact vendor choice and launch-era cost numbers are implementation details, not the core contract.
 
 This Draft was originally written against RFC 031's generated-Rust library artifact shape. The package format and resolution model below are now amended to align with the backend replacement direction: generated Rust may remain an internal/debug artifact, but it is not the public package compatibility path. The registry stores Incan package artifacts with semantic manifests, ABI/package metadata, and optional backend artifacts; consumers resolve Incan semantics first, not downloaded generated Rust source.
 
@@ -40,13 +40,13 @@ The `incan.pub` registry closes this gap. It is the canonical source for publish
 
 ```bash
 # One-time setup: create an account and save credentials
-$ incan login
+$ oven login
   Opening https://incan.pub/tokens in your browser...
   Paste your API token: ****
   Saved to ~/.incan/credentials
 
 # Publish from a library project
-$ incan publish
+$ oven publish
   Building library...
   Packaging mylib 0.1.0...
   Signing with Sigstore (GitHub: @dannymeijer)...
@@ -57,13 +57,13 @@ $ incan publish
 ### Consuming a published package
 
 ```toml
-# my-app/incan.toml
+# my-app/Loaf.toml
 [project]
 name = "my-app"
 version = "0.1.0"
 
 [dependencies]
-mylib = "0.1.0"
+mylib = { loaf = "mylib", version = "0.1.0" }
 ```
 
 ```incan
@@ -76,7 +76,7 @@ def main():
 ```
 
 ```bash
-$ incan build
+$ oven bake
   Resolving dependencies...
     mylib 0.1.0 (incan.pub)
   Downloading mylib 0.1.0...
@@ -89,7 +89,7 @@ $ incan build
 ### Yanking a version
 
 ```bash
-$ incan yank mylib 0.1.0
+$ oven yank mylib 0.1.0
   Yanked mylib 0.1.0 — existing lockfiles still resolve, new resolves skip it.
 ```
 
@@ -253,7 +253,7 @@ Returns the package archive. Served from object storage, cached at CDN edge. Imm
 
 #### Token-based auth
 
-Publishers authenticate with API tokens. Tokens are generated via the `incan.pub` web UI (or a future `incan token create` CLI command).
+Publishers authenticate with API tokens. Tokens are generated via the `incan.pub` web UI (or a future `oven token create` CLI command).
 
 Token storage:
 
@@ -261,7 +261,7 @@ Token storage:
 - **Client side:** `~/.incan/credentials` (file permissions 0600). Format: `[registry]\ntoken = "incan_tok_..."`.
 
 ```bash
-$ incan login
+$ oven login
   Opening https://incan.pub/tokens in your browser...
   Paste your API token: ****
   Saved to ~/.incan/credentials
@@ -270,23 +270,23 @@ $ incan login
 #### Package ownership
 
 - First publish of a name → publisher becomes owner
-- Owners can add co-owners via `incan owner add <username> <package>`
+- Owners can add co-owners via `oven owner add <username> <package>`
 - Only owners can publish new versions or yank existing ones
 - Reserved names: `std`, `incan`, `core`, `test` — cannot be claimed by users
 
 ### Package signing with Sigstore
 
-Every `incan publish` signs the package archive using [Sigstore](https://sigstore.dev) keyless signing:
+Every `oven publish` signs the package archive using [Sigstore](https://sigstore.dev) keyless signing:
 
 **Publish side:**
 
-1. `incan publish` initiates an OIDC flow (opens browser → GitHub/GitLab/Google login)
+1. `oven publish` initiates an OIDC flow (opens browser → GitHub/GitLab/Google login)
 2. Sigstore's Fulcio CA issues a short-lived signing certificate tied to the OIDC identity
 3. The package archive's SHA256 digest is signed with the ephemeral private key
 4. The signature + certificate + checksum are recorded in Sigstore's Rekor transparency log
 5. The signature and certificate are sent to the registry alongside the package archive
 
-**Verification side (`incan build`):**
+**Verification side (`oven bake`):**
 
 1. Download package archive + `.sig` + `.cert` from registry
 2. Verify SHA256 of the archive matches the index checksum
@@ -295,9 +295,9 @@ Every `incan publish` signs the package archive using [Sigstore](https://sigstor
 5. Verify the signer identity in the certificate matches the `publisher` field in the index
 6. Verify the signature is recorded in Sigstore Rekor (transparency log lookup)
 
-If verification fails, `incan build` refuses to use the package and emits a clear diagnostic.
+If verification fails, `oven bake` refuses to use the package and emits a clear diagnostic.
 
-**Sigstore is optional in Phase 1** — the `signatures` field in the index is nullable. Unsigned packages are accepted but display a warning during `incan build`. The goal is to make signing the default from early on, then make it mandatory once the tooling is proven.
+**Sigstore is optional in Phase 1** — the `signatures` field in the index is nullable. Unsigned packages are accepted but display a warning during `oven bake`. The goal is to make signing the default from early on, then make it mandatory once the tooling is proven.
 
 **Implementation note:** the service can rely on existing Sigstore client libraries rather than inventing its own signing stack. The registry still verifies signatures on publish so invalid artifacts are rejected early.
 
@@ -318,18 +318,18 @@ RFC 079 generalizes this package-level integrity model for the wider `incan.pub`
 
 ### Consumer resolution flow
 
-When `incan build` encounters a registry dependency:
+When Oven resolves a registry dependency:
 
 ```text
 [dependencies]
-mylib = "0.1.0"          # exact version
-mylib = "^0.1"           # SemVer-compatible range
-mylib = { version = "0.1.0", registry = "incan.pub" }  # explicit (default)
+mylib = { loaf = "mylib", version = "0.1.0" } # exact version
+mylib = { loaf = "mylib", version = "^0.1" }  # SemVer-compatible range
+mylib = { loaf = "mylib", version = "0.1.0", registry = "incan.pub" } # explicit default
 ```
 
 Resolution:
 
-1. Read `[dependencies]` from `incan.toml`
+1. Read the typed dependency entry from `Loaf.toml`
 2. For each registry dep: `GET https://incan.pub/index/<prefix>/<name>`
 3. Parse JSON lines, filter by version requirement, select newest matching non-yanked version
 4. Check local cache `~/.incan/libs/<name>-<version>/` — if cached and checksum matches, skip download
@@ -342,58 +342,59 @@ Resolution:
 
 The resolver must not wire downloaded generated Rust source into generated `Cargo.toml` as the package compatibility path. Rust-facing consumption should go through the ABI/Cargo-native package direction rather than treating generated Rust internals as public API.
 
-**Lockfile (`incan.lock`):** on first resolution, write resolved versions + checksums to `incan.lock`. Subsequent builds use the lockfile for reproducibility. `incan update` re-resolves.
+**Lockfile (`Oven.lock`):** on first resolution, write resolved versions, canonical registry identity, integrity facts, and checksums to `Oven.lock`. Subsequent bakes use the lockfile for reproducibility. `oven update` re-resolves.
 
 ### CLI commands
 
 | Command | Description |
 |---|---|
-| `incan add <pkg>` | Add a dependency to `incan.toml` (fetch latest version from registry) |
-| `incan remove <pkg>` | Remove a dependency from `incan.toml` |
-| `incan update` | Re-resolve all dependencies and update `incan.lock` |
-| `incan login` | Authenticate with `incan.pub`, save token to `~/.incan/credentials` |
-| `incan publish` | Build library, package `.incanpkg`, sign, upload to registry |
-| `incan yank <pkg> <ver>` | Mark a version as yanked (still downloadable but skipped in new resolves) |
-| `incan search <query>` | Search the registry index (client-side text search over cached index) |
-| `incan owner add <user> <pkg>` | Add a co-owner for a package |
-| `incan owner list <pkg>` | List owners of a package |
+| `oven add <pkg>` | Add a Loaf dependency to `Loaf.toml` (fetch latest version from `incan.pub`) |
+| `oven add --crate <pkg>` | Add a crate dependency to `Loaf.toml` (fetch from crates.io by default) |
+| `oven remove <pkg>` | Remove a typed dependency from `Loaf.toml` |
+| `oven update` | Re-resolve the selected closure and update `Oven.lock` |
+| `oven login` | Authenticate with `incan.pub`, save credentials in Oven-controlled secure storage |
+| `oven publish` | Bake the selected Loaf, package `.incanpkg`, sign, and upload it |
+| `oven yank <pkg> <ver>` | Mark a version as yanked (still downloadable but skipped in new resolves) |
+| `oven search <query>` | Search the registry index (client-side text search over cached index) |
+| `oven owner add <user> <pkg>` | Add a co-owner for a package |
+| `oven owner list <pkg>` | List owners of a package |
 
-#### `incan add` in detail
+#### `oven add` in detail
 
-Like `cargo add`, this is the primary way users add dependencies. It edits `incan.toml` for you:
+Like `cargo add`, this is the primary way users add dependencies. It edits `Loaf.toml` for you. The final aliases exposed through `incan` are owned by RFC 118; they must delegate to Oven rather than duplicate this resolution behavior.
 
 ```bash
 # Add latest version from incan.pub
-$ incan add widgets
-  Added widgets = "^0.2.1" to [dependencies]
+$ oven add widgets
+  Added widgets = { loaf = "widgets", version = "^0.2.1" } to [dependencies]
 
 # Add a specific version
-$ incan add widgets@0.1.0
-  Added widgets = "0.1.0" to [dependencies]
+$ oven add widgets@0.1.0
+  Added widgets = { loaf = "widgets", version = "0.1.0" } to [dependencies]
 
-# Add a Rust crate (to [rust-dependencies])
-$ incan add --rust serde
-  Added serde = "1.0" to [rust-dependencies]
+# Add a Rust crate to the same typed dependency graph
+$ oven add --crate serde
+  Added serde = { crate = "serde", version = "1.0" } to [dependencies]
 
 # Add a path dependency (local library)
-$ incan add widgets --path ../widgets
-  Added widgets = { path = "../widgets" } to [dependencies]
+$ oven add widgets --path ../widgets
+  Added widgets = { loaf = "widgets", path = "../widgets" } to [dependencies]
 
 # Add a git dependency (Phase 2)
-$ incan add widgets --git https://github.com/example/widgets --tag v0.2.0
-  Added widgets = { git = "https://...", tag = "v0.2.0" } to [dependencies]
+$ oven add widgets --git https://github.com/example/widgets --tag v0.2.0
+  Added widgets = { loaf = "widgets", git = "https://...", tag = "v0.2.0" } to [dependencies]
 ```
 
 **Behavior:**
 
-1. If no `incan.toml` exists, error with "run `incan init` first"
+1. If no `Loaf.toml` exists, error with "run `oven init` first"
 2. Query the registry index for the latest non-yanked version (unless `@version` or `--path`/`--git` specified)
 3. Default to `^major.minor.patch` range (SemVer-compatible, like Cargo)
-4. Write the entry to `[dependencies]` (or `[rust-dependencies]` with `--rust`)
-5. If the package is already in `incan.toml`, update the version (with a confirmation prompt unless `--force`)
-6. Run `incan lock` to update `incan.lock` with the resolved version
+4. Write the typed entry to `[dependencies]`
+5. If the package is already in `Loaf.toml`, update the version (with a confirmation prompt unless `--force`)
+6. Update `Oven.lock` with the resolved closure
 
-`incan remove` does the inverse: removes the entry from `incan.toml` and re-locks.
+`oven remove` does the inverse: removes the entry from `Loaf.toml` and re-locks.
 
 ## Infrastructure: provider selection
 
@@ -459,8 +460,8 @@ The important design constraint is portability:
 
 ## Interaction with existing features
 
-- **RFC 031 (library system):** This RFC builds on RFC 031's `.incnlib` manifest format, `pub::` import syntax, and `incan build --lib` command, but supersedes any assumption that generated Rust source is the registry package contract.
-- **RFC 027 (incan-vocab):** Library soft keyword declarations are serialized into checked package metadata during `incan build --lib` and included in the package archive. The registry is unaware of soft keywords; it stores and serves packages.
+- **RFC 031 (library system):** This RFC builds on RFC 031's `.incnlib` manifest format and `pub::` import syntax, but supersedes any assumption that generated Rust source is the registry package contract. The package lifecycle operation is `oven bake --lib` under RFCs 117 and 118.
+- **RFC 027 (incan-vocab):** Library soft keyword declarations are serialized into checked package metadata during `oven bake --lib` and included in the package archive. The registry is unaware of soft keywords; it stores and serves packages.
 - **`rust::` imports (RFC 005):** `pub::` registry imports and `rust::` Rust crate imports coexist. A package's Rust dependencies may appear in package metadata, but the compiler backend owns how they are linked into the target build.
 
 ## Alternatives considered
@@ -498,14 +499,14 @@ German provider, good pricing. However: no scale-to-zero compute (minimum €4.5
 
 - Registry service for publish, yank, index reads, and package downloads
 - Object storage integration for package, index, and signature artifacts
-- `incan login` credential management
-- `incan publish` packaging and upload flow
+- `oven login` credential management
+- `oven publish` packaging and upload flow
 - Index reader and package cache integration on the consumer side
 - Lockfile integration consistent with the broader library-resolution story
 
 ### Phase 2: Sigstore signing
 
-- `incan publish` integration for keyless signing
+- `oven publish` integration for keyless signing
 - Registry-side signature verification on publish
 - Consumer-side verification during download/build
 - Web and CLI surfacing of signer identity and verification status
@@ -513,7 +514,7 @@ German provider, good pricing. However: no scale-to-zero compute (minimum €4.5
 ### Phase 3: Web UI + search
 
 - Static site generation for package pages from index data
-- `incan search` over registry metadata
+- `oven search` over registry metadata
 - Download counters or equivalent package-usage reporting
 
 ## Layers affected
@@ -540,7 +541,7 @@ German provider, good pricing. However: no scale-to-zero compute (minimum €4.5
 
 ## Future extensions (out of scope)
 
-- **Private registries.** Organizations running their own `incan.pub`-compatible registry for internal packages. Uses the same protocol and CLI commands with a different registry URL in `incan.toml`.
+- **Private registries.** Organizations may register an `incan.pub`-compatible registry in Oven-controlled organization or user configuration, then allow-list that registered identity from a Loaf or workspace. Credentials and trust policy never live in `Loaf.toml`; `Oven.lock` records the resolved canonical identity and observed trust facts.
 - **Trusted Publishers (GitHub Actions OIDC).** Like PyPI's Trusted Publishers — CI/CD can publish without long-lived tokens by using GitHub Actions' OIDC identity directly with Sigstore.
-- **Package auditing tools.** `incan audit` to check dependencies against a vulnerability database.
+- **Package auditing tools.** `oven audit` to check dependencies against a vulnerability database.
 - **Mirror support.** Read-only mirrors of `incan.pub` for network-restricted environments or regional performance.

--- a/workspaces/docs-site/docs/RFCs/034_incan_pub_registry.md
+++ b/workspaces/docs-site/docs/RFCs/034_incan_pub_registry.md
@@ -346,18 +346,18 @@ The resolver must not wire downloaded generated Rust source into generated `Carg
 
 ### CLI commands
 
-| Command | Description |
-|---|---|
-| `oven add <pkg>` | Add a Loaf dependency to `Loaf.toml` (fetch latest version from `incan.pub`) |
-| `oven add --crate <pkg>` | Add a crate dependency to `Loaf.toml` (fetch from crates.io by default) |
-| `oven remove <pkg>` | Remove a typed dependency from `Loaf.toml` |
-| `oven update` | Re-resolve the selected closure and update `Oven.lock` |
-| `oven login` | Authenticate with `incan.pub`, save credentials in Oven-controlled secure storage |
-| `oven publish` | Bake the selected Loaf, package `.incanpkg`, sign, and upload it |
-| `oven yank <pkg> <ver>` | Mark a version as yanked (still downloadable but skipped in new resolves) |
-| `oven search <query>` | Search the registry index (client-side text search over cached index) |
-| `oven owner add <user> <pkg>` | Add a co-owner for a package |
-| `oven owner list <pkg>` | List owners of a package |
+| Command                       | Description                                                                       |
+| ----------------------------- | --------------------------------------------------------------------------------- |
+| `oven add <pkg>`              | Add a Loaf dependency to `Loaf.toml` (fetch latest version from `incan.pub`)      |
+| `oven add --crate <pkg>`      | Add a crate dependency to `Loaf.toml` (fetch from crates.io by default)           |
+| `oven remove <pkg>`           | Remove a typed dependency from `Loaf.toml`                                        |
+| `oven update`                 | Re-resolve the selected closure and update `Oven.lock`                            |
+| `oven login`                  | Authenticate with `incan.pub`, save credentials in Oven-controlled secure storage |
+| `oven publish`                | Bake the selected Loaf, package `.incanpkg`, sign, and upload it                  |
+| `oven yank <pkg> <ver>`       | Mark a version as yanked (still downloadable but skipped in new resolves)         |
+| `oven search <query>`         | Search the registry index (client-side text search over cached index)             |
+| `oven owner add <user> <pkg>` | Add a co-owner for a package                                                      |
+| `oven owner list <pkg>`       | List owners of a package                                                          |
 
 #### `oven add` in detail
 

--- a/workspaces/docs-site/docs/RFCs/073_env_matrices_and_toolchain_constraints.md
+++ b/workspaces/docs-site/docs/RFCs/073_env_matrices_and_toolchain_constraints.md
@@ -9,14 +9,16 @@
     - RFC 018 (language primitives for testing)
     - RFC 019 (test runner, CLI, and ecosystem)
     - RFC 020 (Cargo offline and locked policy)
+    - RFC 117 (`Loaf.toml` and Oven's language-neutral project model)
+    - RFC 118 (Incan and Oven command-line surfaces)
 - **Issue:** https://github.com/encero-systems/incan/issues/401
 - **RFC PR:** —
-- **Written against:** v0.3
+- **Written against:** ~~v0.3~~ v0.5
 - **Shipped in:** —
 
 ## Summary
 
-This RFC extends RFC 015 with two missing parts of the Hatch-like environment model: enforceable Incan toolchain constraints and matrix-expanded environments. Projects and named environments may declare `requires-incan` constraints that the active toolchain must satisfy before project-aware execution begins, and environments may define matrices that expand one logical env into multiple concrete env instances. Environment and matrix constraints only narrow inherited compatibility; they do not loosen it. Matrix execution stays at the lifecycle layer: it repeats env scripts across resolved env cells, but it does not define test-runner semantics, parallel scheduling policy, or toolchain installation.
+This RFC defines two parts of the Oven-managed environment model: enforceable Incan toolchain constraints and matrix-expanded environments. `Loaf.toml` projects and named environments may declare `requires-incan` constraints that the active toolchain must satisfy before project-aware execution begins, and environments may define matrices that expand one logical env into multiple concrete env instances. Environment and matrix constraints only narrow inherited compatibility; they do not loosen it. Matrix execution stays at the Oven lifecycle layer: it repeats env scripts across resolved env cells, but it does not define test-runner semantics, parallel scheduling policy, or toolchain installation.
 
 ## Core model
 
@@ -25,9 +27,9 @@ Read this RFC as four foundations plus three mechanisms:
 1. **Foundation:** `requires-incan` is not documentation; it is an executable constraint that project-aware commands must enforce.
 2. **Foundation:** The project root defines a baseline toolchain contract, and each environment or matrix cell may only narrow that contract for its own workflows.
 3. **Foundation:** A matrix env is still one named env in the manifest, but it expands into multiple concrete env instances at execution time.
-4. **Foundation:** Matrix orchestration belongs to the lifecycle CLI, not to the test runner. RFC 019 remains the owner of test collection, parametrization, fixtures, reporting, and parallel test execution semantics.
+4. **Foundation:** Matrix orchestration belongs to Oven, not to the test runner. RFC 019 remains the owner of test collection, parametrization, fixtures, reporting, and parallel test execution semantics.
 5. **Mechanism A:** Execution commands compute an effective `requires-incan` constraint and fail early when the active toolchain does not satisfy it, while inspection commands surface compatibility without being blocked by it.
-6. **Mechanism B:** `[[tool.incan.envs.<name>.matrix]]` declares one or more axes that generate concrete env instances by Cartesian product.
+6. **Mechanism B:** `[[oven.envs.<name>.matrix]]` in `Loaf.toml` declares one or more axes that generate concrete env instances by Cartesian product.
 7. **Mechanism C:** Selecting a concrete env instance runs one resolved env; selecting a matrix root env runs the target script across all generated env instances in deterministic order.
 
 ## Motivation
@@ -36,7 +38,7 @@ RFC 015 deliberately stopped before two capabilities that matter in real project
 
 Second, named envs without matrices solve only the single-configuration case. Hatch's value is not just that it names environments; it also lets one logical workflow expand across versions and variants without repo-local shell scripts. Incan needs the same capability for compatibility checks, release validation, feature toggles, and future runner work built on top of RFC 019.
 
-The key boundary is that this RFC should not re-specify the test runner. A matrix env may run `incan test`, but the semantics of how tests are discovered, filtered, reported, or parallelized remain owned by RFC 019. This RFC is about orchestrating repeated command contexts, not about changing what a test run means.
+The key boundary is that this RFC should not re-specify the test runner. A matrix env may run `oven test`, but the semantics of how tests are discovered, filtered, reported, or parallelized remain owned by RFC 019. This RFC is about orchestrating repeated command contexts, not about changing what a test run means.
 
 ## Goals
 
@@ -72,16 +74,16 @@ requires-incan = ">=0.3,<0.4"
 From that point on, project-aware execution commands must validate the active toolchain before doing real work:
 
 ```text
-incan run
-incan build
-incan test
-incan lock
-incan env run default test
+oven run
+oven bake
+oven test
+oven lock
+oven env run default test
 ```
 
 If the active toolchain does not satisfy the constraint, the command fails immediately with a diagnostic that names the active version and the required constraint.
 
-Inspection commands such as `incan env show` should still be able to report the effective constraint and whether the current toolchain satisfies it.
+Inspection commands such as `oven env show` should still be able to report the effective constraint and whether the current toolchain satisfies it.
 
 Single-file commands remain separate. `incan run script.incn` without a project root does not consult `requires-incan` because there is no project manifest to read.
 
@@ -95,24 +97,24 @@ name = "foo_bar"
 version = "0.3.0"
 requires-incan = ">=0.3,<0.5"
 
-[tool.incan.envs.release]
+[oven.envs.release]
 requires-incan = ">=0.4,<0.5"
 
-[tool.incan.envs.release.scripts]
-build = ["incan", "build", "--locked"]
+[oven.envs.release.scripts]
+build = ["oven", "bake", "--locked"]
 ```
 
-Now `incan env run release build` requires an active toolchain compatible with the intersection of the project and env constraints. In this example that intersection is still `>=0.4,<0.5`, because the env narrows the broader project contract.
+Now `oven env run release build` requires an active toolchain compatible with the intersection of the project and env constraints. In this example that intersection is still `>=0.4,<0.5`, because the env narrows the broader project contract.
 
 ### Matrix environments
 
 A matrix environment defines one logical workflow that expands into multiple concrete envs:
 
 ```toml
-[tool.incan.envs.compat]
-scripts.test = ["incan", "test"]
+[oven.envs.compat]
+scripts.test = ["oven", "test"]
 
-[[tool.incan.envs.compat.matrix]]
+[[oven.envs.compat.matrix]]
 incan = [
   { name = "0.3", requires-incan = ">=0.3,<0.4" },
   { name = "0.4", requires-incan = ">=0.4,<0.5" },
@@ -132,30 +134,30 @@ compat[incan=0.4,profile=debug]
 compat[incan=0.4,profile=release]
 ```
 
-`incan env show compat` should show the root env plus the generated cells. `incan env show 'compat[incan=0.4,profile=release]'` should show the resolved concrete env after all overlays have been applied.
+`oven env show compat` should show the root env plus the generated cells. `oven env show 'compat[incan=0.4,profile=release]'` should show the resolved concrete env after all overlays have been applied.
 
 ### Running a matrix env
 
 Running the matrix root executes the chosen script once for each generated cell:
 
 ```text
-incan env run compat test
+oven env run compat test
 ```
 
 This is equivalent to running:
 
 ```text
-incan env run 'compat[incan=0.3,profile=debug]' test
-incan env run 'compat[incan=0.3,profile=release]' test
-incan env run 'compat[incan=0.4,profile=debug]' test
-incan env run 'compat[incan=0.4,profile=release]' test
+oven env run 'compat[incan=0.3,profile=debug]' test
+oven env run 'compat[incan=0.3,profile=release]' test
+oven env run 'compat[incan=0.4,profile=debug]' test
+oven env run 'compat[incan=0.4,profile=release]' test
 ```
 
 The CLI should make that expansion visible in dry-run and show output so users can see what is going to execute.
 
 ### Relationship to RFC 019
 
-If an env script happens to be `["incan", "test"]`, the matrix only repeats the test command in multiple env contexts. It does not change how `incan test` behaves inside any one run. Discovery, fixtures, markers, output formats, and test parallelism remain defined by RFC 019.
+If an env script happens to be `["oven", "test"]`, the matrix only repeats the test command in multiple env contexts. It does not change the selected test semantics inside any one run. Discovery, fixtures, markers, output formats, and test parallelism remain defined by RFC 019.
 
 ## Reference-level explanation
 
@@ -167,17 +169,17 @@ Every `requires-incan` value must use the same SemVer requirement grammar accept
 
 The following commands must resolve the nearest project root and enforce an effective `requires-incan` constraint before beginning project-aware execution:
 
-- `incan run` in project mode
-- `incan build` in project mode
-- `incan test`
-- `incan lock`
-- `incan env run`
-- any future project-aware subcommand that consumes `incan.toml`
+- `oven run`
+- `oven bake`
+- `oven test`
+- `oven lock`
+- `oven env run`
+- any future Oven operation that reads a `Loaf.toml` project
 
 The following commands must resolve and report the effective constraint, but they must not require the active toolchain to satisfy it merely to inspect configuration:
 
-- `incan env list`
-- `incan env show`
+- `oven env list`
+- `oven env show`
 - `incan version`
 - future read-only or manifest-maintenance commands that do not compile, execute, or lock project code
 
@@ -199,12 +201,12 @@ Commands that do not resolve a project root must not attempt to infer or enforce
 
 ### Environment schema additions
 
-This RFC adds the following optional fields to `[tool.incan.envs.<name>]`:
+This RFC adds the following optional fields to `[oven.envs.<name>]` in `Loaf.toml`:
 
 - `requires-incan: str`
 - `matrix: List[Table]`
 
-Each `[[tool.incan.envs.<name>.matrix]]` table defines one matrix declaration. Multiple matrix tables are allowed; their generated cells are concatenated in declaration order rather than merged.
+Each `[[oven.envs.<name>.matrix]]` table defines one matrix declaration. Multiple matrix tables are allowed; their generated cells are concatenated in declaration order rather than merged.
 
 Within a matrix table, each key is an axis name. Each axis value must be a non-empty list. Axis names must be unique within that matrix table.
 
@@ -257,15 +259,15 @@ The effective toolchain constraint for a concrete env is the intersection of eve
 
 ### CLI behavior
 
-`incan env list` should show root envs by default. It may provide `--expanded` to include generated concrete envs.
+`oven env list` should show root envs by default. It may provide `--expanded` to include generated concrete envs.
 
-`incan env show` with no env argument should show an overview of root envs and indicate which envs are matrix roots.
+`oven env show` with no env argument should show an overview of root envs and indicate which envs are matrix roots.
 
-`incan env show <env>` where `<env>` is a matrix root should show the root env summary plus the generated concrete env instances.
+`oven env show <env>` where `<env>` is a matrix root should show the root env summary plus the generated concrete env instances.
 
-`incan env show <concrete-env>` must show the fully resolved concrete env configuration.
+`oven env show <concrete-env>` must show the fully resolved concrete env configuration.
 
-`incan env run <env> <script>` behaves as follows:
+`oven env run <env> <script>` behaves as follows:
 
 - if `<env>` is a non-matrix env, run the script once
 - if `<env>` is a concrete matrix env, run the script once using that concrete env
@@ -279,7 +281,7 @@ The aggregate exit status for matrix-root execution must be non-zero if any conc
 
 ### Dry-run and diagnostics
 
-When `--dry-run` is supported for `incan env run`, it must show:
+When `--dry-run` is supported for `oven env run`, it must show:
 
 - the concrete env instances that would run
 - the effective `requires-incan` for each instance
@@ -334,7 +336,7 @@ Rejected because it fails the main reason to have the field at all. Projects and
 
 Rejected because it leaves the most useful Hatch-like workflow unsupported: one repo validating different toolchain contracts for different named workflows.
 
-### Add matrix execution only for `incan test`
+### Add matrix execution only for `oven test`
 
 Rejected because it would couple environment orchestration to the testing surface and duplicate concepts that belong in the lifecycle layer. A matrix env should be able to run build, test, docs, release, or any future named script.
 
@@ -365,16 +367,16 @@ This separation matters because the same concrete-env resolution should power `l
 ## Layers affected
 
 - **Manifest schema / configuration validation:** the schema must admit env-level `requires-incan` and matrix declarations, validate axis shapes, and reject duplicate concrete env names or invalid overlay keys.
-- **CLI / tooling:** execution commands must enforce effective toolchain constraints; inspection commands must surface effective constraints and compatibility state without blocking basic visibility; `incan env list`, `show`, and `run` must understand root envs versus concrete matrix envs and present them clearly.
+- **CLI / tooling:** Oven execution commands must enforce effective toolchain constraints; inspection commands must surface effective constraints and compatibility state without blocking basic visibility; `oven env list`, `show`, and `run` must understand root envs versus concrete matrix envs and present them clearly. RFC 118 may expose downward-delegating Incan conveniences, but it must not duplicate Oven environment resolution.
 - **Lifecycle env resolution:** env resolution must expand matrices deterministically, normalize concrete env names, and apply overlay merge rules in the specified order.
-- **Testing surface integration:** `incan env run ... test` must remain only an orchestration wrapper around RFC 019 semantics, not a second test-runner implementation.
+- **Testing surface integration:** `oven env run ... test` must remain only an orchestration wrapper around RFC 019 semantics, not a second test-runner implementation.
 - **Documentation:** user docs and reference docs must explain the difference between project constraints, env constraints, root envs, and concrete matrix env instances.
 
 ## Unresolved questions
 
 - Should matrix-root execution stop at the first failing concrete env by default, or should it continue through all cells and summarize failures at the end?
 - Should the lifecycle CLI eventually grow an explicit `--toolchain <version-or-path>` override, or should toolchain selection remain entirely external while this RFC remains a constraint-and-validation layer only?
-- Should `incan env list` eventually default to an expanded view when a project has only matrix envs, or is explicit `--expanded` always the better UX?
+- Should `oven env list` eventually default to an expanded view when a project has only matrix envs, or is explicit `--expanded` always the better UX?
 
 <!-- Rename this section to "Design Decisions" once all questions have been resolved.
      An RFC cannot move from Draft to Planned until no unresolved questions remain. -->

--- a/workspaces/docs-site/docs/RFCs/074_template_rendering_and_boilerplate_provenance.md
+++ b/workspaces/docs-site/docs/RFCs/074_template_rendering_and_boilerplate_provenance.md
@@ -10,14 +10,15 @@
     - RFC 034 (`incan.pub` package registry)
     - RFC 075 (starter profiles and capability packs)
     - RFC 076 (project mutation policy and recovery)
+    - RFC 117 (`Loaf.toml` and Oven's language-neutral project model)
 - **Issue:** https://github.com/encero-systems/incan/issues/402
 - **RFC PR:** —
-- **Written against:** v0.3
+- **Written against:** ~~v0.3~~ v0.5
 - **Shipped in:** —
 
 ## Summary
 
-This RFC defines a deterministic template rendering, generated-file ownership, and provenance model for Incan project tooling. Templates are static input files referenced by lifecycle tooling, starter profiles, capability packs, or package-provided setup data. Rendering is intentionally constrained: v1 templates may substitute declared parameters, but they must not execute arbitrary code, run shell commands, fetch remote data, or infer behavior from filename conventions alone. When rendered files are written into a project, the toolchain may record provenance so users and tools can later check, diff, status, reset, or update generated boilerplate without treating the original template as hidden build state.
+This RFC defines a deterministic template rendering, generated-file ownership, and provenance model for Oven project tooling. Templates are static input files referenced by lifecycle tooling, starter profiles, capability packs, or package-provided setup data. Rendering is intentionally constrained: v1 templates may substitute declared parameters, but they must not execute arbitrary code, run shell commands, fetch remote data, or infer behavior from filename conventions alone. When rendered files are written into a project, Oven may record provenance so users and tools can later check, diff, status, reset, or update generated boilerplate without treating the original template as hidden build state.
 
 ## Core model
 
@@ -155,7 +156,7 @@ The project does not need the template to compile. The template was used to crea
 If the descriptor requests tracked provenance, the lifecycle tool records enough metadata to explain the file later:
 
 ```toml
-[tool.incan.templates."src/data/session.incn"]
+[oven.templates."src/data/session.incn"]
 source = "sample_session:templates/session.incn.tpl"
 package = "sample_session"
 version = "0.1.0"
@@ -174,7 +175,7 @@ This record is tooling provenance. Removing it must not break compilation. Keepi
 A user may ask the toolchain to write the values a template expects before applying it:
 
 ```text
-incan template values-file sample_session:templates/session.incn.tpl --output session.values.toml
+oven template values-file sample_session:templates/session.incn.tpl --output session.values.toml
 ```
 
 The generated file contains declared parameters, defaults, choices, and prompt text:
@@ -189,7 +190,7 @@ backend_type = "DataFusion"
 This gives teams something concrete to review in automation and allows non-interactive application:
 
 ```text
-incan template render sample_session:templates/session.incn.tpl --values session.values.toml --dry-run
+oven template render sample_session:templates/session.incn.tpl --values session.values.toml --dry-run
 ```
 
 The exact command spelling may change, but the lifecycle layer must expose the same capability: inspect required values, write a values file, and render from that file without interactive prompts.
@@ -199,7 +200,7 @@ The exact command spelling may change, but the lifecycle layer must expose the s
 A user may ask whether tracked files are stale or edited:
 
 ```text
-incan template check
+oven template check
 ```
 
 Example output:
@@ -223,7 +224,7 @@ tracked templates:
 When a template source comes from a package, starter, capability, or registry-backed catalog, users need more than byte-level drift. They also need to know whether the project is using the latest compatible template source:
 
 ```text
-incan template status
+oven template status
 ```
 
 Example output:
@@ -241,7 +242,7 @@ If the source catalog is unavailable, status may fall back to local provenance a
 If a package version provides a newer template, tooling can show the proposed change without writing it:
 
 ```text
-incan template diff src/data/session.incn
+oven template diff src/data/session.incn
 ```
 
 The diff is between the current project file and the output that would be rendered from the current descriptor and parameter values. If the file has user edits, the tool must make that clear before offering an update.
@@ -251,8 +252,8 @@ The diff is between the current project file and the output that would be render
 Template updates are explicit:
 
 ```text
-incan template update src/data/session.incn --dry-run
-incan template update src/data/session.incn
+oven template update src/data/session.incn --dry-run
+oven template update src/data/session.incn
 ```
 
 If the current file still matches `rendered_hash`, an explicit receiver-approved update may replace it with the newly rendered output. If the file has user edits, the tool must either stop with a conflict diagnostic or use a documented merge strategy. It must not silently overwrite user edits.
@@ -262,8 +263,8 @@ If the current file still matches `rendered_hash`, an explicit receiver-approved
 If an update cannot be applied cleanly, users may need a stronger operation that recreates managed files from the current template source while preserving recorded values:
 
 ```text
-incan template reset src/data/session.incn --dry-run
-incan template reset src/data/session.incn
+oven template reset src/data/session.incn --dry-run
+oven template reset src/data/session.incn
 ```
 
 Reset is not a normal update. It should be treated as an explicit recovery operation. By default, it must preserve bootstrap-owned files, preserve values from provenance or an explicit values file, show a dry-run plan, require confirmation unless running in an explicit non-interactive mode, and leave the resulting changes for review in source control. Reset is still a receiver-side code mutation and must follow the same rendered-diff review and source-identity checks as update.
@@ -470,7 +471,7 @@ Each rendered file may declare one ownership policy:
 
 `advisory` is appropriate when a tool wants to explain origin without assuming future ownership.
 
-The ownership policy must be independent from whether provenance is recorded. A bootstrap file may still record provenance so tooling can explain where it came from, but `incan template update` must not rewrite it by default.
+The ownership policy must be independent from whether provenance is recorded. A bootstrap file may still record provenance so tooling can explain where it came from, but `oven template update` must not rewrite it by default.
 
 ### Provenance modes
 
@@ -514,13 +515,13 @@ The record must not store secrets. If parameter values may include secrets, the 
 
 This RFC adds the following lifecycle tooling concepts:
 
-- `incan template check`
-- `incan template status`
-- `incan template values-file <template-or-origin>`
-- `incan template render <template-or-origin>`
-- `incan template diff [target]`
-- `incan template update [target]`
-- `incan template reset [target]`
+- `oven template check`
+- `oven template status`
+- `oven template values-file <template-or-origin>`
+- `oven template render <template-or-origin>`
+- `oven template diff [target]`
+- `oven template update [target]`
+- `oven template reset [target]`
 
 The exact command spelling may be adjusted if the lifecycle CLI uses a different namespace, but the toolchain must support these operations before tracked provenance can be considered complete.
 
@@ -562,7 +563,7 @@ Reviewing the template source diff is not sufficient. Update tooling must show t
 
 Template provenance must pin the selected source strongly enough to detect unexpected changes. For git sources, provenance should record an immutable commit, not only a branch or tag. For package or catalog sources, provenance should record the package or descriptor version, source identity, and content hash or verified integrity metadata when available. A later update must surface changes to source identity, publisher identity, integrity state, yanking state, or trust tier before showing file diffs.
 
-`incan template update` must default to a dry-run review path for security-sensitive changes. At minimum, the update plan must call out newly created files, executable source changes, manifest dependency changes, script or task changes, CI/configuration changes, env changes, and agent guidance metadata changes. Non-interactive update modes must still emit this information in machine-readable output and should require an explicit flag for source identity changes.
+`oven template update` must default to a dry-run review path for security-sensitive changes. At minimum, the update plan must call out newly created files, executable source changes, manifest dependency changes, script or task changes, CI/configuration changes, env changes, and agent guidance metadata changes. Non-interactive update modes must still emit this information in machine-readable output and should require an explicit flag for source identity changes.
 
 If two template sources can satisfy the same id, update tooling must not silently switch sources. This is especially important when private and public catalogs both contain a matching id. The lifecycle CLI must either preserve the recorded source identity or require explicit user intent to change it.
 
@@ -675,7 +676,7 @@ Rejected because generated project boilerplate should be reviewable, editable, a
 
 - **Parser:** rendered Incan templates must parse before they are written when `language = "incan"`.
 - **Formatter:** rendered Incan templates should be formatted before write and before `rendered_hash` is recorded when a formatter is available.
-- **Manifest schema / configuration validation:** project tooling must support an explicit provenance location for tracked templates, whether in `incan.toml`, a sidecar state file, or a future lock/state artifact.
+- **Manifest schema / configuration validation:** project tooling must support an explicit provenance location for tracked templates, whether in a typed `Loaf.toml` table or an explicit tool-owned state artifact. `Oven.lock` remains resolver state and must not become a general mutation-history store.
 - **CLI / tooling:** lifecycle tooling must implement deterministic template rendering, path validation, parameter validation, ownership handling, provenance recording, and check/status/values-file/diff/update/reset operations.
 - **LSP / IDE tooling:** editor-facing tools should consume machine-readable template provenance and lifecycle diagnostics rather than reimplementing template rendering.
 - **Package integration:** package-provided templates must be loaded as package data and rendered locally under the same safety rules as built-in templates. Package or registry metadata may feed version-aware status and upgrade previews.
@@ -683,17 +684,17 @@ Rejected because generated project boilerplate should be reviewable, editable, a
 
 ## Unresolved questions
 
-- Should template provenance live in `incan.toml`, `incan.lock`, or a separate tool-owned state file?
+- Should template provenance live in a typed `Loaf.toml` table or a separate tool-owned state file, and which facts must remain outside `Oven.lock`?
 - Is the v1 parameter kind set sufficient, or should it include specific kinds for package names, dependency requirements, env names, and script ids?
 - Which derived-value transforms should be standardized in v1?
 - Should optional file groups live in RFC 074 as template renderer metadata, or should RFC 075 own them as starter/capability mutation metadata?
 - Should generated-file ownership be encoded as a separate `ownership` field, as part of provenance mode, or as part of RFC 075 file mutation metadata?
 - Should descriptors reject declared-but-unused parameters by default, or should unused parameters be permitted for descriptor reuse?
 - Should `tracked` or `none` be the default provenance mode for file templates applied by starter and capability workflows?
-- What merge strategy, if any, should `incan template update` support for edited tracked files in v1?
-- Should `incan template diff` produce a stable machine-readable patch format in v1, or is human-readable diff output enough initially?
-- What is the minimum useful `incan template status` behavior without registry access?
-- Should `incan template reset` be part of v1, or should it wait until normal update behavior has shipped?
+- What merge strategy, if any, should `oven template update` support for edited tracked files in v1?
+- Should `oven template diff` produce a stable machine-readable patch format in v1, or is human-readable diff output enough initially?
+- What is the minimum useful `oven template status` behavior without registry access?
+- Should `oven template reset` be part of v1, or should it wait until normal update behavior has shipped?
 - What provider validation command, if any, should be required before templates can be published or promoted in `incan.pub`?
 - Should `.incn.tpl` be the recommended suffix for all Incan source templates, or should package authors prefer neutral names plus descriptor metadata?
 - How should preserved later-phase placeholders be represented so they are explicit but not awkward for common deployment/configuration tools?

--- a/workspaces/docs-site/docs/RFCs/075_starter_profiles_and_capability_packs.md
+++ b/workspaces/docs-site/docs/RFCs/075_starter_profiles_and_capability_packs.md
@@ -13,53 +13,55 @@
     - RFC 073 (environment matrices and toolchain constraints)
     - RFC 074 (template rendering and boilerplate provenance)
     - RFC 076 (project mutation policy and recovery)
+    - RFC 117 (`Loaf.toml` and Oven's language-neutral project model)
+    - RFC 118 (Incan and Oven command-line surfaces)
 - **Issue:** https://github.com/encero-systems/incan/issues/403
 - **RFC PR:** —
-- **Written against:** v0.3
+- **Written against:** ~~v0.3~~ v0.5
 - **Shipped in:** —
 
 ## Summary
 
-This RFC extends the project lifecycle model from RFC 015 with starter profiles and capability packs. A starter profile is a declarative recipe for creating or initializing a project with a coherent set of files, manifest entries, and capability packs. A capability pack is a reusable, explicit project mutation that can add package dependencies, scripts, environment configuration, starter files, tooling metadata, and follow-up diagnostics to an existing project. Starter and capability descriptors may depend on other descriptors, but they must resolve into one reviewable mutation plan. The goal is not hidden framework magic; the goal is to keep the Rust-like package workflow from RFC 034 (`incan add <pkg>`) while adding an explicit project-capability workflow (`incan capability add <capability>`) for setup that changes source files, scripts, envs, and tooling metadata.
+This RFC extends the Loaf/Oven project model with starter profiles and capability packs. A starter profile is a declarative recipe for creating or initializing a project with a coherent set of files, manifest entries, and capability packs. A capability pack is a reusable, explicit project mutation that can add package dependencies, scripts, environment configuration, starter files, tooling metadata, and follow-up diagnostics to an existing project. Starter and capability descriptors may depend on other descriptors, but they must resolve into one reviewable mutation plan. The goal is not hidden framework magic; the goal is to keep the Cargo-shaped package workflow from RFC 034 (`oven add <pkg>`) while adding an explicit project-capability workflow (`oven capability add <capability>`) for setup that changes source files, scripts, envs, and tooling metadata.
 
 ## Core model
 
 Read this RFC as nine foundations plus five mechanisms:
 
-1. **Foundation:** RFC 015 owns the minimal project lifecycle surface; this RFC layers richer project shapes on top of that surface rather than changing the meaning of `incan.toml`, project roots, or named envs.
+1. **Foundation:** RFC 117 owns the `Loaf.toml` project model and root authority; this RFC layers richer project shapes on top without redefining manifest discovery, workspace inheritance, dependency resolution, or named-environment semantics.
 2. **Foundation:** Starters and capability packs are tooling descriptors, not new language constructs. Applying one must result in explicit project files and manifest entries.
 3. **Foundation:** Generated projects remain ordinary Incan projects. There is no hidden starter mode, no runtime dependency injection container, and no implicit activation that cannot be inspected after creation.
-4. **Foundation:** Capability packs are composition units. A starter profile may include zero or more capability packs, and an existing project may add a capability pack later through `incan capability add`.
+4. **Foundation:** Capability packs are composition units. A starter profile may include zero or more capability packs, and an existing project may add a capability pack later through `oven capability add`.
 5. **Foundation:** Descriptor dependencies are explicit. Starters and capability packs may depend on other starters, capabilities, or templates, but the CLI must resolve that graph before applying any mutation.
 6. **Foundation:** Starter application must be deterministic and safe by default: no arbitrary script execution, no unprompted overwrites, no silent dependency changes, and no secret material embedded into generated files.
-7. **Foundation:** Incan packages may advertise capability packs. Adding a package and applying a capability are separate operations: `incan add <pkg>` changes dependencies; `incan capability add <capability>` applies project setup and may add dependencies as part of an explicit mutation plan.
+7. **Foundation:** Incan packages may advertise capability packs. Adding a package and applying a capability are separate operations: `oven add <pkg>` changes dependencies; `oven capability add <capability>` applies project setup and may add dependencies as part of an explicit mutation plan.
 8. **Foundation:** Applicability and back-off decisions are explicit. A descriptor may explain why it applies, why it is already satisfied, why it skipped a mutation, or why it is blocked, but it must not infer success from undocumented file conventions.
 9. **Foundation:** The same descriptor model must be consumable by CLI and editor tooling. IDE support should not infer project intent from ad-hoc filenames when the starter or capability pack can declare that intent directly.
-10. **Mechanism A:** `incan new <name> --starter <id>` creates a project by resolving one starter profile, applying its capability packs, rendering its files, and writing a normal `incan.toml`.
-11. **Mechanism B:** `incan init --starter <id>` applies starter initialization to an existing directory with adoption-oriented conflict rules. Existing-project initialization must preserve user-authored files more aggressively than greenfield creation.
-12. **Mechanism C:** `incan capability add <capability-id>` resolves one capability pack, which may be advertised by a package, then applies the resulting mutation plan to an existing project.
-13. **Mechanism D:** `incan starter list`, `incan starter show`, and dry-run output expose what a starter or capability pack would change before files are written.
+10. **Mechanism A:** `oven new <name> --starter <id>` creates a project by resolving one starter profile, applying its capability packs, rendering its files, and writing a normal `Loaf.toml`.
+11. **Mechanism B:** `oven init --starter <id>` applies starter initialization to an existing directory with adoption-oriented conflict rules. Existing-project initialization must preserve user-authored files more aggressively than greenfield creation.
+12. **Mechanism C:** `oven capability add <capability-id>` resolves one capability pack, which may be advertised by a package, then applies the resulting mutation plan to an existing project.
+13. **Mechanism D:** `oven starter list`, `oven starter show`, and dry-run output expose what a starter or capability pack would change before files are written.
 14. **Mechanism E:** lifecycle tooling exposes machine-readable starter, capability, and project-capability views so LSP servers and IDE plugins can offer completion, code actions, run actions, and project-shape diagnostics from the same contract as the CLI.
 
 ## Motivation
 
-RFC 015 deliberately defines a small, explicit project lifecycle CLI: create a project, initialize metadata, define scripts and envs, bump versions, and run named env commands. That is the right base layer, but a minimal `hello world` scaffold is not enough once the ecosystem has reusable libraries for common domains such as CLIs, HTTP clients, web entrypoints, serialization, testing, data access, and documentation. Rust users can often add a crate and immediately use its API; Incan should preserve that simple dependency story through RFC 034's `incan add <pkg>` while also recognizing that application capabilities often need a small amount of project setup. Without a first-class starter model, users will copy examples by hand, drift from recommended dependency combinations, and re-learn the same manifest wiring in every repository.
+RFC 015 deliberately defines a small, explicit project lifecycle CLI: create a project, initialize metadata, define scripts and envs, bump versions, and run named env commands. That is the right base layer, but a minimal `hello world` scaffold is not enough once the ecosystem has reusable libraries for common domains such as CLIs, HTTP clients, web entrypoints, serialization, testing, data access, and documentation. Rust users can often add a crate and immediately use its API; Incan should preserve that simple dependency story through RFC 034's `oven add <pkg>` while also recognizing that application capabilities often need a small amount of project setup. Without a first-class starter model, users will copy examples by hand, drift from recommended dependency combinations, and re-learn the same manifest wiring in every repository.
 
 Library metadata and manifests already point toward a more declarative ecosystem. RFC 027 says feature and dependency metadata should travel through library manifests rather than ad-hoc compiler scans, and RFC 031 establishes `.incnlib` as a semantic library artifact. Those pieces help libraries describe themselves, but they do not answer the project-author question: "start this repo with the standard shape for X" or "add the standard support for Y to this repo."
 
-The missing layer is an explicit project mutation contract. Users need a command that can say what it will do, apply the change deterministically, and leave behind normal files that can be reviewed in source control. That is a different problem from typechecking, package resolution, environment matrix execution, or future product-specific app templates. This RFC defines the generic Incan-side layer those higher-level experiences can build on.
+The missing layer is an explicit project mutation contract. Users need a command that can say what it will do, apply the change deterministically, and leave behind normal files that can be reviewed in source control. That is a different problem from typechecking, package resolution, environment matrix execution, or future product-specific app templates. This RFC defines the generic Oven-side layer those higher-level experiences can build on. RFC 118 may expose downward-delegating Incan conveniences, but it must not duplicate Oven mutation planning, resolver, policy, or receipt behavior.
 
 ## Goals
 
-- Define starter profiles as declarative recipes for `incan new` and `incan init`.
-- Define capability packs as reusable project mutations that can be applied independently through `incan capability add`.
+- Define starter profiles as declarative recipes for `oven new` and `oven init`.
+- Define capability packs as reusable project mutations that can be applied independently through `oven capability add`.
 - Define descriptor dependency resolution so starters, capabilities, and templates can compose without hidden ordering.
-- Allow package authors to advertise capability packs so `incan add <package>` can add the package dependency and then point users toward optional setup through `incan capability add <capability>`.
+- Allow package authors to advertise capability packs so `oven add <package>` can add the package dependency and then point users toward optional setup through `oven capability add <capability>`.
 - Make starter and capability application deterministic, conflict-aware, dry-runnable, and reviewable.
 - Define explainable applicability and back-off behavior for existing projects.
 - Distinguish greenfield project creation from existing-project adoption so migration does not overwrite user-authored files under creation-oriented assumptions.
 - Allow starters and capability packs to add manifest entries, dependencies, dev-dependencies, scripts, env definitions, file templates, tooling metadata, agent guidance metadata, and user-facing follow-up notes.
-- Keep generated projects ordinary: all persistent behavior must be represented in source files, `incan.toml`, `incan.lock`, or documented generated artifacts.
+- Keep generated projects ordinary: all persistent behavior must be represented in source files, `Loaf.toml`, `Oven.lock`, or documented generated artifacts.
 - Provide inspection commands so users can list available starters, preview one starter, and see which capabilities are recorded in a project.
 - Define a review-first capability update path so a project can move an applied capability from one recorded descriptor version to another without treating the change as an automatic package upgrade or silent template rewrite.
 - Provide machine-readable inspection surfaces so LSP and IDE tooling can list starters, preview capability changes, show enabled capabilities, and surface project-specific actions without reimplementing descriptor resolution.
@@ -91,7 +93,7 @@ The missing layer is an explicit project mutation contract. Users need a command
 A user can ask the toolchain which starter profiles are available:
 
 ```text
-incan starter list
+oven starter list
 ```
 
 The output should show stable starter ids, short descriptions, source kind, and compatibility with the active Incan version. A built-in `bin` starter may be the default shape already described by RFC 015.
@@ -111,15 +113,15 @@ The exact starter set is not normative. The normative requirement is that availa
 A starter may be selected during project creation:
 
 ```text
-incan new weather_tool --starter cli
+oven new weather_tool --starter cli
 ```
 
-The generated project is still an ordinary Incan project. The starter writes `incan.toml`, source files, docs, test files, and any other explicit artifacts described by the starter descriptor. There is no persistent hidden link to the starter that changes compilation semantics later.
+The generated project is still an ordinary Incan project. The starter writes `Loaf.toml`, source files, docs, test files, and any other explicit artifacts described by the starter descriptor. There is no persistent hidden link to the starter that changes compilation semantics later.
 
 If the starter includes capability packs, the CLI applies them as part of creation and records them in the project manifest for inspection:
 
 ```toml
-[tool.incan.capabilities]
+[oven.capabilities]
 enabled = ["std.process", "testing.basic"]
 ```
 
@@ -127,20 +129,20 @@ The record is tooling provenance, not a runtime feature switch. The actual behav
 
 ### Initializing an existing directory
 
-`incan init` may also accept a starter:
+`oven init` may also accept a starter:
 
 ```text
-incan init --starter cli
+oven init --starter cli
 ```
 
-This uses the same descriptor as `incan new`, but conflict handling is stricter because files may already exist. By default, generated files must not overwrite existing files. If a starter cannot be applied without overwriting or merging conflicting data, the CLI must stop with a diagnostic and suggest `--dry-run` or explicit overwrite flags.
+This uses the same descriptor as `oven new`, but conflict handling is stricter because files may already exist. By default, generated files must not overwrite existing files. If a starter cannot be applied without overwriting or merging conflicting data, the CLI must stop with a diagnostic and suggest `--dry-run` or explicit overwrite flags.
 
 ### Adding a capability pack
 
 An existing project may add one reusable capability without switching to a different starter:
 
 ```text
-incan capability add std.http-client
+oven capability add std.http-client
 ```
 
 The CLI resolves the capability pack, previews or applies its manifest changes, writes any declared files that do not conflict, and records the capability as enabled. If the capability depends on other capability packs, the CLI must show those transitive additions before applying them.
@@ -152,8 +154,8 @@ Capability packs should be small enough to explain. A pack named `std.http-clien
 Both starters and capability packs should support dry-run output:
 
 ```text
-incan new weather_tool --starter cli --dry-run
-incan capability add std.http-client --dry-run
+oven new weather_tool --starter cli --dry-run
+oven capability add std.http-client --dry-run
 ```
 
 Dry-run output must show planned file writes, manifest additions, dependency changes, env/script additions, skipped mutations, already-satisfied expectations, and any conflicts. The dry run should be detailed enough that a user can decide whether the command is safe before mutating the project.
@@ -165,10 +167,10 @@ Capability updates are review-first project migrations, not package upgrades and
 When a project records that it applied `cli` from descriptor version `1.3.0`, a later user should be able to ask what it would mean to move that project concern to `1.6.0`:
 
 ```text
-incan capability status cli
-incan capability diff cli --to 1.6.0
-incan capability update cli --to 1.6.0 --dry-run
-incan capability update cli --to 1.6.0
+oven capability status cli
+oven capability diff cli --to 1.6.0
+oven capability update cli --to 1.6.0 --dry-run
+oven capability update cli --to 1.6.0
 ```
 
 The lifecycle CLI resolves the currently recorded descriptor source and target descriptor version, verifies that the source identity has not silently changed, expands descriptor dependencies, renders affected RFC 074 templates with preserved or supplied values, and produces one receiver-side mutation plan.
@@ -185,8 +187,8 @@ Descriptor integrity: verified
 Would update dependencies:
   app-cli 1.3.0 -> 1.6.0
 
-Would update incan.toml:
-  add [tool.incan.actions.run-cli]
+Would update Loaf.toml:
+  add [oven.actions.run-cli]
   rename script "run" -> "cli.run"
 
 Files:
@@ -208,7 +210,7 @@ Files:
 
 The user-facing update unit is the capability because that is how the project concern was applied. RFC 074 still owns the lower-level template behavior for individual files: managed files may be updated when unchanged, bootstrap files are not rewritten by normal capability updates, advisory files are explained but not owned, and edited managed files must stop with a conflict or use a documented merge strategy. RFC 076 evaluates the resulting mutation plan before anything is written.
 
-`incan capability diff` should show the receiver-side patch that would land in the project. Catalog or registry source diffs between descriptor versions are useful supporting evidence, but they are not a substitute for the rendered project diff.
+`oven capability diff` should show the receiver-side patch that would land in the project. Catalog or registry source diffs between descriptor versions are useful supporting evidence, but they are not a substitute for the rendered project diff.
 
 If the descriptor declares ordered migration steps between intermediate versions, the CLI may collapse them into one target update as long as the resulting plan remains explainable. If a required step cannot be represented declaratively, the update must stop and present manual instructions rather than running arbitrary provider code.
 
@@ -233,7 +235,7 @@ Suppose a user has an existing project:
 
 ```text
 weather_core/
-  incan.toml
+  Loaf.toml
   src/lib.incn
 ```
 
@@ -242,7 +244,7 @@ They want to add a standard command-line entrypoint without hand-copying example
 The user may start with the Rust-like package workflow:
 
 ```text
-incan add app-cli
+oven add app-cli
 ```
 
 That only changes dependencies:
@@ -254,13 +256,13 @@ This package advertises project capabilities:
   cli  Adds a CLI entrypoint, run script, and test skeleton
 
 Apply setup with:
-  incan capability add cli
+  oven capability add cli
 ```
 
 To preview the project setup, the user asks for a capability dry run:
 
 ```text
-incan capability add cli --dry-run
+oven capability add cli --dry-run
 ```
 
 The CLI resolves `cli` as a capability, sees that its recommended provider is `app-cli`, validates the descriptor against the active project, and prints a mutation plan:
@@ -279,15 +281,15 @@ Would create:
   src/main.incn
   tests/test_cli.incn
 
-Would update incan.toml:
+Would update Loaf.toml:
   [project.scripts]
   main = "src/main.incn"
 
-  [tool.incan.envs.default.scripts]
-  run = ["incan", "run"]
-  test = ["incan", "test"]
+  [oven.envs.default.scripts]
+  run = ["oven", "run"]
+  test = ["oven", "test"]
 
-  [tool.incan.capabilities]
+  [oven.capabilities]
   enabled += ["cli"]
 
 Tooling:
@@ -301,14 +303,14 @@ Agent guidance:
 If the plan looks right, they apply it:
 
 ```text
-incan capability add cli
+oven capability add cli
 ```
 
 The result is an ordinary project:
 
 ```text
 weather_core/
-  incan.toml
+  Loaf.toml
   src/lib.incn
   src/main.incn
   tests/test_cli.incn
@@ -327,11 +329,11 @@ app-cli = "0.3.1"
 [project.scripts]
 main = "src/main.incn"
 
-[tool.incan.envs.default.scripts]
-run = ["incan", "run"]
-test = ["incan", "test"]
+[oven.envs.default.scripts]
+run = ["oven", "run"]
+test = ["oven", "test"]
 
-[tool.incan.capabilities]
+[oven.capabilities]
 enabled = ["cli"]
 ```
 
@@ -362,8 +364,8 @@ mode = "create"
 [manifest.project.scripts]
 main = "src/main.incn"
 
-[manifest.tool.incan.envs.default.scripts]
-test = ["incan", "test"]
+[manifest.oven.envs.default.scripts]
+test = ["oven", "test"]
 ```
 
 A capability pack descriptor uses the same project mutation model, but its root identity is a capability rather than a starter:
@@ -380,8 +382,8 @@ source = "templates/test_main.incn"
 target = "tests/test_main.incn"
 mode = "create"
 
-[manifest.tool.incan.envs.default.scripts]
-test = ["incan", "test"]
+[manifest.oven.envs.default.scripts]
+test = ["oven", "test"]
 
 [[tooling.actions]]
 id = "run-tests"
@@ -408,7 +410,7 @@ For the walkthrough above, the provider-side descriptor could be packaged as ord
 
 ```text
 app-cli/
-  incan.toml
+  Loaf.toml
   capabilities/
     cli.toml
   templates/
@@ -443,9 +445,9 @@ mode = "create"
 [manifest.project.scripts]
 main = "src/main.incn"
 
-[manifest.tool.incan.envs.default.scripts]
-run = ["incan", "run"]
-test = ["incan", "test"]
+[manifest.oven.envs.default.scripts]
+run = ["oven", "run"]
+test = ["oven", "test"]
 
 [[tooling.actions]]
 id = "run-cli"
@@ -466,7 +468,7 @@ applies_to = ["cli"]
 description = "Use when extending the command-line entrypoint or tests."
 ```
 
-The provider ships static descriptor data and templates. The provider does not ship an arbitrary setup script that the user's project executes during `incan capability add`.
+The provider ships static descriptor data and templates. The provider does not ship an arbitrary setup script that the user's project executes during `oven capability add`.
 
 ## Reference-level explanation
 
@@ -476,7 +478,7 @@ A **starter profile** is a named descriptor that can create a new project or ini
 
 A **capability pack** is a named descriptor that applies one reusable project concern to an existing project. A starter profile may include capability packs.
 
-A **project mutation** is a planned change to project files, `incan.toml`, dependency declarations, env definitions, scripts, generated docs, or other explicit artifacts owned by the project.
+A **project mutation** is a planned change to project files, `Loaf.toml`, dependency declarations, env definitions, scripts, generated docs, or other explicit artifacts owned by the project.
 
 A **starter catalog** is a source of starter and capability descriptors. V1 implementations must support built-in descriptors. They may also support explicit local descriptor paths. Future source kinds may include git references, package-provided descriptors, public catalog sources, and private catalog sources.
 
@@ -490,36 +492,36 @@ Starter ids and capability ids must be stable ASCII identifiers. They should use
 
 The same id must not resolve to two descriptors in the same catalog source. If two catalog sources provide the same id, the CLI must either reject the ambiguity or apply a documented source precedence rule and show the selected source in diagnostics.
 
-If a capability id is advertised by multiple packages and no default provider is configured, `incan capability add <capability-id>` must not guess silently. It must show the candidate providers and require the user to disambiguate through a package-qualified capability id or an explicit provider flag.
+If a capability id is advertised by multiple packages and no default provider is configured, `oven capability add <capability-id>` must not guess silently. It must show the candidate providers and require the user to disambiguate through a package-qualified capability id or an explicit provider flag.
 
 ### Command surface
 
 This RFC adds the following lifecycle commands and flags:
 
-- `incan starter list`
-- `incan starter show <starter-id>`
-- `incan capability list`
-- `incan capability show <capability-id>`
-- `incan capability status`
-- `incan capability diff <capability-id> --to <version-or-ref>`
-- `incan capability add <capability-id>`
-- `incan capability update <capability-id> --to <version-or-ref>`
-- `incan new <name> --starter <starter-id>`
-- `incan init --starter <starter-id>`
+- `oven starter list`
+- `oven starter show <starter-id>`
+- `oven capability list`
+- `oven capability show <capability-id>`
+- `oven capability status`
+- `oven capability diff <capability-id> --to <version-or-ref>`
+- `oven capability add <capability-id>`
+- `oven capability update <capability-id> --to <version-or-ref>`
+- `oven new <name> --starter <starter-id>`
+- `oven init --starter <starter-id>`
 
-`incan starter show` and `incan capability show` must report the descriptor source, required Incan constraint, descriptor dependencies, included capabilities, planned manifest effects, declared files, and known conflicts if evaluated in a project context.
+`oven starter show` and `oven capability show` must report the descriptor source, required Incan constraint, descriptor dependencies, included capabilities, planned manifest effects, declared files, and known conflicts if evaluated in a project context.
 
-`incan capability add` requires a project root. If no `incan.toml` is found, it must fail with a diagnostic suggesting `incan init` or `incan new`.
+`oven capability add` requires a project root. If no `Loaf.toml` is found, it must fail with a diagnostic suggesting `oven init` or `oven new`.
 
-`incan add <pkg>` remains the RFC 034 package dependency command. If the added package advertises capabilities, the CLI should report those capabilities and show the corresponding `incan capability add <capability-id>` command, but it must not apply project setup as part of plain dependency addition.
+`oven add <pkg>` remains the RFC 034 package dependency command. If the added package advertises capabilities, the CLI should report those capabilities and show the corresponding `oven capability add <capability-id>` command, but it must not apply project setup as part of plain dependency addition.
 
-`incan capability status` requires a project root. It must report enabled capability provenance and should report whether the project still appears consistent with each enabled capability's declared expectations. When catalog or registry metadata is available, status should also report the latest compatible descriptor version and whether the recorded source is yanked, revoked, superseded, or unknown.
+`oven capability status` requires a project root. It must report enabled capability provenance and should report whether the project still appears consistent with each enabled capability's declared expectations. When catalog or registry metadata is available, status should also report the latest compatible descriptor version and whether the recorded source is yanked, revoked, superseded, or unknown.
 
-`incan capability diff` requires a project root and an enabled capability. It must resolve the current recorded descriptor and requested target descriptor, then show the receiver-side mutation plan without writing files. Source-level descriptor diffs may be shown as supporting information, but the rendered project diff is the review artifact.
+`oven capability diff` requires a project root and an enabled capability. It must resolve the current recorded descriptor and requested target descriptor, then show the receiver-side mutation plan without writing files. Source-level descriptor diffs may be shown as supporting information, but the rendered project diff is the review artifact.
 
-`incan capability update` requires a project root and an enabled capability. It applies an explicit receiver-approved mutation plan for moving from the recorded descriptor version to the requested target version or ref. It must support `--dry-run`, must preserve recorded source identity unless the user explicitly requests a source switch, and must not bypass RFC 076 policy.
+`oven capability update` requires a project root and an enabled capability. It applies an explicit receiver-approved mutation plan for moving from the recorded descriptor version to the requested target version or ref. It must support `--dry-run`, must preserve recorded source identity unless the user explicitly requests a source switch, and must not bypass RFC 076 policy.
 
-`incan new` without `--starter` must keep the RFC 015 default behavior. Implementations may model that default internally as a built-in starter, but users must not be required to know that.
+`oven new` without `--starter` must keep the RFC 015 default behavior. Implementations may model that default internally as a built-in starter, but users must not be required to know that.
 
 Commands that list, show, or add starters and capabilities may accept a catalog source selector. The exact flag spelling is not normative, but the model must distinguish built-in descriptors, local descriptor paths, git references, package-provided descriptors, public catalog descriptors, and private catalog descriptors in diagnostics and machine-readable output.
 
@@ -620,14 +622,14 @@ For list-like keys, applying a descriptor should append missing values without d
 
 For dependency tables, applying a descriptor must reject incompatible duplicate dependency requirements unless a documented resolver can prove the resulting requirement is compatible. The CLI must not silently replace a user-authored dependency constraint with a starter-provided one.
 
-For env definitions under `[tool.incan.envs.*]`, applying a descriptor must use RFC 015 and RFC 073 validation rules. Inherited envs, scripts, matrices, and toolchain constraints must remain valid after the mutation.
+For env definitions under `[oven.envs.*]`, applying a descriptor must use RFC 073 validation rules. Inherited envs, scripts, matrices, and toolchain constraints must remain valid after the mutation.
 
 ### Capability provenance
 
-When `incan capability add` applies a capability pack, the project manifest should record that the capability is enabled:
+When `oven capability add` applies a capability pack, the project manifest should record that the capability is enabled:
 
 ```toml
-[tool.incan.capabilities]
+[oven.capabilities]
 enabled = ["testing.basic", "std.http-client"]
 ```
 
@@ -635,13 +637,13 @@ The enabled list is provenance and tooling state. It does not replace explicit d
 
 Capability provenance must preserve the descriptor source kind, source identity, selected descriptor version or content hash when available, provider package when applicable, applied capability id, expanded transitive capability graph, and the Incan version used to apply the descriptor. When available, it should also preserve publisher identity, integrity/signature state, yanking or revocation state, catalog trust tier, and the top-level user request that caused transitive capabilities to be applied.
 
-The compact `enabled = [...]` form is sufficient for human-readable manifest summaries, but tools that support refresh, status, or security review need access to the richer provenance record. That richer record may live in `incan.toml`, a sidecar state file, or a future lock/state artifact, but it must be explicit project tooling state rather than inferred from generated files.
+The compact `enabled = [...]` form is sufficient for human-readable manifest summaries, but tools that support refresh, status, or security review need access to the richer provenance record. That richer record may live in `Loaf.toml`, a sidecar state file, or a future lock/state artifact, but it must be explicit project tooling state rather than inferred from generated files.
 
-If a capability pack is already recorded as enabled, `incan capability add <capability-id>` should be idempotent. It may revalidate that the expected project shape is still present, but it must not duplicate manifest entries or files.
+If a capability pack is already recorded as enabled, `oven capability add <capability-id>` should be idempotent. It may revalidate that the expected project shape is still present, but it must not duplicate manifest entries or files.
 
 Capability provenance should preserve enough information to explain transitive additions. A project may record that a starter enabled `sample_query.project`, and that `sample_query.project` pulled in `sample_query.session` and `testing.basic`. Tooling should be able to show the user both the top-level request and the expanded capability graph.
 
-Capability provenance is also the anchor for future updates. A project that records `cli@1.3.0` can later ask for a reviewable update to `cli@1.6.0` only if tooling can identify the recorded descriptor source, selected version or content hash, parameter values or safe value fingerprints, transitive descriptor graph, generated-file ownership, and applied template provenance. If that information is missing, `incan capability update` must degrade to an explicit adoption or manual-migration flow rather than guessing.
+Capability provenance is also the anchor for future updates. A project that records `cli@1.3.0` can later ask for a reviewable update to `cli@1.6.0` only if tooling can identify the recorded descriptor source, selected version or content hash, parameter values or safe value fingerprints, transitive descriptor graph, generated-file ownership, and applied template provenance. If that information is missing, `oven capability update` must degrade to an explicit adoption or manual-migration flow rather than guessing.
 
 Descriptor-version updates may include declarative migration metadata. V1 migration metadata should stay non-executable: manifest key additions, manifest key renames, parameter renames, template id changes, file ownership changes, dependency version changes, action descriptor changes, and manual instruction blocks are acceptable shapes. Arbitrary shell, Python, plugin, or provider-defined migration hooks are out of scope for this RFC.
 
@@ -663,7 +665,7 @@ If tooling metadata references files, paths must be relative to the project root
 
 The LSP or another editor-facing tool may use this metadata for completions, code actions, diagnostics, project-tree grouping, and run/debug affordances. It must still treat the compiler and lifecycle CLI as the source of truth for validation.
 
-RFC 078 owns typed action semantics, execution modes, risk labels, dry-run expectations for action execution, and `incan action run`. This RFC only lets starters and capabilities contribute or reference action descriptors as part of a project mutation plan. A descriptor that mentions an action must remain descriptive until the user or tooling explicitly invokes the action through RFC 078 behavior.
+RFC 078 owns typed action semantics, execution modes, risk labels, dry-run expectations for action execution, and `oven action run`. This RFC only lets starters and capabilities contribute or reference action descriptors as part of a project mutation plan. A descriptor that mentions an action must remain descriptive until the user or tooling explicitly invokes the action through RFC 078 behavior.
 
 ### Agent guidance metadata
 
@@ -683,7 +685,7 @@ This metadata is useful because capability packs encode project intent. If a pro
 
 ### Dry-run behavior
 
-`--dry-run` must be supported for `incan new --starter`, `incan init --starter`, and `incan capability add`.
+`--dry-run` must be supported for `oven new --starter`, `oven init --starter`, and `oven capability add`.
 
 Dry-run output must include the full mutation plan and must not write project files, lockfiles, or generated artifacts. If a dry run detects conflicts, it must report them with the same diagnostics that a real apply would use. The plan must explain why each descriptor or mutation is applicable, already satisfied, skipped, blocked, conflicting, or unsafe when those states apply.
 
@@ -691,7 +693,7 @@ Implementations must provide a machine-readable dry-run format for the full muta
 
 ### Lockfile interaction
 
-Starter and capability application may update `incan.toml`, but it must not silently rewrite `incan.lock` unless the command documents and exposes that behavior. The default behavior should leave lockfile updates to the next `incan lock`, `incan build`, or `incan test` flow governed by RFC 020.
+Starter and capability application may update `Loaf.toml`, but it must not silently rewrite `Oven.lock` unless the command documents and exposes that behavior. The default behavior should leave lockfile updates to the next `oven lock`, `oven bake`, or `oven test` flow governed by RFC 020.
 
 If a descriptor includes dependency changes and the project is in a locked or frozen mode, the CLI must report that lockfile refresh is required rather than pretending the project remains fully locked.
 
@@ -717,7 +719,7 @@ Catalog resolution must avoid dependency-confusion behavior. A public catalog en
 
 Security-sensitive mutation categories must be explicit in dry-run and machine-readable output. At minimum, plans must identify dependency additions or upgrades, script/task changes, env changes, CI/config changes, executable source changes, generated-file ownership changes, and agent guidance metadata changes.
 
-Project and organization policy may restrict which catalog sources, publishers, trust tiers, or descriptor pin forms are allowed for starters and capabilities. Policy may also require approval for high-risk mutation categories before `incan capability add` or a future capability refresh writes changes. This mirrors code review ownership for CI workflows: source files, scripts, CI config, env definitions, and agent guidance may need different reviewers.
+Project and organization policy may restrict which catalog sources, publishers, trust tiers, or descriptor pin forms are allowed for starters and capabilities. Policy may also require approval for high-risk mutation categories before `oven capability add` or a future capability refresh writes changes. This mirrors code review ownership for CI workflows: source files, scripts, CI config, env definitions, and agent guidance may need different reviewers.
 
 Automated capability update should follow a review-first model. It may detect stale descriptors, vulnerable sources, or newer compatible versions, but it should emit a reviewable mutation plan or pull-request-sized patch rather than applying changes unattended. The plan should show before/after descriptor source, version or content hash, provider identity, known advisory state, yanking state, and every security-sensitive mutation category.
 
@@ -737,15 +739,15 @@ Diagnostics should prefer actionable conflict explanations over generic "templat
 
 ## Design details
 
-### Relationship to RFC 015
+### Relationship to RFCs 015 and 117
 
-RFC 015 defines the baseline project lifecycle: project metadata, root discovery, `incan new`, `incan init`, versioning, and named envs. This RFC does not change those rules. It adds richer starter selection and capability addition on top of the same project model.
+RFC 015 remains the historical source of the baseline lifecycle ideas. RFC 117 prospectively supersedes its manifest filename, discovery, lock, and environment-configuration placement. This RFC adds richer starter selection and capability application on top of the `Loaf.toml` project model without reviving the old manifest contract.
 
 The RFC 015 default scaffold remains valid and should stay small. Starter profiles are the place for opinionated project shapes.
 
 ### Relationship to library metadata
 
-Capability packs are project-level activation units. Library manifests may eventually advertise capabilities, dependencies, config needs, or generated helper files, but applying those capabilities to a project remains a lifecycle CLI operation through `incan capability add`. This avoids a hidden model where merely importing a package or adding a dependency rewrites the project or changes source layout.
+Capability packs are project-level activation units. Library manifests may eventually advertise capabilities, dependencies, config needs, or generated helper files, but applying those capabilities to a project remains a lifecycle CLI operation through `oven capability add`. This avoids a hidden model where merely importing a package or adding a dependency rewrites the project or changes source layout.
 
 Where library manifests and starter descriptors overlap, library manifest data should be the source of truth for package-owned dependency and feature requirements. Starter descriptors should compose those capabilities rather than copy stale requirements by hand.
 
@@ -826,15 +828,15 @@ Rejected because arbitrary scripts make starters powerful but unsafe, hard to in
 
 ### Make package import activate capabilities automatically
 
-Rejected because imports should not mutate projects or create hidden configuration. Capability activation should be explicit through `incan capability add` or a selected starter profile.
+Rejected because imports should not mutate projects or create hidden configuration. Capability activation should be explicit through `oven capability add` or a selected starter profile.
 
-### Make plain `incan add <pkg>` apply default capability setup
+### Make plain `oven add <pkg>` apply default capability setup
 
-Rejected because it overloads dependency addition with project mutation. RFC 034 defines `incan add <pkg>` as the package workflow, analogous to `cargo add`. It should be safe to add a dependency without creating source files or scripts. Packages may advertise capabilities and the CLI may suggest them after adding the dependency, but applying capability setup belongs to `incan capability add`.
+Rejected because it overloads dependency addition with project mutation. RFC 034 defines `oven add <pkg>` as the package workflow, analogous to `cargo add`. It should be safe to add a dependency without creating source files or scripts. Packages may advertise capabilities and the CLI may suggest them after adding the dependency, but applying capability setup belongs to `oven capability add`.
 
-### Store all starter behavior in `incan.toml`
+### Store all starter behavior in `Loaf.toml`
 
-Rejected because starters often need file templates, docs, and sample tests. `incan.toml` should record project metadata and applied capability provenance, not become a large embedded template archive.
+Rejected because starters often need file templates, docs, and sample tests. `Loaf.toml` should record project metadata and applied capability provenance, not become a large embedded template archive.
 
 ### Add capability removal in v1
 
@@ -854,12 +856,12 @@ The recommended implementation shape is to treat starter and capability applicat
 
 First, resolve the descriptor from a catalog. Then expand included capability packs and template dependencies into one ordered acyclic mutation plan. Then validate the plan against the target project, including manifest conflicts, file conflicts, generated-file ownership policy, toolchain constraints, env validity, and path safety. Finally, apply the plan atomically or report diagnostics without writing anything.
 
-The same mutation plan should power dry-run output, human diagnostics, and machine-readable inspection. This keeps `incan new --starter`, `incan init --starter`, `incan capability add`, and `incan capability update` aligned rather than implementing separate generators and updaters.
+The same mutation plan should power dry-run output, human diagnostics, and machine-readable inspection. This keeps `oven new --starter`, `oven init --starter`, `oven capability add`, and `oven capability update` aligned rather than implementing separate generators and updaters.
 
 ## Layers affected
 
-- **Manifest schema / configuration validation:** `incan.toml` should allow capability provenance under `[tool.incan.capabilities]`; starter-applied env, script, dependency, and project metadata changes must validate under existing RFC 015, RFC 020, and RFC 073 rules.
-- **CLI / tooling:** `incan starter`, `incan capability`, `incan new --starter`, `incan init --starter`, `incan capability add`, `incan capability diff`, and `incan capability update` are new lifecycle tooling surfaces. They must support inspection, dry-run planning, conflict diagnostics, deterministic application, and review-first descriptor-version updates.
+- **Manifest schema / configuration validation:** `Loaf.toml` should allow capability provenance under `[oven.capabilities]`; starter-applied env, script, dependency, and project metadata changes must validate under RFCs 020, 073, 076, and 117.
+- **CLI / tooling:** `oven starter`, `oven capability`, `oven new --starter`, `oven init --starter`, `oven capability add`, `oven capability diff`, and `oven capability update` are new lifecycle tooling surfaces. They must support inspection, dry-run planning, conflict diagnostics, deterministic application, and review-first descriptor-version updates.
 - **LSP / IDE tooling:** editor-facing tools should consume machine-readable starter, capability, mutation-plan, file-role, and action metadata from the lifecycle layer. They may expose completions, code actions, project diagnostics, and run/debug affordances, but they must not fork descriptor semantics.
 - **Agentic tooling:** agent-facing tools may consume capability provenance, file roles, and agent guidance metadata to select relevant skills or workflows, but starter/capability descriptors remain descriptive and must not execute agents implicitly.
 - **Project scaffolding:** the project generator must support descriptor-backed file creation, manifest mutation, safe path normalization, and non-overwrite defaults.
@@ -869,10 +871,10 @@ The same mutation plan should power dry-run output, human diagnostics, and machi
 ## Unresolved questions
 
 - Should v1 support only built-in starter catalogs and explicit local descriptor paths, with `incan.pub` as a designed follow-up, or should registry-backed descriptor discovery be part of the first accepted design?
-- Should `incan capability add` always record capability provenance under `[tool.incan.capabilities]`, or should provenance be opt-in for projects that want very small manifests?
+- Should `oven capability add` always record capability provenance under `[oven.capabilities]`, or should provenance be opt-in for projects that want very small manifests?
 - How much of descriptor dependency resolution belongs in v1, and should optional dependencies be allowed before required dependency graphs are fully implemented?
 - Which files should starters mark as bootstrap-owned versus managed by default?
-- Should `incan init --starter` have an explicit adoption mode, or should existing-project adoption be auto-detected?
+- Should `oven init --starter` have an explicit adoption mode, or should existing-project adoption be auto-detected?
 - What provider validation should be required before a starter or capability can be published or promoted through `incan.pub`?
 - Should starter descriptors support interactive prompts in v1, or should all parameterization come from command-line flags and project metadata?
 - Which `tooling.file_roles` and `tooling.actions` values should be standardized in v1 versus left as free-form extension strings?

--- a/workspaces/docs-site/docs/RFCs/076_project_mutation_policy_and_recovery.md
+++ b/workspaces/docs-site/docs/RFCs/076_project_mutation_policy_and_recovery.md
@@ -9,9 +9,11 @@
     - RFC 034 (`incan.pub` package registry)
     - RFC 074 (template rendering and boilerplate provenance)
     - RFC 075 (starter profiles and capability packs)
+    - RFC 117 (`Loaf.toml` and Oven's language-neutral project model)
+    - RFC 118 (Incan and Oven command-line surfaces)
 - **Issue:** https://github.com/encero-systems/incan/issues/404
 - **RFC PR:** —
-- **Written against:** v0.3
+- **Written against:** ~~v0.3~~ v0.5
 - **Shipped in:** —
 
 ## Summary
@@ -65,14 +67,14 @@ This RFC intentionally stays above hosting and registry transport. It captures t
 A project can define a policy that describes which mutation sources are allowed and which categories require review:
 
 ```toml
-[tool.incan.policy.sources]
+[oven.policy.sources]
 builtin = "allow"
 local = "warn"
 git = "require-immutable-pin"
 public-catalog = "require-review"
 private-catalog = "allow"
 
-[tool.incan.policy.risk]
+[oven.policy.risk]
 source = "require-review"
 dependency = "require-review"
 script = "require-review"
@@ -89,7 +91,7 @@ The exact policy encoding is not normative in this Draft. The contract is that p
 When a user previews a capability, policy evaluation appears alongside the mutation plan:
 
 ```text
-incan capability add cli --dry-run
+oven capability add cli --dry-run
 ```
 
 Example output:
@@ -102,7 +104,7 @@ Policy: requires review
 Risk categories:
   source            src/main.incn
   source            tests/test_cli.incn
-  script            [tool.incan.envs.default.scripts].run
+  script            [oven.envs.default.scripts].run
   dependency        app-cli = "0.3.1"
   agent-guidance    cli.write-commands
 
@@ -120,7 +122,7 @@ The important behavior is not the exact wording. The important behavior is that 
 Automation may detect that a template or capability source has a newer compatible version or a known advisory:
 
 ```text
-incan mutation propose --stale --security
+oven mutation propose --stale --security
 ```
 
 A valid implementation may choose a different command name, but the behavior should be review-first. Automation creates a patch-sized proposal containing source identity changes, integrity or advisory changes, rendered receiver-side diffs, and policy outcomes. It does not merge, approve, or apply the proposal by itself when policy requires review.
@@ -128,9 +130,9 @@ A valid implementation may choose a different command name, but the behavior sho
 For capability version updates, automation should follow the same shape a user would run manually:
 
 ```text
-incan capability status cli
-incan capability diff cli --to 1.6.0
-incan capability update cli --to 1.6.0 --dry-run
+oven capability status cli
+oven capability diff cli --to 1.6.0
+oven capability update cli --to 1.6.0 --dry-run
 ```
 
 Automation may package that dry-run output as a pull-request-sized patch or review artifact, but it must not turn a detected `1.3.0 -> 1.6.0` opportunity into an unattended write unless receiver policy explicitly allows that class of mutation. Even then, source identity changes, newly introduced scripts, CI/workflow edits, env changes, executable source changes, dependency upgrades, generated-file ownership changes, and agent guidance changes remain policy-visible events.
@@ -140,7 +142,7 @@ Automation may package that dry-run output as a pull-request-sized patch or revi
 If a previously applied template or capability is later yanked, revoked, or marked unsafe, status should show a receiver-actionable state:
 
 ```text
-incan mutation status
+oven mutation status
 ```
 
 Example output:
@@ -326,7 +328,7 @@ The same policy result should power terminal diagnostics, machine-readable JSON,
 
 ## Layers affected
 
-- **Manifest schema / configuration validation:** project tooling needs a place to describe project-local policy and record policy-related audit metadata, whether in `incan.toml`, a sidecar state file, or a future lock/state artifact.
+- **Manifest schema / configuration validation:** project tooling needs a place to describe project-local policy and record policy-related audit metadata, whether in a typed `Loaf.toml` policy table or an explicit tool-owned policy state artifact. `Oven.lock` is not a general policy store.
 - **CLI / tooling:** lifecycle commands must evaluate policy before applying template, starter, capability, update, reset, refresh, or recovery mutations.
 - **LSP / IDE tooling:** editor-facing tools should surface policy outcomes, blocked mutation reasons, review requirements, and recovery actions from machine-readable lifecycle output.
 - **Package and catalog integration:** registries and catalogs may provide source identity, integrity, yanking, revocation, advisory, compatibility, and trust-tier metadata that policy can consume.
@@ -335,7 +337,7 @@ The same policy result should power terminal diagnostics, machine-readable JSON,
 
 ## Unresolved questions
 
-- Where should project-local mutation policy live: `incan.toml`, a sidecar policy file, or a future lock/state artifact?
+- Should project-local mutation policy live in a typed `Loaf.toml` table or an explicit tool-owned policy state artifact, and which audit facts belong in receipts rather than either location?
 - What is the minimum useful policy syntax for v1?
 - Which risk categories should be standardized in v1, and which should remain extension labels?
 - Should policy support explicit reviewer or owner requirements, or should it only emit categories for external review systems to interpret?

--- a/workspaces/docs-site/docs/RFCs/078_tool_execution_and_typed_workflow_actions.md
+++ b/workspaces/docs-site/docs/RFCs/078_tool_execution_and_typed_workflow_actions.md
@@ -12,14 +12,16 @@
     - RFC 077 (workspace and multi-package projects)
     - RFC 079 (`incan.pub` artifact graph)
     - RFC 080 (AI assets and agent metadata)
+    - RFC 117 (`Loaf.toml` and Oven's language-neutral project model)
+    - RFC 118 (Incan and Oven command-line surfaces)
 - **Issue:** https://github.com/encero-systems/incan/issues/406
 - **RFC PR:** —
-- **Written against:** v0.3
+- **Written against:** ~~v0.3~~ v0.5
 - **Shipped in:** —
 
 ## Summary
 
-This RFC defines a typed workflow-action and tool-execution model for Incan projects. It gives Incan the ergonomic center of gravity that npm scripts and uv tool execution provide, while avoiding arbitrary install-time mutation as the default: packages, starters, capabilities, and AI assets may advertise actions, but lifecycle tooling exposes them as typed, inspectable, policy-gated commands.
+This RFC defines a typed workflow-action and tool-execution model for Loaf projects. It gives Oven the inspectable lifecycle center of gravity that npm scripts and uv tool execution provide, while avoiding arbitrary install-time mutation as the default: packages, starters, capabilities, and AI assets may advertise actions, but Oven exposes them as typed, inspectable, policy-gated commands.
 
 ## Core model
 
@@ -67,14 +69,14 @@ RFC 015 already has envs and scripts. RFC 075 lets capabilities advertise toolin
 A project or capability may declare typed actions:
 
 ```toml
-[[tool.incan.actions]]
+[[oven.actions]]
 id = "test"
 kind = "test"
 command = ["incan", "test"]
 scope = "member"
 mutates = []
 
-[[tool.incan.actions]]
+[[oven.actions]]
 id = "generate-client"
 kind = "generate"
 tool = "pub:openapi-client"
@@ -91,8 +93,8 @@ The exact encoding is not normative in this Draft. The key requirement is that a
 A user can run a project action:
 
 ```text
-incan action run test
-incan action run generate-client --dry-run
+oven action run test
+oven action run generate-client --dry-run
 ```
 
 The dry run shows the tool source, inputs, outputs, workspace scope, env, mutation risk categories, and policy outcome.
@@ -104,8 +106,8 @@ For capability-aware actions, the dry run should also show required capabilities
 Incan may support isolated tool execution:
 
 ```text
-incan tool run formatter@1.2.0 -- src/
-incan tool run pub:docs-preview --port 8000
+oven tool run formatter@1.2.0 -- src/
+oven tool run pub:docs-preview --port 8000
 ```
 
 An isolated tool should not become a project dependency merely because it was executed once. If it mutates the project, the mutation must still be visible and policy-gated.
@@ -261,13 +263,13 @@ Rejected because install-time hooks are difficult to review and policy-gate. Pro
 
 ## Implementation architecture
 
-The recommended implementation shape is to build an action registry from built-ins, project manifests, workspace manifests, package metadata, starter/capability descriptors, and AI assets. `incan action list` and IDE tooling consume this registry. `incan action run` resolves source, scope, env, policy, and execution mode before invoking anything.
+The recommended implementation shape is to build an action registry from built-ins, `Loaf.toml` project and workspace data, package metadata, starter/capability descriptors, and AI assets. `oven action list` and IDE tooling consume this registry. `oven action run` resolves source, inherited workspace scope, env, policy, target context, and execution mode before invoking anything. RFC 118 may expose an Incan convenience that delegates downward to this operation, but it must not resolve or execute actions independently.
 
 ## Layers affected
 
 - **Manifest schema / configuration validation:** projects need typed action metadata, tool source references, execution modes, inputs, outputs, and mutation categories.
 - **CLI / tooling:** commands need action listing, dry-run planning, isolated tool execution, source resolution, capability preview, receipt expectation display, and policy gating.
-- **Workspace tooling:** actions must support member scope and workspace-level execution.
+- **Workspace tooling:** actions must support hierarchical sub-Loaf selection within one inherited root-workspace authority and must show the selected closure in plans and receipts.
 - **LSP / IDE tooling:** editor integrations should surface actions, run/debug affordances, policy outcomes, and mutation previews.
 - **Package and catalog integration:** packages and catalogs may advertise tool binaries and action descriptors.
 - **Runtime / reporting:** actions that execute through capability-aware runtimes should produce RFC 104-compatible report identities so declared authority and actual receipts can be compared.
@@ -277,7 +279,7 @@ The recommended implementation shape is to build an action registry from built-i
 ## Unresolved questions
 
 - Which action kinds should be standardized in v1?
-- Should `incan run` and `incan test` become aliases for typed actions, or remain separate command families?
+- Should `oven run` and `oven test` become aliases for typed actions, or remain separate command families? RFC 118 separately decides which, if any, Incan aliases delegate to those Oven operations.
 - What is the minimum useful dry-run contract for mutating external tools?
 - Should isolated tool execution use a global cache, per-project cache, or always temporary environment?
 - How should action inputs and outputs be represented for tools that cannot predict outputs?

--- a/workspaces/docs-site/docs/RFCs/090_typed_cli_framework.md
+++ b/workspaces/docs-site/docs/RFCs/090_typed_cli_framework.md
@@ -12,9 +12,11 @@
     - RFC 073 (environment matrices and toolchain constraints)
     - RFC 083 (symbol and method aliases)
     - RFC 089 (`std.environ` runtime environment access)
+    - RFC 117 (`Loaf.toml` and Oven's language-neutral project model)
+    - RFC 118 (Incan and Oven command-line surfaces)
 - **Issue:** https://github.com/encero-systems/incan/issues/87
 - **RFC PR:** —
-- **Written against:** v0.3
+- **Written against:** ~~v0.3~~ v0.5
 - **Shipped in:** —
 
 ## Summary
@@ -56,7 +58,7 @@ This also helps library and application tests. A CLI program should be testable 
 
 - Requiring the `incan` compiler CLI to adopt this framework.
 - Replacing `std.process.Command`, `Pipeline`, or shell DSL execution from RFC 063.
-- Replacing project lifecycle env execution, matrix execution, or `incan env run` behavior from RFC 015 and RFC 073.
+- Replacing Oven project lifecycle env execution, matrix execution, or `oven env run` behavior from RFCs 073 and 117.
 - Replacing direct runtime environment access from RFC 089.
 - Defining terminal UI widgets, progress bars, prompts, interactive menus, curses-style interfaces, or rich text styling.
 - Defining shell completion script generation in full detail, though the spec should preserve enough structure for a later RFC or extension to add it.
@@ -473,7 +475,7 @@ When a CLI argument has `env`, parsing should use the same missing, malformed, p
 
 ### Boundary with project lifecycle tooling
 
-This RFC is for applications written in Incan. It does not change `incan env run`, matrix expansion, project scripts, or compiler lifecycle commands. Those remain owned by RFC 015, RFC 019, and RFC 073.
+This RFC is for applications written in Incan. It does not change `oven env run`, matrix expansion, project scripts, or Oven lifecycle commands. Those remain owned by RFCs 019, 073, 117, and 118.
 
 The long-term compiler CLI may eventually dogfood `std.cli`, but this RFC deliberately does not make compiler CLI migration part of the contract. A forced migration would make the RFC larger and tie framework design to current compiler implementation details.
 

--- a/workspaces/docs-site/docs/RFCs/097_rust_hosted_incan_caller.md
+++ b/workspaces/docs-site/docs/RFCs/097_rust_hosted_incan_caller.md
@@ -13,27 +13,31 @@
     - RFC 043 (Rust trait implementation from Incan)
     - RFC 079 (`incan.pub` artifact graph)
     - RFC 092 (interactive runtime stdlib contracts)
+    - RFC 117 (`Loaf.toml` and Oven's language-neutral project model)
+    - RFC 119 (Oven-native Rust build facets and Cargo interoperation)
+    - #656 (Rust-facing ABI and Incan package compatibility direction)
+    - #975 (Oven: Cargo-free Incan/Rust toolchain)
 - **Issue:** https://github.com/encero-systems/incan/issues/569
 - **RFC PR:** —
-- **Written against:** v0.3
+- **Written against:** ~~v0.3~~ v0.5
 - **Shipped in:** —
 
 ## Summary
 
-This RFC defines a Rust-hosted Incan caller model: a native Rust application should be able to depend on an Incan-authored library through ordinary Cargo mechanics and call a curated, typed Rust-facing API without reverse-engineering compiler output, manually wiring Incan runtime helpers, or treating every public Incan export as a stable Rust API.
+This RFC defines a Rust-hosted Incan caller model: a native Rust application should be able to depend on an Incan-authored library through a Cargo-compatible caller package or an Oven-native Rust-host path and call a curated, typed Rust-facing API without reverse-engineering compiler output, manually wiring Incan runtime helpers, or treating every public Incan export as a stable Rust API.
 
-This Draft is now framed around a Rust-facing caller ABI and Cargo-usable Incan package artifact. Generated Rust source may remain useful for inspection, debugging, migration, or an implementation backend, but it must not be the public package compatibility path. The caller boundary is the stable host API shape; it is backed by checked Incan metadata, ABI/package metadata, generated adapters where needed, and a small support crate that owns initialization, conversions, async/runtime policy, diagnostics, version checks, and panic/error containment.
+This Draft is framed around a Rust-facing caller facet and caller ABI/package metadata. Generated Rust source may remain useful for inspection, debugging, migration, or an implementation backend, but it must not be the public package compatibility path. Oven plans and materializes target-compatible caller build units and `*.loaf` assets from the selected facet. A Cargo-usable package is a compatibility projection for a Rust host, not Oven's build authority. The caller boundary is the stable host API shape; it is backed by checked Incan metadata, ABI/package metadata, generated adapters where needed, and a small support crate that owns initialization, conversions, async/runtime policy, diagnostics, version checks, and panic/error containment.
 
 ## Core model
 
 1. **Rust-hosted consumption is a first-class direction:** Incan already lets Incan code call Rust; this RFC defines the reverse direction where Rust code deliberately calls Incan-authored behavior.
-2. **The Cargo-usable artifact is not generated Rust source as contract:** Rust hosts need a Cargo-native dependency shape, but the public compatibility promise is the caller ABI/package metadata, not compiler-emitted Rust internals.
+2. **The Rust-host artifact is not generated Rust source as contract:** a Cargo-compatible package may be useful to a Rust host, but the public compatibility promise is the caller facet and ABI/package metadata, not compiler-emitted Rust internals.
 3. **Implementation artifacts remain inspectable:** generated Rust, object code, IR snapshots, or other backend artifacts should be inspectable and debuggable where emitted, but they are not the host-facing semantic contract.
 4. **The caller boundary is the stable host-facing shape:** Rust consumers should target caller helpers and support traits that make calls feel natural from Rust while preserving Incan semantics.
 5. **The `pub` system should grow rather than be bypassed:** Rust-hosted exports should be modeled as a public export profile or facet, not as an unrelated side channel.
 6. **Types cross through reusable helpers:** primitive values, models, newtypes, enums, `Result`, `Option`, collections, and Rust-backed types should cross through explicit, versioned conversion helpers that can also simplify emitter responsibilities.
 7. **Runtime policy is explicit:** async execution, logger/telemetry hooks, host capabilities, panic handling, and initialization must be part of the caller contract rather than incidental generated code behavior.
-8. **Cargo remains the host integration substrate:** Rust applications should use normal dependency declarations, build scripts, or Cargo-usable package artifacts instead of a bespoke binary loader.
+8. **Cargo is a host compatibility surface, not Incan's build authority:** an ordinary Rust application may use normal Cargo dependency declarations and a caller package, while Oven remains responsible for resolving, baking, selecting, and verifying the Incan artifact graph. Oven-native Rust hosts consume the same caller facet without Cargo.
 
 ## Motivation
 
@@ -42,6 +46,8 @@ Incan's current interop story is strong in one direction: Incan source imports R
 That question exposes a deeper product direction. Incan should produce Rust-native integration artifacts without making generated Rust source the package contract. Generated Rust can still be valuable as an implementation artifact and inspection surface, but the durable promise to Rust hosts should be an explicit caller ABI, metadata, support crate contract, and Cargo-native package shape.
 
 RFC 031 created the first library artifact foundation: an Incan library can build a semantic manifest and implementation artifacts. The missing product-level answer is the shape above those artifacts: which public exports are intended for Rust hosts, which helper types make calls feel Incan-like from Rust, which support code owns repeated boundary mechanics, and which metadata defines compatibility without exposing generated Rust internals as API.
+
+Oven completes the delivery boundary without replacing this caller model. A selected Rust-hosted export facet is a target-neutral public contract; Oven turns it into target-specific build units and verified `*.loaf` assets. RFC 117 owns the authored-manifest, resolved-graph, asset-identity, and receipt model that this RFC consumes. A Rust application that already uses Cargo may consume a lightweight caller package over that Oven-produced output, but it must not need Cargo to resolve or compile the Incan library itself.
 
 The missing piece is not only a command. It is a boundary. A Rust application embedding Incan code needs to know which calls are stable, how values convert, how errors surface, whether async calls need a runtime, whether panics are contained, how logs and telemetry are connected, and which compiler/runtime version produced the artifact. Without that boundary, users either treat compiler output as hand-authored Rust or avoid Rust-hosted Incan entirely.
 
@@ -56,7 +62,8 @@ The end-state should be simple: an application team writes domain logic, policy,
 - Define conversion requirements for primitives, collections, models, enums, newtypes, results, options, and Rust-backed values.
 - Define reusable caller helpers that can reduce bespoke emitter output for common boundary shapes.
 - Define initialization, version, diagnostics, panic, async, logging, telemetry, and host capability responsibilities at the caller boundary.
-- Preserve Cargo-native Rust host ergonomics without requiring generated Rust source to be the concrete public artifact.
+- Preserve Cargo-compatible Rust host ergonomics without making Cargo the authority for Incan resolution, baking, or provenance.
+- Define how a selected caller facet becomes a target-compatible Oven caller artifact with inspectable build and source-map receipts.
 - Leave room for both local path development and published package consumption.
 - Keep Rust integration Rust-shaped enough to feel natural in Rust applications without making Incan source adopt Rust's full API design model.
 
@@ -68,8 +75,10 @@ The end-state should be simple: an application team writes domain logic, policy,
 - This RFC does not replace `rust::` imports or Rust interop from Incan source.
 - This RFC does not define a C ABI, dynamic plugin ABI, `extern "C"` boundary, or cross-language FFI story.
 - This RFC does not require a Rust application to run the Incan compiler at runtime.
+- This RFC does not require Cargo to resolve or compile an Incan package before a Rust host can call it.
 - This RFC does not require every Incan public export to be Rust-callable by default.
 - This RFC does not define registry publication mechanics beyond compatibility with RFC 034 and RFC 079.
+- This RFC does not define `Loaf.toml`, `Oven.lock`, or the `*.loaf` asset format; it consumes the project, asset-identity, and receipt contract from RFC 117.
 - This RFC does not define the full implementation of async runtime internals, host capability enforcement, or telemetry backends.
 - This RFC does not guarantee that every Rust type imported through `rust::` can automatically cross back into a host Rust application without an adapter.
 
@@ -102,17 +111,12 @@ pub caller from pricing import quote_order
 
 That example is intentionally minimal. A synchronous function does not need to spell `mode = "sync"`, and a Rust caller name does not need to be repeated when it matches the Incan export name. Extra metadata should appear only when the Rust-hosted profile needs an alias, a projection choice, a blocking wrapper, or another non-default policy.
 
-The library is built for Rust-hosted consumption:
-
-```bash
-incan build --lib --caller rust
-```
-
-That command emits or materializes a Cargo-usable caller artifact with caller metadata. A Rust application can then depend on it through Cargo:
+Oven materializes a target-compatible caller artifact from the selected Rust-hosted facet. The exact command spelling is not normative. The artifact carries caller metadata, ABI/package metadata, target compatibility, source-map references, and its verified Oven build receipt. A Rust application that uses Cargo can consume the resulting compatibility package without compiling the Incan library:
 
 ```toml
 [dependencies]
-pricing_rules = { path = "../pricing_rules/target/lib" }
+# This is a caller package materialized from a verified Oven artifact.
+pricing_rules = { path = "../pricing_rules/caller" }
 ```
 
 The Rust application calls the typed caller wrapper rather than internal implementation details:
@@ -155,7 +159,9 @@ The author-facing model is:
 Incan library source
   -> checked public Incan API
   -> Rust-hosted public profile
-  -> Rust-facing ABI/package metadata + caller artifact
+  -> Rust-facing caller facet + ABI/package metadata
+  -> Oven-selected target caller build unit and `*.loaf` asset
+  -> Oven-native Rust host or Cargo-compatible caller package
   -> native Rust application
 ```
 
@@ -175,13 +181,13 @@ The caller boundary must include:
 
 The caller boundary must not require Rust consumers to import arbitrary compiler-generated implementation modules as the host API. Internal generated modules may exist and should remain readable, but only the caller namespace is stable for Rust-hosted consumption.
 
-The caller boundary should be generated or materialized as a Cargo-usable artifact. It may live in the same package as implementation artifacts or in a sibling package, but Rust consumers must not need to know the compiler's internal implementation layout.
+The caller boundary must be materialized by Oven as a target-compatible caller artifact. A Cargo-compatible package may live beside that artifact or be projected from it for a Rust host, but Cargo must not become responsible for resolving, compiling, or selecting the Incan implementation graph. Rust consumers must not need to know the compiler's internal implementation layout.
 
 Caller-visible Incan functions must have a representable Rust signature. The compiler must reject a Rust-hosted public export when any parameter, return value, type parameter, effect, or captured dependency cannot be represented by the caller boundary.
 
 Caller-visible synchronous functions must expose a synchronous Rust call. Caller-visible async functions must expose an async Rust call or an explicit runtime-backed blocking call, depending on the declared caller mode. The generated API must not silently create or own a runtime in a way that surprises the host application.
 
-Caller initialization must validate compiler/runtime compatibility before the first call. The generated artifact must expose enough metadata to identify the Incan compiler version, manifest format, caller ABI version, and generated support crate version.
+Caller initialization must validate compiler/runtime compatibility before the first call. The generated artifact must expose enough metadata to identify the Incan compiler version, manifest format, caller facet, caller ABI version, generated support crate version, target/profile compatibility, and the selected Oven build receipt or `*.loaf` asset identity.
 
 Incan `Result[T, E]` crossing into Rust must map to Rust `Result<T, E>` when both `T` and `E` are representable. Boundary failures that occur outside the Incan function's declared return value must use the caller error type, not the Incan function's domain error type.
 
@@ -199,28 +205,38 @@ Panics from generated Incan code or Rust code called by Incan must not be indist
 
 Host capabilities used by caller-visible Incan code must be visible through metadata. If an Incan caller export requires filesystem, network, process, environment, telemetry, clock, async runtime, or other host services, the Rust caller initialization must provide or validate those services before use when the target supports such validation.
 
+Caller diagnostics and capability outcomes must reference stable public source-map and receipt identities. They must not expose private HIR, Body IR, compiler session state, or backend implementation representations.
+
 ## Design details
 
-### Caller artifact shape
+### Caller facet and artifact shape
 
-The caller artifact should be a Cargo-usable package backed by Incan-owned caller metadata and ABI metadata. A current implementation may materialize that as a generated Rust package, but the normative contract is the Cargo-usable caller artifact and its metadata, not the emitted source layout.
+The Rust-hosted caller facet is the target-neutral public selection of Incan exports, type projections, capability requirements, caller ABI version, and source-map schema. Oven materializes that facet into target-compatible caller artifacts. A current implementation may use generated Rust adapters or a Cargo-compatible package, but the normative contract is the caller facet and metadata, not the emitted source layout or Cargo package structure.
 
-Conceptually, the package contains:
+Conceptually, the caller artifact set contains:
 
 ```text
 stable caller namespace
-caller metadata
+caller facet metadata
 ABI/package metadata
 semantic manifest
-Cargo metadata
+source-map and Oven-receipt references
 implementation artifact(s)
+target-compatible caller `*.loaf` asset(s)
+optional Cargo-compatible package projection
 ```
 
-The exact directory layout is not normative. The normative requirement is that Rust consumers do not need to know which files came from Incan source lowering, backend emission, support glue, or ABI materialization.
+The exact directory layout, static-versus-dynamic linkage, and Cargo package arrangement are not normative. Rust consumers must not need to know which files came from Incan source lowering, backend emission, support glue, ABI materialization, or Oven storage.
+
+### Oven planning and Cargo compatibility
+
+Oven must include the selected caller facet, public feature projection, compiler and support compatibility, target/profile, native-linkage requirements, and relevant source/ABI metadata in the caller build-unit identity. The resulting `*.loaf` asset must identify the caller facet and the exact public receipt through which it was built.
+
+An Oven-native Rust host may consume that selected caller artifact directly. A Cargo-compatible package may instead provide Rust source, metadata, and linkage directives that connect an ordinary Cargo host application to the same selected artifact. Such a package must not invoke the Incan compiler, discover a different Incan artifact, or treat generated implementation modules as public API. It may validate that the selected artifact is compatible with the host target and caller ABI.
 
 ### Support crate
 
-The Incan toolchain should provide a small Rust support crate for caller boundaries. That crate should own shared traits, error types, version checks, conversion helpers, and host context traits that would otherwise be duplicated into every generated package or embedded directly into emitter output.
+The Incan toolchain should provide a small Rust support crate for caller boundaries. That crate should own shared traits, error types, version checks, conversion helpers, and host context traits that would otherwise be duplicated into every generated package or embedded directly into emitter output. It may be a dependency of a Cargo-compatible caller package, but its existence must not make Cargo a prerequisite for Oven to bake or select caller artifacts.
 
 The support crate should not become a large runtime framework. It should be boundary infrastructure: initialization, compatibility checks, conversions, diagnostics, panic policy, host context plumbing, and reusable call-shape helpers. Those helpers should make Rust-hosted calls feel closer to Incan's domain model while giving the emitter fewer bespoke cases to print inline.
 
@@ -271,15 +287,15 @@ Caller failures should identify the caller export name, the Incan function name,
 
 ### Compatibility and migration
 
-This RFC is additive but reframes older generated-crate consumption as transitional. Existing `incan build --lib` consumers may continue depending directly on generated crates while that path exists, but that should be documented as a lower-level implementation-artifact path rather than the recommended Rust-hosted integration path.
+This RFC is additive but reframes older generated-crate consumption as transitional. Existing direct generated-crate consumers may continue while that path exists, but it must be documented as a lower-level implementation-artifact path rather than the recommended Rust-hosted integration path.
 
-Once caller artifacts exist, docs should steer Rust application authors toward caller APIs and reserve backend artifacts for debugging, compiler tests, inspection, or advanced toolchain integration.
+Once caller artifacts exist, docs should steer Rust application authors toward caller APIs and reserve backend artifacts for debugging, compiler tests, inspection, or advanced toolchain integration. Migration reporting must classify direct generated-crate use as supported through the caller facet, temporarily retained for migration/debugging, or unsupported with an explicit diagnostic.
 
 ## Alternatives considered
 
 - **Tell Rust users to depend on the generated crate directly** — Rejected because it makes generated Rust internals the compatibility path. Rust hosts need a stable caller ABI/package contract even if the current backend happens to emit Rust.
 - **Use a dynamic plugin or C ABI boundary** — Rejected for this RFC because Incan already emits Rust, and Rust-hosted applications should get normal Cargo type checking, optimization, and dependency resolution.
-- **Use only a `build.rs` helper in the Rust application** — Useful for local development, but insufficient as the whole model because published artifacts and registry workflows should not require every consumer to run the Incan compiler.
+- **Use only a `build.rs` helper in the Rust application** — A development helper may hydrate or validate a selected caller artifact, but it is insufficient as the whole model because published artifacts and registry workflows must not require every consumer to run the Incan compiler.
 - **Make every public Incan export Rust-callable automatically** — Rejected as the default because Incan's `pub` system should be enriched with host-facing profiles instead of flattening every public Incan symbol into the same Rust-hosted contract.
 - **Generate only untyped stringly dynamic calls** — Rejected because it gives up the main benefit of compiling Incan into the Rust ecosystem: typed, auditable integration.
 
@@ -293,13 +309,13 @@ Once caller artifacts exist, docs should steer Rust application authors toward c
 
 ## Implementation architecture
 
-The recommended architecture is to extend library builds with a caller adapter generation pass that consumes checked public API metadata, semantic facts, ABI metadata, and caller export declarations. The adapter should call into backend-owned implementation artifacts through compiler-owned internal paths or ABI entrypoints, while exposing only the caller namespace to host Rust code.
+The recommended architecture is to extend library builds with a caller adapter generation pass that consumes checked public API metadata, semantic facts, ABI metadata, and caller export declarations. Oven plans that adapter, its implementation dependencies, target/profile requirements, and native linkage as one caller build-unit graph. The adapter calls backend-owned implementation artifacts through compiler-owned internal paths or ABI entrypoints while exposing only the caller namespace to host Rust code.
 
-The support crate should remain narrow and versioned. Caller artifacts should declare the caller ABI version they were emitted against and validate it at initialization. Metadata should be inspectable by docs, LSP, and registry tooling so Rust-hosted integration can be documented and discovered without building the package.
+The support crate should remain narrow and versioned. Caller artifacts should declare the caller ABI version they were emitted against and validate it at initialization. Metadata, source maps, and Oven receipts should be inspectable by docs, LSP, registry tooling, and hosts so Rust-hosted integration can be documented and discovered without building the package.
 
-Local development may later add a build-script helper that invokes the Incan compiler from a Rust workspace, but that helper should produce the same caller boundary as a prebuilt or published package.
+Local development may later add a Cargo helper that hydrates or validates a selected Oven caller artifact from a Rust workspace, but the helper must not define a second caller boundary or require Cargo to compile the Incan library.
 
-Current package-facing characterization shows why generated implementation artifacts are not enough as the public contract. Ordinary `incan build --lib` artifacts can already expose owned scalar callable parameters through package exports, but borrowed non-`Copy` callable parameters are not yet consumable across a `pub::` package boundary. A producer export such as `Callable[Payload, None]` currently emits a Rust signature shaped like `fn(&Payload) -> ()`, while a downstream Incan consumer observer still emits `fn(Payload)`, causing Cargo type checking to fail. The caller adapter work must either generate a compatible borrowed wrapper for that boundary or reject/document the unsupported export before producing a broken consumer build.
+Borrowed non-`Copy` callable parameters illustrate why implementation artifacts are not enough as the public contract. The caller adapter must generate a compatible caller projection or reject the unsupported export before producing a caller artifact. It must not publish a boundary whose generated Rust shape is incompatible with its declared caller signature.
 
 ## Layers affected
 
@@ -307,21 +323,21 @@ Current package-facing characterization shows why generated implementation artif
 - **Typechecker / API metadata**: caller export validation must prove that selected entrypoints and boundary types are representable for Rust-hosted calls.
 - **IR Lowering / Emission**: backend output must preserve a stable caller namespace or ABI entrypoint and avoid making internal generated modules part of the Rust-hosted contract.
 - **Stdlib / Runtime (`incan_stdlib`)**: host-facing runtime hooks, errors, logging, telemetry, async, and capability surfaces may need caller-compatible contracts.
-- **CLI / Tooling**: build commands should expose a caller artifact mode and diagnostics for unsupported caller exports.
+- **Oven / Tooling**: Oven must plan, materialize, inspect, and verify caller build units and `*.loaf` assets under RFC 117's project/asset contract; tooling must report diagnostics for unsupported caller exports and incompatible caller artifacts.
 - **LSP / Docs tooling**: tooling should surface caller-visible exports, Rust-facing signatures, compatibility metadata, and unsupported-boundary diagnostics.
 - **Registry / Package metadata**: published packages should advertise whether they provide a Rust-hosted caller surface and which caller ABI version they require.
 
 ## Unresolved questions
 
 - What is the exact source syntax for marking caller-visible exports?
-- Should caller adapters live in the same Cargo package as the implementation artifact or in a sibling package?
+- Should a Cargo-compatible caller package live beside the target caller artifact or be materialized as a separate compatibility projection?
 - What is the first stable shape of the Rust support crate API?
 - Should synchronous wrappers around async Incan exports be generated by default, opt-in only, or disallowed?
 - How should nested domain results and boundary errors be represented ergonomically in Rust signatures?
 - Which derives should caller-projected models and enums receive by default?
 - How should generic Incan functions and generic model types be projected into Rust caller APIs?
 - How should host capability metadata from RFC 092 connect to caller initialization before RFC 092 is fully implemented?
-- Should local Rust workspaces use a build-script helper first, or should the first implementation require explicit `incan build --lib --caller rust` before Cargo builds the host application?
+- What local Rust-host hydration or validation workflow is sufficient without making Cargo compile the Incan library?
 
 <!-- Rename this section to "Design Decisions" once all questions have been resolved.
      An RFC cannot move from Draft to Planned until no unresolved questions remain. -->

--- a/workspaces/docs-site/docs/RFCs/105_architect_rule_engine.md
+++ b/workspaces/docs-site/docs/RFCs/105_architect_rule_engine.md
@@ -9,9 +9,11 @@
     - RFC 070 (Result combinators)
     - RFC 088 (iterator adapter surface)
     - RFC 096 (declaration metadata blocks)
+    - RFC 117 (`Loaf.toml` and Oven's language-neutral project model)
+    - RFC 118 (Incan and Oven command-line surfaces)
 - **Issue:** https://github.com/encero-systems/incan/issues/663
 - **RFC PR:** -
-- **Written against:** v0.3
+- **Written against:** ~~v0.3~~ v0.5
 - **Shipped in:** —
 
 ## Summary
@@ -412,7 +414,7 @@ Experimental peer-baseline analysis is a later consumer of the same fact and que
 
 - What is the default profile for `incan architect .`: architecture-only, architecture plus safety, or all stable rules?
 - What suppression syntax should Incan use for architect findings, and should it share vocabulary with compiler diagnostic suppressions?
-- Should baselines live in `incan.toml`, a separate lock-like file, or a generated artifact under project tooling state?
+- Should baselines live in a typed `Loaf.toml` table, a separate versioned baseline artifact, or generated project-tooling state? They must not be folded into `Oven.lock` merely because a project uses Oven.
 - Where should peer-group metadata live, and which membership or boundary declarations belong in source, package metadata, or local tooling state?
 - Which peer-signature facts are stable and useful enough to expose without turning names, paths, or aggregate similarity into semantic authority?
 - How should a project review, accept, version, and retire an experimental baseline or intentional outlier without allowing a scan to rewrite its own comparison set?

--- a/workspaces/docs-site/docs/RFCs/116_typed_c_abi_interop.md
+++ b/workspaces/docs-site/docs/RFCs/116_typed_c_abi_interop.md
@@ -16,6 +16,8 @@
     - RFC 104 (ambient runtime capabilities and receipts)
     - RFC 112 (crash-safe local publication and file coordination)
     - RFC 114 (compiled providers, SDK components, and package features)
+    - RFC 117 (`Loaf.toml` and Oven's language-neutral project model)
+    - RFC 118 (Incan and Oven command-line surfaces)
 - **Issue:** [#939](https://github.com/encero-systems/incan/issues/939)
 - **RFC PR:** —
 - **Written against:** v0.5
@@ -24,6 +26,19 @@
 ## Summary
 
 This RFC defines a typed, explicit C ABI interop surface for Incan. `from std.interop import c` activates a local `binding` vocabulary whose declarations are ordinarily private and normally feed a safe Incan façade. Binding declarations preserve exact ABI types, symbols, layouts, ownership, nullability, output positions, buffers, headers, toolchain constraints, and target-native artifacts without assigning application meaning to foreign status values. The Incan toolchain verifies declarations with a Clang-compatible target toolchain, resolves and locks static, bundled, and system-native artifacts through the package graph, and lowers calls from compiler-owned semantic ownership facts rather than backend guesses. The same package, provenance, inspection, and façade boundaries remain extensible to future foreign runtimes without making C pointers or C ownership the universal interop model.
+
+## 0.5 release boundary and post-0.5 envelope transition
+
+The v0.5 RFC 116 release contract is the currently implemented `incan.toml` `[oven.interop]` schema and its bounded checked-binding, target-requirement, and locked-input behavior. It must remain internally coherent through the v0.5 release; this RFC does not claim that it already uses the future `Loaf.toml` project model.
+
+The release-bound implementation is deliberately distinct from later work:
+
+- **Implemented and closed v0.5 slices:** #940 provides the checked-binding and Clang-verification foundation; #942 provides declared native artifacts, shims, and normalized locked requirement facts.
+- **Remaining v0.5 completion work:** #941 owns the resource/bounded-value acceptance closure and #943 owns final inspection, editor, and documentation projection. Their issue state—not a source branch or this RFC prose—determines when RFC 116 can close.
+- **v0.6 execution and evidence:** #944 resolves the declared requirements into selected tool and SDK receipts, bakes/stages artifacts, produces adapter inputs, and gathers virtual-device evidence. It does not reopen RFC 116's source declaration or current requirement semantics.
+- **v0.6 Loaf-envelope successor:** [#1008](https://github.com/encero-systems/incan/issues/1008) moves the established requirement data from `incan.toml` to `Loaf.toml` and from the current semantic lock to `Oven.lock` after the RFC 117 cutover. It preserves the v0.5 requirement meaning, rejects legacy parsing, and does not duplicate #944.
+
+RFC 117 owns the project-model cutover; RFC 118 owns the later CLI presentation. Neither changes the C-specific source safety contract in this RFC.
 
 ## Core model
 
@@ -767,15 +782,15 @@ Deliver the import-activated `std.interop` vocabulary, exact scalar declarations
 
 Add resource release associations, inferred call-scoped borrowing, `Out` / `InOut` initialization rules, bounded strings and spans, scoped copies, and a SQLite proof.
 
-### Phase 3: Governed artifacts and shims (#942)
+### Phase 3: Governed artifacts and shims (#942, v0.5)
 
-Extend the package and lock graph with `[oven.interop]` target requirements, package-owned artifacts, authored C/C++ shim inputs, content identities, and offline drift detection.
+Extend the v0.5 package and lock graph with `[oven.interop]` target requirements in `incan.toml`, package-owned artifacts, authored C/C++ shim inputs, content identities, and offline drift detection. RFC 117 successor chore #1008 relocates the same declared envelope after v0.5.
 
 ### Phase 4: Tooling projection (#943)
 
 Project checked binding facts, bridge and façade edges, diagnostics, inspection, editor support, generated references, and compatibility documentation from the same descriptor.
 
-### Phase 5: Mobile inference proof (#944)
+### Phase 5: Mobile inference proof (#944, v0.6 follow-up)
 
 Verify Android and iOS target paths with a real native inference binding and define the directional handoff from a Loaf to Gradle or Xcode without freezing their command protocol.
 
@@ -793,7 +808,7 @@ Verify Android and iOS target paths with a real native inference binding and def
 - [x] Verify declared function signatures, enum carriers and values, and plain layouts with Clang before code generation.
 - [x] Add positive consumer execution and declaration-mismatch diagnostics.
 - [x] Add reference documentation, release-note inventory, and generated capability inventory.
-- [ ] Complete the slice review and PR-readiness gate.
+- [x] Complete the slice review and PR-readiness gate.
 
 ### Owned resources and bounded bridge values (#941)
 
@@ -801,10 +816,11 @@ Verify Android and iOS target paths with a real native inference binding and def
 - [ ] Implement `Out` / `InOut` slot construction, initialization conditions, and `take()` checks.
 - [ ] Add bounded string, span, and scoped-view bridge operations with SQLite acceptance evidence.
 
-### Governed artifacts and shims (#942)
+### Governed artifacts and shims (#942, v0.5)
 
-- [ ] Define target-specific native artifact and shim inputs, lock identity, provenance, and offline verification.
-- [ ] Define source versus `incan.toml` responsibilities for target-specific physical configuration.
+- [x] Define target-specific native artifact and shim inputs, lock identity, provenance, and offline verification.
+- [x] Define the v0.5 source versus `incan.toml` responsibilities for target-specific physical configuration.
+- [ ] Complete #1008 after v0.5 to relocate the unchanged declared envelope to `Loaf.toml` and `Oven.lock`.
 
 ### Tooling projection (#943)
 
@@ -827,7 +843,7 @@ Verify Android and iOS target paths with a real native inference binding and def
 - Call-scoped foreign borrows are inferred from semantic parameter modes and recorded before backend emission.
 - `c.Out[T]` and `c.InOut[T]` describe declaration positions without enabling arbitrary dereference. Private bridge code creates compiler-managed slots with ordinary expressions such as `c.out[c.Owned[Database]]()` and `c.inout(value)`, then consumes them with `take()` only on the declared valid outcome or post-call path.
 - Returned foreign views may be copied within the current unsafe region or declared static; owner-tied escaping views are excluded.
-- Source declarations remain the semantic authority. Target-specific artifact requirements, authored shim sources, and package-owned physical inputs may live under `[oven.interop]` in `incan.toml` when an author needs them; they do not replace the binding declaration or claim that Oven has already selected a local toolchain.
+- Source declarations remain the semantic authority. For v0.5, target-specific artifact requirements, authored shim sources, and package-owned physical inputs live under `[oven.interop]` in `incan.toml`; they do not replace the binding declaration or claim that Oven has already selected a local toolchain. After the RFC 117 cutover, #1008 relocates this same authored requirement envelope to `Loaf.toml` without legacy parsing or a C-safety redesign.
 - Shims are first-class governed package assets.
 - Verification requires a managed Clang-compatible target toolchain.
 - Oven interop deployment classes are static, bundled, and explicit system capability.

--- a/workspaces/docs-site/docs/RFCs/117_loaf_toml_and_oven_project_model.md
+++ b/workspaces/docs-site/docs/RFCs/117_loaf_toml_and_oven_project_model.md
@@ -1,0 +1,604 @@
+# RFC 117: `Loaf.toml` and Oven's language-neutral project model
+
+- **Status:** Draft
+- **Created:** 2026-08-04
+- **Author(s):** Danny Meijer (@dannymeijer)
+- **Related:**
+    - RFC 013 (Rust crate dependencies)
+    - RFC 015 (hatch-like tooling and project lifecycle CLI)
+    - RFC 020 (offline, locked, and reproducible builds)
+    - RFC 023 (compilable stdlib and Rust module binding)
+    - RFC 031 (Incan library system)
+    - RFC 034 (`incan.pub` package registry)
+    - RFC 073 (environment matrices and toolchain constraints)
+    - RFC 076 (project mutation policy and recovery)
+    - RFC 077 (workspace and multi-package projects)
+    - RFC 078 (tool execution and typed workflow actions)
+    - RFC 079 (`incan.pub` artifact graph)
+    - RFC 097 (Rust-hosted Incan caller)
+    - RFC 104 (ambient runtime capabilities and receipts)
+    - RFC 112 (crash-safe local publication and file coordination)
+    - RFC 114 (compiled providers, SDK components, and package features)
+    - RFC 116 (typed C ABI interop)
+    - RFC 118 (Incan and Oven command-line surfaces)
+    - RFC 119 (Oven-native Rust build facets and Cargo interoperation)
+- **Issue:** [#1009](https://github.com/encero-systems/incan/issues/1009)
+- **RFC PR:** —
+- **Written against:** v0.5
+- **Target scope:** v0.6 design and implementation planning; this is not a shipment claim.
+- **Shipped in:** —
+
+## Summary
+
+This RFC replaces `incan.toml` with `Loaf.toml` as the sole authored manifest for an Oven-managed project. A `Loaf.toml` may describe one project, a rooted workspace, or a virtual workspace. It is language-neutral: a project may contain Incan sources, Rust sources, both, or checked foreign interfaces without making any implementation language the repository's organizing principle.
+
+`[project]` remains the familiar metadata table. `[workspace]` remains the explicit repository-coordination table. Dependencies use one typed graph whose unit kind and origin are explicit when the defaults are insufficient: Incan Loaf packages default to `incan.pub`, Rust crates default to crates.io, and foreign/system requirements use Oven-managed capability providers. Oven resolves authored intent into `Oven.lock`, then bakes the selected target into immutable, verified `*.loaf` assets and receipts. Cargo remains a deliberately explicit compatibility mode for repositories that have no `Loaf.toml`; it is never inferred as part of a Loaf build.
+
+This RFC also rehomes the authored configuration boundaries of existing environment, matrix, action, workspace, provider, and interop RFCs. It does not define the final command spelling or a general-purpose task shell.
+
+## Core model
+
+Read this RFC as thirteen foundations:
+
+1. **One authored manifest:** `Loaf.toml` is the only Incan/Oven project manifest. `incan.toml` is not read as a compatibility format.
+2. **A familiar project table:** `[project]` owns package identity and publication metadata. The filename carries the Loaf vocabulary; the metadata table remains ordinary and legible.
+3. **A workspace is an optional hierarchy:** `[workspace]` declares explicit members and shared policy. A root with both `[project]` and `[workspace]` is a rooted workspace; a root with only `[workspace]` is virtual. Members may declare sub-Loaves, but the root remains the sole authority for resolution, locking, registry trust, target policy, and receipts.
+4. **The package graph is language-neutral:** every dependency is one logical requirement with a typed provider contract. The author does not choose a separate Incan-versus-Rust dependency table.
+5. **Origins are configurable:** Loaf packages default to `incan.pub`; crates default to crates.io. A project may explicitly select registered private registries, Git, path, or other supported controlled sources.
+6. **Provider semantics stay visible:** an `incan.pub` package contributes checked Incan semantic/provider facts, a Cargo ecosystem crate contributes Rust interop and implementation requirements, and a system/foreign capability contributes a verified target requirement. Oven must not flatten those differences or expose backend details as public Incan API.
+7. **Source discovery is convention-first:** Oven discovers supported source files under `src/` by language extension. Nonstandard roots or generated inputs require explicit configuration. A Loaf never implicitly consumes a neighbouring `Cargo.toml`.
+8. **Targets have three scopes:** a Loaf declares supported target/interface combinations; a workspace declares shared delivery policy; a bake invocation chooses one concrete target, carrier, profile, and feature closure that produces a target-bound `*.loaf` asset.
+9. **Plans precede effects:** resolution, import, installation, or the presence of a file must not execute package code. Oven exposes a plan before baking and records the actual execution in a receipt.
+10. **Environments and actions belong to Oven:** existing environment/matrix and typed-action semantics remain, but their authored configuration moves out of `[tool.incan.*]` and into the Loaf model. Oven materializes environments and explicitly runs actions.
+11. **Derived state is separate:** `Oven.lock`, immutable `*.loaf` assets, the artifact store, selected host toolchains, caches, staged outputs, generated code, and receipts are not authored Loaf configuration.
+12. **Distribution assets are verifiable:** a `*.loaf` asset is immutable and target-bound. It identifies the selected project/facet, target, carrier, profile, resolved graph, payload digest, and receipt; its wire or bundle format is intentionally deferred.
+13. **Cargo compatibility is explicit:** a directory with only `Cargo.toml` may be run by Oven in Cargo-compatibility mode. A directory containing `Loaf.toml` is a Loaf project; Cargo files there are ignored with a diagnostic unless the user explicitly invokes Cargo compatibility.
+
+## Motivation
+
+The current `incan.toml` correctly introduced project identity, dependency declarations, SDK selection, build configuration, workspaces, environment configuration, Rust dependency declarations, and Oven interop requirements. It now carries an assumption that no longer fits the intended architecture: that a project's identity is primarily Incan source and that Rust is a special external implementation substrate.
+
+That assumption is constraining in both directions. An Incan-authored package may need a Rust crate, a C ABI library, a C++ shim, a target SDK, or a later JNI/Python carrier without ceasing to be one package. A Rust-authored project that elects to use Oven should be able to adopt the same package, target, receipt, and workspace model without being forced to rewrite its sources into Incan. Cargo must remain runnable where Cargo is explicitly authoritative, but Cargo's implicit build scripts, proc macros, target conventions, and workspace semantics must not become accidental Loaf semantics.
+
+The same pressure exists at the repository root. A separate `Oven.toml` would distinguish package metadata from workspace orchestration, but introduces two canonical files and an ownership/discovery boundary without a demonstrated capability need. Cargo already demonstrates that one manifest can express a root package, a virtual workspace, or both. `Loaf.toml` can do the same when its table scopes are explicit.
+
+Oven is more than a package resolver. It must plan target-specific C ABI, JNI, Python, Rust-host, and future carrier builds; select and verify toolchains; materialize controlled environments; protect shared artifact stores; and describe exactly what happened. That requires a manifest that captures desired inputs, not hidden host discovery or arbitrary execution.
+
+## Goals
+
+- Replace `incan.toml` with `Loaf.toml` wholesale before Incan 1.0.
+- Preserve `[project]` as the familiar package-metadata surface.
+- Preserve rooted and virtual workspace forms using optional `[workspace]`.
+- Give Incan packages, Rust crates, and foreign/system capabilities one dependency grammar while retaining their distinct resolver and linkage contracts.
+- Make `incan.pub` the default origin for Loaf packages and crates.io the default origin for Rust crates, while allowing registered alternative registries and explicit sources.
+- Define safe discovery when `Loaf.toml` and `Cargo.toml` coexist.
+- Permit explicitly declared hierarchical sub-Loaves under one inherited root-workspace authority.
+- Keep source-language choice out of the package identity while avoiding implicit Cargo participation.
+- Define a target model that distinguishes platform target, deployable carrier, profile, and delivery policy.
+- Distinguish authored intent (`Loaf.toml`), resolved graph (`Oven.lock`), and immutable target-bound distribution assets (`*.loaf`) without making any of them hidden state.
+- Make plans, declared effects, selected inputs, output artifacts, and receipts inspectable.
+- Rehome environment/matrix/action configuration ownership to Oven without re-specifying the semantics already owned by RFCs 073 and 078.
+- Rehome package-level C ABI configuration from `[oven.interop]` into an interop section that future binding kinds may share, while retaining RFC 116 as the owner of C safety semantics.
+- Keep locks, caches, credentials, selected SDK paths, staged artifacts, and generated output out of the authored manifest.
+- Leave command spelling and CLI ergonomics for a dedicated follow-up RFC.
+
+## Non-Goals
+
+- Defining a separate `Oven.toml` root manifest.
+- Preserving `incan.toml`, `incan.lock`, or `[tool.incan.*]` as legacy compatibility formats.
+- Defining the final `oven` versus `incan` command-line binary, aliases, or command hierarchy.
+- Reimplementing arbitrary Cargo behavior, including implicit `build.rs` execution, proc-macro execution policy, or Cargo workspace discovery, for Loaf projects.
+- Defining crates.io's protocol, the full `incan.pub` registry protocol, registry hosting, or publishing UX.
+- Defining C ABI safety rules, direct C++ ABI interop, JNI safety rules, Python extension safety rules, or a universal foreign-runtime type system.
+- Defining remote execution, distributed builds, or a general-purpose shell/task runner.
+- Defining the `*.loaf` wire or bundle format, registry transport, or archive layout; a dedicated artifact-format RFC owns those details.
+- Allowing packages to run arbitrary installation, import, or lifecycle hooks.
+- Giving cold, warm, and hot Loaves normative compiler or package semantics in this RFC.
+
+## Prospective supersession of closed RFC decisions
+
+Closed RFCs remain historical records and are not retroactively edited. This RFC explicitly supersedes the following decisions for implementations that adopt the Loaf/Oven project model:
+
+- **RFC 013 and RFC 031:** separate authored `[dependencies]` and `[rust-dependencies]` tables, and the assumption that a consumer's dependency graph is authored as Cargo wiring. `Loaf.toml` has one typed dependency graph; provider-specific Rust requirements remain visible facts rather than a second authoring domain.
+- **RFC 015:** `incan.toml` as the project manifest, nearest-manifest root discovery, project generation that writes `incan.toml`, and `[tool.incan.envs]` as the environment-configuration home. `Loaf.toml` is the sole authored manifest, while environment semantics remain owned by their dedicated RFCs.
+- **RFC 020:** `incan.lock` as the generated resolution identity. The reproducibility and locked/offline requirements remain; their generated artifact is `Oven.lock`.
+- **RFC 077:** a flat workspace that forbids nested workspaces. Explicit membership, rooted and virtual workspace forms, and one shared resolution boundary remain; a member may now declare explicit sub-Loaves within a single inherited root-workspace authority.
+- **RFC 112:** the public lockfile path used by its publication examples. Crash-safe publication and coordination requirements remain unchanged, but the published lockfile is `Oven.lock` and its companion coordination identity follows that name.
+- **RFC 114:** references to the canonical `incan.lock` graph. Its distinction between public Loaf features and provider-specific implementation features remains unchanged; the resolved graph is recorded in `Oven.lock`.
+
+This RFC does not supersede the retained semantic contracts in those RFCs: reproducibility, explicit workspace membership, crash-safe publication, checked library surfaces, and public package-feature meaning remain requirements. It changes the authored manifest, authority hierarchy, dependency presentation, and derived-state names through which those contracts are implemented.
+
+## Terminology and mental model
+
+The user-facing contract is intentionally small: authors write `Loaf.toml`; Oven plans and bakes it. The surrounding bread vocabulary is a guide-level model and an Oven inspection affordance, not a second vocabulary users must configure.
+
+```text
+Loaf.toml + declared sources + declared inputs
+  -> Doughball (internal source-and-input mass)
+  -> Oven shapes one or more Loaves (resolved logical build units)
+  -> Oven bakes a selected Loaf for a selected target
+  -> immutable target-bound *.loaf asset + execution receipt
+```
+
+- A **project** is the independently named and versioned unit described by `[project]`.
+- A **workspace** is the explicit repository coordination boundary described by `[workspace]`; it is not itself a compiled package unless it also has `[project]`.
+- A **Doughball** is Oven's internal representation of the selected sources, declared dependencies, features, interop inputs, and policy before target shaping.
+- A **Loaf** is the resolved logical build unit Oven obtains by shaping a Doughball for a selected package facet and target-compatible plan.
+- A **`*.loaf` asset** is the immutable, verified, target-bound build and distribution asset emitted by a bake. It carries the selected Loaf identity, target/carrier/profile, resolved-graph identity, payload digest, and receipt identity. Its archive or wire format is outside this RFC.
+- To **bake** is the operation that executes a resolved plan for a selected target/carrier/profile and produces a `*.loaf` asset plus a receipt. "Bake" is a verb, not a required artifact type.
+- **Cold**, **warm**, and **hot** Loaves may be shown by Oven's internal inspection and cache-status UX. Their precise state semantics are intentionally not specified here.
+- A **carrier** is the target deliverable form: for example, a static library, framework, JNI shared library, Python wheel, Rust-host caller projection, executable, or another declared artifact family.
+
+## Guide-level explanation
+
+### A single project
+
+An ordinary project needs only `Loaf.toml`:
+
+```toml
+[project]
+name = "weather_service"
+version = "0.6.0"
+description = "A service that happens to use Incan and Rust sources"
+requires-incan = ">=0.6,<0.7"
+
+[dependencies]
+web = { loaf = "stdlib-web", version = "^0.6" }
+serde = { crate = "serde", version = "1", features = ["derive"] }
+```
+
+`web` defaults to `incan.pub`; `serde` defaults to crates.io. Neither the project identity nor the command to bake it changes because its implementation contains Incan, Rust, or both. The public package feature graph remains an Incan/Loaf contract. A requested Cargo feature is a typed implementation request for `serde`; it does not automatically become a public feature of `weather_service`.
+
+Oven discovers supported source files below `src/`. A project with only conventional source roots does not need to list its implementation languages.
+
+### A workspace of Loaves
+
+The root `Loaf.toml` can be a project and a workspace:
+
+```toml
+[project]
+name = "incan"
+version = "0.6.0"
+
+[workspace]
+members = ["loaves/*"]
+default-members = [".", "loaves/incan_lsp"]
+
+[workspace.delivery.mobile]
+members = ["loaves/stdlib_interop", "loaves/stdlib_web"]
+targets = ["aarch64-apple-ios", "aarch64-linux-android"]
+profile = "release"
+```
+
+A virtual workspace omits `[project]` and retains `[workspace]`. Every member has its own `Loaf.toml`; no member is inferred merely because it lives under `loaves/`.
+
+The directory name is a repository convention, not an identity rule. A member can live anywhere inside the workspace root if it is explicitly included by `members`.
+
+### Hierarchical sub-Loaves
+
+A member may itself declare explicit child members. This is a structural hierarchy, not a nested independent workspace:
+
+```text
+incan/
+├── Loaf.toml                         # root authority and Oven.lock
+└── loaves/
+    └── incan_oven/
+        ├── Loaf.toml                 # an Incan sub-Loaf
+        └── loaves/
+            ├── oven_store/Loaf.toml
+            └── oven_provider_cargo/Loaf.toml
+```
+
+The root's selected closure contains `incan_oven` and its declared children. A sub-Loaf may declare local requirements and local member selection, but it inherits the root's resolved graph, lock, registry trust, target/delivery policy, and receipt boundary. It cannot create a second `Oven.lock`, rebind a registry, widen target policy, or form a second publication authority.
+
+Membership hierarchy is not a dependency graph. Parent/child placement, a shared workspace, and a selected closure create no runtime, linkage, or publication dependency between packages; those relationships exist only through declared typed dependencies. For example, `incql-core`, `incql-db`, and `incql-datafusion` can remain independently versioned packages whether or not one is structurally nested below another; any dependency between them is explicit in the consuming package's dependency table.
+
+This hierarchy also permits efficient cache-status inspection: Oven can compare a receipt-bound aggregate for a parent before it descends into a child's declared closure. The exact cold/warm/hot definitions remain an Oven inspection concern rather than this RFC's package contract.
+
+### Registries without ambient trust
+
+Oven has built-in defaults for the public ecosystems:
+
+```text
+Loaf package  -> incan.pub
+Rust crate    -> crates.io
+```
+
+Users or organizations explicitly register additional registries in Oven-controlled user or organization configuration. Registry configuration identifies the registry kind, endpoint/index, trust policy, and a reference to credentials held outside the project.
+
+```toml
+# Illustrative Oven user/organization configuration, not Loaf.toml.
+[registries.encero]
+kind = "loaf"
+index = "https://packages.encero.dev/index"
+trust = "require-signature"
+
+[registries.internal-cargo]
+kind = "crate"
+index = "sparse+https://cargo.encero.dev/index"
+trust = "organization"
+```
+
+The project can select a registered source and the workspace can allow-list source identities:
+
+```toml
+[dependencies]
+web = { loaf = "web", registry = "encero" }
+serde = { crate = "serde", registry = "internal-cargo" }
+
+[workspace.registries]
+allow = ["encero", "internal-cargo"]
+```
+
+The registry alias is convenience, not the security identity. `Oven.lock` records the canonical registry endpoint and protocol, exact package identity, immutable digest, and observed signature/trust result. Credentials never enter `Loaf.toml` or the lock. A project cannot silently register, rebind, or trust a registry on a developer's machine.
+
+### Declaring C ABI and future carriers
+
+A package declares interface intent and physical input requirements. Oven resolves the concrete target toolchain, SDK, artifacts, and deployment placement when it plans a bake.
+
+```toml
+[project]
+name = "vision_runtime"
+version = "0.6.0"
+
+[oven.interop.c]
+headers = ["interop/include/vision.h"]
+requires = ["vision-runtime"]
+
+[targets.ios]
+platform = "aarch64-apple-ios"
+carrier = "framework"
+
+[targets.android]
+platform = "aarch64-linux-android"
+carrier = "jni-library"
+```
+
+This example is intentionally schematic. `[oven.interop]` remains Oven-owned in `Loaf.toml`; `[oven.interop.c]` is the direct successor to RFC 116's C envelope. RFC 116 continues to define C declarations, ownership, buffers, verification, and checked shims. A future JNI or Python RFC defines the corresponding language/runtime safety contract. They all reuse the same package-envelope distinctions: declared requirement, selected provider/toolchain, target-compatible carrier, lock identity, plan, `*.loaf` asset, and receipt.
+
+### Baking and inspecting
+
+Before Oven performs external work, it can show a plan containing selected members, dependencies, providers, target, carrier, profile, capabilities, declared inputs/outputs, and expected effect classes. Baking executes only that plan and emits a target-bound `*.loaf` asset plus a receipt.
+
+The exact CLI spelling is intentionally outside this RFC. The semantic operation is:
+
+```text
+select project/workspace member(s)
+select target, carrier, profile, and features
+resolve the locked provider graph
+show/approve the plan when policy requires it
+bake
+inspect artifacts and receipt
+```
+
+### Cargo compatibility is a different mode
+
+A repository containing only `Cargo.toml` remains runnable by Oven in explicitly selected Cargo-compatibility mode. Cargo remains authoritative for that operation and its own build-script/proc-macro side effects are Cargo-mode behavior.
+
+If both files are present, Oven must continue as a Loaf project and issue a warning equivalent to:
+
+```text
+Found Loaf.toml and Cargo.toml. Loaf.toml is authoritative; Cargo configuration
+was ignored. Use an explicit Cargo-compatibility operation to run Cargo semantics.
+```
+
+Oven must not parse, merge, or infer dependency, feature, source, workspace, build-script, or target policy from the adjacent Cargo manifest.
+
+## Reference-level explanation
+
+### Manifest discovery and shapes
+
+1. `Loaf.toml` is the canonical manifest filename. Project-aware discovery walks upward from the working directory or source path to the nearest directory containing it.
+2. A manifest containing `[project]` and no `[workspace]` describes one project.
+3. A manifest containing `[project]` and `[workspace]` describes a rooted workspace. The root project is a member without requiring `"."` in `members`.
+4. A manifest containing `[workspace]` and no `[project]` describes a virtual workspace. It must declare at least one resolved member.
+5. Workspace membership is explicit. The root's selected closure is formed by recursively expanding each selected member's explicit `members` declaration, subject to `exclude`; a path dependency does not imply membership.
+6. A member may declare explicit child members, producing hierarchical sub-Loaves. Each non-root member has exactly one direct parent in the selected closure.
+7. Membership and parent/child hierarchy are never dependency, linkage, or publication edges. Those edges arise only from declared typed dependency requirements; a path dependency does not imply membership, and membership does not imply a dependency.
+8. The root workspace is the sole authority for the resolved graph, `Oven.lock`, registry trust, workspace delivery policy, and receipt boundary. Child workspace declarations may add local membership and narrow local requirements, but may not create a lock, rebind registries, weaken trust, broaden target policy, or establish an independent publication authority.
+9. A manifest containing neither `[project]` nor `[workspace]` is invalid.
+10. `incan.toml` is not a project manifest after this RFC. A directory that contains it but no `Loaf.toml` must receive a targeted diagnostic rather than legacy parsing.
+11. If a `Loaf.toml` project also contains `Cargo.toml`, Oven must warn and ignore Cargo configuration. The diagnostic must name the ignored file and explain explicit Cargo-compatibility selection.
+
+### Project metadata and source domains
+
+`[project]` retains the project identity and publication fields from RFC 015: name, version, description, authors, maintainers, license, license files, readme, homepage, repository, documentation, issues, keywords, classifiers, toolchain constraint, privacy, entry points, and public features.
+
+`requires-incan` remains an enforceable project compatibility requirement under RFC 073. It is a language/toolchain compatibility fact, not a claim that all implementation sources must be Incan.
+
+Supported source files below the conventional `src/` root participate according to their language extension and declared package facet. An implementation must not require an author to declare `incan = [...]` or `rust = [...]` merely because both file kinds appear under conventional roots. A later concrete schema may provide an optional source-root table for nonstandard roots, generated inputs, exclusions, or explicit source-domain policy.
+
+When a Loaf project contains Rust source, Oven determines its compilation/linkage path from the Loaf plan and declared crate/provider requirements. The presence of `Cargo.toml`, `build.rs`, or another Cargo convention does not grant that file execution or planning authority.
+
+### Rust source facet
+
+A Rust-bearing Loaf has a bounded, inspectable Rust facet. The planner must know, either through the conventional default or an explicit declaration, every compiled crate's package name, crate root, edition, crate type, entry point where applicable, enabled feature set, and linkage/dependency requirements. A conventional `src/lib.rs` or `src/main.rs` may supply a default root only when it yields one unambiguous crate; multiple crates, nonstandard roots, nondefault crate names, nondefault editions, additional crate types, binary entry points, or feature mapping require explicit facet data.
+
+The exact TOML table spelling remains an RFC 117 syntax decision, but no Rust compilation plan may be inferred from Cargo metadata. `Oven.lock` and the receipt must record the selected Rust facet, compiler/toolchain identity, crate dependency closure, feature choices, and all provider-produced inputs that affect the resulting `*.loaf` asset.
+
+The existence of `build.rs` must never execute it. A Loaf may support its intent only through an explicitly selected Oven provider or typed action whose inputs, outputs, capabilities, target/host role, policy decision, and receipt effects are declared and inspectable. Likewise, a procedural macro must be an explicitly resolved compiler-time provider with a recorded host identity and execution policy; an unsupported macro is a diagnostic, not a fallback to Cargo. Cargo compatibility remains the only mode in which Cargo itself is authoritative for these behaviors.
+
+RFC 119 owns the detailed native-Rust facet grammar, crate-provider graph, direct-`rustc` planner, build-time provider envelope, Rust test/IDE projections, and explicit Cargo interoperation. This RFC retains the one-manifest, one-lock, one-workspace-authority boundary those facilities must obey.
+
+### Typed dependencies and features
+
+Every dependency requirement has a **unit kind** and an **origin**.
+
+| Unit kind | Default origin | Contributes | Does not become |
+| --- | --- | --- | --- |
+| `loaf` | `incan.pub` | checked Incan semantic/provider facts and public package features | a Cargo crate or generated Rust source contract |
+| `crate` | crates.io | Rust interop metadata and backend implementation/linkage requirements | a public Incan feature namespace by accident |
+| `capability` | Oven-managed system/foreign catalog | target-specific library, SDK, toolchain, runtime, or deployment requirement | an ambient host discovery result |
+
+An entry may override its default origin through a registered registry, Git, path, or another supported source form. The resolved provider contract determines the legal source forms; a Loaf registry must not be accepted as a Cargo registry merely because it has a URL.
+
+Project features remain additive public Loaf capabilities as defined by RFC 114. They may enable optional Loaf dependencies and request public features from Loaf dependencies. A project may explicitly request a provider-specific crate feature as part of a crate dependency requirement, but that request is not exposed as a public project feature unless the project explicitly maps it through its public feature definition. Cargo feature names, generated crate names, and backend module paths remain implementation details.
+
+Workspace inheritance remains explicit. A workspace may own a dependency identity and members may opt into it. A member may refine only the usage properties RFC 114 and the selected dependency kind allow; it may not silently replace the source, registry, package identity, or trust policy selected by the workspace.
+
+### Registry registration and trust
+
+1. Oven provides the built-in origins `incan.pub` for `loaf` dependencies and crates.io for `crate` dependencies.
+2. Additional registries are registered through Oven-controlled user or organization configuration, never by an unreviewed dependency or an implicit network lookup.
+3. A registry registration must declare a stable identity, unit kind/protocol, endpoint/index, and trust policy. Credentials are referenced from secure user/organization storage rather than copied into project files.
+4. A Loaf or workspace may allow-list registered registry identities. It may select an allowed alias but may not define credentials, rebind an alias, or weaken a user/organization trust policy.
+5. The lock records canonical registry identity, protocol, exact resolved package/crate/capability identity, version, immutable digest, source reference, and signature/trust outcome. An alias alone is insufficient for reproducibility or audit.
+6. Resolution in locked or offline mode must not query an unrecorded registry, substitute an ambient local package, or accept a source with different trust facts.
+
+RFC 034 remains the protocol and publication authority for `incan.pub`; this RFC defines how `incan.pub` participates in the generic Loaf graph. A future Cargo-registry adapter must respect Cargo registry identity and integrity semantics without making Cargo the authority for a Loaf bake.
+
+### Targets, carriers, profiles, and delivery policy
+
+Target selection has three distinct levels:
+
+| Level | Responsibility | Constraint rule |
+| --- | --- | --- |
+| Loaf | Declares supported platform/interface/carrier combinations and package requirements | Defines the maximum compatibility surface the package claims |
+| Workspace | Declares named delivery policy, allowed targets, selected members, shared provider rules, and defaults | May narrow a member's support; must not broaden it |
+| Bake invocation | Selects the concrete target, carrier, profile, feature closure, and optional delivery policy | Must satisfy both workspace policy and every selected Loaf |
+
+The resolved plan must distinguish:
+
+- the **build host** on which Oven executes;
+- the **platform target** such as `aarch64-apple-ios`;
+- the **carrier** such as framework, static library, JNI shared library, Python wheel, executable, or Rust-host caller projection;
+- the **profile** such as development or release;
+- the enabled public features and selected provider requirements; and
+- the destination/deployment policy when relevant.
+
+An explicit invocation has the highest selection precedence but cannot override package support or workspace policy. A workspace delivery policy may narrow a project choice but cannot make a package claim an unsupported target. An unqualified local bake may choose a deterministic host-development target and profile, and the receipt must record that choice. Publication or deployment must require an explicit target/carrier or named delivery policy; it must not silently publish a host-default artifact.
+
+### Plans, effects, extensions, and receipts
+
+Oven uses the following boundary:
+
+```text
+authored Loaf configuration
+  -> resolution
+  -> inspectable plan
+  -> policy/capability decision
+  -> bake
+  -> artifacts and receipt
+```
+
+The resolver may fetch, verify, and stage immutable declared inputs according to the selected mode, but it must not execute package-provided code merely to resolve a dependency, inspect an import, discover a source file, or find a manifest.
+
+Every execution edge in a bake must belong to one of these categories:
+
+1. **Oven-managed provider operation:** a known provider kind performs typed work, such as compiling declared Rust sources, verifying C headers, compiling a declared C/C++ shim, or materializing a selected SDK component.
+2. **Declared generator operation:** a generator has typed inputs, outputs, provider identity, target constraints, capability requirements, and generated-output ownership. It may not overwrite authored source through an ordinary bake.
+3. **Explicit workflow action:** an action from RFC 078 is selected by the user or an authorized tool and is evaluated under RFC 076 policy before execution.
+
+An extension must have a versioned, typed schema and a known provider/action identity. Unknown extension kinds are invalid; they are not a generic `[tool.*]` escape hatch. A provider or action may advertise a required capability, network requirement, external executable, or mutation class, but it must not gain authority merely by being selected as a dependency.
+
+Before executing a nontrivial plan, Oven must be able to inspect the selected members, dependency/provider identities, target/carrier/profile, toolchains, declared inputs and outputs, execution categories, capabilities, mutation classes, and expected receipt facts. Policy may require approval for a plan according to RFC 076. After execution, the receipt must identify the actual provider/toolchain selections, input identities, output artifacts, declared and observed effects, and deviations or denials.
+
+RFC 104 owns capability-enforcement and receipt semantics. RFC 112 owns crash-safe publication and file coordination. This RFC requires their identities to be included in the Loaf/Oven plan rather than recreated through hidden backend behavior.
+
+### Environments and actions
+
+The following authored concepts move into `Loaf.toml` under Oven ownership. Their table roots are intentionally typed and reserved; arbitrary `[tool.*]` namespaces do not carry forward:
+
+| Concept | Semantic owner | Oven responsibility |
+| --- | --- | --- |
+| project and environment toolchain constraints | RFC 073 | resolve and enforce compatible toolchains |
+| named environments and matrices | RFC 073 | materialize the resolved environment and expand matrix cells deterministically |
+| typed workflow actions | RFC 078 | resolve scope, show plan, policy-gate, and execute explicit actions |
+| mutation policy | RFC 076 | evaluate receiver authority over planned changes/effects |
+
+RFC 015 is implemented, so RFC 117 supersedes its `incan.toml` discovery and `[tool.incan.envs]` configuration placement. RFCs 073, 076, and 078 are still Draft and must be amended to name the new Loaf/Oven tables and terminology rather than preserving legacy configuration compatibility.
+
+The initial table roots are `[oven.envs]`, `[oven.actions]`, `[oven.policy]`, `[oven.capabilities]`, and `[oven.templates]`. Their dedicated RFCs own the detailed schema and semantics. They must remain explicit, scoped, inspectable, and free of implicit lifecycle execution. RFC 118 owns whether users invoke those semantics through `incan`, `oven`, aliases, or another command arrangement.
+
+### Interop package envelope
+
+RFC 116's current `[oven.interop]` shape is package-owned requirement data, not a record of a host toolchain already selected. Under this RFC it remains Oven-owned in the Loaf-level `[oven.interop]` namespace: C declarations use `[oven.interop.c]`. The file name changes from `incan.toml` to `Loaf.toml`; the ownership boundary does not.
+
+The interop envelope must be binding-kind neutral. It represents declared headers, shims, foreign artifacts, toolchain/SDK capabilities, target variants, carrier requirements, lock identities, plan inputs, generated verification records, artifact staging, and receipts. It does not make C pointer types, C ownership, JNI handles, Python reference counts, or another runtime's safety rules universal. Each binding-kind RFC continues to define its own source vocabulary and checking rules.
+
+### Locks and derived state
+
+`Oven.lock` is the canonical generated resolution state for a project or workspace. A workspace has one root lock that represents every member's selected dependency/provider graph and target-relevant resolution facts. `incan.lock` is not read after this RFC.
+
+The lock must include every semantic or physical input whose change can alter checking, linking, target compatibility, generated output, or the baked artifact closure. It must not contain credentials, mutable cache paths, arbitrary environment values, or unreviewed host discovery output.
+
+`*.loaf` is the immutable, target-bound distribution/build asset derived from the lock and the selected bake plan. It must identify its project/facet, target, carrier, profile, resolved graph identity, payload digest, and receipt identity; it is not an editable project manifest or a replacement lockfile. The artifact store, provider payload store, staged deployment files, generated Rust, target intermediates, and receipts are separate from the lock. They are inspectable and may be content-addressed, but they are not user-authored package configuration or semantic authority.
+
+## Design details
+
+### Manifest ownership map
+
+`Loaf.toml` is the authored envelope. Existing RFCs continue to own the meaning of their respective content:
+
+```text
+Loaf.toml
+├── [project]                 RFC 117
+├── [workspace]               RFC 117; prospectively supersedes RFC 077's flat-workspace restriction
+├── dependencies/features     RFC 117 + RFC 114
+├── registry selection        RFC 117 + RFC 034
+├── [oven.envs]               RFC 073, rehomed by RFC 117
+├── [oven.actions]            RFC 078, rehomed by RFC 117
+├── [oven.policy]             RFC 076, rehomed by RFC 117
+├── [oven.capabilities]       RFC 075, governed by RFC 076
+├── [oven.templates]          RFC 074, governed by RFC 076
+├── [oven.interop]            RFC 116 now; future binding RFCs later
+├── Oven.lock                 resolved graph, RFCs 020, 104, 112, and 114
+└── *.loaf + receipt          immutable target-bound artifact, RFC 117; wire format deferred
+```
+
+This map does not make RFC 117 the owner of every detailed sub-schema. It establishes one manifest root and prevents every feature family from inventing its own root file, discovery rule, or source-language split.
+
+### Source language and authored Rust
+
+The Loaf package model is language-neutral; it does not relax Incan's authoring policy. Incan products and dogfooding projects should remain Incan-authored and use `rust::` interop for existing Rust capabilities. New authored Rust still requires a demonstrated Incan limitation and a tracked removal path.
+
+That policy is distinct from the manifest contract. Oven must be capable of baking a Loaf whose implementation is Rust, Incan, or mixed because the build system cannot make a package's identity depend on the language mix. Project governance can constrain which sources its maintainers choose to author.
+
+The Rust facet is the language-neutral planner contract for Rust-authored or mixed Loaves. It does not license authored Rust in Incan products without the demonstrated limitation and tracked removal path required above.
+
+### Cargo compatibility boundary
+
+Cargo compatibility has two valid states:
+
+1. **Cargo project:** a directory has `Cargo.toml` and no `Loaf.toml`. An explicitly selected Oven Cargo-compatibility operation delegates to Cargo. Cargo retains authority over its manifest and side effects.
+2. **Loaf project:** a directory has `Loaf.toml`, with or without `Cargo.toml`. Oven uses only the Loaf graph. Cargo is not an implicit source of build policy.
+
+There is no mixed automatic state. In particular, Oven must not merge dependency tables, inherit Cargo workspace membership, execute a discovered `build.rs`, or allow a Cargo feature to silently change a Loaf's public feature API.
+
+### Inspectability and diagnostics
+
+Oven must make the following facts inspectable without reading generated Rust, private compiler IR, a cache directory, or an implementation-specific backend manifest:
+
+- discovered manifest root, project/workspace shape, members, and selected scope;
+- source roots and ignored adjacent `Cargo.toml` files;
+- each dependency's unit kind, configured/default origin, resolved canonical source, integrity/trust facts, and public feature closure;
+- registry registrations and allow-list/policy decision, with credentials redacted;
+- selected target, build host, carrier, profile, delivery policy, toolchain/SDK/provider identities, and compatibility constraints;
+- planned execution categories, inputs, outputs, capabilities, mutation classes, policy outcome, and expected receipts;
+- actual baked artifacts, receipt identities, cache status, and declared-versus-observed effects.
+
+For each `*.loaf` asset, inspection must report the project/facet, target, carrier, profile, resolved graph identity, payload digest, signature/trust facts where applicable, and receipt identity without requiring an author to inspect a cache path or container implementation.
+
+Diagnostics must distinguish configuration errors, unsupported target/carrier combinations, unmet package requirements, unavailable registered registries, trust failures, stale or incompatible locks, missing provider/toolchain capabilities, explicit Cargo compatibility, and accidental Cargo coexistence. They must explain which declaration or policy constraint led to the outcome.
+
+## Compatibility and migration
+
+This RFC is intentionally breaking and should land before Incan 1.0.
+
+- `incan.toml` is replaced wholesale with `Loaf.toml`.
+- `incan.lock` is replaced with `Oven.lock`.
+- Existing implemented project/workspace/environment code must be updated to discover and write the new schema; it must not retain a legacy `incan.toml` parser.
+- Existing Draft RFCs that refer to `[tool.incan.*]` must be amended before their implementation is scheduled.
+- Existing project authors must explicitly adopt the Loaf contract; a raw rename is valid only when the resulting tables satisfy the new schema.
+- Cargo-only repositories require no adoption to be runnable in explicit Cargo-compatibility mode.
+
+The tool should emit a targeted diagnostic when it finds `incan.toml` without `Loaf.toml`, but it must not silently interpret the old file. This keeps the authority transition explicit and avoids supporting every interaction between old Incan configuration, Cargo configuration, and the new Oven model.
+
+## Alternatives considered
+
+### Add `Oven.toml` beside `Loaf.toml`
+
+Rejected for now. A separate root file makes the package-versus-workspace vocabulary literal, but it creates two canonical documents, discovery precedence, and synchronization questions. A single `Loaf.toml` with explicit `[project]` and `[workspace]` scopes supports single projects, rooted workspaces, and virtual workspaces without losing capability. A future RFC may introduce a separate file only if independently versioned workspace policy demonstrates a real need.
+
+### Keep `incan.toml` and add Loaf concepts inside it
+
+Rejected. The filename embeds a source-language assumption that the package model is deliberately outgrowing. Keeping it would make Rust-authored and mixed projects second-class by name even when the model is technically neutral.
+
+### Keep separate Incan and Rust dependency tables
+
+Rejected. The package graph must be one user-facing graph. Resolver, feature, semantic-provider, and linkage differences remain typed provider facts, but should not force authors to split their logical dependencies by implementation language.
+
+### Treat all registries as equivalent URLs
+
+Rejected. `incan.pub` packages, Cargo ecosystem crates, and foreign/system catalogs have different package formats, integrity, semantic metadata, and execution/linkage contracts. Registry identity requires a kind/protocol and trust policy, not only an endpoint string.
+
+### Infer workspace members or build behavior from the directory tree
+
+Rejected. A `loaves/` directory is a useful convention, not authority. Implicit membership and implicit Cargo conventions make plans surprising and make receipt identity incomplete.
+
+### Run dependency hooks like Cargo `build.rs` or npm lifecycle scripts
+
+Rejected. Oven must know what it intends to execute before it executes it. Typed provider operations, declared generators, and explicit policy-gated actions preserve practical integration without hidden lifecycle behavior.
+
+### Let `[tool.*]` be an unbounded extension namespace
+
+Rejected. Unconstrained tool tables make the canonical manifest a dumping ground and prevent Oven from planning effects or validating ownership. Extensions need versioned schemas and explicit provider/action identities.
+
+## Drawbacks
+
+- This is a breaking pre-1.0 configuration change touching project creation, discovery, documentation, workspaces, locking, environments, package resolution, interop, and tooling.
+- Typed dependencies and registered registries are more explicit than one string version requirement; good defaults and concise syntax are necessary for everyday use.
+- A strict Cargo boundary means Rust projects that adopt `Loaf.toml` cannot rely on arbitrary Cargo manifest behavior without an explicit supported Oven provider/action model.
+- Plans, policies, and receipts impose vocabulary and implementation work beyond a simple compiler wrapper.
+- One manifest filename means a virtual workspace has a `Loaf.toml` without a `[project]` table. The explicit table scopes must make that form obvious.
+
+## Layers affected
+
+- **Manifest discovery and validation** — must recognize only `Loaf.toml`, validate rooted/virtual workspace shapes, reject unknown or conflicting scope, and diagnose legacy or coexisting manifests precisely.
+- **Workspace resolution** — must preserve explicit membership, shared lock ownership, scoped command selection, and typed dependency inheritance while replacing `incan.toml` paths and tables.
+- **Provider and dependency resolution** — must normalize typed dependencies, apply default origins, resolve registered registries, preserve provider-specific semantics, verify trust/integrity, and construct one session-owned plan.
+- **Source and backend planning** — must discover conventional supported sources, require explicit nonstandard declarations, define the bounded Rust facet needed to plan Rust compilation, and prevent Cargo conventions from participating in Loaf planning.
+- **Target and interop planning** — must resolve host/target/carrier/profile/delivery combinations, select providers/toolchains, and reuse RFC 116's checked C package facts without C-specific assumptions in the envelope.
+- **Environment and action tooling** — must rehome RFC 073 and RFC 078 configuration to Loaf/Oven while retaining matrix, scope, dry-run, policy, and receipt contracts.
+- **Locking, stores, and publication** — must rename the canonical lock to `Oven.lock`, preserve deterministic whole-workspace resolution, reserve immutable target-bound `*.loaf` identities, and keep locks, receipts, caches, and publication artifacts distinct.
+- **Cargo compatibility adapter** — must run Cargo only when explicitly selected, report its mode and side-effect boundary, and never act as a fallback inside a Loaf build.
+- **CLI and inspection** — must expose manifest shape, plan, target selection, registry/trust facts, effects, `*.loaf` assets, and receipts; RFC 118 owns final binary/subcommand spelling and alias behavior.
+- **Documentation, templates, LSP, and IDEs** — must create, discover, edit, display, and diagnose `Loaf.toml` consistently without making generated Rust or hidden backend state the public model.
+
+## Acceptance criteria
+
+RFC 117 is ready to move beyond Draft when its normative rules and updated related RFCs establish all of the following:
+
+- A standalone project, rooted workspace, and virtual workspace have unambiguous `Loaf.toml` examples and discovery rules.
+- The dependency grammar distinguishes unit kind from origin and explains defaults, source overrides, features, integrity, and trust.
+- The `incan.pub` and crates.io defaults, explicit registry registration, project allow-list, credential boundary, and lock identity are defined precisely enough to implement.
+- A Loaf containing Incan, Rust, and mixed conventional sources has defined planning behavior, including bounded Rust-facet inputs and no implicit Cargo participation.
+- Target, carrier, profile, workspace delivery policy, and invocation precedence have explicit validation and receipt requirements.
+- Provider operations, generators, actions, policy, and receipts have a complete no-hidden-effects boundary.
+- RFCs 015, 073, 076, 077, 078, 114, and 116 identify exactly which manifest/discovery clauses RFC 117 supersedes or amends.
+- The lock rename and legacy-manifest rejection have a complete pre-1.0 compatibility decision.
+- RFC 118 has a clear command-ownership and alias boundary that does not reopen the manifest model.
+
+## Implementation plan
+
+### Phase 1: Manifest and workspace authority
+
+- Introduce `Loaf.toml` discovery and validation; remove `incan.toml` discovery from project-aware operations.
+- Implement rooted and virtual workspace shapes, explicit member selection, and precise coexisting-Cargo diagnostics.
+- Update project creation, documentation, LSP/IDE manifest discovery, and fixtures.
+
+### Phase 2: Typed graph, registries, and lock
+
+- Normalize Loaf, crate, and capability dependencies into one resolver-owned graph.
+- Implement default origins, registered registry identities, workspace allow-lists, integrity/trust facts, and the `Oven.lock` format.
+- Amend RFC 034 integration and retain RFC 114's public-feature/provider boundaries.
+
+### Phase 3: Target plan and controlled effects
+
+- Implement target/carrier/profile/delivery validation and receipt identity.
+- Make provider operations and declared generators plan-visible; connect policy and receipt facts from RFCs 076 and 104.
+- Rehome RFC 116 package requirements into the generic interop envelope.
+
+### Phase 4: Environment and action rehoming
+
+- Amend and implement the `Loaf.toml` configuration location for RFC 073 environments/matrices and RFC 078 typed actions.
+- Make Oven materialization, scope selection, dry-run, and policy gating consume the same project/workspace plan.
+
+### Phase 5: Explicit Cargo compatibility and documentation
+
+- Implement the distinct Cargo compatibility adapter and receipt/reporting boundary.
+- Add compatibility fixtures for Cargo-only projects, Loaf-only Rust projects, mixed-source Loaves, workspaces, private registries, and C ABI target carriers.
+- Document the command-surface handoff to RFC 118 without defining aliases or final command spelling here.
+
+## Unresolved questions
+
+1. What is the final compact TOML syntax for typed dependency entries and provider-specific feature requests, while preserving the unit-kind/origin distinction?
+2. What exact table names should environments, matrices, actions, policy, and interop use under `Loaf.toml` after RFCs 073, 076, 078, and 116 are amended?
+3. Which nonstandard source-root and generated-input declarations are necessary for the first 0.6 implementation, beyond convention-first `src/` discovery?
+4. How should an organization distribute and administer trusted registry registrations without letting a checked-out project overwrite user or organization trust policy?
+5. Which target/carrier combinations and named delivery-policy grammar constitute the first 0.6 proof set?
+6. What is the smallest typed generator/provider extension API that supports real code generation and native shims without becoming a generic script hook?
+7. Which `*.loaf` container or wire format, registry transport, and multi-asset publication protocol best carries the already-reserved immutable target-bound identity without changing its authored/lock/receipt contract?
+8. What precise inspection meaning, if any, should cold, warm, and hot Loaves have after the Oven's cache and lifecycle model is settled?
+
+<!-- Rename this section to "Design Decisions" once all questions have been resolved. -->

--- a/workspaces/docs-site/docs/RFCs/117_loaf_toml_and_oven_project_model.md
+++ b/workspaces/docs-site/docs/RFCs/117_loaf_toml_and_oven_project_model.md
@@ -324,11 +324,11 @@ RFC 119 owns the detailed native-Rust facet grammar, crate-provider graph, direc
 
 Every dependency requirement has a **unit kind** and an **origin**.
 
-| Unit kind | Default origin | Contributes | Does not become |
-| --- | --- | --- | --- |
-| `loaf` | `incan.pub` | checked Incan semantic/provider facts and public package features | a Cargo crate or generated Rust source contract |
-| `crate` | crates.io | Rust interop metadata and backend implementation/linkage requirements | a public Incan feature namespace by accident |
-| `capability` | Oven-managed system/foreign catalog | target-specific library, SDK, toolchain, runtime, or deployment requirement | an ambient host discovery result |
+| Unit kind    | Default origin                      | Contributes                                                                 | Does not become                                 |
+| ------------ | ----------------------------------- | --------------------------------------------------------------------------- | ----------------------------------------------- |
+| `loaf`       | `incan.pub`                         | checked Incan semantic/provider facts and public package features           | a Cargo crate or generated Rust source contract |
+| `crate`      | crates.io                           | Rust interop metadata and backend implementation/linkage requirements       | a public Incan feature namespace by accident    |
+| `capability` | Oven-managed system/foreign catalog | target-specific library, SDK, toolchain, runtime, or deployment requirement | an ambient host discovery result                |
 
 An entry may override its default origin through a registered registry, Git, path, or another supported source form. The resolved provider contract determines the legal source forms; a Loaf registry must not be accepted as a Cargo registry merely because it has a URL.
 
@@ -351,11 +351,11 @@ RFC 034 remains the protocol and publication authority for `incan.pub`; this RFC
 
 Target selection has three distinct levels:
 
-| Level | Responsibility | Constraint rule |
-| --- | --- | --- |
-| Loaf | Declares supported platform/interface/carrier combinations and package requirements | Defines the maximum compatibility surface the package claims |
-| Workspace | Declares named delivery policy, allowed targets, selected members, shared provider rules, and defaults | May narrow a member's support; must not broaden it |
-| Bake invocation | Selects the concrete target, carrier, profile, feature closure, and optional delivery policy | Must satisfy both workspace policy and every selected Loaf |
+| Level           | Responsibility                                                                                         | Constraint rule                                              |
+| --------------- | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------ |
+| Loaf            | Declares supported platform/interface/carrier combinations and package requirements                    | Defines the maximum compatibility surface the package claims |
+| Workspace       | Declares named delivery policy, allowed targets, selected members, shared provider rules, and defaults | May narrow a member's support; must not broaden it           |
+| Bake invocation | Selects the concrete target, carrier, profile, feature closure, and optional delivery policy           | Must satisfy both workspace policy and every selected Loaf   |
 
 The resolved plan must distinguish:
 
@@ -399,12 +399,12 @@ RFC 104 owns capability-enforcement and receipt semantics. RFC 112 owns crash-sa
 
 The following authored concepts move into `Loaf.toml` under Oven ownership. Their table roots are intentionally typed and reserved; arbitrary `[tool.*]` namespaces do not carry forward:
 
-| Concept | Semantic owner | Oven responsibility |
-| --- | --- | --- |
-| project and environment toolchain constraints | RFC 073 | resolve and enforce compatible toolchains |
-| named environments and matrices | RFC 073 | materialize the resolved environment and expand matrix cells deterministically |
-| typed workflow actions | RFC 078 | resolve scope, show plan, policy-gate, and execute explicit actions |
-| mutation policy | RFC 076 | evaluate receiver authority over planned changes/effects |
+| Concept                                       | Semantic owner | Oven responsibility                                                            |
+| --------------------------------------------- | -------------- | ------------------------------------------------------------------------------ |
+| project and environment toolchain constraints | RFC 073        | resolve and enforce compatible toolchains                                      |
+| named environments and matrices               | RFC 073        | materialize the resolved environment and expand matrix cells deterministically |
+| typed workflow actions                        | RFC 078        | resolve scope, show plan, policy-gate, and execute explicit actions            |
+| mutation policy                               | RFC 076        | evaluate receiver authority over planned changes/effects                       |
 
 RFC 015 is implemented, so RFC 117 supersedes its `incan.toml` discovery and `[tool.incan.envs]` configuration placement. RFCs 073, 076, and 078 are still Draft and must be amended to name the new Loaf/Oven tables and terminology rather than preserving legacy configuration compatibility.
 

--- a/workspaces/docs-site/docs/RFCs/118_incan_and_oven_command_line_surfaces.md
+++ b/workspaces/docs-site/docs/RFCs/118_incan_and_oven_command_line_surfaces.md
@@ -1,0 +1,258 @@
+# RFC 118: Incan and Oven command-line surfaces
+
+- **Status:** Draft
+- **Created:** 2026-08-04
+- **Author(s):** Danny Meijer (@dannymeijer)
+- **Related:**
+    - RFC 073 (environment matrices and toolchain constraints)
+    - RFC 078 (tool execution and typed workflow actions)
+    - RFC 090 (typed CLI framework)
+    - RFC 102 (Incan semantic layer inspection surface)
+    - RFC 105 (`incan architect` rule engine)
+    - RFC 106 (compiler-backed agent context graph)
+    - RFC 116 (typed C ABI interop)
+    - RFC 117 (`Loaf.toml` and Oven's language-neutral project model)
+    - RFC 119 (Oven-native Rust build facets and Cargo interoperation)
+- **Issue:** [#1010](https://github.com/encero-systems/incan/issues/1010)
+- **RFC PR:** —
+- **Written against:** v0.5
+- **Target scope:** v0.7 design and implementation planning; this is not a shipment claim.
+- **Shipped in:** —
+
+## Summary
+
+This RFC defines two command surfaces delivered in one Incan installation. `incan` is the language and semantic-tooling command: it is deliberately Python-shaped for direct source use, modules, REPL work, formatting, language-server work, semantic inspection, codegraph, and architect analysis. `oven` is the project, package, environment, target, registry, and artifact-lifecycle command: it is deliberately Cargo-shaped for `Loaf.toml` workspaces, planning, baking, locking, testing, actions, and publication.
+
+The surfaces are not peer orchestrators. Incan may delegate downward to the Oven API when a semantic command needs a project plan or build work. Oven must not invoke the Incan CLI, expose Incan semantic subcommands, or learn Cargo behavior through Incan. Oven consumes compiler service APIs and owns its own operational plan, policy, cache, receipt, and provider lifecycle.
+
+## Core model
+
+1. **One installation, two surfaces:** installing Incan provides the compiler/runtime, Oven core and providers, `incan`, and `oven`. Oven is not a separately installed product.
+2. **`incan` is semantic and source-oriented:** outside a Loaf it owns direct-file and module execution, checking, formatting, REPL/LSP operation, compiler diagnostics, semantic inspection, `codegraph`, and `architect`. Inside a Loaf, its approved project-scale conveniences remain shallow calls to Oven.
+3. **`oven` is project-oriented:** it owns `Loaf.toml` discovery, workspaces, dependency resolution, registry trust, environments, targets, carriers, plans, baking, locks, artifacts, receipts, publication, and explicit Cargo compatibility.
+4. **Cargo familiarity is deliberate but bounded:** Oven may use recognizable Cargo-shaped verbs such as `add`, `update`, `lock`, `test`, and `publish`; it does not promise Cargo's implicit workspace, build-script, proc-macro, or manifest semantics for a Loaf.
+5. **Incan familiarity is deliberate but bounded:** Incan may use familiar direct-source affordances such as a file argument, `-m`, `-c`, and a REPL. It must not grow a second dependency resolver, environment manager, cache, or package lifecycle model.
+6. **Delegation is downward only:** an Incan command may request work from the Oven API. Oven may call compiler service APIs, but it must never shell out to or route its behavior through the Incan CLI.
+7. **One operational authority:** every project operation, whether invoked as `oven ...` or through an approved Incan convenience, produces the same Oven plan, policy decision, selected target, `*.loaf` asset, and receipt.
+8. **Language-neutral package operation:** neither command surface makes Rust, Incan, C ABI, JNI, Python, or another implementation substrate second-class. A selected Loaf behaves according to its declared provider and target requirements.
+
+## Motivation
+
+The existing compiler CLI, historical project lifecycle commands, Cargo compatibility, and emerging Oven capabilities otherwise converge into one ambiguous command family. That ambiguity is costly: users cannot tell which operations are language semantics, which mutate project state, which own caches and lockfiles, or whether a command is silently adopting Cargo behavior.
+
+The desired experience has two useful mental models without two competing systems. `incan` should feel immediate and source-oriented in the way Python tooling does: run a file, run a module, inspect a program, format code, open a REPL, and ask semantic tools useful questions. `oven` should feel deliberate and project-oriented in the way Cargo does: select a member, resolve it, plan it, bake it for a target, test it, update the lock, inspect the result, and publish it.
+
+This separation also protects the architecture. Incan's semantic products—diagnostics, codegraph facts, architect findings, checked package interfaces, and compiler-owned source meaning—must not be reimplemented by a build tool. Conversely, Oven's operational products—provider selection, target policy, content-addressed storage, leases, crash-safe publication, effect receipts, and registry trust—must not be recreated by each Incan subcommand.
+
+## Goals
+
+- Deliver `incan` and `oven` together in one Incan distribution without creating two competing package systems.
+- Give direct source and semantic work a Python-shaped `incan` surface while giving project, registry, target, artifact, and receipt work a Cargo-shaped `oven` surface.
+- Make the owner of every command observable through its plan, diagnostics, selected manifest/target, and receipt.
+- Require project-scale `incan run` and `incan test` conveniences to delegate shallowly to the same Oven plan, scheduler, bake, `*.loaf` asset, and receipt as the canonical Oven operation.
+- Keep the Incan CLI native Incan while preserving Oven's Rust operational core/API as the explicit cache, store, lease, lifetime, concurrency, and crash-safety exception.
+- Ensure that neither CLI makes Incan, Rust, C ABI, JNI, Python, or another supported implementation substrate second-class.
+
+## Non-Goals
+
+- Defining `Loaf.toml`, `Oven.lock`, dependency resolution, target/carrier semantics, artifact format, or interop safety rules; RFC 117 and the corresponding interop RFCs own those contracts.
+- Creating a second resolver, environment manager, cache, registry/trust model, or package lifecycle in the Incan CLI.
+- Requiring the Oven CLI itself to be implemented in Incan by v0.7, or allowing its implementation language to change the Oven API/receipt contract.
+- Inferring or emulating Cargo workspace, build-script, proc-macro, or manifest semantics in a Loaf command.
+- Making every Oven operation available through an Incan alias.
+
+## Guide-level explanation
+
+### Use Incan for direct language work outside a Loaf
+
+```text
+incan run app.incn
+incan run -m tools.release_notes
+incan check src/
+incan fmt src/ tests/
+incan repl
+incan lsp
+incan inspect symbols src/main.incn
+incan codegraph export --format json
+incan architect src/
+```
+
+These commands are about source, language behavior, and semantic facts. A direct-file invocation does not require a `Loaf.toml` project. When a semantic command is given a Loaf project, it may ask Oven for the selected dependency/provider context, but the compiler remains the authority for semantic results.
+
+### Use shallow Incan conveniences inside a Loaf
+
+Within a discovered `Loaf.toml` project, project-scale execution is not a second build system:
+
+```text
+incan run                 # shallow alias to the selected Oven run/bake plan
+incan test                # shallow alias to the selected Oven test plan and scheduler
+incan run --direct tool.incn  # explicit direct-source escape hatch
+```
+
+`incan run` and `incan test` inside a Loaf forward project selection to Oven. Oven resolves the same dependencies, target, carrier, profile, policy, scheduler, artifacts, and receipt that it would for the corresponding `oven` operation. Incan contributes source collection and semantic diagnostics; it does not create build state, choose a separate target, or issue a second receipt. `--direct` is explicit because a nearby manifest must not silently turn deliberate scratch execution into a project bake.
+
+### Use Oven for project work
+
+```text
+oven init
+oven add stdlib-web
+oven add --crate serde
+oven plan --target aarch64-apple-ios --carrier framework
+oven bake --target aarch64-apple-ios --carrier framework
+oven test --workspace
+oven env run ci test
+oven action run generate-client --dry-run
+oven inspect receipt
+oven update
+oven publish
+```
+
+These commands operate on a selected Loaf or workspace closure. They discover `Loaf.toml`, resolve the typed dependency graph, apply inherited workspace authority, and report a plan before effects where policy requires it.
+
+### Inspecting semantic and operational facts
+
+The names intentionally overlap only where the underlying questions differ:
+
+| Question | Command surface | Example |
+| --- | --- | --- |
+| What declarations, types, imports, and source relationships exist? | Incan semantic inspection | `incan inspect symbols`, `incan codegraph export` |
+| What architecture or safety findings follow from checked source? | Incan analysis | `incan architect` |
+| Which members, providers, targets, artifacts, cache entries, and receipts were selected? | Oven operational inspection | `oven inspect plan`, `oven inspect receipt`, `oven inspect cache` |
+
+`oven inspect` must not masquerade as a semantic codegraph API, and `incan inspect` must not infer provider/cache facts from generated Rust or filesystem conventions.
+
+### Cargo-only projects remain explicit
+
+```text
+oven cargo test
+oven cargo build --release
+```
+
+Cargo compatibility is a clearly selected mode for a directory with `Cargo.toml` and no `Loaf.toml`. Cargo remains authoritative, including its own side effects. If both files exist, normal Oven commands use `Loaf.toml`, warn that Cargo was ignored, and require explicit Cargo compatibility to run Cargo semantics.
+
+## Reference-level explanation
+
+### Command ownership
+
+| Domain | Canonical owner | Illustrative commands |
+| --- | --- | --- |
+| Direct source/module execution outside a Loaf, or explicitly requested direct work | `incan` | `run --direct`, `-m`, `-c`, `repl` |
+| Parsing, checking, formatting, compiler diagnostics | `incan` | `check`, `fmt` |
+| Language services and semantic products | `incan` | `lsp`, `inspect`, `codegraph`, `architect` |
+| Manifest and workspace selection | `oven` | `init`, `new`, member selection |
+| Dependency, lock, and registry lifecycle | `oven` | `add`, `remove`, `update`, `lock`, `registry`, `publish` |
+| Target, carrier, provider, and artifact lifecycle | `oven` | `plan`, `bake`, `run`, `test`, `inspect` |
+| Environments, typed actions, project mutations | `oven` | `env`, `action`, `starter`, `capability` |
+| Cargo compatibility | `oven` | `cargo` |
+
+An operation that changes dependency resolution, registry trust, a lock, generated project state, selected toolchain/provider, target output, or execution receipt belongs to Oven even when the selected sources are entirely Incan.
+
+### Delegation and API boundary
+
+The supported call direction is:
+
+```text
+incan CLI (native Incan)
+  -> compiler semantic service API
+  -> Oven API when project work is needed
+       -> providers, stores, targets, receipts
+```
+
+```text
+oven CLI
+  -> Oven API
+  -> compiler semantic service API when compilation is required
+```
+
+The second path deliberately has no arrow to the Incan CLI. Oven must not depend on parsing Incan CLI output, invoking `incan build`, importing CLI command handlers, or acquiring Cargo knowledge through the Incan surface.
+
+The Incan CLI must be authored in native Incan. Oven's operational API remains a narrow Rust exception: planning, dependency/provider resolution, policy evaluation, cache/store access, leases, concurrency, provider execution, and crash-safe publication require explicit ownership and lifetime control at one coherent boundary. The public Oven API is language-neutral: it returns owned plan and receipt snapshots plus opaque leased handles, never Rust borrows across the Incan boundary. Rust's in-process lifetimes are necessary but insufficient; durable leases, content identities, atomic publication, and recovery remain Oven requirements.
+
+The Oven CLI may use the same Rust operational API directly. Its implementation language is not a user-facing contract and may change without changing command behavior or receipt semantics.
+
+### Alias rules
+
+RFC 118 does not require every canonical Oven operation to have an Incan alias. An approved alias must be shallow: it forwards the user's selection to Oven and returns Oven's diagnostics, plan, target choice, and receipt identity without reinterpretation. It must not:
+
+- resolve dependencies or registries itself;
+- rewrite a target, profile, environment, action, or policy decision;
+- conceal an explicit Cargo compatibility operation; or
+- turn an Oven effect into an unplanned Incan compiler side effect.
+
+Inside a discovered Loaf, `incan run` and `incan test` are required shallow aliases. They must produce the same Oven plan identity, scheduler decision, selected target/carrier/profile, `*.loaf` asset where applicable, and receipt as the canonical Oven operation. A direct `incan run` in that directory requires `--direct`; the explicit flag makes the absence of Oven planning visible.
+
+The remaining alias set is intentionally deferred until the first native Incan CLI vertical slice proves which conveniences improve direct language use rather than making the ownership boundary less legible.
+
+### Distribution and versioning
+
+The Incan distribution is the installation and update unit. It includes a compatible compiler/runtime and Oven core/provider set, and exposes both command entry points. A Rust-only project may use Oven, but installs the Incan distribution; it does not need to author Incan sources or separately install a competing Oven product.
+
+The distribution must report compatible component versions and reject an unsupported Oven/provider/compiler combination before it claims to have produced a plan or bake. The receipt records the selected component identities.
+
+### Relationship to RFC 090
+
+RFC 090 owns `std.cli`, the framework for applications authored in Incan. It does not own project lifecycle behavior. The native Incan CLI should dogfood `std.cli` when its surface is ready, but RFC 118 does not make the Incan/Oven command contract contingent on a particular parser implementation. Oven's command semantics must remain defined by the Oven API rather than by a second application-level command model.
+
+### Release boundaries
+
+- **v0.5:** retains the current bounded RFC 116 interop release work and its existing `incan.toml` contract; this RFC does not backport a Loaf transition into that release.
+- **v0.6:** RFC 117 introduces `Loaf.toml`, `Oven.lock`, hierarchical sub-Loaves, and the language-neutral project model.
+- **v0.7:** this RFC introduces the canonical command-surface split over the v0.6 Oven API and project model.
+
+## Compatibility and migration
+
+This RFC does not require a separate Oven installation or a second lockfile format. It is intentionally incompatible with a model in which every project operation remains an `incan` command and owns its own package behavior.
+
+Direct Incan source commands remain usable without a project manifest. Inside a discovered Loaf, project-scale `incan run` and `incan test` use Oven as specified above; `incan run --direct` is the explicit direct-source alternative. Oven project commands require `Loaf.toml`, except explicit Cargo compatibility. Existing 0.5 `incan.toml` behavior is governed by the RFC 117 cutover; it is not preserved as a CLI compatibility parser.
+
+## Alternatives considered
+
+### One universal `incan` CLI
+
+Rejected. It collapses language semantics, project mutation, cache/store ownership, registry trust, and Cargo compatibility into one ambiguous command family. It would also pressure the native Incan CLI to know Cargo behavior and Oven operational internals.
+
+### A wholly independent Oven product
+
+Rejected. Oven is a core Incan capability and shares versioning, compiler service APIs, providers, receipts, and user support. Separate installation would make Rust users install two overlapping toolchains without gaining architectural independence.
+
+### Oven delegates upward to the Incan CLI
+
+Rejected. Shelling out to a CLI creates an unstable text protocol, makes planner behavior depend on presentation code, and reverses the semantic/operational authority boundary. Oven uses compiler service APIs instead.
+
+### Make Cargo compatibility implicit whenever a `Cargo.toml` exists
+
+Rejected. It would allow Cargo workspace discovery and side effects to leak into Loaf behavior. Cargo mode is an explicit command choice.
+
+## Drawbacks
+
+- Two command names introduce a learning cost, especially for users who expect a language toolchain to have one executable.
+- The native Incan CLI and the Oven CLI need consistent help, diagnostics, exit behavior, and installation reporting without duplicating implementation.
+- Some familiar words—`run`, `test`, and `inspect`—exist on both surfaces, so documentation and diagnostics must name the selected authority plainly.
+- The split requires a stable compiler service API and a stable Oven API earlier than a monolithic CLI would.
+
+## Layers affected
+
+- **Incan CLI** — must be authored in native Incan, own direct-source and semantic command behavior, and forward approved project-scale conveniences without reinterpreting Oven decisions.
+- **Oven API and operational core** — must own planning, resolver/provider choice, policy, target selection, scheduling, artifacts, receipts, caches, stores, leases, and crash-safe publication through language-neutral owned snapshots and opaque handles.
+- **Oven CLI** — must present the canonical project lifecycle surface over the Oven API. Its implementation language is non-normative; it must not become a second semantic CLI.
+- **Compiler service API** — must expose bounded compilation and semantic services to Oven without making Oven invoke or import the Incan CLI.
+- **Project execution and testing** — must make in-Loaf `incan run` and `incan test` shallow aliases over the same Oven plan, scheduler, target/carrier/profile, `*.loaf` asset, and receipt as the canonical Oven operation.
+- **Diagnostics and inspection** — must identify direct-source, Loaf/Oven, and Cargo-compatibility modes and preserve the semantic-versus-operational `inspect` boundary.
+- **Distribution and documentation** — must install and document both entry points as one versioned Incan distribution, including the explicit direct-source escape hatch.
+
+## Inspectability and tooling surface
+
+- **Artifacts and metadata:** `Loaf.toml`, `Oven.lock`, selected plan, target-bound `*.loaf` assets, execution receipt, compiler diagnostics, semantic inspection facts, codegraph records, and architect findings expose the chosen authority.
+- **Inspection commands:** `oven inspect` reports operational plan/store/receipt facts; `incan inspect`, `incan codegraph`, and `incan architect` report checked semantic facts.
+- **Diagnostics:** commands must name whether failure occurred in direct-source mode, Loaf/Oven mode, or explicit Cargo-compatibility mode, and identify the selected manifest or target where relevant.
+- **Not implicit:** neither command surface may infer Cargo behavior from an adjacent manifest, execute an action during resolution, or hide the delegation path that produced a receipt.
+
+## Unresolved questions
+
+1. Which shallow Incan-to-Oven aliases beyond the required in-Loaf `run` and `test` demonstrably improve direct language workflows without weakening the ownership boundary?
+2. Should `oven` support a single-command spelling such as `oven bake`, or retain a compatibility alias such as `oven build` for Cargo familiarity?
+3. What exact command hierarchy and output contract should `oven registry` use for registration, credentials, trust inspection, and publishing?
+4. How should global flags for JSON output, color, verbosity, profile, target, and project selection be shared while preserving each command's authority?
+5. What evidence would justify an Incan-authored Oven CLI while preserving the Rust operational-core boundary and unchanged command/receipt contract?
+
+<!-- Rename this section to "Design Decisions" once all questions have been resolved. An RFC cannot move from Draft to Planned until no unresolved questions remain. -->

--- a/workspaces/docs-site/docs/RFCs/118_incan_and_oven_command_line_surfaces.md
+++ b/workspaces/docs-site/docs/RFCs/118_incan_and_oven_command_line_surfaces.md
@@ -113,10 +113,10 @@ These commands operate on a selected Loaf or workspace closure. They discover `L
 
 The names intentionally overlap only where the underlying questions differ:
 
-| Question | Command surface | Example |
-| --- | --- | --- |
-| What declarations, types, imports, and source relationships exist? | Incan semantic inspection | `incan inspect symbols`, `incan codegraph export` |
-| What architecture or safety findings follow from checked source? | Incan analysis | `incan architect` |
+| Question                                                                                 | Command surface             | Example                                                           |
+| ---------------------------------------------------------------------------------------- | --------------------------- | ----------------------------------------------------------------- |
+| What declarations, types, imports, and source relationships exist?                       | Incan semantic inspection   | `incan inspect symbols`, `incan codegraph export`                 |
+| What architecture or safety findings follow from checked source?                         | Incan analysis              | `incan architect`                                                 |
 | Which members, providers, targets, artifacts, cache entries, and receipts were selected? | Oven operational inspection | `oven inspect plan`, `oven inspect receipt`, `oven inspect cache` |
 
 `oven inspect` must not masquerade as a semantic codegraph API, and `incan inspect` must not infer provider/cache facts from generated Rust or filesystem conventions.
@@ -134,16 +134,16 @@ Cargo compatibility is a clearly selected mode for a directory with `Cargo.toml`
 
 ### Command ownership
 
-| Domain | Canonical owner | Illustrative commands |
-| --- | --- | --- |
-| Direct source/module execution outside a Loaf, or explicitly requested direct work | `incan` | `run --direct`, `-m`, `-c`, `repl` |
-| Parsing, checking, formatting, compiler diagnostics | `incan` | `check`, `fmt` |
-| Language services and semantic products | `incan` | `lsp`, `inspect`, `codegraph`, `architect` |
-| Manifest and workspace selection | `oven` | `init`, `new`, member selection |
-| Dependency, lock, and registry lifecycle | `oven` | `add`, `remove`, `update`, `lock`, `registry`, `publish` |
-| Target, carrier, provider, and artifact lifecycle | `oven` | `plan`, `bake`, `run`, `test`, `inspect` |
-| Environments, typed actions, project mutations | `oven` | `env`, `action`, `starter`, `capability` |
-| Cargo compatibility | `oven` | `cargo` |
+| Domain                                                                             | Canonical owner | Illustrative commands                                    |
+| ---------------------------------------------------------------------------------- | --------------- | -------------------------------------------------------- |
+| Direct source/module execution outside a Loaf, or explicitly requested direct work | `incan`         | `run --direct`, `-m`, `-c`, `repl`                       |
+| Parsing, checking, formatting, compiler diagnostics                                | `incan`         | `check`, `fmt`                                           |
+| Language services and semantic products                                            | `incan`         | `lsp`, `inspect`, `codegraph`, `architect`               |
+| Manifest and workspace selection                                                   | `oven`          | `init`, `new`, member selection                          |
+| Dependency, lock, and registry lifecycle                                           | `oven`          | `add`, `remove`, `update`, `lock`, `registry`, `publish` |
+| Target, carrier, provider, and artifact lifecycle                                  | `oven`          | `plan`, `bake`, `run`, `test`, `inspect`                 |
+| Environments, typed actions, project mutations                                     | `oven`          | `env`, `action`, `starter`, `capability`                 |
+| Cargo compatibility                                                                | `oven`          | `cargo`                                                  |
 
 An operation that changes dependency resolution, registry trust, a lock, generated project state, selected toolchain/provider, target output, or execution receipt belongs to Oven even when the selected sources are entirely Incan.
 

--- a/workspaces/docs-site/docs/RFCs/119_oven_native_rust_build_facets_and_cargo_interoperation.md
+++ b/workspaces/docs-site/docs/RFCs/119_oven_native_rust_build_facets_and_cargo_interoperation.md
@@ -226,16 +226,16 @@ Oven can consume a crate from crates.io because Rust libraries are part of the w
 
 The native Rust claim is valid only for the published conformance envelope. The initial matrix must include at least:
 
-| Class | Required evidence |
-| --- | --- |
-| Pure Rust library and binary | direct `rustc` graph, feature closure, lock/offline/relocation, receipt and cache reuse |
-| Mixed Incan/Rust Loaf | cross-language dependency/linkage facts and source-mapped diagnostics |
-| Rust integration and doctests | separately selected test roles, scheduler/receipt behavior, failure diagnostics |
+| Class                         | Required evidence                                                                                  |
+| ----------------------------- | -------------------------------------------------------------------------------------------------- |
+| Pure Rust library and binary  | direct `rustc` graph, feature closure, lock/offline/relocation, receipt and cache reuse            |
+| Mixed Incan/Rust Loaf         | cross-language dependency/linkage facts and source-mapped diagnostics                              |
+| Rust integration and doctests | separately selected test roles, scheduler/receipt behavior, failure diagnostics                    |
 | Proc macro and build provider | distinct host unit, declared authority, generated-input invalidation, cross-target target consumer |
-| Native-link crate | capability/toolchain/linker facts and target-bound carrier asset |
-| Cross target | separated host/target plan, sysroot/linker identity, no host result mislabelled as target proof |
-| Cargo project | explicit `oven cargo` execution and a no-implicit-adoption diagnostic |
-| Cargo adoption | proposed Loaf contract, policy-gated write, unsupported-feature diagnostic, then Loaf-only bake |
+| Native-link crate             | capability/toolchain/linker facts and target-bound carrier asset                                   |
+| Cross target                  | separated host/target plan, sysroot/linker identity, no host result mislabelled as target proof    |
+| Cargo project                 | explicit `oven cargo` execution and a no-implicit-adoption diagnostic                              |
+| Cargo adoption                | proposed Loaf contract, policy-gated write, unsupported-feature diagnostic, then Loaf-only bake    |
 
 The matrix is a compatibility statement, not a one-time benchmark. It must run on every change that can alter resolver, provider, compiler, cache, target, or receipt behavior.
 

--- a/workspaces/docs-site/docs/RFCs/119_oven_native_rust_build_facets_and_cargo_interoperation.md
+++ b/workspaces/docs-site/docs/RFCs/119_oven_native_rust_build_facets_and_cargo_interoperation.md
@@ -1,0 +1,356 @@
+# RFC 119: Oven-native Rust build facets and Cargo interoperation
+
+- **Status:** Draft
+- **Created:** 2026-08-04
+- **Author(s):** Danny Meijer (@dannymeijer)
+- **Related:**
+    - RFC 013 (Rust crate dependencies)
+    - RFC 020 (offline, locked, and reproducible builds)
+    - RFC 034 (`incan.pub` package registry)
+    - RFC 041 (first-class Rust interop authoring)
+    - RFC 043 (Rust trait implementation from Incan)
+    - RFC 097 (Rust-hosted Incan caller)
+    - RFC 114 (compiled providers, SDK components, and package features)
+    - RFC 117 (`Loaf.toml` and Oven's language-neutral project model)
+    - RFC 118 (Incan and Oven command-line surfaces)
+    - #975 (Oven: Cargo-free Incan/Rust toolchain)
+    - #990 (governed `std.process` for Oven execution)
+    - #991 (Oven host-kernel and Incan-module bootstrap contract)
+- **Issue:** [#1012](https://github.com/encero-systems/incan/issues/1012)
+- **RFC PR:** —
+- **Written against:** v0.5
+- **Target scope:** v0.8 design and implementation planning; this is not a shipment claim.
+- **Shipped in:** —
+
+## Summary
+
+RFC 117 establishes a language-neutral Loaf project model, but it deliberately does not specify enough Rust build behavior to replace Cargo as the normal authority for an explicitly supported Rust project. This RFC defines that next layer: Oven-native Rust build facets, an Oven-owned crate graph and direct-`rustc` plan, controlled build-time providers, Rust test and IDE projections, and explicit Cargo interoperation.
+
+Oven consumes crates.io and registered Cargo-compatible sources through the typed `crate` provider contract. It does not publish Loaves or `*.loaf` assets to crates.io. `Loaf.toml` remains the sole authored project manifest, `Oven.lock` remains the resolved graph, and a bake emits immutable target-bound `*.loaf` assets plus receipts. Cargo remains runnable only through explicit Cargo-compatibility mode; an existing Cargo project must explicitly opt into Loaf adoption and is never silently merged into an Oven project.
+
+## Core model
+
+1. **A Rust facet is a Loaf facet:** a Rust-bearing Loaf declares the crate facts Oven needs to plan and invoke `rustc`; a neighbouring `Cargo.toml` never supplies ordinary Loaf authority.
+2. **Oven owns the graph:** dependency selection, feature resolution, target/host partitioning, toolchain choice, lock identity, execution plan, cache reuse, artifacts, and receipts belong to Oven.
+3. **Crates.io is consumption-only:** typed `crate` dependencies default to crates.io and may use registered compatible sources. Publishing remains in Incan's registry ecosystem.
+4. **Cargo manifests are provider metadata only when explicitly selected:** a registry crate's `Cargo.toml` can be parsed by the selected crate provider as constrained source metadata. It cannot define a Loaf workspace, lock, registry trust, lifecycle action, project target policy, or publication identity.
+5. **Build-time code is typed work:** build scripts and procedural macros are host-side providers with declared authority, inputs, outputs, toolchain identity, target/host role, policy decision, and receipt facts. Their existence never grants execution authority.
+6. **Host and target are different build domains:** build scripts, procedural macros, and compiler plugins execute for the build host; libraries, binaries, test subjects, and carriers are compiled for the selected target. Oven plans and locks both domains separately.
+7. **Rust test work is first-class:** unit tests, integration tests, doctests, examples, and benchmarks are explicit build/run roles, not side effects of a generic `rustc` invocation.
+8. **IDE projection is derived:** Oven may emit a Rust-analyzer-compatible project projection from the selected plan. It does not create or require a synthetic authoritative `Cargo.toml`.
+9. **Cargo is an explicit interoperation boundary:** `oven cargo ...` invokes Cargo as Cargo-authoritative compatibility mode. Explicit adoption may import selected facts into a new `Loaf.toml`, but no directory with both manifests receives mixed semantics.
+10. **The Rust core remains narrow but real:** as decided by RFC 118, Oven's operational core/API owns planning, resolution, policy, stores, leases, provider execution, and crash-safe publication in Rust. Its public API is language-neutral and does not leak Rust borrows.
+11. **Incan-first authoring remains policy:** a Rust facet makes Rust projects and explicitly justified mixed work supportable. It does not authorize new Rust in Incan products without a demonstrated limitation and tracked removal path.
+12. **Native compatibility is proved, not implied:** the supported Rust envelope is defined by an executable conformance corpus. Unsupported Cargo behavior produces a precise diagnostic or requires explicit Cargo mode.
+
+## Motivation
+
+RFC 117 makes an Oven-native Rust project architecturally possible: it has an authored manifest, a typed dependency graph, provider trust, target policy, lock identity, receipts, and an explicit boundary around Cargo. That is necessary but not sufficient. A Rust source file alone does not identify a complete compilation unit, determine which dependencies compile for the build host versus the final target, express crate features, control native linking, or explain test and documentation artifacts.
+
+Cargo is valuable because it solves those practical concerns for a large Rust ecosystem. But it is not a sufficient authority for a project that includes Incan sources, checked interop, target carriers, governed actions, receipts, persistent stores, and Incan package publication. Oven should not hide Cargo under a different command name; it must own its build graph and make any Cargo interoperation explicit.
+
+The right v0.8 objective is therefore neither “emulate every Cargo behavior” nor “rewrite Rust as Incan.” It is a bounded native-Rust contract that builds serious selected Rust Loaves, consumes the ordinary crate ecosystem, produces target-bound `*.loaf` assets, and makes its limits inspectable. Cargo remains available for compatibility while that envelope expands through evidence.
+
+## Goals
+
+- Specify the full Rust facet needed to bake an Oven-native Rust Loaf without using project Cargo metadata as authority.
+- Resolve `crate` dependencies from crates.io or registered compatible sources into the same `Oven.lock` and receipt model as Loaf and capability dependencies.
+- Specify deterministic Rust feature resolution, dependency roles, source checksums, target conditions, toolchain selection, and host-versus-target build units.
+- Support an explicitly bounded and inspectable path for Rust build scripts, procedural macros, native linking, generated Rust inputs, and linker/sysroot selection.
+- Specify first-class roles for Rust libraries, binaries, integration tests, unit tests, examples, doctests, benchmarks, and caller projections.
+- Produce `*.loaf` assets and receipts whose identities cover the complete Rust compilation and provider closure.
+- Define a Rust-analyzer-compatible derived project projection without restoring Cargo manifest authority.
+- Preserve explicit `oven cargo ...` behavior for Cargo projects and define a deliberate adoption boundary for projects choosing to become Loaves.
+- Establish a conformance corpus that identifies the supported native Rust envelope and guards Cargo-free regressions.
+
+## Non-Goals
+
+- Publishing Oven-native Loaves, `*.loaf` assets, or normal Oven packages to crates.io.
+- Making `Cargo.toml`, `Cargo.lock`, Cargo workspace discovery, Cargo build profiles, or arbitrary Cargo command behavior part of ordinary Loaf semantics.
+- Supporting every Cargo crate on day one, or claiming compatibility from source discovery alone.
+- Implicitly importing, merging, or executing a neighbouring Cargo project after `Loaf.toml` exists.
+- Defining the `*.loaf` archive/wire format, Incan registry transport protocol, or whether `bakery.io` becomes an Incan registry endpoint or alias.
+- Redefining RFC 097's Rust-host caller ABI, RFC 116's C ABI safety contract, RFC 117's project authority, or RFC 118's command ownership.
+- Moving Oven's operational core/API into Incan. RFC 118's justified Rust exception remains in force.
+
+## Guide-level explanation
+
+### An Oven-native Rust Loaf
+
+An explicitly Rust-authored project adopts Oven by authoring `Loaf.toml`, not by placing Cargo configuration beside Rust sources and hoping it is inferred:
+
+```toml
+[project]
+name = "telemetry-engine"
+version = "0.8.0"
+
+[[rust.crates]]
+name = "telemetry_engine"
+root = "src/lib.rs"
+edition = "2024"
+crate-types = ["rlib", "cdylib"]
+
+[[rust.binaries]]
+name = "telemetry"
+root = "src/bin/telemetry.rs"
+edition = "2024"
+requires-features = ["cli"]
+
+[dependencies]
+serde = { crate = "serde", version = "1", features = ["derive"] }
+tokio = { crate = "tokio", version = "1", features = ["rt-multi-thread", "macros"] }
+```
+
+This syntax is illustrative of the RFC's intended information model. The essential contract is that Oven can identify every compiled crate, its root, edition, crate types, entry point, enabled features, and dependency/linkage closure without reading a project `Cargo.toml`. A simple single-library project may use RFC 119's conventional defaults; multiple roots or any nondefault identity must be explicit.
+
+The `crate` dependencies are ordinary Rust ecosystem inputs. They default to crates.io, but Oven records their canonical source, checksum, signatures or trust facts where available, selected feature closure, and host/target use in `Oven.lock`. The project's publication identity remains an Incan registry identity; `oven publish` does not mean `cargo publish`.
+
+### Build-time work is visible before it runs
+
+Suppose `native-sys` requires code generation and native linking. Its `build.rs` does not execute simply because the file exists. Oven's selected crate provider declares a build-time provider and exposes a plan like:
+
+```text
+host provider: native-sys build script
+  inputs: native-sys source digest, declared headers, selected compiler, allowed environment keys
+  outputs: generated bindings, link search paths, link libraries, cfg facts
+  effects: execute host helper, read declared inputs, write provider staging area
+
+target Rust crate: native-sys
+  target: aarch64-linux-android
+  consumes: locked generated bindings and normalized link facts
+```
+
+The provider's host executable, argument vector, allowed environment, observed directives, generated-output digests, and policy result enter the receipt. Unsupported or undeclared behavior fails with a provider diagnostic; Oven does not silently retry through Cargo.
+
+Procedural macros follow the same split. Oven compiles and loads the macro for the build host, records its source/toolchain/feature identity, and uses its expansion only in the locked build unit that requested it. The target crate never treats the host macro binary as a target artifact.
+
+### Rust testing, documentation, and IDEs
+
+Rust work has explicit roles:
+
+```text
+oven test --rust unit
+oven test --rust integration
+oven test --rust doc
+oven bake --example telemetry-smoke
+oven bench --rust parser
+```
+
+The exact command spelling remains RFC 118 territory. The roles do not: an integration test is a separate target-linked test crate; a doctest is a compiled test input with a source origin; an example and a benchmark are named build units. Each can be selected, planned, cached, and receipted independently.
+
+For editor support, Oven may materialize a derived `rust-project.json`-style projection from the selected Rust graph. That projection identifies the same roots, crate dependencies, cfg facts, features, build-data outputs, and target configuration used by the plan. It is generated state, not a second authored manifest.
+
+### Cargo remains available, but never ambiguous
+
+There are three intentionally distinct routes:
+
+```text
+oven cargo test
+  Cargo compatibility mode: Cargo.toml is authoritative.
+
+oven adopt cargo --manifest ./Cargo.toml
+  Explicit adoption: inspect/import selected source facts, write or propose Loaf.toml,
+  then make future Oven operations Loaf-authoritative.
+
+oven bake
+  Oven-native mode: Loaf.toml and Oven.lock are authoritative; Cargo files are ignored.
+```
+
+`oven adopt cargo` is illustrative command spelling. The important rule is explicit re-authoring: a user chooses to cross the boundary, sees the proposed Loaf contract and unsupported Cargo behavior, and accepts the resulting project state. Oven does not treat every checked-out `Cargo.toml` as a latent Loaf.
+
+### Publishing and consuming
+
+Oven-native packages publish to Incan's registry ecosystem. The configured public endpoint may eventually be branded `bakery.io`, but registry identity and trust remain explicit Oven configuration rather than a hard-coded domain in `Loaf.toml`.
+
+Oven can consume a crate from crates.io because Rust libraries are part of the world it interoperates with. That is not reciprocal authority: an Oven-native package is not automatically a crates.io package. If a future product needs a Cargo-consumable publication projection, it must be a separately specified bridge with explicit provenance to a selected `*.loaf` asset.
+
+## Reference-level explanation
+
+### Rust facet identity and discovery
+
+1. A Loaf that selects a Rust facet must resolve every compiled Rust unit before execution. A unit has a crate name, package identity, root, edition, role, crate type or target kind, enabled feature set, target condition, dependency/linkage closure, and source digest.
+2. A conventional single library root may default to `src/lib.rs`; a conventional single binary may default to `src/main.rs`. The derived crate name follows the project name only when that mapping is unambiguous. All other roots and identities must be explicitly declared.
+3. Libraries, binaries, integration tests, examples, doctests, benchmarks, build scripts, procedural macros, generated sources, and caller projections have distinct roles. A role determines its compilation mode, host/target domain, artifact kind, test scheduling, and receipt contribution.
+4. The Rust facet may use `cfg`-style target conditions only as explicit, normalized predicates over the selected target and build host. Ambient host probing must not silently add a source or feature.
+5. Project public features remain RFC 114 Loaf capabilities. A Rust-provider feature is requested through the typed `crate` dependency and affects a Rust unit only through an explicit mapping; it never becomes a public Loaf feature by name coincidence.
+
+### Crate providers and feature resolution
+
+1. A `crate` dependency defaults to crates.io. A registered compatible source may override that origin only through RFC 117 registry configuration and workspace trust policy.
+2. A selected crate provider may read the crate package's `Cargo.toml` as constrained provider metadata after the typed `crate` dependency and source have already been selected. It may use only the metadata required to understand that dependency package's Rust units, dependency requirements, feature declarations, target conditions, build-time code, and native-link facts.
+3. A provider Cargo manifest must not establish workspace membership outside the package, alter a Loaf registry or trust policy, introduce a second lock, change a Loaf target/delivery policy, run an undeclared lifecycle operation, or publish a Loaf.
+4. Oven resolves a deterministic feature closure over selected crate provider requirements. The lock records requested and selected features for every host and target unit. Development-only and test-only requirements do not enter a release artifact closure unless a declared role requires them.
+5. `Oven.lock` records the provider's canonical source, immutable package identity, checksum or content digest, selected Rust metadata subset, feature closure, target predicates, transitive provider graph, and observed trust facts. It does not copy a `Cargo.lock` as Oven authority.
+6. An unsupported provider manifest construct must identify the dependency, field, source span when available, and the available choices: a supported provider, an explicit adaptation declaration, or Cargo compatibility mode.
+
+### Direct Rust compilation and artifact identity
+
+1. Oven invokes the selected Rust compiler through its controlled Rust operational core/API; Cargo is not a subprocess in an Oven-native bake.
+2. Each compile unit is keyed by the compiler/toolchain identity, normalized command inputs, source digests, dependency artifact identities, selected features, cfg facts, build host, target, profile, generated inputs, native-link facts, and provider receipts.
+3. Host units and target units are distinct graph nodes. A build script, procedural macro, or compiler plugin is always a host node even when it was selected by a target crate.
+4. A profile is an Oven target policy that maps to normalized compiler/codegen/link options. Cargo profile inheritance is not read; any Cargo-compatible translation is only part of explicit adoption or Cargo mode.
+5. A completed bake emits one or more target-bound `*.loaf` assets according to the selected Rust roles and carriers. Every asset identifies the selected Loaf/facet, target, carrier, profile, graph digest, payload digest, relevant provider receipts, and final execution receipt.
+
+### Build scripts, procedural macros, and generated inputs
+
+1. `build.rs` is never automatically executed in a Loaf. A build-script provider must declare its source identity, build host, executable/toolchain requirements, allowed environment keys, declared input classes, output schema, capability/effect policy, and expected directive vocabulary.
+2. Oven runs an approved build-script provider in an isolated staging area. It captures its arguments, allowed environment values or redacted identities, outputs, normalized directives, generated-input digests, filesystem/network/process effects, and exit status in a provider receipt.
+3. The initial supported directive vocabulary must be explicit. It includes only directives Oven can normalize into plan facts—such as rerun inputs, generated source locations, cfg facts, link search paths, link libraries, link arguments, and controlled environment outputs. Unknown directives are errors, not opaque passthroughs.
+4. A procedural macro is a host compiler-time provider. Oven locks its host crate closure, compiler identity, dynamic-loading policy, expansion inputs, and diagnostics identity separately from target artifacts.
+5. Providers may not smuggle arbitrary network, filesystem, compiler, linker, or environment discovery into the target bake. Any expanded authority must be declared, policy-approved, and receipt-visible.
+6. A generated source participates only through an identified provider output. A change to its producing receipt or digest invalidates the dependent unit; a cache hit must identify the provider receipt it reused.
+
+### Native linkage, carriers, and cross compilation
+
+1. A Rust unit's native library, framework, system SDK, C ABI shim, linker, and sysroot requirements are typed capability/provider facts under RFCs 116 and 117. They are never inferred from an unrecorded local linker search path.
+2. Cross compilation selects a build host and target separately. The plan must report both, the toolchain/sysroot/linker identities, selected capability providers, and any provider node that executes for the host.
+3. Target artifacts are assigned to an explicit carrier. A Rust library, executable, `cdylib`, Rust-host caller projection, JNI library, Python carrier, or C ABI carrier can be selected only when the target and provider contracts permit it.
+4. The receipt distinguishes compile, link, package, test, and deployment facts so a successful host test cannot be mistaken for a target bake or device proof.
+
+### Rust test, documentation, and IDE projections
+
+1. Unit tests compile with their owning crate. Integration tests, examples, doctests, and benchmarks are distinct named units with declared source origins and dependency roles.
+2. Test execution uses Oven's scheduler, selected environment, capability policy, target selection, output retention, and receipt model. It must not silently dispatch to `cargo test` in Loaf mode.
+3. A doctest extraction or documentation generator must record its source spans, generated test inputs, compiler/provider facts, and diagnostics mapping. Generated Rust remains inspectable but is not the public source of truth.
+4. A Rust-analyzer-compatible projection is derived from the selected Oven graph and may be invalidated with the same receipt-bound facts. It must not require a Cargo workspace or invent a Cargo lock as editor authority.
+
+### Cargo compatibility and explicit adoption
+
+1. `oven cargo ...` is an explicit compatibility operation for a directory with `Cargo.toml` and no `Loaf.toml`. Cargo remains authoritative for its manifest, lock, build scripts, procedural macros, profiles, workspace discovery, and side effects. Oven records that it ran Cargo mode and may retain a wrapper receipt; it does not reinterpret Cargo results as an Oven-native lock.
+2. A directory that contains `Loaf.toml` is always a Loaf project for normal Oven operations. A neighbouring Cargo manifest is diagnosed and ignored.
+3. Adoption is an explicit user-requested transformation. It may parse Cargo metadata as input, propose a `Loaf.toml`, enumerate unsupported or policy-sensitive behavior, and write project state only after the mutation/policy rules of RFC 076 approve it.
+4. Adoption must never leave an implicit mixed state. Once a user accepts the Loaf contract, future Oven-native operations use `Loaf.toml` and `Oven.lock`; continuing to run Cargo requires an explicit Cargo operation.
+5. Cargo-compatible caller packages remain RFC 097 interoperability projections. They may consume selected outputs, but must not cause Cargo to resolve, compile, or select the Incan implementation graph.
+
+### Supported-envelope conformance
+
+The native Rust claim is valid only for the published conformance envelope. The initial matrix must include at least:
+
+| Class | Required evidence |
+| --- | --- |
+| Pure Rust library and binary | direct `rustc` graph, feature closure, lock/offline/relocation, receipt and cache reuse |
+| Mixed Incan/Rust Loaf | cross-language dependency/linkage facts and source-mapped diagnostics |
+| Rust integration and doctests | separately selected test roles, scheduler/receipt behavior, failure diagnostics |
+| Proc macro and build provider | distinct host unit, declared authority, generated-input invalidation, cross-target target consumer |
+| Native-link crate | capability/toolchain/linker facts and target-bound carrier asset |
+| Cross target | separated host/target plan, sysroot/linker identity, no host result mislabelled as target proof |
+| Cargo project | explicit `oven cargo` execution and a no-implicit-adoption diagnostic |
+| Cargo adoption | proposed Loaf contract, policy-gated write, unsupported-feature diagnostic, then Loaf-only bake |
+
+The matrix is a compatibility statement, not a one-time benchmark. It must run on every change that can alter resolver, provider, compiler, cache, target, or receipt behavior.
+
+## Design details
+
+### Relationship to RFC 117
+
+RFC 117 owns one manifest authority, one typed dependency graph, target policy, registry trust, `Oven.lock`, `*.loaf` identity, and the rule that a discovered Cargo file is ignored in Loaf mode. This RFC supplies the detailed Rust planner and provider contract that RFC 117 intentionally leaves open. It does not create a second Rust manifest or make a Rust facet an exception to workspace authority.
+
+The illustrative `[rust]` tables in this RFC are source-facet data within `Loaf.toml`, not a return to one manifest per implementation language. Incan and foreign sources remain convention-first or use their own explicit facets where required.
+
+### Relationship to RFC 118
+
+RFC 118 owns command ownership. This RFC defines what the Rust-oriented project operations mean once selected:
+
+- `oven bake`, `oven test`, inspection, lock, registry, and publication are Oven operations;
+- `incan run` and `incan test` inside a Loaf remain shallow delegates to the same Oven plan and receipt;
+- `oven cargo ...` is the only ordinary path that invokes Cargo; and
+- any `oven adopt cargo` spelling remains a user-visible, policy-gated mutation rather than an implicit discovery behavior.
+
+### Relationship to RFC 097
+
+RFC 097 defines a Rust-host caller facet and its stable ABI/package metadata. RFC 119 supplies the native-Rust build graph that can compile a caller projection, but does not make Cargo a dependency of the Incan implementation graph or expose generated implementation Rust as the caller contract.
+
+### Publication authority
+
+An Oven-native package's publication identity is a Loaf registry identity. `incan.pub` is the current default; a future `bakery.io` endpoint or alias must be registered and trusted through Oven configuration. Crates.io is a Rust crate source, not an Oven-native publish target.
+
+## Alternatives considered
+
+### Keep Cargo as the hidden Oven backend
+
+Rejected. It would leave build planning, invalidation, feature selection, build-time effects, target identity, and diagnostics under Cargo's opaque authority while presenting Oven as if it owned them.
+
+### Implement all Cargo behavior before supporting Rust Loaves
+
+Rejected. Cargo has a large historical compatibility surface. Oven should publish a growing explicit conformance envelope instead of promising undocumented parity or delaying useful native support indefinitely.
+
+### Refuse crates.io inputs
+
+Rejected. Rust crates, SemVer requirements, target triples, compiler artifacts, and registry packages are part of the ecosystem Oven must interoperate with. Refusing them would create an isolated package universe rather than a better build authority.
+
+### Publish Oven-native packages to crates.io
+
+Rejected. It would make Cargo's package format and release lifecycle a public authority over Loaves. Rust-host interoperability can use explicit projections without turning crates.io into Oven's publication system.
+
+### Treat every Cargo project as an adoptable Loaf automatically
+
+Rejected. It would revive implicit Cargo semantics, surprise build-script/proc-macro effects, and make support obligations unbounded. Adoption must be explicit, reviewed, and policy-gated.
+
+## Drawbacks
+
+- The Rust facet and direct compiler planner are substantial engineering work; Cargo currently hides much of this complexity.
+- Provider-mediated build scripts and procedural macros need sandboxing, receipt storage, and a practical support policy.
+- A bounded compatibility matrix will reject some ordinary Cargo packages until their behavior gains an explicit provider model.
+- Maintaining a Rust-analyzer projection and source-mapped diagnostics is additional tooling work.
+- A different publication authority means Cargo-native consumption of an Oven package remains an explicit interoperability problem, not a default workflow.
+
+## Layers affected
+
+- **Loaf manifest and validation** — must validate Rust facet identities, roles, crate roots, editions, crate types, feature mappings, target predicates, and adoption proposals.
+- **Resolver and registries** — must resolve crate providers, constrained provider metadata, deterministic feature closures, trust/integrity facts, and host/target partitions into `Oven.lock`.
+- **Rust operational core/API** — must plan direct `rustc` units, toolchains, sysroots, linkers, provider execution, artifacts, receipts, stores, leases, and recovery without Cargo in native mode.
+- **Provider and policy engine** — must declare, approve, execute, cache, invalidate, and inspect build scripts, procedural macros, generated inputs, native-link facts, and effect receipts.
+- **Compiler service API and diagnostics** — must expose Rust/compiled-source diagnostics and source maps without making Oven invoke the Incan CLI or generated Rust the public contract.
+- **Test, docs, and IDE tooling** — must model Rust test/documentation roles, scheduler facts, outputs, and derived Rust-analyzer-compatible project metadata.
+- **CLI and project mutation** — must expose canonical Oven operations and explicit Cargo/adoption modes according to RFCs 076 and 118.
+- **Registry and publication tooling** — must publish Loaf artifacts only to registered Incan registry identities and prevent accidental crates.io publication.
+
+## Inspectability and tooling surface
+
+- **Manifest and lock:** inspection reports the selected Rust facet, crate roles, conventional defaults or explicit declarations, provider origins, feature closure, host/target partition, and normalized toolchain/linker facts.
+- **Plan:** before execution, Oven shows every Rust compile unit, build-time provider, declared/allowed effect, selected target/carrier/profile, and expected `*.loaf` asset/receipt.
+- **Artifacts and receipts:** each `*.loaf` asset exposes its facet, graph digest, payload digest, target, carrier, profile, provider receipts, and final bake receipt.
+- **Diagnostics:** invalid roots, unsupported provider metadata, build-script directives, proc-macro behavior, feature conflicts, source/target incompatibility, Cargo coexistence, and failed adoption name the affected source/dependency and the relevant explicit alternative.
+- **IDE:** the derived Rust project projection identifies the Oven plan and receipt from which it was created; it is not edited as authority.
+- **Not implicit:** no Cargo project discovery, Cargo lock reuse, build-script execution, proc-macro execution, native linker search path, registry registration, or crates.io publication occurs merely because a file or dependency exists.
+
+## Implementation plan
+
+### Phase 1: Rust facet and crate-provider graph
+
+- Settle the Rust-facet TOML grammar and conventional-default rules.
+- Resolve crates.io and registered crate providers into the typed Oven graph with source/trust/feature/target identities.
+- Produce a direct-`rustc` proof for a library and binary with locked/offline/relocation receipts.
+
+### Phase 2: Roles, linkage, and target artifacts
+
+- Add explicit test, example, benchmark, doctest, caller-projection, carrier, native-link, linker, and sysroot roles.
+- Prove host and cross-target planning with target-bound `*.loaf` assets and carrier-aware receipts.
+
+### Phase 3: Controlled build-time providers
+
+- Implement the initial build-script directive vocabulary, provider isolation, policy gate, output capture, and invalidation rules.
+- Add procedural-macro host providers and source-mapped diagnostics.
+- Extend the conformance corpus with generated-input, native-link, and cross-target cases.
+
+### Phase 4: IDE and Cargo interoperation
+
+- Materialize the derived Rust-analyzer project projection.
+- Implement explicit Cargo compatibility receipts and policy-gated adoption proposals.
+- Prove that normal Loaf execution never falls back to Cargo.
+
+### Phase 5: Release gate
+
+- Publish the supported native-Rust conformance envelope and run it as a release gate.
+- Keep unsupported behavior diagnostic and route only explicit compatibility invocations through Cargo.
+
+## Unresolved questions
+
+1. What exact `Loaf.toml` grammar best expresses multiple Rust crates, test/documentation roles, crate types, feature mappings, and target predicates without reproducing Cargo's manifest surface wholesale?
+2. Which build-script directive vocabulary is sufficient for the first native envelope, and which directives require a dedicated typed provider rather than controlled execution?
+3. What dynamic-loading/process isolation model is required for procedural macros across supported build hosts?
+4. Which Rust-analyzer project-projection fields are necessary for a useful editor experience without depending on Cargo workspace metadata?
+5. What evidence should promote a crate/provider class from Cargo-only compatibility to Oven-native support?
+6. If a public “Bakery” registry endpoint is introduced, should it be an alias of the current Incan registry identity or a separately registered registry kind?
+
+<!-- Rename this section to "Design Decisions" once all questions have been resolved. An RFC cannot move from Draft to Planned until no unresolved questions remain. -->


### PR DESCRIPTION
## Summary

Documents the prospective Loaf/Oven project model and aligns the active RFC set around it. This PR introduces RFCs 117–119 and updates their open predecessors so implementation can proceed against one coherent north-star contract.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [x] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: no runtime behavior changes. The RFCs define the intended future `Loaf.toml` authoring model, `Oven.lock` resolved graph, `.loaf` verified asset, and Incan/Oven command boundaries.
- **Internals**: RFC 117 defines the project, dependency, workspace, interop, and registry model; RFC 118 defines CLI ownership; RFC 119 defines the north-star Rust-facet and explicit Cargo-interoperation contract. Active predecessor RFCs are aligned without modifying closed historical RFCs.
- **Risks**: these specifications intentionally affect future implementation decisions. The change does not activate `Loaf.toml`, alter current Cargo behavior, or modify the compiler/runtime.

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `make -C workspaces/docs-site docs-build`
- `git diff --check origin/main...HEAD`
- Reviewed the 13 RFC files changed against their linked tracking issues.

No product test suite was run because this PR changes RFC documentation only.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- RFC 117: Loaf.toml and Oven project model — #1009
- RFC 118: Incan and Oven command-line surfaces — #1010
- RFC 119: Oven-native Rust build facets and Cargo interoperation — #1012
- Related post-v0.5 C ABI transition — #1008
- Related Cargo-free delivery roadmap — #975

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions
