### PR TITLE
chore - clarify AI execution and contract evidence

### DIFF
--- a/workspaces/docs-site/docs/RFCs/080_ai_assets_models_prompts_evals_and_agent_metadata.md
+++ b/workspaces/docs-site/docs/RFCs/080_ai_assets_models_prompts_evals_and_agent_metadata.md
@@ -10,6 +10,7 @@
     - RFC 076 (project mutation policy and recovery)
     - RFC 078 (tool execution and typed workflow actions)
     - RFC 079 (`incan.pub` artifact graph)
+    - RFC 104 (ambient runtime capabilities and receipts)
 - **Issue:** https://github.com/encero-systems/incan/issues/408
 - **RFC PR:** —
 - **Written against:** v0.3
@@ -45,6 +46,7 @@ Hugging Face demonstrates the value of metadata-rich model and dataset cards. Ol
 - Require prompt templates, system messages, and agent guidance to be inspectable and provenance-aware.
 - Define how AI assets connect to capabilities, actions, policies, and the `incan.pub` artifact graph.
 - Define evaluation metadata so AI-backed capabilities can declare quality and regression checks.
+- Distinguish a declared model asset from a captured execution profile and measured execution observation.
 - Leave room for multiple model providers and local runtimes without hardcoding one AI platform.
 
 ## Non-Goals
@@ -140,6 +142,16 @@ Model assets should include:
 - privacy and data-retention labels when remote execution is involved
 - intended use and limitations
 
+### Model execution profiles
+
+A model asset declaration identifies what a capability may use. It does not establish that a particular runtime, device, or provider can execute that asset, nor does it make a universal quality, latency, privacy, or compatibility claim. Those are separate versioned execution-profile and execution-observation records.
+
+An execution profile should identify the model asset and immutable source or artifact identity it evaluated, plus the runtime engine and version, local or remote execution class, device and operating-environment facts that materially affect compatibility, configured context and batching limits, quantization or adapter configuration when applicable, and declared data-handling constraints. It must not contain credentials, raw prompts, raw user data, or endpoint secrets.
+
+An execution observation should additionally identify its workload or eval suite, environment scope, measurement method, warm or cold state where relevant, result status, and any measured latency, throughput, memory, failure, fallback, or quality value. Measurements are scoped observations, not portable properties of the model. Tooling must show a missing, incompatible, stale, or non-comparable profile as such instead of borrowing a nearby model or device record.
+
+Model selection may use declared compatibility requirements and available execution profiles, but its result must preserve the selected asset and profile identities, rejected alternatives when they materially affected the decision, and any fallback. Non-interactive execution must not silently replace a pinned local asset with a remote provider, a different model revision, a different quantization, or a weaker data-handling profile. This RFC defines descriptive selection provenance only; it does not grant an agent authority to invoke a model, select a tool, or perform another effect.
+
 ### Prompt and system metadata
 
 Prompt templates and system messages must be inspectable artifacts. They should include:
@@ -164,6 +176,7 @@ Eval assets should include:
 - eval kind such as golden, benchmark, safety, regression, human-review, or policy-check
 - dataset reference
 - target model, prompt, capability, or action
+- execution-profile or environment constraint when the result depends on one
 - metric names and expected thresholds when applicable
 - local or remote execution requirement
 - privacy labels for data used during evaluation
@@ -192,6 +205,7 @@ AI assets should record enough provenance to reproduce or explain behavior:
 - dataset hash or version
 - eval suite version
 - runtime version when available
+- selected execution-profile identity and scoped execution-observation identities when an action actually ran
 - parameter values such as temperature, context length, seed, or embedding dimensions when relevant
 
 If an AI action affects project files, generated artifacts, or diagnostics, the action output should reference the AI asset provenance used.
@@ -210,6 +224,7 @@ RFC 076 policy may restrict:
 - agent tool permissions
 - project mutation by AI-backed actions
 - use of unpinned or unknown model versions
+- execution profiles or fallback paths that violate declared locality, data-handling, or compatibility constraints
 
 Policy outcomes must be visible in machine-readable action and asset inspection.
 
@@ -222,6 +237,10 @@ Capabilities may declare AI assets when the capability needs a model, prompt, ev
 ### Relationship to RFC 078
 
 AI-backed operations should be exposed as typed actions. Evaluation, embedding generation, prompt validation, model conversion, and agent workflows are action kinds or action providers subject to policy.
+
+### Relationship to RFC 104
+
+RFC 104 owns ambient runtime capabilities and their run receipts. This RFC's model execution profiles describe asset compatibility and observed inference conditions; they do not grant a process a runtime capability, authorize model invocation, or replace RFC 104's effect and receipt boundary. An action that runs a model must satisfy both the selected profile's declared constraints and the applicable runtime capability and policy contract.
 
 ### Relationship to RFC 079
 
@@ -268,6 +287,7 @@ This RFC should not block the lifecycle core. AI asset metadata becomes useful a
 - **Manifest schema / configuration validation:** packages and projects need AI asset metadata for models, prompts, evals, datasets, and agent guidance.
 - **CLI / tooling:** lifecycle tooling needs AI asset inspection, status, provenance, and policy evaluation.
 - **Action execution:** RFC 078 actions need AI-backed execution modes and risk categories.
+- **Execution profiles and observations:** tooling must keep declared model assets, selected execution profiles, and measured observations distinct, versioned, and scope-aware.
 - **Package and catalog integration:** `incan.pub` should index AI assets as artifact graph nodes with cards and relationships.
 - **LSP / IDE tooling:** editor tooling may surface AI capabilities, prompts, evals, and policy warnings.
 - **Agentic tooling:** agents may consume asset metadata but must respect policy and explicit user approval.
@@ -283,6 +303,7 @@ This RFC should not block the lifecycle core. AI asset metadata becomes useful a
 - What privacy labels are required before remote AI actions can be considered safe enough to standardize?
 - Should model downloads be handled by `incan tool`, `incan pub`, provider-specific CLIs, or a future AI runtime command?
 - How should agent guidance reference skills without becoming an agent marketplace spec?
+- Which execution-profile fields and measurement methods are required before an observation can support a compatibility, fallback, or performance decision?
 
 <!-- Rename this section to "Design Decisions" once all questions have been resolved.
      An RFC cannot move from Draft to Planned until no unresolved questions remain. -->

--- a/workspaces/docs-site/docs/RFCs/111_proof_aware_agentic_contract_feedback.md
+++ b/workspaces/docs-site/docs/RFCs/111_proof_aware_agentic_contract_feedback.md
@@ -33,6 +33,7 @@ This RFC defines proof-aware contracts for Incan: a source-level contract surfac
 8. **The graph carries repair context:** RFC 106 is the delivery substrate for contract declarations, generated obligations, outcomes, counterexamples, runtime checks, and proof receipts so agents receive targeted repair context.
 9. **Proof is bounded:** Incan proves a clearly defined subset and records assumptions; it must not claim full program correctness beyond the authored contracts and supported reasoning fragment.
 10. **Trust is inspectable:** every proof result must record enough provenance for tools to distinguish compiler-local checks, solver-backed checks, runtime checks, cached results, unsupported fragments, and degraded work-in-progress output.
+11. **Contract authority and proof scope are explicit:** source presence, a passing verification result, and a project approval are distinct facts. A proof establishes only the named formal obligation under recorded assumptions; it does not establish business correctness, operational suitability, or human approval.
 
 ## Motivation
 
@@ -55,6 +56,7 @@ This also keeps Incan honest about correctness. A spec can be wrong, incomplete,
 - Define when proved obligations may allow a generated runtime check to be skipped because proof made it unnecessary, and require visible proof or verification receipts for that skipped-check decision.
 - Define how unproved obligations remain protected by runtime checks when runtime enforcement is sound and configured.
 - Define RFC 106 graph fact families for contracts, obligations, outcomes, counterexamples, runtime checks, and verification receipts.
+- Preserve contract declaration identity, origin, review or approval status when a project supplies it, and the exact scope of every verification result without treating any one of those facts as another.
 - Keep the Rust backend as the ordinary emission target while making proof facts backend-independent where possible.
 - Learn from Ada/SPARK-like systems, Dafny, F*, Why3, and ACSL while preserving Incan's Python-like authoring surface and agent-native tooling model.
 
@@ -67,6 +69,7 @@ This also keeps Incan honest about correctness. A spec can be wrong, incomplete,
 - This RFC does not require a particular SMT solver, theorem prover, storage engine, MCP server, or hosted verification service.
 - This RFC does not claim that all Incan programs become formally verified.
 - This RFC does not prove correctness of specifications themselves.
+- This RFC does not infer that a source contract was human-approved, policy-approved, complete, suitable for a particular business purpose, or true about the external world merely because it parsed or was proved.
 - This RFC does not remove runtime validation from validated newtypes, model constructors, or library contracts unless a matching proof result and configuration justify skipping the redundant generated check.
 - This RFC does not define every possible contract predicate in the first release.
 - This RFC does not make agent output correct by default; it makes agent output more mechanically checkable against human-authored contracts.
@@ -198,6 +201,12 @@ Contract declarations must be typechecked before they produce verification oblig
 
 An `assert` statement is not a contract declaration under this RFC. It retains RFC 018's always-on runtime assertion semantics: it checks an implementation fact at a specific program point, may produce a local verification obligation, and may become a fact available to later obligations only after that assertion is itself checked, proved, or runtime-protected. An implementation-local `assert` must not be exported as a caller-visible precondition or postcondition unless the source also declares `requires` or `ensures`.
 
+### Contract provenance and approval boundary
+
+Every contract declaration must have a stable declaration identity, source anchor, and source revision or digest suitable for its checked metadata and RFC 106 graph facts. The compiler may record a declaration origin such as source-authored, generated, imported through a checked interface, or agent-proposed when that fact is available. It must not infer a human author, reviewer, approver, or business owner from source presence, a commit identity, a passing check, or a provider result.
+
+A project may attach an explicit review or approval record through a trusted project-policy or checked-metadata boundary. That record must identify the exact contract declaration or immutable contract set, the applicable policy, its scope, and its revision. Approval metadata is not part of logical proof and must not change whether an obligation is `proved`, `violated`, `unknown`, `unsupported`, or `runtime_enforced`. Conversely, a proof result must not upgrade an unreviewed contract to approved. Agent-generated contract text must remain distinguishable from an explicit approved declaration until the project records a separate approval.
+
 ### Verification obligations
 
 A verification obligation is a compiler-generated question derived from checked source semantics and contract declarations. The compiler must generate obligations for at least:
@@ -223,6 +232,10 @@ Every obligation must receive one of these outcomes:
 - `runtime_enforced`: the obligation is not statically proved, but generated code or an existing validated construction path enforces the same property at runtime.
 
 `runtime_enforced` may be reported alongside `unknown` or `unsupported` in detailed tooling, but user-facing summaries must make the fallback explicit. A build must not silently present an unproved runtime-enforced obligation as `proved`.
+
+### Scope of proof
+
+Every verification result must identify the exact contract declaration or obligation, checked source and semantic revision, verification provider and configuration, material assumptions, supported-fragment version, and runtime-enforcement or skipped-check status. A result classified as `proved` means only that the named obligation was established under that recorded scope. It does not establish that the contract captures the intended business rule, that external systems behave as modeled, that a user approved the contract, that a model-generated implementation is safe for every deployment, or that a required effect was authorized. Tooling and generated documentation must preserve this distinction in their vocabulary.
 
 ### Build and verification modes
 
@@ -253,6 +266,7 @@ The agent context graph should support these node kinds when this RFC is impleme
 - `runtime_check`: a generated or preserved runtime enforcement site.
 - `verification_receipt`: a cacheable proof or verification-result identity that records provider, configuration, assumptions, source identity, and checked fragment.
 - `verification_assumption`: a fact used by one or more verification results.
+- `contract_provenance`: an optional project-supplied origin, review, or approval record attached to an exact contract identity without changing proof semantics.
 
 The graph should support these edge kinds when this RFC is implemented:
 
@@ -264,6 +278,7 @@ The graph should support these edge kinds when this RFC is implemented:
 - `elides_check`: from a proved result to a runtime check that was removed or skipped.
 - `assumes`: from an obligation or result to a verification assumption.
 - `repairs_context_for`: from a verification result to task-ranked context packs or advisory records that explain likely repair targets.
+- `has_provenance`: from a contract declaration to an optional contract-provenance record.
 
 These records must preserve RFC 106 provenance. A solver-backed result must not be marked as `compiler_checked` unless the compiler owns the validation of that result under the graph schema. Provider-specific facts should identify the provider while preserving a stable Incan outcome vocabulary.
 
@@ -411,7 +426,7 @@ This section is non-normative. The recommended architecture is to introduce a ve
 - **Stdlib / Runtime (`incan_stdlib`)**: validation helpers, result/option predicates, assertion behavior, and domain constructors may need stable contract summaries that verification can trust.
 - **Formatter**: contract statements should be formatted predictably and kept visually attached to the function or loop they constrain.
 - **LSP / Tooling**: editors, CLI, and MCP consumers should show verification outcomes, counterexamples, assumptions, strict/permissive mode state, runtime fallback status, and graph-backed repair context.
-- **Checked metadata and docs**: public contract declarations, supported predicates, proof outcomes where appropriate, and runtime-enforcement status should be exposed through checked metadata and generated documentation without exposing provider internals as the source of truth.
+- **Checked metadata and docs**: public contract declarations, declaration identity and optional explicit approval provenance, supported predicates, proof outcomes where appropriate, proof scope, and runtime-enforcement status should be exposed through checked metadata and generated documentation without exposing provider internals as the source of truth or turning proof into a business-correctness claim.
 - **Agent context graph**: RFC 106 graph export and context packing should expose contract, obligation, result, counterexample, assumption, runtime-check, and verification-receipt records with provenance and source anchors.
 - **Packaging / Workspaces**: packages may need to record verification configuration, provider requirements, cached receipt identities, and policy around strict verification or runtime fallback.
 
@@ -425,6 +440,7 @@ This section is non-normative. The recommended architecture is to introduce a ve
 - How should trusted summaries for Rust interop, stdlib functions, and generated behavior be authored, reviewed, versioned, and exposed through metadata?
 - Should proof receipts be cacheable across packages and machines, or should the first implementation limit receipts to local deterministic result caching?
 - How much counterexample translation is required before this RFC can move to Planned status?
+- Which checked-metadata or project-policy boundary can carry explicit contract review and approval records without making author identity or approval a compiler inference?
 
 <!-- Rename this section to "Design Decisions" once all questions have been resolved.
      An RFC cannot move from Draft to Planned until no unresolved questions remain. -->


### PR DESCRIPTION
## Summary

This RFC-only PR sharpens two planned Incan boundaries. RFC 080 now distinguishes a declared model asset from a versioned execution profile and scoped execution observation, including explicit fallback and locality provenance. RFC 111 now makes contract declaration identity, optional explicit approval provenance, and proof scope first-class so a passing result cannot be mistaken for business correctness or human approval.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [x] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [x] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: No implemented compiler behavior changes. RFC 080 defines better inspection provenance for model execution; RFC 111 clarifies what an eventual proof result does and does not establish.
- **Internals**: RFC 080 remains descriptive and defers runtime capability and receipt authority to RFC 104. RFC 111 adds a distinct provenance record to the RFC 106 graph vocabulary without changing proof outcomes.
- **Risks**: Both RFCs remain Draft. The exact execution-profile fields and the trusted checked-metadata or policy boundary for approval records are unresolved before implementation.

## Testing / verification

- [ ] `make test` / `cargo test` (not applicable: no compiler or runtime source changed)
- [ ] `make examples` (not applicable: no executable example changed)
- [ ] `incan fmt --check .` (not applicable: no Incan source changed)
- [x] Manual verification described below

Manual verification notes:

- `make docs-build`
- `git diff --check origin/main...HEAD`

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s):
  - `workspaces/docs-site/docs/RFCs/080_ai_assets_models_prompts_evals_and_agent_metadata.md`
  - `workspaces/docs-site/docs/RFCs/111_proof_aware_agentic_contract_feedback.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Refs #408
Refs #787