### PR TITLE
chore - record Loaf source and interop boundaries (#1009, #1012)

### DIFF
--- a/workspaces/docs-site/docs/RFCs/117_loaf_toml_and_oven_project_model.md
+++ b/workspaces/docs-site/docs/RFCs/117_loaf_toml_and_oven_project_model.md
@@ -30,7 +30,7 @@
 
 ## Summary
 
-This RFC replaces `incan.toml` with `Loaf.toml` as the sole authored manifest for an Oven-managed project. A `Loaf.toml` may describe one project, a rooted workspace, or a virtual workspace. It is language-neutral: a project may contain Incan sources, Rust sources, both, or checked foreign interfaces without making any implementation language the repository's organizing principle.
+This RFC replaces `incan.toml` with `Loaf.toml` as the sole authored manifest for an Oven-managed project. A `Loaf.toml` may describe one project, a rooted workspace, or a virtual workspace. Its package, target, lock, cache, and receipt model is language-neutral. Incan and Rust are the built-in authored source facets in v0.6; checked C interop remains under `[interop.c]`; later foreign integrations require their own explicit interop RFC rather than becoming ambient source languages.
 
 `[project]` remains the familiar metadata table. `[workspace]` remains the explicit repository-coordination table. Dependencies use one typed graph whose unit kind and origin are explicit when the defaults are insufficient: Incan Loaf packages default to `incan.pub`, Rust crates default to crates.io, and foreign/system requirements use Oven-managed capability providers. Oven resolves authored intent into `Oven.lock`, then bakes the selected target into immutable, verified `*.loaf` assets and receipts. Cargo remains a deliberately explicit compatibility mode for repositories that have no `Loaf.toml`; it is never inferred as part of a Loaf build.
 
@@ -42,16 +42,16 @@ Read this RFC as thirteen foundations:
 
 1. **One authored manifest:** `Loaf.toml` is the only Incan/Oven project manifest. `incan.toml` is not read as a compatibility format.
 2. **A familiar project table:** `[project]` owns package identity and publication metadata. The filename carries the Loaf vocabulary; the metadata table remains ordinary and legible.
-3. **A workspace is an optional hierarchy:** `[workspace]` declares explicit members and shared policy. A root with both `[project]` and `[workspace]` is a rooted workspace; a root with only `[workspace]` is virtual. Members may declare sub-Loaves, but the root remains the sole authority for resolution, locking, registry trust, target policy, and receipts.
+3. **A workspace is an optional hierarchy:** `[workspace]` declares explicit members and shared policy. A root with both `[project]` and `[workspace]` is a rooted workspace; a root with only `[workspace]` is virtual. Members may form explicit structural child groups, but the root remains the sole authority for resolution, locking, registry trust, target policy, and receipts.
 4. **The package graph is language-neutral:** every dependency is one logical requirement with a typed provider contract. The author does not choose a separate Incan-versus-Rust dependency table.
 5. **Origins are configurable:** Loaf packages default to `incan.pub`; crates default to crates.io. A project may explicitly select registered private registries, Git, path, or other supported controlled sources.
 6. **Provider semantics stay visible:** an `incan.pub` package contributes checked Incan semantic/provider facts, a Cargo ecosystem crate contributes Rust interop and implementation requirements, and a system/foreign capability contributes a verified target requirement. Oven must not flatten those differences or expose backend details as public Incan API.
-7. **Source discovery is convention-first:** Oven discovers supported source files under `src/` by language extension. Nonstandard roots or generated inputs require explicit configuration. A Loaf never implicitly consumes a neighbouring `Cargo.toml`.
+7. **Core source facets are convention-first and unambiguous:** a conventional single-language project uses the ordinary `src/` layout. A mixed or nonstandard project declares non-overlapping `[incan.source]` and `[rust.source]` roots; `.incn` and `.rs` files never compete within one undiscriminated source root. C source inputs, headers, shims, and artifacts remain deliberate `[interop.c]` concerns. A Loaf never implicitly consumes a neighbouring `Cargo.toml`.
 8. **Targets have three scopes:** a Loaf declares supported target/interface combinations; a workspace declares shared delivery policy; a bake invocation chooses one concrete target, carrier, profile, and feature closure that produces a target-bound `*.loaf` asset.
 9. **Plans precede effects:** resolution, import, installation, or the presence of a file must not execute package code. Oven exposes a plan before baking and records the actual execution in a receipt.
-10. **Environments and actions belong to Oven:** existing environment/matrix and typed-action semantics remain, but their authored configuration moves out of `[tool.incan.*]` and into the Loaf model. Oven materializes environments and explicitly runs actions.
+10. **Named environments and actions are explicit Loaf intent:** the standard `dev`, `test`, `lint`, and `docs` environments always exist; authored environment and typed-action configuration moves out of `[tool.incan.*]` and into the Loaf model. Environments select named, reproducible command contexts; they do not silently change a production bake.
 11. **Derived state is separate:** `Oven.lock`, immutable `*.loaf` assets, the artifact store, selected host toolchains, caches, staged outputs, generated code, and receipts are not authored Loaf configuration.
-12. **Distribution assets are verifiable:** a `*.loaf` asset is immutable and target-bound. It identifies the selected project/facet, target, carrier, profile, resolved graph, payload digest, and receipt; its wire or bundle format is intentionally deferred.
+12. **Distribution assets are verifiable and future-reusable:** a `*.loaf` asset is immutable and target-bound. It identifies the selected project/facet, target, carrier, profile, resolved graph, payload digest, and receipt; those facts reserve the compatibility boundary through which a future `incan.pub` consumer can safely reuse a pre-warmed asset rather than rebuild it. Its wire or bundle format is intentionally deferred.
 13. **Cargo compatibility is explicit:** a directory with only `Cargo.toml` may be run by Oven in Cargo-compatibility mode. A directory containing `Loaf.toml` is a Loaf project; Cargo files there are ignored with a diagnostic unless the user explicitly invokes Cargo compatibility.
 
 ## Motivation
@@ -78,7 +78,9 @@ Oven is more than a package resolver. It must plan target-specific C ABI, JNI, P
 - Distinguish authored intent (`Loaf.toml`), resolved graph (`Oven.lock`), and immutable target-bound distribution assets (`*.loaf`) without making any of them hidden state.
 - Make plans, declared effects, selected inputs, output artifacts, and receipts inspectable.
 - Rehome environment/matrix/action configuration ownership to Oven without re-specifying the semantics already owned by RFCs 073 and 078.
-- Rehome package-level C ABI configuration from `[oven.interop]` into an interop section that future binding kinds may share, while retaining RFC 116 as the owner of C safety semantics.
+- Rehome package-level C ABI configuration from `[oven.interop]` into `[interop]`, a direct semantic root that future binding kinds may share, while retaining RFC 116 as the owner of C safety semantics.
+- Establish `[incan.source]` and `[rust.source]` as the built-in source-facet roots for mixed or nonstandard projects, while retaining convention-first simple projects.
+- Reserve `[interop.*]` for future typed binding integrations without defining a plugin system, arbitrary foreign-tool execution, or a Python/JNI/Go/Ruby source model in v0.6.
 - Keep locks, caches, credentials, selected SDK paths, staged artifacts, and generated output out of the authored manifest.
 - Leave command spelling and CLI ergonomics for a dedicated follow-up RFC.
 
@@ -90,6 +92,7 @@ Oven is more than a package resolver. It must plan target-specific C ABI, JNI, P
 - Reimplementing arbitrary Cargo behavior, including implicit `build.rs` execution, proc-macro execution policy, or Cargo workspace discovery, for Loaf projects.
 - Defining crates.io's protocol, the full `incan.pub` registry protocol, registry hosting, or publishing UX.
 - Defining C ABI safety rules, direct C++ ABI interop, JNI safety rules, Python extension safety rules, or a universal foreign-runtime type system.
+- Defining pluggable interop registration, installation, discovery, or execution. Future binding kinds require their own RFC and implementation work.
 - Defining remote execution, distributed builds, or a general-purpose shell/task runner.
 - Defining the `*.loaf` wire or bundle format, registry transport, or archive layout; a dedicated artifact-format RFC owns those details.
 - Allowing packages to run arbitrary installation, import, or lifecycle hooks.
@@ -122,6 +125,7 @@ Loaf.toml + declared sources + declared inputs
 
 - A **project** is the independently named and versioned unit described by `[project]`.
 - A **workspace** is the explicit repository coordination boundary described by `[workspace]`; it is not itself a compiled package unless it also has `[project]`.
+- A **`loaves/` group** is the repository convention for non-root workspace members. It may be nested, for example `loaves/stdlib/web/`; its path is not a dependency, publication, or Rust-crate identity.
 - A **Doughball** is Oven's internal representation of the selected sources, declared dependencies, features, interop inputs, and policy before target shaping.
 - A **Loaf** is the resolved logical build unit Oven obtains by shaping a Doughball for a selected package facet and target-compatible plan.
 - A **`*.loaf` asset** is the immutable, verified, target-bound build and distribution asset emitted by a bake. It carries the selected Loaf identity, target/carrier/profile, resolved-graph identity, payload digest, and receipt identity. Its archive or wire format is outside this RFC.
@@ -145,11 +149,17 @@ requires-incan = ">=0.6,<0.7"
 [dependencies]
 web = { loaf = "stdlib-web", version = "^0.6" }
 serde = { crate = "serde", version = "1", features = ["derive"] }
+
+[incan.source]
+root = "sources/incan"
+
+[rust.source]
+root = "sources/rust"
 ```
 
 `web` defaults to `incan.pub`; `serde` defaults to crates.io. Neither the project identity nor the command to bake it changes because its implementation contains Incan, Rust, or both. The public package feature graph remains an Incan/Loaf contract. A requested Cargo feature is a typed implementation request for `serde`; it does not automatically become a public feature of `weather_service`.
 
-Oven discovers supported source files below `src/`. A project with only conventional source roots does not need to list its implementation languages.
+This example is mixed, so it names separate roots. An Incan-only project conventionally uses `src/*.incn`; a Rust-only project conventionally uses `src/lib.rs` or `src/main.rs`. Neither needs a source table. A mixed project must declare separate roots rather than placing `main.incn` and `main.rs` beside one another.
 
 ### A workspace of Loaves
 
@@ -161,39 +171,68 @@ name = "incan"
 version = "0.6.0"
 
 [workspace]
-members = ["loaves/*"]
-default-members = [".", "loaves/incan_lsp"]
+members = [
+  "loaves/compiler/syntax",
+  "loaves/compiler/semantics",
+  "loaves/stdlib/web",
+  "loaves/stdlib/io",
+]
+default-members = [".", "loaves/compiler/semantics"]
 
 [workspace.delivery.mobile]
-members = ["loaves/stdlib_interop", "loaves/stdlib_web"]
+members = ["loaves/stdlib/web"]
 targets = ["aarch64-apple-ios", "aarch64-linux-android"]
 profile = "release"
 ```
 
-A virtual workspace omits `[project]` and retains `[workspace]`. Every member has its own `Loaf.toml`; no member is inferred merely because it lives under `loaves/`.
+A virtual workspace omits `[project]` and retains `[workspace]`. Every member has its own `Loaf.toml`; no member is inferred merely because it lives under `loaves/` or a nested group beneath it. A Rust-only member remains a Rust crate in its own source facet; `loaves/` is the repository's package hierarchy, not a replacement name for Rust compilation units.
 
 The directory name is a repository convention, not an identity rule. A member can live anywhere inside the workspace root if it is explicitly included by `members`.
 
-### Hierarchical sub-Loaves
+### Nested `loaves/` groups
 
-A member may itself declare explicit child members. This is a structural hierarchy, not a nested independent workspace:
+A workspace can group members recursively without flattening its repository layout. A group directory does not itself need a manifest:
 
 ```text
 incan/
 ├── Loaf.toml                         # root authority and Oven.lock
 └── loaves/
-    └── incan_oven/
-        ├── Loaf.toml                 # an Incan sub-Loaf
-        └── loaves/
-            ├── oven_store/Loaf.toml
-            └── oven_provider_cargo/Loaf.toml
+    ├── compiler/
+    │   ├── syntax/Loaf.toml
+    │   └── semantics/Loaf.toml
+    └── stdlib/
+        ├── io/Loaf.toml
+        └── web/Loaf.toml
 ```
 
-The root's selected closure contains `incan_oven` and its declared children. A sub-Loaf may declare local requirements and local member selection, but it inherits the root's resolved graph, lock, registry trust, target/delivery policy, and receipt boundary. It cannot create a second `Oven.lock`, rebind a registry, widen target policy, or form a second publication authority.
+If a group itself needs a local member-selection boundary or narrower local requirements, it may declare a structural parent `Loaf.toml` with explicit children. That parent inherits the root's resolved graph, lock, registry trust, target/delivery policy, and receipt boundary. It cannot create a second `Oven.lock`, rebind a registry, widen target policy, or form a second publication authority.
 
 Membership hierarchy is not a dependency graph. Parent/child placement, a shared workspace, and a selected closure create no runtime, linkage, or publication dependency between packages; those relationships exist only through declared typed dependencies. For example, `incql-core`, `incql-db`, and `incql-datafusion` can remain independently versioned packages whether or not one is structurally nested below another; any dependency between them is explicit in the consuming package's dependency table.
 
 This hierarchy also permits efficient cache-status inspection: Oven can compare a receipt-bound aggregate for a parent before it descends into a child's declared closure. The exact cold/warm/hot definitions remain an Oven inspection concern rather than this RFC's package contract.
+
+### Core source facets and deliberate interop
+
+The source-root contract is intentionally small. A conventional single-language project requires no configuration. A mixed root names the two built-in source facets directly:
+
+```toml
+[incan.source]
+root = "sources/incan"
+
+[rust.source]
+root = "sources/rust"
+```
+
+The roots must not overlap. Generated output is not an authored source root. The root's package/target authority remains in `Loaf.toml`; neither source facet can select a different lock, registry, target, policy, or carrier.
+
+C is not a peer top-level source namespace. When a C integration needs authored shim source, it remains behind the deliberate C interop contract:
+
+```toml
+[interop.c.source]
+root = "sources/c"
+```
+
+`[interop.c]` also owns C headers, ABI declarations, checked shims, linker artifacts, selected toolchain/provider facts, and their receipts. `[interop.python]`, `[interop.jni]`, `[interop.go]`, and similar names are reserved for later concrete interop RFCs; v0.6 does not define their schemas, plugin installation, or arbitrary foreign-language execution.
 
 ### Registries without ambient trust
 
@@ -241,7 +280,7 @@ A package declares interface intent and physical input requirements. Oven resolv
 name = "vision_runtime"
 version = "0.6.0"
 
-[oven.interop.c]
+[interop.c]
 headers = ["interop/include/vision.h"]
 requires = ["vision-runtime"]
 
@@ -254,7 +293,7 @@ platform = "aarch64-linux-android"
 carrier = "jni-library"
 ```
 
-This example is intentionally schematic. `[oven.interop]` remains Oven-owned in `Loaf.toml`; `[oven.interop.c]` is the direct successor to RFC 116's C envelope. RFC 116 continues to define C declarations, ownership, buffers, verification, and checked shims. A future JNI or Python RFC defines the corresponding language/runtime safety contract. They all reuse the same package-envelope distinctions: declared requirement, selected provider/toolchain, target-compatible carrier, lock identity, plan, `*.loaf` asset, and receipt.
+This example is intentionally schematic. `[interop]` is Loaf-owned requirement data; `[interop.c]` is the direct successor to RFC 116's C envelope. RFC 116 continues to define C declarations, ownership, buffers, verification, and checked shims. A future JNI or Python RFC defines the corresponding language/runtime safety contract. They all reuse the same package-envelope distinctions: declared requirement, selected provider/toolchain, target-compatible carrier, lock identity, plan, `*.loaf` asset, and receipt.
 
 ### Baking and inspecting
 
@@ -306,15 +345,15 @@ Oven must not parse, merge, or infer dependency, feature, source, workspace, bui
 
 `requires-incan` remains an enforceable project compatibility requirement under RFC 073. It is a language/toolchain compatibility fact, not a claim that all implementation sources must be Incan.
 
-Supported source files below the conventional `src/` root participate according to their language extension and declared package facet. An implementation must not require an author to declare `incan = [...]` or `rust = [...]` merely because both file kinds appear under conventional roots. A later concrete schema may provide an optional source-root table for nonstandard roots, generated inputs, exclusions, or explicit source-domain policy.
+An Incan-only or Rust-only project uses its conventional `src/` layout without a source declaration. A project that contains both built-in source languages, uses nonstandard roots, or needs an authored C shim must declare the relevant non-overlapping root: `[incan.source]`, `[rust.source]`, or `[interop.c.source]`. A Loaf must diagnose `.incn` and `.rs` files in one undiscriminated root; it must not apply filename precedence. Generated inputs remain declared provider outputs rather than source roots.
 
 When a Loaf project contains Rust source, Oven determines its compilation/linkage path from the Loaf plan and declared crate/provider requirements. The presence of `Cargo.toml`, `build.rs`, or another Cargo convention does not grant that file execution or planning authority.
 
 ### Rust source facet
 
-A Rust-bearing Loaf has a bounded, inspectable Rust facet. The planner must know, either through the conventional default or an explicit declaration, every compiled crate's package name, crate root, edition, crate type, entry point where applicable, enabled feature set, and linkage/dependency requirements. A conventional `src/lib.rs` or `src/main.rs` may supply a default root only when it yields one unambiguous crate; multiple crates, nonstandard roots, nondefault crate names, nondefault editions, additional crate types, binary entry points, or feature mapping require explicit facet data.
+A Rust-bearing Loaf has a bounded, inspectable Rust facet. `[rust.source]` declares its root only when convention cannot. Rust-specific exceptions live beneath `rust.*`, not in a generic source table. The planner must know, either through the conventional default or an explicit declaration, every compiled crate's package name, crate root, edition, crate type, entry point where applicable, enabled feature set, and linkage/dependency requirements. A conventional `src/lib.rs` or `src/main.rs` may supply a default root only when it yields one unambiguous crate; multiple crates, nonstandard roots, nondefault crate names, nondefault editions, additional crate types, binary entry points, or feature mapping require explicit facet data.
 
-The exact TOML table spelling remains an RFC 117 syntax decision, but no Rust compilation plan may be inferred from Cargo metadata. `Oven.lock` and the receipt must record the selected Rust facet, compiler/toolchain identity, crate dependency closure, feature choices, and all provider-produced inputs that affect the resulting `*.loaf` asset.
+The root spelling is settled; the compact `rust.*` exception fields remain RFC 119 work. No Rust compilation plan may be inferred from Cargo metadata. `Oven.lock` and the receipt must record the selected Rust facet, compiler/toolchain identity, crate dependency closure, feature choices, and all provider-produced inputs that affect the resulting `*.loaf` asset.
 
 The existence of `build.rs` must never execute it. A Loaf may support its intent only through an explicitly selected Oven provider or typed action whose inputs, outputs, capabilities, target/host role, policy decision, and receipt effects are declared and inspectable. Likewise, a procedural macro must be an explicitly resolved compiler-time provider with a recorded host identity and execution policy; an unsupported macro is a diagnostic, not a fallback to Cargo. Cargo compatibility remains the only mode in which Cargo itself is authoritative for these behaviors.
 
@@ -406,15 +445,37 @@ The following authored concepts move into `Loaf.toml` under Oven ownership. Thei
 | typed workflow actions                        | RFC 078        | resolve scope, show plan, policy-gate, and execute explicit actions            |
 | mutation policy                               | RFC 076        | evaluate receiver authority over planned changes/effects                       |
 
-RFC 015 is implemented, so RFC 117 supersedes its `incan.toml` discovery and `[tool.incan.envs]` configuration placement. RFCs 073, 076, and 078 are still Draft and must be amended to name the new Loaf/Oven tables and terminology rather than preserving legacy configuration compatibility.
+RFC 015 is implemented, so RFC 117 supersedes its `incan.toml` discovery and `[tool.incan.envs]` configuration placement. RFCs 073, 076, and 078 are still Draft and must be amended to name the new Loaf tables and terminology rather than preserving legacy configuration compatibility.
 
-The initial table roots are `[oven.envs]`, `[oven.actions]`, `[oven.policy]`, `[oven.capabilities]`, and `[oven.templates]`. Their dedicated RFCs own the detailed schema and semantics. They must remain explicit, scoped, inspectable, and free of implicit lifecycle execution. RFC 118 owns whether users invoke those semantics through `incan`, `oven`, aliases, or another command arrangement.
+The initial table roots are `[envs]`, `[actions]`, `[policy]`, `[capabilities]`, and `[templates]`. Their dedicated RFCs own the detailed schema and semantics. No `[oven.*]` prefix is needed: a `Loaf.toml` is already Oven's authored project document, and roots should name their semantic domain instead. They must remain explicit, scoped, inspectable, and free of implicit lifecycle execution. RFC 118 owns whether users invoke those semantics through `incan`, `oven`, aliases, or another command arrangement.
+
+### Standard environments
+
+Every Loaf has the standard named environments `dev`, `test`, `lint`, and `docs`, even when no `[envs.*]` tables are authored. `dev` is the local host-development context. `test`, `lint`, and `docs` extend it conceptually and add only the roles and dependencies selected by their operation. A project adds a table only to declare an addition or override:
+
+```toml
+[envs.test]
+extends = "dev"
+
+[envs.test.dependencies]
+assert_cmd = { crate = "assert_cmd", version = "2" }
+
+[envs.docs]
+extends = "dev"
+
+[envs.docs.dependencies]
+mdbook = { crate = "mdbook", version = "0.4" }
+```
+
+An environment is a named, reproducible command context. It may select extra development tools and project features, but it must not silently alter the selected target, carrier, profile, provider closure, or release dependency closure of an ordinary bake. `bake` is therefore not a standard environment: a bake records its target, carrier, profile, and feature selection directly in the plan and receipt. Dependencies needed to compile or execute a provider belong to that provider; target-specific dependencies belong to the target. Environment inheritance must diagnose conflicting bindings in the selected closure rather than silently choose one.
+
+Project scaffolding must generate a valid, minimal `Loaf.toml` and include the four standard environments as commented examples. The comments must explain that the defaults already exist and show where test, lint, and documentation dependencies belong; they must not materialize active configuration that merely duplicates the defaults.
 
 ### Interop package envelope
 
-RFC 116's current `[oven.interop]` shape is package-owned requirement data, not a record of a host toolchain already selected. Under this RFC it remains Oven-owned in the Loaf-level `[oven.interop]` namespace: C declarations use `[oven.interop.c]`. The file name changes from `incan.toml` to `Loaf.toml`; the ownership boundary does not.
+RFC 116's current `[oven.interop]` shape is package-owned requirement data, not a record of a host toolchain already selected. Under this RFC it moves to the Loaf-level `[interop]` namespace: C declarations use `[interop.c]`. The file name changes from `incan.toml` to `Loaf.toml`; the ownership boundary does not.
 
-The interop envelope must be binding-kind neutral. It represents declared headers, shims, foreign artifacts, toolchain/SDK capabilities, target variants, carrier requirements, lock identities, plan inputs, generated verification records, artifact staging, and receipts. It does not make C pointer types, C ownership, JNI handles, Python reference counts, or another runtime's safety rules universal. Each binding-kind RFC continues to define its own source vocabulary and checking rules.
+The interop envelope must be binding-kind neutral. It represents declared headers, shims, foreign artifacts, toolchain/SDK capabilities, target variants, carrier requirements, lock identities, plan inputs, generated verification records, artifact staging, and receipts. It does not make C pointer types, C ownership, JNI handles, Python reference counts, or another runtime's safety rules universal. Each binding-kind RFC continues to define its own source vocabulary and checking rules. Loaf-facing configuration uses precise terms such as `interop.c`, `host`, `target`, and declared linker artifact form; it does not introduce a catch-all `native` configuration namespace. Existing RFC 116 source syntax remains historical until a future language-level proposal changes it.
 
 ### Locks and derived state
 
@@ -423,6 +484,12 @@ The interop envelope must be binding-kind neutral. It represents declared header
 The lock must include every semantic or physical input whose change can alter checking, linking, target compatibility, generated output, or the baked artifact closure. It must not contain credentials, mutable cache paths, arbitrary environment values, or unreviewed host discovery output.
 
 `*.loaf` is the immutable, target-bound distribution/build asset derived from the lock and the selected bake plan. It must identify its project/facet, target, carrier, profile, resolved graph identity, payload digest, and receipt identity; it is not an editable project manifest or a replacement lockfile. The artifact store, provider payload store, staged deployment files, generated Rust, target intermediates, and receipts are separate from the lock. They are inspectable and may be content-addressed, but they are not user-authored package configuration or semantic authority.
+
+### Future registry-supplied warm reuse
+
+The long-term advantage of a package published as a Loaf is that `incan.pub` can offer a verified, target-compatible pre-warmed closure rather than only source material. A consumer selects such a closure only when its package identity, trust facts, resolved features and graph, target, carrier, profile, toolchain/ABI, native-link requirements, provider receipts, and policy constraints are compatible with the selected plan. On a match, Oven verifies and materializes the existing assets; it does not repeat the package or dependency compilation merely because the consumer is a different project, clean worktree, or implementation slice. The local store may retain the result under the same receipt-compatible identity.
+
+This is not a promise that one published binary works on every machine, nor that every `incan.pub` package ships a pre-warmed closure for every selection. A mismatch is a normal targeted miss: Oven resolves the checked source/provider closure and builds only the missing compatible units. Cargo crates remain valid ecosystem inputs, but they do not gain this Loaf-native distribution advantage merely by being consumed. This RFC does not require registry-supplied warm closures in v0.6; it requires the identity, trust, receipt, and target model that lets a later registry/artifact protocol provide them without reopening package authority.
 
 ## Design details
 
@@ -436,12 +503,15 @@ Loaf.toml
 ├── [workspace]               RFC 117; prospectively supersedes RFC 077's flat-workspace restriction
 ├── dependencies/features     RFC 117 + RFC 114
 ├── registry selection        RFC 117 + RFC 034
-├── [oven.envs]               RFC 073, rehomed by RFC 117
-├── [oven.actions]            RFC 078, rehomed by RFC 117
-├── [oven.policy]             RFC 076, rehomed by RFC 117
-├── [oven.capabilities]       RFC 075, governed by RFC 076
-├── [oven.templates]          RFC 074, governed by RFC 076
-├── [oven.interop]            RFC 116 now; future binding RFCs later
+├── [envs]                    RFC 073, rehomed by RFC 117
+├── [actions]                 RFC 078, rehomed by RFC 117
+├── [policy]                  RFC 076, rehomed by RFC 117
+├── [capabilities]            RFC 075, governed by RFC 076
+├── [templates]               RFC 074, governed by RFC 076
+├── [incan.source]            built-in Incan source facet
+├── [rust.source] / [rust.*]  built-in Rust source facet; RFC 119 owns exceptions
+├── [interop.c]               RFC 116's checked C interop envelope
+├── [interop.*]               reserved for later concrete binding RFCs; no v0.6 plugin system
 ├── Oven.lock                 resolved graph, RFCs 020, 104, 112, and 114
 └── *.loaf + receipt          immutable target-bound artifact, RFC 117; wire format deferred
 ```
@@ -450,7 +520,7 @@ This map does not make RFC 117 the owner of every detailed sub-schema. It establ
 
 ### Source language and authored Rust
 
-The Loaf package model is language-neutral; it does not relax Incan's authoring policy. Incan products and dogfooding projects should remain Incan-authored and use `rust::` interop for existing Rust capabilities. New authored Rust still requires a demonstrated Incan limitation and a tracked removal path.
+The Loaf package model is language-neutral in package and build authority; it does not claim that every language is an equivalent v0.6 source facet or relax Incan's authoring policy. Incan products and dogfooding projects should remain Incan-authored and use `rust::` interop for existing Rust capabilities. New authored Rust still requires a demonstrated Incan limitation and a tracked removal path.
 
 That policy is distinct from the manifest contract. Oven must be capable of baking a Loaf whose implementation is Rust, Incan, or mixed because the build system cannot make a package's identity depend on the language mix. Project governance can constrain which sources its maintainers choose to author.
 
@@ -537,8 +607,8 @@ Rejected. Unconstrained tool tables make the canonical manifest a dumping ground
 - **Manifest discovery and validation** — must recognize only `Loaf.toml`, validate rooted/virtual workspace shapes, reject unknown or conflicting scope, and diagnose legacy or coexisting manifests precisely.
 - **Workspace resolution** — must preserve explicit membership, shared lock ownership, scoped command selection, and typed dependency inheritance while replacing `incan.toml` paths and tables.
 - **Provider and dependency resolution** — must normalize typed dependencies, apply default origins, resolve registered registries, preserve provider-specific semantics, verify trust/integrity, and construct one session-owned plan.
-- **Source and backend planning** — must discover conventional supported sources, require explicit nonstandard declarations, define the bounded Rust facet needed to plan Rust compilation, and prevent Cargo conventions from participating in Loaf planning.
-- **Target and interop planning** — must resolve host/target/carrier/profile/delivery combinations, select providers/toolchains, and reuse RFC 116's checked C package facts without C-specific assumptions in the envelope.
+- **Source and backend planning** — must discover one conventional built-in source facet, require `[incan.source]` and `[rust.source]` for mixed or nonstandard roots, diagnose ambiguous mixed roots, define the bounded Rust facet needed to plan Rust compilation, and prevent Cargo conventions from participating in Loaf planning.
+- **Target and interop planning** — must resolve host/target/carrier/profile/delivery combinations, select providers/toolchains, and reuse RFC 116's checked `[interop.c]` facts without turning C or a future foreign ecosystem into an ambient top-level source language.
 - **Environment and action tooling** — must rehome RFC 073 and RFC 078 configuration to Loaf/Oven while retaining matrix, scope, dry-run, policy, and receipt contracts.
 - **Locking, stores, and publication** — must rename the canonical lock to `Oven.lock`, preserve deterministic whole-workspace resolution, reserve immutable target-bound `*.loaf` identities, and keep locks, receipts, caches, and publication artifacts distinct.
 - **Cargo compatibility adapter** — must run Cargo only when explicitly selected, report its mode and side-effect boundary, and never act as a fallback inside a Loaf build.
@@ -552,9 +622,11 @@ RFC 117 is ready to move beyond Draft when its normative rules and updated relat
 - A standalone project, rooted workspace, and virtual workspace have unambiguous `Loaf.toml` examples and discovery rules.
 - The dependency grammar distinguishes unit kind from origin and explains defaults, source overrides, features, integrity, and trust.
 - The `incan.pub` and crates.io defaults, explicit registry registration, project allow-list, credential boundary, and lock identity are defined precisely enough to implement.
-- A Loaf containing Incan, Rust, and mixed conventional sources has defined planning behavior, including bounded Rust-facet inputs and no implicit Cargo participation.
+- An Incan-only, Rust-only, and mixed Incan/Rust Loaf have defined source-root behavior: simple projects are convention-first, mixed roots use `[incan.source]` and `[rust.source]`, ambiguous co-located `.incn`/`.rs` sources diagnose, and no implicit Cargo participation occurs.
+- A C integration has a defined `[interop.c]` envelope without promising Python, JNI, Go, Ruby, or a general plugin system in v0.6.
 - Target, carrier, profile, workspace delivery policy, and invocation precedence have explicit validation and receipt requirements.
 - Provider operations, generators, actions, policy, and receipts have a complete no-hidden-effects boundary.
+- The standard `dev`, `test`, `lint`, and `docs` environments, their inheritance/selection rules, their dependency boundaries, and their commented scaffold presentation are explicit enough to implement and explain without treating a bake as an environment.
 - RFCs 015, 073, 076, 077, 078, 114, and 116 identify exactly which manifest/discovery clauses RFC 117 supersedes or amends.
 - The lock rename and legacy-manifest rejection have a complete pre-1.0 compatibility decision.
 - RFC 118 has a clear command-ownership and alias boundary that does not reopen the manifest model.
@@ -565,6 +637,7 @@ RFC 117 is ready to move beyond Draft when its normative rules and updated relat
 
 - Introduce `Loaf.toml` discovery and validation; remove `incan.toml` discovery from project-aware operations.
 - Implement rooted and virtual workspace shapes, explicit member selection, and precise coexisting-Cargo diagnostics.
+- Support nested `loaves/` groups, retaining explicit membership and allowing a structural parent manifest only when it has real child-selection or local-requirement work to do.
 - Update project creation, documentation, LSP/IDE manifest discovery, and fixtures.
 
 ### Phase 2: Typed graph, registries, and lock
@@ -582,19 +655,28 @@ RFC 117 is ready to move beyond Draft when its normative rules and updated relat
 ### Phase 4: Environment and action rehoming
 
 - Amend and implement the `Loaf.toml` configuration location for RFC 073 environments/matrices and RFC 078 typed actions.
-- Make Oven materialization, scope selection, dry-run, and policy gating consume the same project/workspace plan.
+- Materialize the standard `dev`, `test`, `lint`, and `docs` environments; support explicit inheritance, environment dependency closure, conflict diagnostics, and commented scaffold defaults.
+- Make Oven materialization, scope selection, dry-run, and policy gating consume the same project/workspace plan without allowing an environment to change an ordinary bake implicitly.
 
 ### Phase 5: Explicit Cargo compatibility and documentation
 
 - Implement the distinct Cargo compatibility adapter and receipt/reporting boundary.
-- Add compatibility fixtures for Cargo-only projects, Loaf-only Rust projects, mixed-source Loaves, workspaces, private registries, and C ABI target carriers.
+- Add compatibility fixtures for Cargo-only projects, convention-first Incan-only and Rust-only Loaves, explicit mixed `[incan.source]`/`[rust.source]` Loaves, nested `loaves/` workspaces, private registries, and C ABI target carriers.
 - Document the command-surface handoff to RFC 118 without defining aliases or final command spelling here.
+
+## Design decisions
+
+- **Loafified-package distribution advantage:** the long-term `incan.pub` value proposition is a verified, target-compatible pre-warmed Loaf closure that Oven can reuse across consumers after compatibility and trust verification. It is not universal-binary distribution, an implicit network effect, or a v0.6 release requirement. The v0.6 package/lock/receipt model must nevertheless preserve the identities needed to make it a later registry capability rather than a new authority model.
+- **Nested Loaf topology:** `loaves/` is the conventional home for all non-root workspace member projects, including Rust-only members. It supports arbitrary nested groups such as `loaves/stdlib/web`; paths are never implicit membership, dependency, linkage, or publication edges. A group gains a `Loaf.toml` only when it needs a real structural parent contract, and it always inherits the root authority.
+- **Built-in source facets:** Incan and Rust are the v0.6 built-in authored source facets. Simple one-language projects use `src/` by convention. Mixed or nonstandard projects use `[incan.source]` and `[rust.source]` with non-overlapping roots; the compiler diagnoses co-located `.incn` and `.rs` source files instead of imposing precedence. Rust exceptions remain beneath `rust.*`.
+- **Deliberate interop boundary:** C remains behind the existing `[interop.c]` facade, including any authored C shim root. `[interop.*]` is reserved for later concrete integrations such as JNI or Python; v0.6 does not define a plugin system, automatic foreign-tool discovery, or generic foreign-source execution.
+- **Precise C configuration terminology:** Loaf configuration names C interop, host, target, and linker artifact form directly. It does not use `native` as an interop configuration keyword or a generic foreign-language category. Any change to RFC 116's existing source-level binding spelling requires a later language proposal rather than a retroactive edit to that closed RFC.
 
 ## Unresolved questions
 
 1. What is the final compact TOML syntax for typed dependency entries and provider-specific feature requests, while preserving the unit-kind/origin distinction?
-2. What exact table names should environments, matrices, actions, policy, and interop use under `Loaf.toml` after RFCs 073, 076, 078, and 116 are amended?
-3. Which nonstandard source-root and generated-input declarations are necessary for the first 0.6 implementation, beyond convention-first `src/` discovery?
+2. Which detailed environment matrix and action/policy subtable shapes are needed under the settled direct semantic roots without weakening the standard-environment or explicit-effect boundaries?
+3. Which generated-input declarations and compact `rust.*` exception fields are necessary for the first 0.6 implementation, beyond the settled core source-root syntax?
 4. How should an organization distribute and administer trusted registry registrations without letting a checked-out project overwrite user or organization trust policy?
 5. Which target/carrier combinations and named delivery-policy grammar constitute the first 0.6 proof set?
 6. What is the smallest typed generator/provider extension API that supports real code generation and native shims without becoming a generic script hook?

--- a/workspaces/docs-site/docs/RFCs/119_oven_native_rust_build_facets_and_cargo_interoperation.md
+++ b/workspaces/docs-site/docs/RFCs/119_oven_native_rust_build_facets_and_cargo_interoperation.md
@@ -30,14 +30,14 @@ Oven consumes crates.io and registered Cargo-compatible sources through the type
 
 ## Core model
 
-1. **A Rust facet is a Loaf facet:** a Rust-bearing Loaf declares the crate facts Oven needs to plan and invoke `rustc`; a neighbouring `Cargo.toml` never supplies ordinary Loaf authority.
+1. **A Rust facet is a built-in Loaf facet:** a conventional Rust-only Loaf uses the ordinary `src/` layout. A mixed or nonstandard Rust root declares `[rust.source]`; compact Rust-specific exceptions live beneath `rust.*`. In every case Oven, not a neighbouring `Cargo.toml`, supplies the crate facts needed to plan and invoke `rustc`.
 2. **Oven owns the graph:** dependency selection, feature resolution, target/host partitioning, toolchain choice, lock identity, execution plan, cache reuse, artifacts, and receipts belong to Oven.
 3. **Crates.io is consumption-only:** typed `crate` dependencies default to crates.io and may use registered compatible sources. Publishing remains in Incan's registry ecosystem.
 4. **Cargo manifests are provider metadata only when explicitly selected:** a registry crate's `Cargo.toml` can be parsed by the selected crate provider as constrained source metadata. It cannot define a Loaf workspace, lock, registry trust, lifecycle action, project target policy, or publication identity.
-5. **Build-time code is typed work:** build scripts and procedural macros are host-side providers with declared authority, inputs, outputs, toolchain identity, target/host role, policy decision, and receipt facts. Their existence never grants execution authority.
+5. **Build-time code has explicit host semantics:** a discovered `build.rs` is a generic host-provider candidate and never self-authorizes execution. A selected procedural-macro crate is compiled for the build host and executed by the selected `rustc` through its normal proc-macro ABI, as in Cargo; Oven does not replace that expansion mechanism. Both paths have explicit toolchain, host/target, policy, and receipt facts.
 6. **Host and target are different build domains:** build scripts, procedural macros, and compiler plugins execute for the build host; libraries, binaries, test subjects, and carriers are compiled for the selected target. Oven plans and locks both domains separately.
-7. **Rust test work is first-class:** unit tests, integration tests, doctests, examples, and benchmarks are explicit build/run roles, not side effects of a generic `rustc` invocation.
-8. **IDE projection is derived:** Oven may emit a Rust-analyzer-compatible project projection from the selected plan. It does not create or require a synthetic authoritative `Cargo.toml`.
+7. **Rust test work is first-class:** unit tests, integration tests, doctests, examples, and benchmarks are explicit build/run roles, not side effects of a generic `rustc` invocation. They use RFC 117's named environments: `test` by default for test roles and `docs` by default for documentation roles.
+8. **IDE projection is derived and warm-reusing:** Oven materializes a Rust-analyzer-compatible project projection from one explicit inspection selection. It first reuses every receipt-compatible pre-warmed `*.loaf` asset and provider/artifact closure, including across equivalent clean worktrees or implementation slices; the lightweight local projection then describes that selected graph. Switching an editor selection never implies rebuilding every target, dependency, or provider, and the projection does not create or require a synthetic authoritative `Cargo.toml`.
 9. **Cargo is an explicit interoperation boundary:** `oven cargo ...` invokes Cargo as Cargo-authoritative compatibility mode. Explicit adoption may import selected facts into a new `Loaf.toml`, but no directory with both manifests receives mixed semantics.
 10. **The Rust core remains narrow but real:** as decided by RFC 118, Oven's operational core/API owns planning, resolution, policy, stores, leases, provider execution, and crash-safe publication in Rust. Its public API is language-neutral and does not leak Rust borrows.
 11. **Incan-first authoring remains policy:** a Rust facet makes Rust projects and explicitly justified mixed work supportable. It does not authorize new Rust in Incan products without a demonstrated limitation and tracked removal path.
@@ -84,34 +84,34 @@ An explicitly Rust-authored project adopts Oven by authoring `Loaf.toml`, not by
 name = "telemetry-engine"
 version = "0.8.0"
 
-[[rust.crates]]
-name = "telemetry_engine"
-root = "src/lib.rs"
-edition = "2024"
-crate-types = ["rlib", "cdylib"]
-
-[[rust.binaries]]
-name = "telemetry"
-root = "src/bin/telemetry.rs"
-edition = "2024"
-requires-features = ["cli"]
-
 [dependencies]
 serde = { crate = "serde", version = "1", features = ["derive"] }
 tokio = { crate = "tokio", version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 
-This syntax is illustrative of the RFC's intended information model. The essential contract is that Oven can identify every compiled crate, its root, edition, crate types, entry point, enabled features, and dependency/linkage closure without reading a project `Cargo.toml`. A simple single-library project may use RFC 119's conventional defaults; multiple roots or any nondefault identity must be explicit.
+With `src/lib.rs`, `src/main.rs`, or `src/bin/telemetry.rs` in the conventional locations, this project needs no Rust table. The essential contract is that Oven can identify every compiled crate, its root, edition, crate types, entry point, enabled features, and dependency/linkage closure without reading a project `Cargo.toml`. The Rust facet remains convention-first: `src/lib.rs`, `src/bin/`, `tests/`, `examples/`, `benches/`, and documentation tests require no restatement in the manifest. Authors declare only meaningful deviations, such as an additional crate, a nonstandard root or crate type, a feature-gated target, a locally authored proc macro, or build-provider intent. The expanded host/target unit graph is derived inspection state in `oven plan` and `Oven.lock`, not normal authoring burden.
+
+A project that mixes Incan and Rust names both roots explicitly:
+
+```toml
+[incan.source]
+root = "sources/incan"
+
+[rust.source]
+root = "sources/rust"
+```
+
+The roots must not overlap. The exact compact shape for a genuine Rust exception belongs beneath `rust.*`; for example, a future settled grammar may name a non-conventional proc-macro crate as `[rust.crates.incan_derive]`. This RFC deliberately does not use an anonymous `[[sources]]` list or require an author to reproduce Cargo's whole manifest surface.
 
 The `crate` dependencies are ordinary Rust ecosystem inputs. They default to crates.io, but Oven records their canonical source, checksum, signatures or trust facts where available, selected feature closure, and host/target use in `Oven.lock`. The project's publication identity remains an Incan registry identity; `oven publish` does not mean `cargo publish`.
 
 ### Build-time work is visible before it runs
 
-Suppose `native-sys` requires code generation and native linking. Its `build.rs` does not execute simply because the file exists. Oven's selected crate provider declares a build-time provider and exposes a plan like:
+Suppose `native-sys` requires code generation and native linking. Its `build.rs` does not execute simply because the file exists. The selected crate metadata reports a provider candidate; Oven's generic build-script provider exposes a plan like:
 
 ```text
-host provider: native-sys build script
-  inputs: native-sys source digest, declared headers, selected compiler, allowed environment keys
+host provider: native-sys build script via rust.build-script
+  inputs: native-sys permitted source tree, selected features, build host/target, selected toolchain, allowed environment keys
   outputs: generated bindings, link search paths, link libraries, cfg facts
   effects: execute host helper, read declared inputs, write provider staging area
 
@@ -120,9 +120,9 @@ target Rust crate: native-sys
   consumes: locked generated bindings and normalized link facts
 ```
 
-The provider's host executable, argument vector, allowed environment, observed directives, generated-output digests, and policy result enter the receipt. Unsupported or undeclared behavior fails with a provider diagnostic; Oven does not silently retry through Cargo.
+The provider's host executable, argument vector, allowed environment, observed directives, generated-output digests, and policy result enter the receipt. Unsupported directives fail with a provider diagnostic; observe mode records an admitted provider's actual effects, while governed mode denies an ungranted effect class. Oven does not silently retry through Cargo.
 
-Procedural macros follow the same split. Oven compiles and loads the macro for the build host, records its source/toolchain/feature identity, and uses its expansion only in the locked build unit that requested it. The target crate never treats the host macro binary as a target artifact.
+Procedural macros follow the same host/target split, but not a new Oven expansion protocol. Oven compiles the macro for the build host, then invokes the selected `rustc` with the normal proc-macro artifact so that `rustc` loads and expands it through its native ABI, as it would in a Cargo build. The target crate never treats the host macro binary as a target artifact. Oven records the macro artifact and host toolchain as facts of the consuming compile unit; it does not cache individual macro expansions or route a bake through a separate macro server.
 
 ### Rust testing, documentation, and IDEs
 
@@ -193,12 +193,15 @@ Oven can consume a crate from crates.io because Rust libraries are part of the w
 
 ### Build scripts, procedural macros, and generated inputs
 
-1. `build.rs` is never automatically executed in a Loaf. A build-script provider must declare its source identity, build host, executable/toolchain requirements, allowed environment keys, declared input classes, output schema, capability/effect policy, and expected directive vocabulary.
-2. Oven runs an approved build-script provider in an isolated staging area. It captures its arguments, allowed environment values or redacted identities, outputs, normalized directives, generated-input digests, filesystem/network/process effects, and exit status in a provider receipt.
-3. The initial supported directive vocabulary must be explicit. It includes only directives Oven can normalize into plan facts—such as rerun inputs, generated source locations, cfg facts, link search paths, link libraries, link arguments, and controlled environment outputs. Unknown directives are errors, not opaque passthroughs.
-4. A procedural macro is a host compiler-time provider. Oven locks its host crate closure, compiler identity, dynamic-loading policy, expansion inputs, and diagnostics identity separately from target artifacts.
-5. Providers may not smuggle arbitrary network, filesystem, compiler, linker, or environment discovery into the target bake. Any expanded authority must be declared, policy-approved, and receipt-visible.
-6. A generated source participates only through an identified provider output. A change to its producing receipt or digest invalidates the dependent unit; a cache hit must identify the provider receipt it reused.
+1. A `build.rs` discovered from selected crate metadata is a provider candidate, not permission to execute. Oven supplies the generic `rust.build-script` host-provider role; Cargo metadata may report the role and its source facts, but cannot select or authorize it.
+2. Oven runs an admitted `rust.build-script` provider in isolated staging. Its conservative base input identity contains the permitted package input tree, selected features, build host, target, provider and toolchain identities, and approved environment values or redacted identities. Its receipt captures arguments, outputs, normalized directives, generated-input digests, filesystem/network/process effects, and exit status.
+3. The initial directive vocabulary is explicit: rerun source and environment inputs, cfg and check-cfg facts, controlled environment outputs, generated-input locations and digests, warnings and diagnostics, and native link search paths, libraries, and arguments. Unknown directives are errors, not opaque passthroughs.
+4. A procedural-macro crate is a host Rust unit. Oven locks its host crate closure, compiler identity, macro artifact digest, and diagnostics identity. The selected `rustc` loads and invokes that artifact through its normal proc-macro ABI; Oven must not insert a custom expansion bridge or standalone macro server into a bake. The target crate never treats the host macro binary as a target artifact.
+5. Observe mode preserves Cargo-equivalent host execution for a selected procedural macro while recording macro artifact, compiler invocation, observable inputs/effects, and diagnostics at the consuming compile-unit boundary. Oven does not claim an independently controlled receipt for every macro call. A backend that cannot observe an input needed for cache correctness must mark the result uncacheable rather than reuse it falsely.
+6. In governed mode, any containment applies around the compiler process that hosts macro execution. It must be explicit and receipt-visible; if the host cannot enforce the selected policy without changing behavior, Oven denies the governed operation rather than silently weakening policy. Permissive mode remains an explicit escape hatch. There is no implicit Cargo fallback.
+7. Native compilation/linking, system probing, and named external tools remain separate effect classes for a build-script provider, such as `native.cc`, `native.pkg-config`, `tool.cmake`, `tool.protoc`, and `tool.git`. A package can report a needed effect class but cannot grant it.
+8. Rerun directives refine inspection and later invalidation but are not assumed to capture every dynamic read on a first execution; the conservative base input identity remains part of cache correctness.
+9. A generated source participates only through an identified provider output. A change to its producing receipt or digest invalidates the dependent unit; a cache hit must identify the provider receipt it reused.
 
 ### Native linkage, carriers, and cross compilation
 
@@ -210,9 +213,13 @@ Oven can consume a crate from crates.io because Rust libraries are part of the w
 ### Rust test, documentation, and IDE projections
 
 1. Unit tests compile with their owning crate. Integration tests, examples, doctests, and benchmarks are distinct named units with declared source origins and dependency roles.
-2. Test execution uses Oven's scheduler, selected environment, capability policy, target selection, output retention, and receipt model. It must not silently dispatch to `cargo test` in Loaf mode.
+2. Test execution uses Oven's scheduler, selected environment, capability policy, target selection, output retention, and receipt model. Test roles select the standard `test` environment unless an explicit compatible environment is selected; documentation roles select `docs` by default. Environment-only dependencies do not enter an ordinary release bake unless the selected role requires them. Test execution must not silently dispatch to `cargo test` in Loaf mode.
 3. A doctest extraction or documentation generator must record its source spans, generated test inputs, compiler/provider facts, and diagnostics mapping. Generated Rust remains inspectable but is not the public source of truth.
-4. A Rust-analyzer-compatible projection is derived from the selected Oven graph and may be invalidated with the same receipt-bound facts. It must not require a Cargo workspace or invent a Cargo lock as editor authority.
+4. A Rust-analyzer-compatible projection is derived from one explicit Oven inspection selection and may be invalidated with the same receipt-bound facts. Its standard project descriptor contains only the selected crate roots, editions, exact dependency aliases, first-party membership, resolved cfg/target facts, selected sysroot, and non-sensitive compile environment or identified generated-output paths needed for analysis. An Oven sidecar identifies the selection's plan and receipt, freshness state, policy state, and diagnostics mapping; that sidecar, not the descriptor, retains Oven provenance.
+5. The active inspection selection defaults to the `dev` environment and the Loaf-selected target, or the host-native target if no project target is selected. Target switching is explicit and visible; Oven must not prepare every target merely because an editor is open.
+6. Before materializing a selection, Oven must look up the receipt-compatible pre-warmed `*.loaf` asset and provider/artifact closure. It must reuse that closure across equivalent clean worktrees and implementation slices, then materialize only the small workspace-local projection needed for the current source paths. A miss invalidates and rebuilds only the affected selection and units.
+7. An Oven-owned inspection session may enable editor-side procedural-macro expansion under explicit observe, governed, or permissive policy. That session records the selected macro artifact, toolchain, policy result, and expansion status without treating editor expansion as a bake or affecting a bake cache. A general compatibility export cannot claim to govern or receipt macro execution performed by an independent editor process.
+8. Editor diagnostics and runnable actions must delegate through the selected Oven plan and emit the required Rust diagnostics; they must not dispatch to Cargo. Projection data must not disclose sensitive environment values or duplicate dependency trees merely for inspection.
 
 ### Cargo compatibility and explicit adoption
 
@@ -231,7 +238,8 @@ The native Rust claim is valid only for the published conformance envelope. The 
 | Pure Rust library and binary  | direct `rustc` graph, feature closure, lock/offline/relocation, receipt and cache reuse            |
 | Mixed Incan/Rust Loaf         | cross-language dependency/linkage facts and source-mapped diagnostics                              |
 | Rust integration and doctests | separately selected test roles, scheduler/receipt behavior, failure diagnostics                    |
-| Proc macro and build provider | distinct host unit, declared authority, generated-input invalidation, cross-target target consumer |
+| Proc macro and build provider | Cargo-equivalent direct-`rustc` macro expansion, host artifact/compile-unit receipt, observe/governed policy behavior, directive diagnostics, generated-input invalidation, cross-target target consumer |
+| Rust IDE selection            | selected-plan projection and provenance sidecar, cfg/target/generated-input analysis, Oven-only diagnostics actions, explicit editor macro policy, and pre-warmed closure reuse across equivalent slices |
 | Native-link crate             | capability/toolchain/linker facts and target-bound carrier asset                                   |
 | Cross target                  | separated host/target plan, sysroot/linker identity, no host result mislabelled as target proof    |
 | Cargo project                 | explicit `oven cargo` execution and a no-implicit-adoption diagnostic                              |
@@ -245,7 +253,7 @@ The matrix is a compatibility statement, not a one-time benchmark. It must run o
 
 RFC 117 owns one manifest authority, one typed dependency graph, target policy, registry trust, `Oven.lock`, `*.loaf` identity, and the rule that a discovered Cargo file is ignored in Loaf mode. This RFC supplies the detailed Rust planner and provider contract that RFC 117 intentionally leaves open. It does not create a second Rust manifest or make a Rust facet an exception to workspace authority.
 
-The illustrative `[rust]` tables in this RFC are source-facet data within `Loaf.toml`, not a return to one manifest per implementation language. Incan and foreign sources remain convention-first or use their own explicit facets where required.
+The illustrative `rust.*` tables in this RFC are source-facet data within `Loaf.toml`, not a return to one manifest per implementation language. `[rust.source]` names a mixed or nonstandard Rust root, and other `rust.*` tables carry compact Rust-specific exceptions. No `[oven.rust]` prefix is needed: `Loaf.toml` is already the Oven-managed project document. Incan uses the parallel built-in `[incan.source]` root; C remains behind `[interop.c]` rather than becoming a peer top-level source namespace.
 
 ### Relationship to RFC 118
 
@@ -290,7 +298,7 @@ Rejected. It would revive implicit Cargo semantics, surprise build-script/proc-m
 
 - The Rust facet and direct compiler planner are substantial engineering work; Cargo currently hides much of this complexity.
 - Provider-mediated build scripts and procedural macros need sandboxing, receipt storage, and a practical support policy.
-- A bounded compatibility matrix will reject some ordinary Cargo packages until their behavior gains an explicit provider model.
+- A bounded compatibility matrix will require explicit effect grants or Cargo compatibility for ordinary Cargo packages whose host behavior lacks a supported, inspectable provider path.
 - Maintaining a Rust-analyzer projection and source-mapped diagnostics is additional tooling work.
 - A different publication authority means Cargo-native consumption of an Oven package remains an explicit interoperability problem, not a default workflow.
 
@@ -299,7 +307,7 @@ Rejected. It would revive implicit Cargo semantics, surprise build-script/proc-m
 - **Loaf manifest and validation** — must validate Rust facet identities, roles, crate roots, editions, crate types, feature mappings, target predicates, and adoption proposals.
 - **Resolver and registries** — must resolve crate providers, constrained provider metadata, deterministic feature closures, trust/integrity facts, and host/target partitions into `Oven.lock`.
 - **Rust operational core/API** — must plan direct `rustc` units, toolchains, sysroots, linkers, provider execution, artifacts, receipts, stores, leases, and recovery without Cargo in native mode.
-- **Provider and policy engine** — must declare, approve, execute, cache, invalidate, and inspect build scripts, procedural macros, generated inputs, native-link facts, and effect receipts.
+- **Provider and policy engine** — must declare, approve, execute, cache, invalidate, and inspect build scripts, generated inputs, native-link facts, and effect receipts; it must apply governed containment around compiler processes that host proc macros without substituting a new expansion mechanism.
 - **Compiler service API and diagnostics** — must expose Rust/compiled-source diagnostics and source maps without making Oven invoke the Incan CLI or generated Rust the public contract.
 - **Test, docs, and IDE tooling** — must model Rust test/documentation roles, scheduler facts, outputs, and derived Rust-analyzer-compatible project metadata.
 - **CLI and project mutation** — must expose canonical Oven operations and explicit Cargo/adoption modes according to RFCs 076 and 118.
@@ -308,10 +316,10 @@ Rejected. It would revive implicit Cargo semantics, surprise build-script/proc-m
 ## Inspectability and tooling surface
 
 - **Manifest and lock:** inspection reports the selected Rust facet, crate roles, conventional defaults or explicit declarations, provider origins, feature closure, host/target partition, and normalized toolchain/linker facts.
-- **Plan:** before execution, Oven shows every Rust compile unit, build-time provider, declared/allowed effect, selected target/carrier/profile, and expected `*.loaf` asset/receipt.
+- **Plan:** before execution, Oven shows every Rust compile unit, host macro artifacts, build-script providers, policy mode, expected effect classes, selected target/carrier/profile, and expected `*.loaf` asset/receipt.
 - **Artifacts and receipts:** each `*.loaf` asset exposes its facet, graph digest, payload digest, target, carrier, profile, provider receipts, and final bake receipt.
 - **Diagnostics:** invalid roots, unsupported provider metadata, build-script directives, proc-macro behavior, feature conflicts, source/target incompatibility, Cargo coexistence, and failed adoption name the affected source/dependency and the relevant explicit alternative.
-- **IDE:** the derived Rust project projection identifies the Oven plan and receipt from which it was created; it is not edited as authority.
+- **IDE:** the derived Rust project projection and Oven provenance sidecar identify the selected plan and receipt from which they were created, whether a receipt-compatible pre-warmed closure was reused, and whether the projection is fresh; neither is edited as authority.
 - **Not implicit:** no Cargo project discovery, Cargo lock reuse, build-script execution, proc-macro execution, native linker search path, registry registration, or crates.io publication occurs merely because a file or dependency exists.
 
 ## Implementation plan
@@ -329,13 +337,14 @@ Rejected. It would revive implicit Cargo semantics, surprise build-script/proc-m
 
 ### Phase 3: Controlled build-time providers
 
-- Implement the initial build-script directive vocabulary, provider isolation, policy gate, output capture, and invalidation rules.
-- Add procedural-macro host providers and source-mapped diagnostics.
+- Implement the generic build-script directive vocabulary, provider isolation, observe/governed effect policy, output capture, and conservative invalidation rules.
+- Add Cargo-equivalent direct-`rustc` procedural-macro support, source-mapped diagnostics, and observe/governed host-process conformance proofs.
 - Extend the conformance corpus with generated-input, native-link, and cross-target cases.
 
 ### Phase 4: IDE and Cargo interoperation
 
-- Materialize the derived Rust-analyzer project projection.
+- Materialize the derived Rust-analyzer project projection and Oven provenance sidecar from explicit inspection selections, reusing receipt-compatible pre-warmed Loaf closures across equivalent worktrees and slices.
+- Prove target switching, generated-input analysis, Oven-only diagnostics actions, and explicit editor macro policy without rebuilding an unchanged dependency/provider closure.
 - Implement explicit Cargo compatibility receipts and policy-gated adoption proposals.
 - Prove that normal Loaf execution never falls back to Cargo.
 
@@ -344,13 +353,19 @@ Rejected. It would revive implicit Cargo semantics, surprise build-script/proc-m
 - Publish the supported native-Rust conformance envelope and run it as a release gate.
 - Keep unsupported behavior diagnostic and route only explicit compatibility invocations through Cargo.
 
+## Design decisions
+
+- **Convention-first Rust authoring:** Rust is a direct built-in semantic facet. A conventional Rust source layout must not be restated merely to adopt Loaf. `[rust.source]` is used only for a mixed or nonstandard root, and compact Rust-specific deviations remain beneath `rust.*`; the complete compilation graph remains plan and lock state.
+- **Named environment use:** RFC 117 supplies the standard `dev`, `test`, `lint`, and `docs` environments. Rust test roles select `test` by default and documentation roles select `docs` by default. A bake is not an environment: its target, carrier, profile, and feature closure remain explicit plan selections.
+- **Proc-macro compatibility:** a proc macro is a foreign Rust compiler feature. Oven compiles it for the build host and lets the selected `rustc` load and invoke it through the normal ABI, matching Cargo behavior. Oven improves graph/artifact reuse without caching individual expansions or changing macro execution semantics; stricter containment is governed-policy behavior only.
+- **IDE selection, provenance, and warm reuse:** an editor uses one visible Oven inspection selection, defaulting to `dev` and the Loaf-selected or host-native target. Oven first reuses receipt-compatible pre-warmed Loaf/provider/artifact closures across equivalent clean worktrees and implementation slices, then derives a small local standard Rust project descriptor plus an Oven provenance sidecar. The descriptor is a compatibility export, not authority; it neither triggers every target build nor duplicates dependency output.
+- **Editor-side macro execution:** an Oven-owned inspection session may expand procedural macros only under explicit observe, governed, or permissive policy and records session-level macro/toolchain/policy status separately from bake receipts. A third-party editor that consumes the compatibility descriptor is never presented as governed Oven execution.
+
 ## Unresolved questions
 
-1. What exact `Loaf.toml` grammar best expresses multiple Rust crates, test/documentation roles, crate types, feature mappings, and target predicates without reproducing Cargo's manifest surface wholesale?
-2. Which build-script directive vocabulary is sufficient for the first native envelope, and which directives require a dedicated typed provider rather than controlled execution?
-3. What dynamic-loading/process isolation model is required for procedural macros across supported build hosts?
-4. Which Rust-analyzer project-projection fields are necessary for a useful editor experience without depending on Cargo workspace metadata?
-5. What evidence should promote a crate/provider class from Cargo-only compatibility to Oven-native support?
-6. If a public “Bakery” registry endpoint is introduced, should it be an alias of the current Incan registry identity or a separately registered registry kind?
+1. Which compact exception declarations are needed for nonconventional Rust crates, feature-gated targets, and target predicates without turning the convention-first facet into a restatement of Cargo's manifest surface?
+2. Which governed compiler-process containment backends meet the policy/receipt contract on supported build hosts without changing the Cargo-equivalent observe-mode behavior?
+3. What evidence should promote a crate/provider class from Cargo-only compatibility to Oven-native support?
+4. If a public “Bakery” registry endpoint is introduced, should it be an alias of the current Incan registry identity or a separately registered registry kind?
 
 <!-- Rename this section to "Design Decisions" once all questions have been resolved. An RFC cannot move from Draft to Planned until no unresolved questions remain. -->


### PR DESCRIPTION
## Summary

This PR records the agreed v0.6 Loaf project-model decisions in RFC 117 and RFC 119: nested `loaves/` groups, convention-first Incan/Rust source roots, deliberate C interop, and the deferred boundary for future `interop.*` integrations. It aligns the existing drafts without claiming that either RFC is implemented.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [x] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: Documents that simple Incan-only and Rust-only projects use conventional `src/` layouts; mixed projects explicitly use `[incan.source]` and `[rust.source]` with no filename precedence.
- **Internals**: Records explicit nested `loaves/` membership, keeps C behind `[interop.c]`, reserves later `interop.*` integrations without defining a v0.6 plugin system, and retains Rust-specific exceptions beneath `rust.*`.
- **Risks**: These are Draft-RFC decisions only. The exact compact Rust exception fields and future interop schemas remain intentionally unresolved; no implementation behavior changes in this PR.

## Testing / verification

- [ ] `make test` / `cargo test` (not applicable: documentation-only)
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `make -C workspaces/docs-site docs-build`
- `git diff --check origin/main...HEAD`
- Confirmed the public deferred follow-up is #1047; it is explicitly post-v0.6.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Updated RFC 117 and RFC 119. Both remain **Draft**; this PR records design decisions and does not close #1009 or #1012.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions (not applicable: documentation-only)
