### PR TITLE
RFC decision-closure: Oven project model, Rust build facets, CLI surfaces, runtime capabilities, typed CLI framework

### DIFF
--- a/workspaces/docs-site/docs/RFCs/034_incan_pub_registry.md
+++ b/workspaces/docs-site/docs/RFCs/034_incan_pub_registry.md
@@ -3,7 +3,7 @@
 - **Status:** Draft
 - **Created:** 2026-03-06
 - **Author(s):** Danny Meijer (@dannymeijer)
-- **Related:** RFC 027 (incan-vocab), RFC 031 (library system phase 1), RFC 117 (`Loaf.toml` and Oven's language-neutral project model), RFC 118 (Incan and Oven command-line surfaces)
+- **Related:** RFC 027 (incan-vocab), RFC 031 (library system phase 1), RFC 117 (`loaf.toml` and Oven's language-neutral project model), RFC 118 (Incan and Oven command-line surfaces)
 - **Issue:** [#168](https://github.com/encero-systems/incan/issues/168)
 - **RFC PR:** —
 - **Written against:** ~~v0.2~~ v0.5
@@ -57,7 +57,7 @@ $ oven publish
 ### Consuming a published package
 
 ```toml
-# my-app/Loaf.toml
+# my-app/loaf.toml
 [project]
 name = "my-app"
 version = "0.1.0"
@@ -329,7 +329,7 @@ mylib = { loaf = "mylib", version = "0.1.0", registry = "incan.pub" } # explicit
 
 Resolution:
 
-1. Read the typed dependency entry from `Loaf.toml`
+1. Read the typed dependency entry from `loaf.toml`
 2. For each registry dep: `GET https://incan.pub/index/<prefix>/<name>`
 3. Parse JSON lines, filter by version requirement, select newest matching non-yanked version
 4. Check local cache `~/.incan/libs/<name>-<version>/` — if cached and checksum matches, skip download
@@ -348,9 +348,9 @@ The resolver must not wire downloaded generated Rust source into generated `Carg
 
 | Command                       | Description                                                                       |
 | ----------------------------- | --------------------------------------------------------------------------------- |
-| `oven add <pkg>`              | Add a Loaf dependency to `Loaf.toml` (fetch latest version from `incan.pub`)      |
-| `oven add --crate <pkg>`      | Add a crate dependency to `Loaf.toml` (fetch from crates.io by default)           |
-| `oven remove <pkg>`           | Remove a typed dependency from `Loaf.toml`                                        |
+| `oven add <pkg>`              | Add a Loaf dependency to `loaf.toml` (fetch latest version from `incan.pub`)      |
+| `oven add --crate <pkg>`      | Add a crate dependency to `loaf.toml` (fetch from crates.io by default)           |
+| `oven remove <pkg>`           | Remove a typed dependency from `loaf.toml`                                        |
 | `oven update`                 | Re-resolve the selected closure and update `Oven.lock`                            |
 | `oven login`                  | Authenticate with `incan.pub`, save credentials in Oven-controlled secure storage |
 | `oven publish`                | Bake the selected Loaf, package `.incanpkg`, sign, and upload it                  |
@@ -361,7 +361,7 @@ The resolver must not wire downloaded generated Rust source into generated `Carg
 
 #### `oven add` in detail
 
-Like `cargo add`, this is the primary way users add dependencies. It edits `Loaf.toml` for you. The final aliases exposed through `incan` are owned by RFC 118; they must delegate to Oven rather than duplicate this resolution behavior.
+Like `cargo add`, this is the primary way users add dependencies. It edits `loaf.toml` for you. The final aliases exposed through `incan` are owned by RFC 118; they must delegate to Oven rather than duplicate this resolution behavior.
 
 ```bash
 # Add latest version from incan.pub
@@ -387,14 +387,14 @@ $ oven add widgets --git https://github.com/example/widgets --tag v0.2.0
 
 **Behavior:**
 
-1. If no `Loaf.toml` exists, error with "run `oven init` first"
+1. If no `loaf.toml` exists, error with "run `oven init` first"
 2. Query the registry index for the latest non-yanked version (unless `@version` or `--path`/`--git` specified)
 3. Default to `^major.minor.patch` range (SemVer-compatible, like Cargo)
 4. Write the typed entry to `[dependencies]`
-5. If the package is already in `Loaf.toml`, update the version (with a confirmation prompt unless `--force`)
+5. If the package is already in `loaf.toml`, update the version (with a confirmation prompt unless `--force`)
 6. Update `Oven.lock` with the resolved closure
 
-`oven remove` does the inverse: removes the entry from `Loaf.toml` and re-locks.
+`oven remove` does the inverse: removes the entry from `loaf.toml` and re-locks.
 
 ## Infrastructure: provider selection
 
@@ -541,7 +541,7 @@ German provider, good pricing. However: no scale-to-zero compute (minimum €4.5
 
 ## Future extensions (out of scope)
 
-- **Private registries.** Organizations may register an `incan.pub`-compatible registry in Oven-controlled organization or user configuration, then allow-list that registered identity from a Loaf or workspace. Credentials and trust policy never live in `Loaf.toml`; `Oven.lock` records the resolved canonical identity and observed trust facts.
+- **Private registries.** Organizations may register an `incan.pub`-compatible registry in Oven-controlled organization or user configuration, then allow-list that registered identity from a Loaf or workspace. Credentials and trust policy never live in `loaf.toml`; `Oven.lock` records the resolved canonical identity and observed trust facts.
 - **Trusted Publishers (GitHub Actions OIDC).** Like PyPI's Trusted Publishers — CI/CD can publish without long-lived tokens by using GitHub Actions' OIDC identity directly with Sigstore.
 - **Package auditing tools.** `oven audit` to check dependencies against a vulnerability database.
 - **Mirror support.** Read-only mirrors of `incan.pub` for network-restricted environments or regional performance.

--- a/workspaces/docs-site/docs/RFCs/073_env_matrices_and_toolchain_constraints.md
+++ b/workspaces/docs-site/docs/RFCs/073_env_matrices_and_toolchain_constraints.md
@@ -9,7 +9,7 @@
     - RFC 018 (language primitives for testing)
     - RFC 019 (test runner, CLI, and ecosystem)
     - RFC 020 (Cargo offline and locked policy)
-    - RFC 117 (`Loaf.toml` and Oven's language-neutral project model)
+    - RFC 117 (`loaf.toml` and Oven's language-neutral project model)
     - RFC 118 (Incan and Oven command-line surfaces)
 - **Issue:** https://github.com/encero-systems/incan/issues/401
 - **RFC PR:** —
@@ -18,7 +18,7 @@
 
 ## Summary
 
-This RFC defines two parts of the Oven-managed environment model: enforceable Incan toolchain constraints and matrix-expanded environments. `Loaf.toml` projects and named environments may declare `requires-incan` constraints that the active toolchain must satisfy before project-aware execution begins, and environments may define matrices that expand one logical env into multiple concrete env instances. Environment and matrix constraints only narrow inherited compatibility; they do not loosen it. Matrix execution stays at the Oven lifecycle layer: it repeats env scripts across resolved env cells, but it does not define test-runner semantics, parallel scheduling policy, or toolchain installation.
+This RFC defines two parts of the Oven-managed environment model: enforceable Incan toolchain constraints and matrix-expanded environments. `loaf.toml` projects and named environments may declare `requires-incan` constraints that the active toolchain must satisfy before project-aware execution begins, and environments may define matrices that expand one logical env into multiple concrete env instances. Environment and matrix constraints only narrow inherited compatibility; they do not loosen it. Matrix execution stays at the Oven lifecycle layer: it repeats env scripts across resolved env cells, but it does not define test-runner semantics, parallel scheduling policy, or toolchain installation.
 
 ## Core model
 
@@ -29,7 +29,7 @@ Read this RFC as four foundations plus three mechanisms:
 3. **Foundation:** A matrix env is still one named env in the manifest, but it expands into multiple concrete env instances at execution time.
 4. **Foundation:** Matrix orchestration belongs to Oven, not to the test runner. RFC 019 remains the owner of test collection, parametrization, fixtures, reporting, and parallel test execution semantics.
 5. **Mechanism A:** Execution commands compute an effective `requires-incan` constraint and fail early when the active toolchain does not satisfy it, while inspection commands surface compatibility without being blocked by it.
-6. **Mechanism B:** `[[oven.envs.<name>.matrix]]` in `Loaf.toml` declares one or more axes that generate concrete env instances by Cartesian product.
+6. **Mechanism B:** `[[oven.envs.<name>.matrix]]` in `loaf.toml` declares one or more axes that generate concrete env instances by Cartesian product.
 7. **Mechanism C:** Selecting a concrete env instance runs one resolved env; selecting a matrix root env runs the target script across all generated env instances in deterministic order.
 
 ## Motivation
@@ -174,7 +174,7 @@ The following commands must resolve the nearest project root and enforce an effe
 - `oven test`
 - `oven lock`
 - `oven env run`
-- any future Oven operation that reads a `Loaf.toml` project
+- any future Oven operation that reads a `loaf.toml` project
 
 The following commands must resolve and report the effective constraint, but they must not require the active toolchain to satisfy it merely to inspect configuration:
 
@@ -201,7 +201,7 @@ Commands that do not resolve a project root must not attempt to infer or enforce
 
 ### Environment schema additions
 
-This RFC adds the following optional fields to `[oven.envs.<name>]` in `Loaf.toml`:
+This RFC adds the following optional fields to `[oven.envs.<name>]` in `loaf.toml`:
 
 - `requires-incan: str`
 - `matrix: List[Table]`

--- a/workspaces/docs-site/docs/RFCs/074_template_rendering_and_boilerplate_provenance.md
+++ b/workspaces/docs-site/docs/RFCs/074_template_rendering_and_boilerplate_provenance.md
@@ -10,7 +10,7 @@
     - RFC 034 (`incan.pub` package registry)
     - RFC 075 (starter profiles and capability packs)
     - RFC 076 (project mutation policy and recovery)
-    - RFC 117 (`Loaf.toml` and Oven's language-neutral project model)
+    - RFC 117 (`loaf.toml` and Oven's language-neutral project model)
 - **Issue:** https://github.com/encero-systems/incan/issues/402
 - **RFC PR:** —
 - **Written against:** ~~v0.3~~ v0.5
@@ -676,7 +676,7 @@ Rejected because generated project boilerplate should be reviewable, editable, a
 
 - **Parser:** rendered Incan templates must parse before they are written when `language = "incan"`.
 - **Formatter:** rendered Incan templates should be formatted before write and before `rendered_hash` is recorded when a formatter is available.
-- **Manifest schema / configuration validation:** project tooling must support an explicit provenance location for tracked templates, whether in a typed `Loaf.toml` table or an explicit tool-owned state artifact. `Oven.lock` remains resolver state and must not become a general mutation-history store.
+- **Manifest schema / configuration validation:** project tooling must support an explicit provenance location for tracked templates, whether in a typed `loaf.toml` table or an explicit tool-owned state artifact. `Oven.lock` remains resolver state and must not become a general mutation-history store.
 - **CLI / tooling:** lifecycle tooling must implement deterministic template rendering, path validation, parameter validation, ownership handling, provenance recording, and check/status/values-file/diff/update/reset operations.
 - **LSP / IDE tooling:** editor-facing tools should consume machine-readable template provenance and lifecycle diagnostics rather than reimplementing template rendering.
 - **Package integration:** package-provided templates must be loaded as package data and rendered locally under the same safety rules as built-in templates. Package or registry metadata may feed version-aware status and upgrade previews.
@@ -684,7 +684,7 @@ Rejected because generated project boilerplate should be reviewable, editable, a
 
 ## Unresolved questions
 
-- Should template provenance live in a typed `Loaf.toml` table or a separate tool-owned state file, and which facts must remain outside `Oven.lock`?
+- Should template provenance live in a typed `loaf.toml` table or a separate tool-owned state file, and which facts must remain outside `Oven.lock`?
 - Is the v1 parameter kind set sufficient, or should it include specific kinds for package names, dependency requirements, env names, and script ids?
 - Which derived-value transforms should be standardized in v1?
 - Should optional file groups live in RFC 074 as template renderer metadata, or should RFC 075 own them as starter/capability mutation metadata?

--- a/workspaces/docs-site/docs/RFCs/075_starter_profiles_and_capability_packs.md
+++ b/workspaces/docs-site/docs/RFCs/075_starter_profiles_and_capability_packs.md
@@ -1,4 +1,4 @@
-# RFC 075: starter profiles and capability packs
+# RFC 075: starter profiles and mixes
 
 - **Status:** Draft
 - **Created:** 2026-04-25
@@ -22,30 +22,30 @@
 
 ## Summary
 
-This RFC extends the Loaf/Oven project model with starter profiles and capability packs. A starter profile is a declarative recipe for creating or initializing a project with a coherent set of files, manifest entries, and capability packs. A capability pack is a reusable, explicit project mutation that can add package dependencies, scripts, environment configuration, starter files, tooling metadata, and follow-up diagnostics to an existing project. Starter and capability descriptors may depend on other descriptors, but they must resolve into one reviewable mutation plan. The goal is not hidden framework magic; the goal is to keep the Cargo-shaped package workflow from RFC 034 (`oven add <pkg>`) while adding an explicit project-capability workflow (`oven capability add <capability>`) for setup that changes source files, scripts, envs, and tooling metadata.
+This RFC extends the Loaf/Oven project model with starter profiles and mixes. A starter profile is a declarative recipe for creating or initializing a project with a coherent set of files, manifest entries, and mixes. A mix is a reusable, explicit project mutation that can add package dependencies, scripts, environment configuration, starter files, tooling metadata, and follow-up diagnostics to an existing project. Starter and mix descriptors may depend on other descriptors, but they must resolve into one reviewable mutation plan. The goal is not hidden framework magic; the goal is to keep the Cargo-shaped package workflow from RFC 034 (`oven add <pkg>`) while adding an explicit project-mix workflow (`oven mix add <mix>`) for setup that changes source files, scripts, envs, and tooling metadata.
 
 ## Core model
 
 Read this RFC as nine foundations plus five mechanisms:
 
 1. **Foundation:** RFC 117 owns the `Loaf.toml` project model and root authority; this RFC layers richer project shapes on top without redefining manifest discovery, workspace inheritance, dependency resolution, or named-environment semantics.
-2. **Foundation:** Starters and capability packs are tooling descriptors, not new language constructs. Applying one must result in explicit project files and manifest entries.
+2. **Foundation:** Starters and mixes are tooling descriptors, not new language constructs. Applying one must result in explicit project files and manifest entries.
 3. **Foundation:** Generated projects remain ordinary Incan projects. There is no hidden starter mode, no runtime dependency injection container, and no implicit activation that cannot be inspected after creation.
-4. **Foundation:** Capability packs are composition units. A starter profile may include zero or more capability packs, and an existing project may add a capability pack later through `oven capability add`.
-5. **Foundation:** Descriptor dependencies are explicit. Starters and capability packs may depend on other starters, capabilities, or templates, but the CLI must resolve that graph before applying any mutation.
+4. **Foundation:** Mixes are composition units. A starter profile may include zero or more mixes, and an existing project may add a mix later through `oven mix add`.
+5. **Foundation:** Descriptor dependencies are explicit. Starters and mixes may depend on other starters, mixes, or templates, but the CLI must resolve that graph before applying any mutation.
 6. **Foundation:** Starter application must be deterministic and safe by default: no arbitrary script execution, no unprompted overwrites, no silent dependency changes, and no secret material embedded into generated files.
-7. **Foundation:** Incan packages may advertise capability packs. Adding a package and applying a capability are separate operations: `oven add <pkg>` changes dependencies; `oven capability add <capability>` applies project setup and may add dependencies as part of an explicit mutation plan.
+7. **Foundation:** Incan packages may advertise mixes. Adding a package and applying a mix are separate operations: `oven add <pkg>` changes dependencies; `oven mix add <mix>` applies project setup and may add dependencies as part of an explicit mutation plan.
 8. **Foundation:** Applicability and back-off decisions are explicit. A descriptor may explain why it applies, why it is already satisfied, why it skipped a mutation, or why it is blocked, but it must not infer success from undocumented file conventions.
-9. **Foundation:** The same descriptor model must be consumable by CLI and editor tooling. IDE support should not infer project intent from ad-hoc filenames when the starter or capability pack can declare that intent directly.
-10. **Mechanism A:** `oven new <name> --starter <id>` creates a project by resolving one starter profile, applying its capability packs, rendering its files, and writing a normal `Loaf.toml`.
+9. **Foundation:** The same descriptor model must be consumable by CLI and editor tooling. IDE support should not infer project intent from ad-hoc filenames when the starter or mix can declare that intent directly.
+10. **Mechanism A:** `oven new <name> --starter <id>` creates a project by resolving one starter profile, applying its mixes, rendering its files, and writing a normal `Loaf.toml`.
 11. **Mechanism B:** `oven init --starter <id>` applies starter initialization to an existing directory with adoption-oriented conflict rules. Existing-project initialization must preserve user-authored files more aggressively than greenfield creation.
-12. **Mechanism C:** `oven capability add <capability-id>` resolves one capability pack, which may be advertised by a package, then applies the resulting mutation plan to an existing project.
-13. **Mechanism D:** `oven starter list`, `oven starter show`, and dry-run output expose what a starter or capability pack would change before files are written.
-14. **Mechanism E:** lifecycle tooling exposes machine-readable starter, capability, and project-capability views so LSP servers and IDE plugins can offer completion, code actions, run actions, and project-shape diagnostics from the same contract as the CLI.
+12. **Mechanism C:** `oven mix add <mix-id>` resolves one mix, which may be advertised by a package, then applies the resulting mutation plan to an existing project.
+13. **Mechanism D:** `oven starter list`, `oven starter show`, and dry-run output expose what a starter or mix would change before files are written.
+14. **Mechanism E:** lifecycle tooling exposes machine-readable starter, mix, and project-mix views so LSP servers and IDE plugins can offer completion, code actions, run actions, and project-shape diagnostics from the same contract as the CLI.
 
 ## Motivation
 
-RFC 015 deliberately defines a small, explicit project lifecycle CLI: create a project, initialize metadata, define scripts and envs, bump versions, and run named env commands. That is the right base layer, but a minimal `hello world` scaffold is not enough once the ecosystem has reusable libraries for common domains such as CLIs, HTTP clients, web entrypoints, serialization, testing, data access, and documentation. Rust users can often add a crate and immediately use its API; Incan should preserve that simple dependency story through RFC 034's `oven add <pkg>` while also recognizing that application capabilities often need a small amount of project setup. Without a first-class starter model, users will copy examples by hand, drift from recommended dependency combinations, and re-learn the same manifest wiring in every repository.
+RFC 015 deliberately defines a small, explicit project lifecycle CLI: create a project, initialize metadata, define scripts and envs, bump versions, and run named env commands. That is the right base layer, but a minimal `hello world` scaffold is not enough once the ecosystem has reusable libraries for common domains such as CLIs, HTTP clients, web entrypoints, serialization, testing, data access, and documentation. Rust users can often add a crate and immediately use its API; Incan should preserve that simple dependency story through RFC 034's `oven add <pkg>` while also recognizing that application mixes often need a small amount of project setup. Without a first-class starter model, users will copy examples by hand, drift from recommended dependency combinations, and re-learn the same manifest wiring in every repository.
 
 Library metadata and manifests already point toward a more declarative ecosystem. RFC 027 says feature and dependency metadata should travel through library manifests rather than ad-hoc compiler scans, and RFC 031 establishes `.incnlib` as a semantic library artifact. Those pieces help libraries describe themselves, but they do not answer the project-author question: "start this repo with the standard shape for X" or "add the standard support for Y to this repo."
 
@@ -54,20 +54,20 @@ The missing layer is an explicit project mutation contract. Users need a command
 ## Goals
 
 - Define starter profiles as declarative recipes for `oven new` and `oven init`.
-- Define capability packs as reusable project mutations that can be applied independently through `oven capability add`.
-- Define descriptor dependency resolution so starters, capabilities, and templates can compose without hidden ordering.
-- Allow package authors to advertise capability packs so `oven add <package>` can add the package dependency and then point users toward optional setup through `oven capability add <capability>`.
-- Make starter and capability application deterministic, conflict-aware, dry-runnable, and reviewable.
+- Define mixes as reusable project mutations that can be applied independently through `oven mix add`.
+- Define descriptor dependency resolution so starters, mixes, and templates can compose without hidden ordering.
+- Allow package authors to advertise mixes so `oven add <package>` can add the package dependency and then point users toward optional setup through `oven mix add <mix>`.
+- Make starter and mix application deterministic, conflict-aware, dry-runnable, and reviewable.
 - Define explainable applicability and back-off behavior for existing projects.
 - Distinguish greenfield project creation from existing-project adoption so migration does not overwrite user-authored files under creation-oriented assumptions.
-- Allow starters and capability packs to add manifest entries, dependencies, dev-dependencies, scripts, env definitions, file templates, tooling metadata, agent guidance metadata, and user-facing follow-up notes.
+- Allow starters and mixes to add manifest entries, dependencies, dev-dependencies, scripts, env definitions, file templates, tooling metadata, agent guidance metadata, and user-facing follow-up notes.
 - Keep generated projects ordinary: all persistent behavior must be represented in source files, `Loaf.toml`, `Oven.lock`, or documented generated artifacts.
-- Provide inspection commands so users can list available starters, preview one starter, and see which capabilities are recorded in a project.
-- Define a review-first capability update path so a project can move an applied capability from one recorded descriptor version to another without treating the change as an automatic package upgrade or silent template rewrite.
-- Provide machine-readable inspection surfaces so LSP and IDE tooling can list starters, preview capability changes, show enabled capabilities, and surface project-specific actions without reimplementing descriptor resolution.
-- Allow starter and capability descriptors to be resolved from source-agnostic catalogs such as built-in descriptors, local paths, git sources, public package registries, or private catalogs.
+- Provide inspection commands so users can list available starters, preview one starter, and see which mixes are recorded in a project.
+- Define a review-first mix update path so a project can move an applied mix from one recorded descriptor version to another without treating the change as an automatic package upgrade or silent template rewrite.
+- Provide machine-readable inspection surfaces so LSP and IDE tooling can list starters, preview mix changes, show enabled mixes, and surface project-specific actions without reimplementing descriptor resolution.
+- Allow starter and mix descriptors to be resolved from source-agnostic catalogs such as built-in descriptors, local paths, git sources, public package registries, or private catalogs.
 - Leave room for public and private catalog-backed starter discovery without requiring catalog support in the first implementation.
-- Treat `incan.pub` as the eventual default public remote discovery and trust layer for starter and capability descriptors, while allowing non-public catalogs to use the same descriptor semantics and keeping local application semantics in the lifecycle CLI.
+- Treat `incan.pub` as the eventual default public remote discovery and trust layer for starter and mix descriptors, while allowing non-public catalogs to use the same descriptor semantics and keeping local application semantics in the lifecycle CLI.
 - Align with RFC 033 when generated projects need typed configuration: starter-provided config should prefer `ctx` source files over untyped sidecar YAML where compiler visibility matters.
 
 ## Non-Goals
@@ -76,15 +76,15 @@ The missing layer is an explicit project mutation contract. Users need a command
 - Defining a public registry protocol for distributing starters. RFC 034 remains the owner of package registry semantics.
 - Defining package ranking, recommendations, telemetry, download analytics, or marketplace UI details for `incan.pub`.
 - Defining private catalog hosting, identity, authorization, administration, or commercial policy.
-- Defining the low-level `.incnlib` capability manifest schema in full. This RFC may consume library-declared capability metadata when available, but it primarily defines the project lifecycle UX for applying starter and capability descriptors.
-- Making every package addition mutate project structure. Plain dependency addition remains valid; capability setup is for packages that advertise it and for users who request it through the capability command surface.
+- Defining the low-level `.incnlib` mix manifest schema in full. This RFC may consume library-declared mix metadata when available, but it primarily defines the project lifecycle UX for applying starter and mix descriptors.
+- Making every package addition mutate project structure. Plain dependency addition remains valid; mix setup is for packages that advertise it and for users who request it through the mix command surface.
 - Adding a general-purpose templating language with arbitrary code execution.
 - Defining template rendering or generated-file provenance semantics. RFC 074 owns the template layer this RFC consumes.
 - Adding runtime auto-configuration, dependency injection, reflection-based wiring, or hidden framework activation.
 - Defining editor-specific plugin APIs for Visual Studio Code, JetBrains IDEs, Vim, or any other editor. This RFC defines the toolchain contract those integrations may consume.
 - Defining an agent runtime, agent marketplace, prompt format, or autonomous execution policy. This RFC may describe agent-relevant metadata, but it does not specify how agents run.
 - Replacing examples, tutorials, or documentation. Starters complement documentation by making the recommended shape executable.
-- Defining capability removal or arbitrary project migration. This RFC defines descriptor-version updates for previously applied capabilities, but it does not promise that every user-authored project change can be merged automatically.
+- Defining mix removal or arbitrary project migration. This RFC defines descriptor-version updates for previously applied mixes, but it does not promise that every user-authored project change can be merged automatically.
 
 ## Guide-level explanation
 
@@ -118,10 +118,10 @@ oven new weather_tool --starter cli
 
 The generated project is still an ordinary Incan project. The starter writes `Loaf.toml`, source files, docs, test files, and any other explicit artifacts described by the starter descriptor. There is no persistent hidden link to the starter that changes compilation semantics later.
 
-If the starter includes capability packs, the CLI applies them as part of creation and records them in the project manifest for inspection:
+If the starter includes mixes, the CLI applies them as part of creation and records them in the project manifest for inspection:
 
 ```toml
-[oven.capabilities]
+[oven.mixes]
 enabled = ["std.process", "testing.basic"]
 ```
 
@@ -137,40 +137,40 @@ oven init --starter cli
 
 This uses the same descriptor as `oven new`, but conflict handling is stricter because files may already exist. By default, generated files must not overwrite existing files. If a starter cannot be applied without overwriting or merging conflicting data, the CLI must stop with a diagnostic and suggest `--dry-run` or explicit overwrite flags.
 
-### Adding a capability pack
+### Adding a mix
 
-An existing project may add one reusable capability without switching to a different starter:
+An existing project may add one reusable mix without switching to a different starter:
 
 ```text
-oven capability add std.http-client
+oven mix add std.http-client
 ```
 
-The CLI resolves the capability pack, previews or applies its manifest changes, writes any declared files that do not conflict, and records the capability as enabled. If the capability depends on other capability packs, the CLI must show those transitive additions before applying them.
+The CLI resolves the mix, previews or applies its manifest changes, writes any declared files that do not conflict, and records the mix as enabled. If the mix depends on other mixes, the CLI must show those transitive additions before applying them.
 
-Capability packs should be small enough to explain. A pack named `std.http-client` might add a standard HTTP dependency, JSON support, a test fixture file, and a starter `ctx` for endpoint configuration. A pack named `testing.basic` might add test scripts and a sample test file. A pack should not try to become an entire application architecture.
+Mixes should be small enough to explain. A mix named `std.http-client` might add a standard HTTP dependency, JSON support, a test fixture file, and a starter `ctx` for endpoint configuration. A mix named `testing.basic` might add test scripts and a sample test file. A mix should not try to become an entire application architecture.
 
 ### Dry-run and review
 
-Both starters and capability packs should support dry-run output:
+Both starters and mixes should support dry-run output:
 
 ```text
 oven new weather_tool --starter cli --dry-run
-oven capability add std.http-client --dry-run
+oven mix add std.http-client --dry-run
 ```
 
 Dry-run output must show planned file writes, manifest additions, dependency changes, env/script additions, skipped mutations, already-satisfied expectations, and any conflicts. The dry run should be detailed enough that a user can decide whether the command is safe before mutating the project.
 
-### Updating an applied capability
+### Updating an applied mix
 
-Capability updates are review-first project migrations, not package upgrades and not automatic template rewrites.
+Mix updates are review-first project migrations, not package upgrades and not automatic template rewrites.
 
 When a project records that it applied `cli` from descriptor version `1.3.0`, a later user should be able to ask what it would mean to move that project concern to `1.6.0`:
 
 ```text
-oven capability status cli
-oven capability diff cli --to 1.6.0
-oven capability update cli --to 1.6.0 --dry-run
-oven capability update cli --to 1.6.0
+oven mix status cli
+oven mix diff cli --to 1.6.0
+oven mix update cli --to 1.6.0 --dry-run
+oven mix update cli --to 1.6.0
 ```
 
 The lifecycle CLI resolves the currently recorded descriptor source and target descriptor version, verifies that the source identity has not silently changed, expands descriptor dependencies, renders affected RFC 074 templates with preserved or supplied values, and produces one receiver-side mutation plan.
@@ -178,7 +178,7 @@ The lifecycle CLI resolves the currently recorded descriptor source and target d
 For example, a dry run for `cli 1.3.0 -> 1.6.0` might report:
 
 ```text
-Capability update: cli 1.3.0 -> 1.6.0
+Mix update: cli 1.3.0 -> 1.6.0
 Source: incan.pub:app-cli
 Publisher: encero
 Source identity changed: no
@@ -208,28 +208,28 @@ Files:
     action: requires policy approval
 ```
 
-The user-facing update unit is the capability because that is how the project concern was applied. RFC 074 still owns the lower-level template behavior for individual files: managed files may be updated when unchanged, bootstrap files are not rewritten by normal capability updates, advisory files are explained but not owned, and edited managed files must stop with a conflict or use a documented merge strategy. RFC 076 evaluates the resulting mutation plan before anything is written.
+The user-facing update unit is the mix because that is how the project concern was applied. RFC 074 still owns the lower-level template behavior for individual files: managed files may be updated when unchanged, bootstrap files are not rewritten by normal mix updates, advisory files are explained but not owned, and edited managed files must stop with a conflict or use a documented merge strategy. RFC 076 evaluates the resulting mutation plan before anything is written.
 
-`oven capability diff` should show the receiver-side patch that would land in the project. Catalog or registry source diffs between descriptor versions are useful supporting evidence, but they are not a substitute for the rendered project diff.
+`oven mix diff` should show the receiver-side patch that would land in the project. Catalog or registry source diffs between descriptor versions are useful supporting evidence, but they are not a substitute for the rendered project diff.
 
 If the descriptor declares ordered migration steps between intermediate versions, the CLI may collapse them into one target update as long as the resulting plan remains explainable. If a required step cannot be represented declaratively, the update must stop and present manual instructions rather than running arbitrary provider code.
 
 ### IDE and editor support
 
-The same starter and capability metadata should power editor workflows. An editor or LSP client should be able to ask the toolchain which starters and capabilities are available, which ones are compatible with the current project, and what changes a capability would make before applying it.
+The same starter and mix metadata should power editor workflows. An editor or LSP client should be able to ask the toolchain which starters and mixes are available, which ones are compatible with the current project, and what changes a mix would make before applying it.
 
 Examples of editor-facing behavior this RFC enables:
 
-- completion for starter and capability ids in command palettes or manifest fields
-- code actions such as "Add testing.basic capability" when a file imports testing helpers but the project lacks the expected setup
-- run/debug actions for scripts contributed by a starter or capability pack
-- diagnostics for stale capability provenance, invalid generated file roles, or missing project files that an enabled capability expects
-- hover or project-tree annotations that show which capability introduced a source file, env script, or config declaration
-- agent-assist affordances that suggest relevant project skills or maintenance workflows for a capability, without running them implicitly
+- completion for starter and mix ids in command palettes or manifest fields
+- code actions such as "Add testing.basic mix" when a file imports testing helpers but the project lacks the expected setup
+- run/debug actions for scripts contributed by a starter or mix
+- diagnostics for stale mix provenance, invalid generated file roles, or missing project files that an enabled mix expects
+- hover or project-tree annotations that show which mix introduced a source file, env script, or config declaration
+- agent-assist affordances that suggest relevant project skills or maintenance workflows for a mix, without running them implicitly
 
 These workflows must be backed by the same mutation plan and descriptor resolution rules as the CLI. An IDE integration should not have to scrape generated files or duplicate starter semantics to understand the project.
 
-### Concrete walkthrough: adding a CLI capability
+### Concrete walkthrough: adding a CLI mix
 
 Suppose a user has an existing project:
 
@@ -239,7 +239,7 @@ weather_core/
   src/lib.incn
 ```
 
-They want to add a standard command-line entrypoint without hand-copying example files. The provider has published an `app-cli` package that advertises a `cli` capability.
+They want to add a standard command-line entrypoint without hand-copying example files. The provider has published an `app-cli` package that advertises a `cli` mix.
 
 The user may start with the Rust-like package workflow:
 
@@ -252,23 +252,23 @@ That only changes dependencies:
 ```text
 Added app-cli = "0.3.1" to [dependencies]
 
-This package advertises project capabilities:
+This package advertises project mixes:
   cli  Adds a CLI entrypoint, run script, and test skeleton
 
 Apply setup with:
-  oven capability add cli
+  oven mix add cli
 ```
 
-To preview the project setup, the user asks for a capability dry run:
+To preview the project setup, the user asks for a mix dry run:
 
 ```text
-oven capability add cli --dry-run
+oven mix add cli --dry-run
 ```
 
-The CLI resolves `cli` as a capability, sees that its recommended provider is `app-cli`, validates the descriptor against the active project, and prints a mutation plan:
+The CLI resolves `cli` as a mix, sees that its recommended provider is `app-cli`, validates the descriptor against the active project, and prints a mutation plan:
 
 ```text
-Capability: cli
+Mix: cli
 Package: app-cli 0.3.1
 Source: incan.pub:app-cli@0.3.1
 Requires Incan: >=0.3,<0.4
@@ -289,7 +289,7 @@ Would update Loaf.toml:
   run = ["oven", "run"]
   test = ["oven", "test"]
 
-  [oven.capabilities]
+  [oven.mixes]
   enabled += ["cli"]
 
 Tooling:
@@ -303,7 +303,7 @@ Agent guidance:
 If the plan looks right, they apply it:
 
 ```text
-oven capability add cli
+oven mix add cli
 ```
 
 The result is an ordinary project:
@@ -316,7 +316,7 @@ weather_core/
   tests/test_cli.incn
 ```
 
-The updated manifest records the visible project shape and capability provenance:
+The updated manifest records the visible project shape and mix provenance:
 
 ```toml
 [project]
@@ -333,13 +333,13 @@ main = "src/main.incn"
 run = ["oven", "run"]
 test = ["oven", "test"]
 
-[oven.capabilities]
+[oven.mixes]
 enabled = ["cli"]
 ```
 
-After application, the project has both the package dependency and the project setup needed to use it as a CLI application capability. The project does not need the original descriptor to build. The descriptor was the recipe; the resulting source files and manifest are the durable project state. Tooling may still use the recorded capability provenance to explain the project, offer run actions, or suggest relevant agent guidance.
+After application, the project has both the package dependency and the project setup needed to use it as a CLI application mix. The project does not need the original descriptor to build. The descriptor was the recipe; the resulting source files and manifest are the durable project state. Tooling may still use the recorded mix provenance to explain the project, offer run actions, or suggest relevant agent guidance.
 
-### Starter and capability descriptors
+### Starter and mix descriptors
 
 Descriptor syntax is a tooling contract, not Incan source syntax. A descriptor may be represented as TOML, JSON, or another stable encoding, but the semantic fields are:
 
@@ -349,7 +349,7 @@ id = "cli"
 title = "Command-line application"
 description = "Executable project with standard CLI structure and basic tests."
 requires-incan = ">=0.3,<0.4"
-capabilities = ["std.process", "testing.basic"]
+mixes = ["std.process", "testing.basic"]
 
 [[files]]
 source = "templates/main.incn"
@@ -368,10 +368,10 @@ main = "src/main.incn"
 test = ["oven", "test"]
 ```
 
-A capability pack descriptor uses the same project mutation model, but its root identity is a capability rather than a starter:
+A mix descriptor uses the same project mutation model, but its root identity is a mix rather than a starter:
 
 ```toml
-[capability]
+[mix]
 id = "testing.basic"
 title = "Basic testing support"
 description = "Adds a standard test script and sample test layout."
@@ -398,30 +398,30 @@ origin = "testing.basic"
 
 [[agent_guidance]]
 id = "testing.basic.write-tests"
-title = "Write tests for this capability"
+title = "Write tests for this mix"
 kind = "skill"
 applies_to = ["testing.basic"]
-description = "Use when adding or updating tests in projects that enabled this capability."
+description = "Use when adding or updating tests in projects that enabled this mix."
 ```
 
-The concrete descriptor file format may evolve, but implementations must preserve the semantic distinction: a starter creates or initializes a project shape; a capability pack adds one reusable project concern.
+The concrete descriptor file format may evolve, but implementations must preserve the semantic distinction: a starter creates or initializes a project shape; a mix adds one reusable project concern.
 
 For the walkthrough above, the provider-side descriptor could be packaged as ordinary catalog data alongside templates:
 
 ```text
 app-cli/
   Loaf.toml
-  capabilities/
+  mixes/
     cli.toml
   templates/
     main.incn.tpl
     test_cli.incn.tpl
 ```
 
-`capabilities/cli.toml` might contain:
+`mixes/cli.toml` might contain:
 
 ```toml
-[capability]
+[mix]
 id = "cli"
 title = "Command-line application entrypoint"
 description = "Adds a standard CLI entrypoint, run script, and CLI test skeleton."
@@ -468,7 +468,7 @@ applies_to = ["cli"]
 description = "Use when extending the command-line entrypoint or tests."
 ```
 
-The provider ships static descriptor data and templates. The provider does not ship an arbitrary setup script that the user's project executes during `oven capability add`.
+The provider ships static descriptor data and templates. The provider does not ship an arbitrary setup script that the user's project executes during `oven mix add`.
 
 ## Reference-level explanation
 
@@ -476,23 +476,23 @@ The provider ships static descriptor data and templates. The provider does not s
 
 A **starter profile** is a named descriptor that can create a new project or initialize an existing directory by applying a deterministic set of project mutations.
 
-A **capability pack** is a named descriptor that applies one reusable project concern to an existing project. A starter profile may include capability packs.
+A **mix** is a named descriptor that applies one reusable project concern to an existing project. A starter profile may include mixes.
 
 A **project mutation** is a planned change to project files, `Loaf.toml`, dependency declarations, env definitions, scripts, generated docs, or other explicit artifacts owned by the project.
 
-A **starter catalog** is a source of starter and capability descriptors. V1 implementations must support built-in descriptors. They may also support explicit local descriptor paths. Future source kinds may include git references, package-provided descriptors, public catalog sources, and private catalog sources.
+A **starter catalog** is a source of starter and mix descriptors. V1 implementations must support built-in descriptors. They may also support explicit local descriptor paths. Future source kinds may include git references, package-provided descriptors, public catalog sources, and private catalog sources.
 
 A **catalog-backed source** is a starter catalog backed by a registry or service that can provide discovery, integrity metadata, yanking state, publisher identity, compatibility information, and descriptor payloads or references. Catalog-backed sources do not apply mutations directly to a project.
 
-A **private catalog** is a catalog-backed source for organization-specific or team-specific starters and capabilities that should not be discoverable through the public package ecosystem. Private catalog descriptors may describe whole project blueprints, internal platform conventions, or cross-package capabilities. They do not need to be scoped to one public package.
+A **private catalog** is a catalog-backed source for organization-specific or team-specific starters and mixes that should not be discoverable through the public package ecosystem. Private catalog descriptors may describe whole project blueprints, internal platform conventions, or cross-package mixes. They do not need to be scoped to one public package.
 
 ### Identifier rules
 
-Starter ids and capability ids must be stable ASCII identifiers. They should use lowercase words separated by `-` or `.`. Implementations must reject ids containing path separators, shell metacharacters, or whitespace.
+Starter ids and mix ids must be stable ASCII identifiers. They should use lowercase words separated by `-` or `.`. Implementations must reject ids containing path separators, shell metacharacters, or whitespace.
 
 The same id must not resolve to two descriptors in the same catalog source. If two catalog sources provide the same id, the CLI must either reject the ambiguity or apply a documented source precedence rule and show the selected source in diagnostics.
 
-If a capability id is advertised by multiple packages and no default provider is configured, `oven capability add <capability-id>` must not guess silently. It must show the candidate providers and require the user to disambiguate through a package-qualified capability id or an explicit provider flag.
+If a mix id is advertised by multiple packages and no default provider is configured, `oven mix add <mix-id>` must not guess silently. It must show the candidate providers and require the user to disambiguate through a package-qualified mix id or an explicit provider flag.
 
 ### Command surface
 
@@ -500,30 +500,30 @@ This RFC adds the following lifecycle commands and flags:
 
 - `oven starter list`
 - `oven starter show <starter-id>`
-- `oven capability list`
-- `oven capability show <capability-id>`
-- `oven capability status`
-- `oven capability diff <capability-id> --to <version-or-ref>`
-- `oven capability add <capability-id>`
-- `oven capability update <capability-id> --to <version-or-ref>`
+- `oven mix list`
+- `oven mix show <mix-id>`
+- `oven mix status`
+- `oven mix diff <mix-id> --to <version-or-ref>`
+- `oven mix add <mix-id>`
+- `oven mix update <mix-id> --to <version-or-ref>`
 - `oven new <name> --starter <starter-id>`
 - `oven init --starter <starter-id>`
 
-`oven starter show` and `oven capability show` must report the descriptor source, required Incan constraint, descriptor dependencies, included capabilities, planned manifest effects, declared files, and known conflicts if evaluated in a project context.
+`oven starter show` and `oven mix show` must report the descriptor source, required Incan constraint, descriptor dependencies, included mixes, planned manifest effects, declared files, and known conflicts if evaluated in a project context.
 
-`oven capability add` requires a project root. If no `Loaf.toml` is found, it must fail with a diagnostic suggesting `oven init` or `oven new`.
+`oven mix add` requires a project root. If no `Loaf.toml` is found, it must fail with a diagnostic suggesting `oven init` or `oven new`.
 
-`oven add <pkg>` remains the RFC 034 package dependency command. If the added package advertises capabilities, the CLI should report those capabilities and show the corresponding `oven capability add <capability-id>` command, but it must not apply project setup as part of plain dependency addition.
+`oven add <pkg>` remains the RFC 034 package dependency command. If the added package advertises mixes, the CLI should report those mixes and show the corresponding `oven mix add <mix-id>` command, but it must not apply project setup as part of plain dependency addition.
 
-`oven capability status` requires a project root. It must report enabled capability provenance and should report whether the project still appears consistent with each enabled capability's declared expectations. When catalog or registry metadata is available, status should also report the latest compatible descriptor version and whether the recorded source is yanked, revoked, superseded, or unknown.
+`oven mix status` requires a project root. It must report enabled mix provenance and should report whether the project still appears consistent with each enabled mix's declared expectations. When catalog or registry metadata is available, status should also report the latest compatible descriptor version and whether the recorded source is yanked, revoked, superseded, or unknown.
 
-`oven capability diff` requires a project root and an enabled capability. It must resolve the current recorded descriptor and requested target descriptor, then show the receiver-side mutation plan without writing files. Source-level descriptor diffs may be shown as supporting information, but the rendered project diff is the review artifact.
+`oven mix diff` requires a project root and an enabled mix. It must resolve the current recorded descriptor and requested target descriptor, then show the receiver-side mutation plan without writing files. Source-level descriptor diffs may be shown as supporting information, but the rendered project diff is the review artifact.
 
-`oven capability update` requires a project root and an enabled capability. It applies an explicit receiver-approved mutation plan for moving from the recorded descriptor version to the requested target version or ref. It must support `--dry-run`, must preserve recorded source identity unless the user explicitly requests a source switch, and must not bypass RFC 076 policy.
+`oven mix update` requires a project root and an enabled mix. It applies an explicit receiver-approved mutation plan for moving from the recorded descriptor version to the requested target version or ref. It must support `--dry-run`, must preserve recorded source identity unless the user explicitly requests a source switch, and must not bypass RFC 076 policy.
 
 `oven new` without `--starter` must keep the RFC 015 default behavior. Implementations may model that default internally as a built-in starter, but users must not be required to know that.
 
-Commands that list, show, or add starters and capabilities may accept a catalog source selector. The exact flag spelling is not normative, but the model must distinguish built-in descriptors, local descriptor paths, git references, package-provided descriptors, public catalog descriptors, and private catalog descriptors in diagnostics and machine-readable output.
+Commands that list, show, or add starters and mixes may accept a catalog source selector. The exact flag spelling is not normative, but the model must distinguish built-in descriptors, local descriptor paths, git references, package-provided descriptors, public catalog descriptors, and private catalog descriptors in diagnostics and machine-readable output.
 
 ### Machine-readable inspection
 
@@ -531,20 +531,20 @@ The CLI must provide a machine-readable format for these read-only operations:
 
 - listing starters
 - showing one starter
-- listing capabilities
-- showing one capability
-- reporting project capability status
+- listing mixes
+- showing one mix
+- reporting project mix status
 - producing a dry-run mutation plan
 
 The exact flag spelling is not normative, but `--format json` is the recommended shape because it is familiar and easy for LSP servers and editor plugins to consume.
 
-Machine-readable output must include stable ids, titles, descriptions, descriptor sources, compatibility state, descriptor dependencies, included capabilities, file mutations, generated-file ownership policies, manifest mutations, declared tooling actions, file roles, agent guidance metadata, diagnostics, and unresolved conflicts where applicable.
+Machine-readable output must include stable ids, titles, descriptions, descriptor sources, compatibility state, descriptor dependencies, included mixes, file mutations, generated-file ownership policies, manifest mutations, declared tooling actions, file roles, agent guidance metadata, diagnostics, and unresolved conflicts where applicable.
 
 Human-readable output may be optimized for terminal use, but it must not be the only supported inspection surface.
 
 ### Descriptor compatibility
 
-Each starter or capability descriptor may declare `requires-incan`. If present, the active toolchain must satisfy the descriptor constraint before the descriptor is applied.
+Each starter or mix descriptor may declare `requires-incan`. If present, the active toolchain must satisfy the descriptor constraint before the descriptor is applied.
 
 If a descriptor is applied to an existing project, its `requires-incan` must also be compatible with the project's effective toolchain constraint. The descriptor must not silently loosen `[project].requires-incan`. If the descriptor requires a narrower range, the CLI may propose a manifest update, but it must show the resulting effective constraint before writing.
 
@@ -552,33 +552,33 @@ If applying a descriptor would create an invalid RFC 073 environment matrix or e
 
 ### Descriptor dependencies
 
-Starter and capability descriptors may declare dependencies on other descriptors:
+Starter and mix descriptors may declare dependencies on other descriptors:
 
-- required capability packs
-- optional capability packs
+- required mixes
+- optional mixes
 - template sources governed by RFC 074
 - package dependencies or dev-dependencies
-- required project capabilities that must already be enabled
+- required project mixes that must already be enabled
 
 The CLI must resolve descriptor dependencies into a directed acyclic graph before planning file or manifest mutations. If the graph contains a cycle, incompatible version requirements, ambiguous providers, or a missing dependency, planning must fail before any project files are written.
 
 Dependency resolution must be visible in dry-run output. If applying `sample_query.project` also applies `sample_query.session`, `testing.basic`, and three templates, the dry run must show those transitive effects explicitly.
 
-Descriptors should stay small enough that dependency graphs remain explainable. A large starter may compose smaller capability packs, but the user-facing plan must still make clear which concern contributes which files, manifest entries, scripts, and generated-file ownership policies.
+Descriptors should stay small enough that dependency graphs remain explainable. A large starter may compose smaller mixes, but the user-facing plan must still make clear which concern contributes which files, manifest entries, scripts, and generated-file ownership policies.
 
 ### Applicability and back-off
 
-Starter and capability descriptors may declare applicability checks for project state they require or expect. Applicability checks are descriptive planning inputs, not hidden runtime behavior.
+Starter and mix descriptors may declare applicability checks for project state they require or expect. Applicability checks are descriptive planning inputs, not hidden runtime behavior.
 
-Applicability checks may inspect explicit project metadata such as package dependencies, manifest keys, env definitions, scripts, known file roles, capability provenance, template provenance, and declared expected files. They must not depend on executing project code or running arbitrary provider scripts.
+Applicability checks may inspect explicit project metadata such as package dependencies, manifest keys, env definitions, scripts, known file roles, mix provenance, template provenance, and declared expected files. They must not depend on executing project code or running arbitrary provider scripts.
 
-The planner must classify each descriptor and mutation with explainable states such as `applicable`, `already-satisfied`, `skipped`, `blocked`, `conflicting`, or `unsafe` when those states apply. For example, a CLI capability may skip creating `src/main.incn` when the project already has a declared `main` script and file role, but it must show that decision in dry-run and machine-readable output.
+The planner must classify each descriptor and mutation with explainable states such as `applicable`, `already-satisfied`, `skipped`, `blocked`, `conflicting`, or `unsafe` when those states apply. For example, a CLI mix may skip creating `src/main.incn` when the project already has a declared `main` script and file role, but it must show that decision in dry-run and machine-readable output.
 
-Back-off behavior must be conservative. If the planner cannot prove that an existing file, manifest entry, or dependency already satisfies a capability expectation, it must report a conflict or warning rather than silently assuming success.
+Back-off behavior must be conservative. If the planner cannot prove that an existing file, manifest entry, or dependency already satisfies a mix expectation, it must report a conflict or warning rather than silently assuming success.
 
 ### Project mutation planning
 
-Before applying a starter or capability pack, the CLI must build a mutation plan. The plan must include:
+Before applying a starter or mix, the CLI must build a mutation plan. The plan must include:
 
 - files to create
 - files to merge
@@ -587,12 +587,12 @@ Before applying a starter or capability pack, the CLI must build a mutation plan
 - manifest tables and keys to add or update
 - dependency and dev-dependency changes
 - applicability states and back-off decisions
-- enabled capability provenance records
+- enabled mix provenance records
 - env and script changes
 - tooling and agent guidance metadata
 - follow-up notes or warnings
 
-The CLI must either apply the whole valid plan or apply nothing. Partial starter or capability application is not allowed unless the user explicitly asks for a machine-readable plan export and applies it manually outside this RFC.
+The CLI must either apply the whole valid plan or apply nothing. Partial starter or mix application is not allowed unless the user explicitly asks for a machine-readable plan export and applies it manually outside this RFC.
 
 The planner must know whether it is creating a new project or adopting an existing directory. Greenfield creation may include bootstrap files intended to teach or seed a project. Existing-project adoption should preserve user-authored files by default and should skip or mark bootstrap-only files as conflicts rather than silently replacing them.
 
@@ -608,9 +608,9 @@ The default mode is `create`.
 
 A descriptor must not overwrite an existing file by default. If a file conflict occurs, the CLI must stop before writing and report the conflicting path. Overwrite flags may exist, but they must be explicit at the command line and must not be implied by `--yes`.
 
-File entries may reference templates governed by RFC 074. Starter and capability application must consume rendered files from the template layer; it must not define a second templating language or execute arbitrary generator code.
+File entries may reference templates governed by RFC 074. Starter and mix application must consume rendered files from the template layer; it must not define a second templating language or execute arbitrary generator code.
 
-If a file entry references an RFC 074 template, the mutation plan must carry the template's generated-file ownership policy. Bootstrap-owned files are created during greenfield application but should not be updated by normal capability refreshes. Managed files may participate in explicit template update workflows. Advisory files may record origin metadata without granting future ownership to the toolchain.
+If a file entry references an RFC 074 template, the mutation plan must carry the template's generated-file ownership policy. Bootstrap-owned files are created during greenfield application but should not be updated by normal mix refreshes. Managed files may participate in explicit template update workflows. Advisory files may record origin metadata without granting future ownership to the toolchain.
 
 ### Manifest mutation rules
 
@@ -624,39 +624,39 @@ For dependency tables, applying a descriptor must reject incompatible duplicate 
 
 For env definitions under `[oven.envs.*]`, applying a descriptor must use RFC 073 validation rules. Inherited envs, scripts, matrices, and toolchain constraints must remain valid after the mutation.
 
-### Capability provenance
+### Mix provenance
 
-When `oven capability add` applies a capability pack, the project manifest should record that the capability is enabled:
+When `oven mix add` applies a mix, the project manifest should record that the mix is enabled:
 
 ```toml
-[oven.capabilities]
+[oven.mixes]
 enabled = ["testing.basic", "std.http-client"]
 ```
 
 The enabled list is provenance and tooling state. It does not replace explicit dependencies, source files, envs, or config declarations. Removing an item from the list must not be interpreted as uninstalling generated files or dependencies.
 
-Capability provenance must preserve the descriptor source kind, source identity, selected descriptor version or content hash when available, provider package when applicable, applied capability id, expanded transitive capability graph, and the Incan version used to apply the descriptor. When available, it should also preserve publisher identity, integrity/signature state, yanking or revocation state, catalog trust tier, and the top-level user request that caused transitive capabilities to be applied.
+Mix provenance must preserve the descriptor source kind, source identity, selected descriptor version or content hash when available, provider package when applicable, applied mix id, expanded transitive mix graph, and the Incan version used to apply the descriptor. When available, it should also preserve publisher identity, integrity/signature state, yanking or revocation state, catalog trust tier, and the top-level user request that caused transitive mixes to be applied.
 
 The compact `enabled = [...]` form is sufficient for human-readable manifest summaries, but tools that support refresh, status, or security review need access to the richer provenance record. That richer record may live in `Loaf.toml`, a sidecar state file, or a future lock/state artifact, but it must be explicit project tooling state rather than inferred from generated files.
 
-If a capability pack is already recorded as enabled, `oven capability add <capability-id>` should be idempotent. It may revalidate that the expected project shape is still present, but it must not duplicate manifest entries or files.
+If a mix is already recorded as enabled, `oven mix add <mix-id>` should be idempotent. It may revalidate that the expected project shape is still present, but it must not duplicate manifest entries or files.
 
-Capability provenance should preserve enough information to explain transitive additions. A project may record that a starter enabled `sample_query.project`, and that `sample_query.project` pulled in `sample_query.session` and `testing.basic`. Tooling should be able to show the user both the top-level request and the expanded capability graph.
+Mix provenance should preserve enough information to explain transitive additions. A project may record that a starter enabled `sample_query.project`, and that `sample_query.project` pulled in `sample_query.session` and `testing.basic`. Tooling should be able to show the user both the top-level request and the expanded mix graph.
 
-Capability provenance is also the anchor for future updates. A project that records `cli@1.3.0` can later ask for a reviewable update to `cli@1.6.0` only if tooling can identify the recorded descriptor source, selected version or content hash, parameter values or safe value fingerprints, transitive descriptor graph, generated-file ownership, and applied template provenance. If that information is missing, `oven capability update` must degrade to an explicit adoption or manual-migration flow rather than guessing.
+Mix provenance is also the anchor for future updates. A project that records `cli@1.3.0` can later ask for a reviewable update to `cli@1.6.0` only if tooling can identify the recorded descriptor source, selected version or content hash, parameter values or safe value fingerprints, transitive descriptor graph, generated-file ownership, and applied template provenance. If that information is missing, `oven mix update` must degrade to an explicit adoption or manual-migration flow rather than guessing.
 
 Descriptor-version updates may include declarative migration metadata. V1 migration metadata should stay non-executable: manifest key additions, manifest key renames, parameter renames, template id changes, file ownership changes, dependency version changes, action descriptor changes, and manual instruction blocks are acceptable shapes. Arbitrary shell, Python, plugin, or provider-defined migration hooks are out of scope for this RFC.
 
 ### Tooling metadata
 
-Starters and capability packs may declare tooling metadata that describes editor-visible project shape without changing language semantics.
+Starters and mixes may declare tooling metadata that describes editor-visible project shape without changing language semantics.
 
 Tooling metadata may include:
 
 - file roles such as `main`, `library`, `test`, `config`, `generated`, `docs`, or `example`
 - action descriptors or action references mapped to RFC 015 scripts, env scripts, or project entrypoints
 - config declarations that point at generated `ctx` types
-- documentation links for a capability or generated file role
+- documentation links for a mix or generated file role
 - expected files that tooling can validate after application
 
 Tooling metadata must be descriptive. It must not grant special compiler privileges or activate runtime behavior that is not otherwise present in source files or the manifest.
@@ -665,27 +665,27 @@ If tooling metadata references files, paths must be relative to the project root
 
 The LSP or another editor-facing tool may use this metadata for completions, code actions, diagnostics, project-tree grouping, and run/debug affordances. It must still treat the compiler and lifecycle CLI as the source of truth for validation.
 
-RFC 078 owns typed action semantics, execution modes, risk labels, dry-run expectations for action execution, and `oven action run`. This RFC only lets starters and capabilities contribute or reference action descriptors as part of a project mutation plan. A descriptor that mentions an action must remain descriptive until the user or tooling explicitly invokes the action through RFC 078 behavior.
+RFC 078 owns typed action semantics, execution modes, risk labels, dry-run expectations for action execution, and `oven action run`. This RFC only lets starters and mixes contribute or reference action descriptors as part of a project mutation plan. A descriptor that mentions an action must remain descriptive until the user or tooling explicitly invokes the action through RFC 078 behavior.
 
 ### Agent guidance metadata
 
-Starters and capability packs may declare agent guidance metadata that describes project-relevant skills, workflows, or maintenance affordances for agentic tooling.
+Starters and mixes may declare agent guidance metadata that describes project-relevant skills, workflows, or maintenance affordances for agentic tooling.
 
 Agent guidance metadata may include:
 
-- skill ids or workflow ids relevant to the capability
+- skill ids or workflow ids relevant to the mix
 - short descriptions of when the guidance applies
-- file roles, capabilities, or manifest sections that trigger the guidance
+- file roles, mixes, or manifest sections that trigger the guidance
 - links to documentation or local instruction files bundled with the package
 - safety labels such as `read-only`, `project-mutation`, `networked`, or `requires-human-review`
 
-Agent guidance metadata is descriptive. It must not cause a starter or capability pack to install, enable, or execute an agent automatically. It must not embed secrets, credentials, or hidden prompts that change project behavior. If an agent tool consumes this metadata, it remains responsible for its own permission model and user confirmation rules.
+Agent guidance metadata is descriptive. It must not cause a starter or mix to install, enable, or execute an agent automatically. It must not embed secrets, credentials, or hidden prompts that change project behavior. If an agent tool consumes this metadata, it remains responsible for its own permission model and user confirmation rules.
 
-This metadata is useful because capability packs encode project intent. If a project enables a testing capability, an agent can be told which test-writing workflow is relevant. If a project enables an HTTP client capability, an agent can be told which docs, config files, and validation checks matter. The starter/capability layer should expose that intent once instead of forcing every agent integration to rediscover it from filenames.
+This metadata is useful because mixes encode project intent. If a project enables a testing mix, an agent can be told which test-writing workflow is relevant. If a project enables an HTTP client mix, an agent can be told which docs, config files, and validation checks matter. The starter/mix layer should expose that intent once instead of forcing every agent integration to rediscover it from filenames.
 
 ### Dry-run behavior
 
-`--dry-run` must be supported for `oven new --starter`, `oven init --starter`, and `oven capability add`.
+`--dry-run` must be supported for `oven new --starter`, `oven init --starter`, and `oven mix add`.
 
 Dry-run output must include the full mutation plan and must not write project files, lockfiles, or generated artifacts. If a dry run detects conflicts, it must report them with the same diagnostics that a real apply would use. The plan must explain why each descriptor or mutation is applicable, already satisfied, skipped, blocked, conflicting, or unsafe when those states apply.
 
@@ -693,13 +693,13 @@ Implementations must provide a machine-readable dry-run format for the full muta
 
 ### Lockfile interaction
 
-Starter and capability application may update `Loaf.toml`, but it must not silently rewrite `Oven.lock` unless the command documents and exposes that behavior. The default behavior should leave lockfile updates to the next `oven lock`, `oven bake`, or `oven test` flow governed by RFC 020.
+Starter and mix application may update `Loaf.toml`, but it must not silently rewrite `Oven.lock` unless the command documents and exposes that behavior. The default behavior should leave lockfile updates to the next `oven lock`, `oven bake`, or `oven test` flow governed by RFC 020.
 
 If a descriptor includes dependency changes and the project is in a locked or frozen mode, the CLI must report that lockfile refresh is required rather than pretending the project remains fully locked.
 
 ### Security and trust
 
-Applying a starter or capability pack must not execute arbitrary code from the descriptor.
+Applying a starter or mix must not execute arbitrary code from the descriptor.
 
 Descriptors must not embed secrets. If generated code needs credentials, it should create typed configuration placeholders, environment-variable references, or documented setup steps.
 
@@ -707,29 +707,29 @@ Descriptors loaded from local paths must be treated as untrusted input for parsi
 
 Registry-backed descriptors, if added later, must inherit registry integrity, checksum, and signature rules from the package distribution layer rather than creating a second supply-chain story.
 
-Applying or refreshing a capability pack is a supply-chain-sensitive project mutation. It may add dependencies, scripts, env definitions, generated source files, CI configuration, tooling metadata, or agent guidance. The lifecycle CLI must therefore present the mutation as a reviewable project diff, not as a cosmetic package setup step.
+Applying or refreshing a mix is a supply-chain-sensitive project mutation. It may add dependencies, scripts, env definitions, generated source files, CI configuration, tooling metadata, or agent guidance. The lifecycle CLI must therefore present the mutation as a reviewable project diff, not as a cosmetic package setup step.
 
-The receiving project owns acceptance of capability mutations. A starter or capability descriptor is a recipe for a proposed project patch; it is not authority for the provider, registry, catalog, package, or automation system to write into the receiver's codebase. This is especially important for refreshing an already-applied capability, where the command is changing an existing project rather than creating an empty one.
+The receiving project owns acceptance of mix mutations. A starter or mix descriptor is a recipe for a proposed project patch; it is not authority for the provider, registry, catalog, package, or automation system to write into the receiver's codebase. This is especially important for refreshing an already-applied mix, where the command is changing an existing project rather than creating an empty one.
 
-Capability plans must show the rendered receiver-side result, not only descriptor diffs. A descriptor diff can explain why a change is proposed, but reviewers need to inspect the actual project patch: source files, generated tests, scripts, envs, manifests, CI/configuration, tooling metadata, and agent guidance.
+Mix plans must show the rendered receiver-side result, not only descriptor diffs. A descriptor diff can explain why a change is proposed, but reviewers need to inspect the actual project patch: source files, generated tests, scripts, envs, manifests, CI/configuration, tooling metadata, and agent guidance.
 
-Capability provenance must preserve the descriptor source identity and selected descriptor version or content hash when available. If a later refresh would change the descriptor source, publisher identity, catalog trust tier, package provider, checksum/signature state, or yanking state, the CLI must surface that before applying file or manifest changes.
+Mix provenance must preserve the descriptor source identity and selected descriptor version or content hash when available. If a later refresh would change the descriptor source, publisher identity, catalog trust tier, package provider, checksum/signature state, or yanking state, the CLI must surface that before applying file or manifest changes.
 
-Catalog resolution must avoid dependency-confusion behavior. A public catalog entry must not silently shadow a previously recorded private catalog descriptor with the same id, and a private catalog descriptor must not silently replace a public descriptor without explicit user intent. If multiple catalogs can provide the same starter or capability id, the CLI must either fail with an ambiguity diagnostic or show the selected source according to a documented precedence rule.
+Catalog resolution must avoid dependency-confusion behavior. A public catalog entry must not silently shadow a previously recorded private catalog descriptor with the same id, and a private catalog descriptor must not silently replace a public descriptor without explicit user intent. If multiple catalogs can provide the same starter or mix id, the CLI must either fail with an ambiguity diagnostic or show the selected source according to a documented precedence rule.
 
 Security-sensitive mutation categories must be explicit in dry-run and machine-readable output. At minimum, plans must identify dependency additions or upgrades, script/task changes, env changes, CI/config changes, executable source changes, generated-file ownership changes, and agent guidance metadata changes.
 
-Project and organization policy may restrict which catalog sources, publishers, trust tiers, or descriptor pin forms are allowed for starters and capabilities. Policy may also require approval for high-risk mutation categories before `oven capability add` or a future capability refresh writes changes. This mirrors code review ownership for CI workflows: source files, scripts, CI config, env definitions, and agent guidance may need different reviewers.
+Project and organization policy may restrict which catalog sources, publishers, trust tiers, or descriptor pin forms are allowed for starters and mixes. Policy may also require approval for high-risk mutation categories before `oven mix add` or a future mix refresh writes changes. This mirrors code review ownership for CI workflows: source files, scripts, CI config, env definitions, and agent guidance may need different reviewers.
 
-Automated capability update should follow a review-first model. It may detect stale descriptors, vulnerable sources, or newer compatible versions, but it should emit a reviewable mutation plan or pull-request-sized patch rather than applying changes unattended. The plan should show before/after descriptor source, version or content hash, provider identity, known advisory state, yanking state, and every security-sensitive mutation category.
+Automated mix update should follow a review-first model. It may detect stale descriptors, vulnerable sources, or newer compatible versions, but it should emit a reviewable mutation plan or pull-request-sized patch rather than applying changes unattended. The plan should show before/after descriptor source, version or content hash, provider identity, known advisory state, yanking state, and every security-sensitive mutation category.
 
-Automation that proposes a capability update must not also satisfy the receiver's approval requirement. If policy requires review for a mutation category, the approver must be independent from the tool, service, or agent that produced the proposed patch. Capability update should therefore integrate with normal code review instead of bypassing it.
+Automation that proposes a mix update must not also satisfy the receiver's approval requirement. If policy requires review for a mutation category, the approver must be independent from the tool, service, or agent that produced the proposed patch. Mix update should therefore integrate with normal code review instead of bypassing it.
 
 ### Diagnostics
 
-Diagnostics for failed starter or capability application must name:
+Diagnostics for failed starter or mix application must name:
 
-- the selected starter or capability id
+- the selected starter or mix id
 - the descriptor source
 - the project root, when one exists
 - the conflicting file, manifest key, dependency, env, or toolchain constraint
@@ -741,68 +741,68 @@ Diagnostics should prefer actionable conflict explanations over generic "templat
 
 ### Relationship to RFCs 015 and 117
 
-RFC 015 remains the historical source of the baseline lifecycle ideas. RFC 117 prospectively supersedes its manifest filename, discovery, lock, and environment-configuration placement. This RFC adds richer starter selection and capability application on top of the `Loaf.toml` project model without reviving the old manifest contract.
+RFC 015 remains the historical source of the baseline lifecycle ideas. RFC 117 prospectively supersedes its manifest filename, discovery, lock, and environment-configuration placement. This RFC adds richer starter selection and mix application on top of the `Loaf.toml` project model without reviving the old manifest contract.
 
 The RFC 015 default scaffold remains valid and should stay small. Starter profiles are the place for opinionated project shapes.
 
 ### Relationship to library metadata
 
-Capability packs are project-level activation units. Library manifests may eventually advertise capabilities, dependencies, config needs, or generated helper files, but applying those capabilities to a project remains a lifecycle CLI operation through `oven capability add`. This avoids a hidden model where merely importing a package or adding a dependency rewrites the project or changes source layout.
+Mixes are project-level activation units. Library manifests may eventually advertise mixes, dependencies, config needs, or generated helper files, but applying those mixes to a project remains a lifecycle CLI operation through `oven mix add`. This avoids a hidden model where merely importing a package or adding a dependency rewrites the project or changes source layout.
 
-Where library manifests and starter descriptors overlap, library manifest data should be the source of truth for package-owned dependency and feature requirements. Starter descriptors should compose those capabilities rather than copy stale requirements by hand.
+Where library manifests and starter descriptors overlap, library manifest data should be the source of truth for package-owned dependency and feature requirements. Starter descriptors should compose those mixes rather than copy stale requirements by hand.
 
-Plain package addition remains owned by RFC 034. A package may advertise capabilities, and the package-add workflow may point users at those capabilities, but capability application is a separate command surface because it may create files and mutate project structure.
+Plain package addition remains owned by RFC 034. A package may advertise mixes, and the package-add workflow may point users at those mixes, but mix application is a separate command surface because it may create files and mutate project structure.
 
 ### Relationship to `ctx`
 
-If a starter or capability needs application configuration visible to the compiler, it should generate Incan source using `ctx` rather than creating an untyped sidecar configuration format. Sidecar files remain appropriate for operational data that the compiler should not understand.
+If a starter or mix needs application configuration visible to the compiler, it should generate Incan source using `ctx` rather than creating an untyped sidecar configuration format. Sidecar files remain appropriate for operational data that the compiler should not understand.
 
 Generated `ctx` declarations must follow normal source rules. The starter mechanism does not grant special access to configuration values.
 
 ### Relationship to env matrices
 
-Starter and capability descriptors may add env definitions. If they add matrix envs, those envs must satisfy RFC 073. This RFC does not redefine matrix expansion or toolchain constraint semantics.
+Starter and mix descriptors may add env definitions. If they add matrix envs, those envs must satisfy RFC 073. This RFC does not redefine matrix expansion or toolchain constraint semantics.
 
 ### Relationship to catalogs and package registries
 
-This RFC defines descriptor semantics and local lifecycle behavior. Catalog source kind is a distribution concern, not a different capability system. A starter or capability descriptor should mean the same thing whether it came from a built-in source, local file, git reference, public registry, or private catalog.
+This RFC defines descriptor semantics and local lifecycle behavior. Catalog source kind is a distribution concern, not a different mix system. A starter or mix descriptor should mean the same thing whether it came from a built-in source, local file, git reference, public registry, or private catalog.
 
-`incan.pub` is positioned to become the default public remote catalog because it already owns package identity, versioning, checksums, signatures, yanking, dependency metadata, and package discovery. Starter and capability descriptors published through `incan.pub` should reuse that trust and compatibility model instead of creating a parallel public marketplace.
+`incan.pub` is positioned to become the default public remote catalog because it already owns package identity, versioning, checksums, signatures, yanking, dependency metadata, and package discovery. Starter and mix descriptors published through `incan.pub` should reuse that trust and compatibility model instead of creating a parallel public marketplace.
 
-Private catalogs serve a different need: project and organization blueprints that may be broader than one library package. For example, a private descriptor can describe an end-to-end application shape that includes a CLI, API layer, analytics layer, data quality checks, governance conventions, and agent-relevant guidance. That descriptor can still be represented as ordinary starter and capability metadata. The local lifecycle CLI remains the executor.
+Private catalogs serve a different need: project and organization blueprints that may be broader than one library package. For example, a private descriptor can describe an end-to-end application shape that includes a CLI, API layer, analytics layer, data quality checks, governance conventions, and agent-relevant guidance. That descriptor can still be represented as ordinary starter and mix metadata. The local lifecycle CLI remains the executor.
 
 The catalog or registry role should be discovery and verification:
 
-- find starters and capabilities by id, package, domain, or required Incan version
+- find starters and mixes by id, package, domain, or required Incan version
 - expose descriptor provenance, publisher identity, checksum/signature state, and yanking state
-- expose package and capability compatibility metadata that the local CLI can use during planning
+- expose package and mix compatibility metadata that the local CLI can use during planning
 - expose descriptor dependency graphs and latest compatible versions for status checks
 - expose source diffs or rendered-template diff metadata where that can be computed without local project state
 - provide descriptor payloads or descriptor references for the local CLI to resolve
 
 The catalog or registry must not be required to compute or apply project mutation plans. The local lifecycle CLI remains responsible for resolving the current project, checking local files, producing dry-run output, enforcing overwrite rules, and writing changes. This boundary keeps remote behavior cacheable and auditable while preserving local control over project mutation.
 
-Published starters and capability packs should eventually be validated before promotion. At minimum, catalog tooling should be able to check that descriptors parse, dependency graphs resolve, referenced templates exist, and fixture values can render. Full target-project update tests can be a later quality gate.
+Published starters and mixes should eventually be validated before promotion. At minimum, catalog tooling should be able to check that descriptors parse, dependency graphs resolve, referenced templates exist, and fixture values can render. Full target-project update tests can be a later quality gate.
 
 ### Relationship to RFC 076
 
-RFC 076 owns project and organization policy for approving receiver-side mutations, restricting descriptor sources, classifying mutation risk, handling yanked or malicious sources, and recovering from unsafe applied mutations. This RFC defines the starter and capability mutation plans that RFC 076 policy evaluates.
+RFC 076 owns project and organization policy for approving receiver-side mutations, restricting descriptor sources, classifying mutation risk, handling yanked or malicious sources, and recovering from unsafe applied mutations. This RFC defines the starter and mix mutation plans that RFC 076 policy evaluates.
 
 ### Relationship to RFC 078
 
-RFC 078 owns the action model. Starter and capability descriptors may contribute action descriptors, but they do not define action execution semantics. During starter or capability application, actions are planned and recorded as metadata; they are not run implicitly. When a user later lists, dry-runs, or runs an action, RFC 078 behavior applies.
+RFC 078 owns the action model. Starter and mix descriptors may contribute action descriptors, but they do not define action execution semantics. During starter or mix application, actions are planned and recorded as metadata; they are not run implicitly. When a user later lists, dry-runs, or runs an action, RFC 078 behavior applies.
 
 ### Relationship to LSP and IDE integrations
 
-The lifecycle CLI should expose descriptor and project-capability information in a stable machine-readable form so editor integrations can stay thin. Editor plugins may provide rich UI, and they may use cached `incan.pub` catalog data for discovery, but they should not own the semantics of starter resolution, capability compatibility, conflict detection, or manifest mutation.
+The lifecycle CLI should expose descriptor and project-mix information in a stable machine-readable form so editor integrations can stay thin. Editor plugins may provide rich UI, and they may use cached `incan.pub` catalog data for discovery, but they should not own the semantics of starter resolution, mix compatibility, conflict detection, or manifest mutation.
 
-This mirrors the broader Incan tooling direction: the language server and editor integrations should surface compiler and lifecycle knowledge rather than reverse-engineer it from conventions. Starter profiles and capability packs should therefore be designed as toolchain data first and editor UI inputs second.
+This mirrors the broader Incan tooling direction: the language server and editor integrations should surface compiler and lifecycle knowledge rather than reverse-engineer it from conventions. Starter profiles and mixes should therefore be designed as toolchain data first and editor UI inputs second.
 
 ### Relationship to agentic tooling
 
-Agentic tooling should be treated like another consumer of project metadata, not as a privileged project mutation path. Starters and capability packs may advertise relevant skills and workflows, but those advertisements must flow through the same machine-readable inspection surfaces used by IDEs and CLIs.
+Agentic tooling should be treated like another consumer of project metadata, not as a privileged project mutation path. Starters and mixes may advertise relevant skills and workflows, but those advertisements must flow through the same machine-readable inspection surfaces used by IDEs and CLIs.
 
-This keeps the boundary simple: the capability descriptor says what kind of project concern exists and which guidance may be relevant; the agent runtime decides whether and how to use that guidance under its own safety model. The descriptor must not smuggle executable prompts or bypass local project permissions.
+This keeps the boundary simple: the mix descriptor says what kind of project concern exists and which guidance may be relevant; the agent runtime decides whether and how to use that guidance under its own safety model. The descriptor must not smuggle executable prompts or bypass local project permissions.
 
 ### Compatibility and migration
 
@@ -810,13 +810,13 @@ This RFC is additive. Existing projects that use RFC 015 commands without starte
 
 Existing examples can be converted into starter profiles gradually, but examples remain valuable documentation. A starter profile should not replace explanatory docs; it should make a documented recommended shape executable.
 
-Projects may choose never to record capability provenance. That should not prevent ordinary builds, but it may limit future inspection commands that explain which project concerns were added by tooling.
+Projects may choose never to record mix provenance. That should not prevent ordinary builds, but it may limit future inspection commands that explain which project concerns were added by tooling.
 
 ## Alternatives considered
 
 ### Fold starter profiles into RFC 015
 
-Rejected because RFC 015 is already a coherent lifecycle foundation. Adding starter catalogs, capability composition, conflict planning, and provenance would broaden it from "project lifecycle CLI" into "project application framework setup." A follow-up RFC keeps the base layer shippable and easier to implement.
+Rejected because RFC 015 is already a coherent lifecycle foundation. Adding starter catalogs, mix composition, conflict planning, and provenance would broaden it from "project lifecycle CLI" into "project application framework setup." A follow-up RFC keeps the base layer shippable and easier to implement.
 
 ### Keep only examples and documentation
 
@@ -826,62 +826,62 @@ Rejected because copy-paste examples drift. Users need a deterministic command t
 
 Rejected because arbitrary scripts make starters powerful but unsafe, hard to inspect, and hard to reproduce. Static descriptors plus file templates are sufficient for v1 and keep the trust boundary narrow.
 
-### Make package import activate capabilities automatically
+### Make package import activate mixes automatically
 
-Rejected because imports should not mutate projects or create hidden configuration. Capability activation should be explicit through `oven capability add` or a selected starter profile.
+Rejected because imports should not mutate projects or create hidden configuration. Mix activation should be explicit through `oven mix add` or a selected starter profile.
 
-### Make plain `oven add <pkg>` apply default capability setup
+### Make plain `oven add <pkg>` apply default mix setup
 
-Rejected because it overloads dependency addition with project mutation. RFC 034 defines `oven add <pkg>` as the package workflow, analogous to `cargo add`. It should be safe to add a dependency without creating source files or scripts. Packages may advertise capabilities and the CLI may suggest them after adding the dependency, but applying capability setup belongs to `oven capability add`.
+Rejected because it overloads dependency addition with project mutation. RFC 034 defines `oven add <pkg>` as the package workflow, analogous to `cargo add`. It should be safe to add a dependency without creating source files or scripts. Packages may advertise mixes and the CLI may suggest them after adding the dependency, but applying mix setup belongs to `oven mix add`.
 
 ### Store all starter behavior in `Loaf.toml`
 
-Rejected because starters often need file templates, docs, and sample tests. `Loaf.toml` should record project metadata and applied capability provenance, not become a large embedded template archive.
+Rejected because starters often need file templates, docs, and sample tests. `Loaf.toml` should record project metadata and applied mix provenance, not become a large embedded template archive.
 
-### Add capability removal in v1
+### Add mix removal in v1
 
-Rejected because removal is substantially harder than addition. Generated files may have been edited by users, dependencies may be shared by multiple capabilities, and manifest changes may no longer be attributable to one pack. V1 should focus on safe creation, addition, and inspection.
+Rejected because removal is substantially harder than addition. Generated files may have been edited by users, dependencies may be shared by multiple mixes, and manifest changes may no longer be attributable to one mix. V1 should focus on safe creation, addition, and inspection.
 
 ## Drawbacks
 
 - Starter catalogs introduce another project-facing concept that must be documented and supported.
-- Capability provenance can drift from the actual project shape if users manually edit generated files or dependencies.
+- Mix provenance can drift from the actual project shape if users manually edit generated files or dependencies.
 - Descriptor conflict handling will need careful design to avoid both false positives and accidental overwrites.
 - Built-in starters may create expectations that the core toolchain supports every domain equally well.
 - Without registry-backed catalogs in v1, the first implementation may feel limited to built-in and local descriptors.
 
 ## Implementation architecture
 
-The recommended implementation shape is to treat starter and capability application as a planning problem before it is a file-writing problem.
+The recommended implementation shape is to treat starter and mix application as a planning problem before it is a file-writing problem.
 
-First, resolve the descriptor from a catalog. Then expand included capability packs and template dependencies into one ordered acyclic mutation plan. Then validate the plan against the target project, including manifest conflicts, file conflicts, generated-file ownership policy, toolchain constraints, env validity, and path safety. Finally, apply the plan atomically or report diagnostics without writing anything.
+First, resolve the descriptor from a catalog. Then expand included mixes and template dependencies into one ordered acyclic mutation plan. Then validate the plan against the target project, including manifest conflicts, file conflicts, generated-file ownership policy, toolchain constraints, env validity, and path safety. Finally, apply the plan atomically or report diagnostics without writing anything.
 
-The same mutation plan should power dry-run output, human diagnostics, and machine-readable inspection. This keeps `oven new --starter`, `oven init --starter`, `oven capability add`, and `oven capability update` aligned rather than implementing separate generators and updaters.
+The same mutation plan should power dry-run output, human diagnostics, and machine-readable inspection. This keeps `oven new --starter`, `oven init --starter`, `oven mix add`, and `oven mix update` aligned rather than implementing separate generators and updaters.
 
 ## Layers affected
 
-- **Manifest schema / configuration validation:** `Loaf.toml` should allow capability provenance under `[oven.capabilities]`; starter-applied env, script, dependency, and project metadata changes must validate under RFCs 020, 073, 076, and 117.
-- **CLI / tooling:** `oven starter`, `oven capability`, `oven new --starter`, `oven init --starter`, `oven capability add`, `oven capability diff`, and `oven capability update` are new lifecycle tooling surfaces. They must support inspection, dry-run planning, conflict diagnostics, deterministic application, and review-first descriptor-version updates.
-- **LSP / IDE tooling:** editor-facing tools should consume machine-readable starter, capability, mutation-plan, file-role, and action metadata from the lifecycle layer. They may expose completions, code actions, project diagnostics, and run/debug affordances, but they must not fork descriptor semantics.
-- **Agentic tooling:** agent-facing tools may consume capability provenance, file roles, and agent guidance metadata to select relevant skills or workflows, but starter/capability descriptors remain descriptive and must not execute agents implicitly.
+- **Manifest schema / configuration validation:** `Loaf.toml` should allow mix provenance under `[oven.mixes]`; starter-applied env, script, dependency, and project metadata changes must validate under RFCs 020, 073, 076, and 117.
+- **CLI / tooling:** `oven starter`, `oven mix`, `oven new --starter`, `oven init --starter`, `oven mix add`, `oven mix diff`, and `oven mix update` are new lifecycle tooling surfaces. They must support inspection, dry-run planning, conflict diagnostics, deterministic application, and review-first descriptor-version updates.
+- **LSP / IDE tooling:** editor-facing tools should consume machine-readable starter, mix, mutation-plan, file-role, and action metadata from the lifecycle layer. They may expose completions, code actions, project diagnostics, and run/debug affordances, but they must not fork descriptor semantics.
+- **Agentic tooling:** agent-facing tools may consume mix provenance, file roles, and agent guidance metadata to select relevant skills or workflows, but starter/mix descriptors remain descriptive and must not execute agents implicitly.
 - **Project scaffolding:** the project generator must support descriptor-backed file creation, manifest mutation, safe path normalization, and non-overwrite defaults.
-- **Library/package integration:** future library capability metadata should feed starter and capability descriptors where possible, but project mutation remains explicit. Package and registry metadata may also feed descriptor dependency resolution and status reporting.
-- **Documentation:** user docs must explain the difference between minimal scaffolds, starter profiles, capability packs, package dependencies, and runtime configuration.
+- **Library/package integration:** future library mix metadata should feed starter and mix descriptors where possible, but project mutation remains explicit. Package and registry metadata may also feed descriptor dependency resolution and status reporting.
+- **Documentation:** user docs must explain the difference between minimal scaffolds, starter profiles, mixes, package dependencies, and runtime configuration.
 
 ## Unresolved questions
 
 - Should v1 support only built-in starter catalogs and explicit local descriptor paths, with `incan.pub` as a designed follow-up, or should registry-backed descriptor discovery be part of the first accepted design?
-- Should `oven capability add` always record capability provenance under `[oven.capabilities]`, or should provenance be opt-in for projects that want very small manifests?
+- Should `oven mix add` always record mix provenance under `[oven.mixes]`, or should provenance be opt-in for projects that want very small manifests?
 - How much of descriptor dependency resolution belongs in v1, and should optional dependencies be allowed before required dependency graphs are fully implemented?
 - Which files should starters mark as bootstrap-owned versus managed by default?
 - Should `oven init --starter` have an explicit adoption mode, or should existing-project adoption be auto-detected?
-- What provider validation should be required before a starter or capability can be published or promoted through `incan.pub`?
+- What provider validation should be required before a starter or mix can be published or promoted through `incan.pub`?
 - Should starter descriptors support interactive prompts in v1, or should all parameterization come from command-line flags and project metadata?
 - Which `tooling.file_roles` and `tooling.actions` values should be standardized in v1 versus left as free-form extension strings?
 - Which `agent_guidance` fields should be standardized in v1, and which should remain extension metadata for agent runtimes to interpret?
 - Which applicability states and reason-code vocabulary should be standardized in v1?
-- Which declarative migration operations should be standardized for v1 capability updates, and which should remain manual instructions?
-- Should the LSP call the lifecycle CLI as a subprocess for starter/capability inspection, or should the compiler expose the same descriptor-resolution API directly to tooling crates?
+- Which declarative migration operations should be standardized for v1 mix updates, and which should remain manual instructions?
+- Should the LSP call the lifecycle CLI as a subprocess for starter/mix inspection, or should the compiler expose the same descriptor-resolution API directly to tooling crates?
 
 <!-- Rename this section to "Design Decisions" once all questions have been resolved.
      An RFC cannot move from Draft to Planned until no unresolved questions remain. -->

--- a/workspaces/docs-site/docs/RFCs/075_starter_profiles_and_capability_packs.md
+++ b/workspaces/docs-site/docs/RFCs/075_starter_profiles_and_capability_packs.md
@@ -13,7 +13,7 @@
     - RFC 073 (environment matrices and toolchain constraints)
     - RFC 074 (template rendering and boilerplate provenance)
     - RFC 076 (project mutation policy and recovery)
-    - RFC 117 (`Loaf.toml` and Oven's language-neutral project model)
+    - RFC 117 (`loaf.toml` and Oven's language-neutral project model)
     - RFC 118 (Incan and Oven command-line surfaces)
 - **Issue:** https://github.com/encero-systems/incan/issues/403
 - **RFC PR:** —
@@ -28,7 +28,7 @@ This RFC extends the Loaf/Oven project model with starter profiles and mixes. A 
 
 Read this RFC as nine foundations plus five mechanisms:
 
-1. **Foundation:** RFC 117 owns the `Loaf.toml` project model and root authority; this RFC layers richer project shapes on top without redefining manifest discovery, workspace inheritance, dependency resolution, or named-environment semantics.
+1. **Foundation:** RFC 117 owns the `loaf.toml` project model and root authority; this RFC layers richer project shapes on top without redefining manifest discovery, workspace inheritance, dependency resolution, or named-environment semantics.
 2. **Foundation:** Starters and mixes are tooling descriptors, not new language constructs. Applying one must result in explicit project files and manifest entries.
 3. **Foundation:** Generated projects remain ordinary Incan projects. There is no hidden starter mode, no runtime dependency injection container, and no implicit activation that cannot be inspected after creation.
 4. **Foundation:** Mixes are composition units. A starter profile may include zero or more mixes, and an existing project may add a mix later through `oven mix add`.
@@ -37,7 +37,7 @@ Read this RFC as nine foundations plus five mechanisms:
 7. **Foundation:** Incan packages may advertise mixes. Adding a package and applying a mix are separate operations: `oven add <pkg>` changes dependencies; `oven mix add <mix>` applies project setup and may add dependencies as part of an explicit mutation plan.
 8. **Foundation:** Applicability and back-off decisions are explicit. A descriptor may explain why it applies, why it is already satisfied, why it skipped a mutation, or why it is blocked, but it must not infer success from undocumented file conventions.
 9. **Foundation:** The same descriptor model must be consumable by CLI and editor tooling. IDE support should not infer project intent from ad-hoc filenames when the starter or mix can declare that intent directly.
-10. **Mechanism A:** `oven new <name> --starter <id>` creates a project by resolving one starter profile, applying its mixes, rendering its files, and writing a normal `Loaf.toml`.
+10. **Mechanism A:** `oven new <name> --starter <id>` creates a project by resolving one starter profile, applying its mixes, rendering its files, and writing a normal `loaf.toml`.
 11. **Mechanism B:** `oven init --starter <id>` applies starter initialization to an existing directory with adoption-oriented conflict rules. Existing-project initialization must preserve user-authored files more aggressively than greenfield creation.
 12. **Mechanism C:** `oven mix add <mix-id>` resolves one mix, which may be advertised by a package, then applies the resulting mutation plan to an existing project.
 13. **Mechanism D:** `oven starter list`, `oven starter show`, and dry-run output expose what a starter or mix would change before files are written.
@@ -61,7 +61,7 @@ The missing layer is an explicit project mutation contract. Users need a command
 - Define explainable applicability and back-off behavior for existing projects.
 - Distinguish greenfield project creation from existing-project adoption so migration does not overwrite user-authored files under creation-oriented assumptions.
 - Allow starters and mixes to add manifest entries, dependencies, dev-dependencies, scripts, env definitions, file templates, tooling metadata, agent guidance metadata, and user-facing follow-up notes.
-- Keep generated projects ordinary: all persistent behavior must be represented in source files, `Loaf.toml`, `Oven.lock`, or documented generated artifacts.
+- Keep generated projects ordinary: all persistent behavior must be represented in source files, `loaf.toml`, `Oven.lock`, or documented generated artifacts.
 - Provide inspection commands so users can list available starters, preview one starter, and see which mixes are recorded in a project.
 - Define a review-first mix update path so a project can move an applied mix from one recorded descriptor version to another without treating the change as an automatic package upgrade or silent template rewrite.
 - Provide machine-readable inspection surfaces so LSP and IDE tooling can list starters, preview mix changes, show enabled mixes, and surface project-specific actions without reimplementing descriptor resolution.
@@ -116,7 +116,7 @@ A starter may be selected during project creation:
 oven new weather_tool --starter cli
 ```
 
-The generated project is still an ordinary Incan project. The starter writes `Loaf.toml`, source files, docs, test files, and any other explicit artifacts described by the starter descriptor. There is no persistent hidden link to the starter that changes compilation semantics later.
+The generated project is still an ordinary Incan project. The starter writes `loaf.toml`, source files, docs, test files, and any other explicit artifacts described by the starter descriptor. There is no persistent hidden link to the starter that changes compilation semantics later.
 
 If the starter includes mixes, the CLI applies them as part of creation and records them in the project manifest for inspection:
 
@@ -187,7 +187,7 @@ Descriptor integrity: verified
 Would update dependencies:
   app-cli 1.3.0 -> 1.6.0
 
-Would update Loaf.toml:
+Would update loaf.toml:
   add [oven.actions.run-cli]
   rename script "run" -> "cli.run"
 
@@ -235,7 +235,7 @@ Suppose a user has an existing project:
 
 ```text
 weather_core/
-  Loaf.toml
+  loaf.toml
   src/lib.incn
 ```
 
@@ -281,7 +281,7 @@ Would create:
   src/main.incn
   tests/test_cli.incn
 
-Would update Loaf.toml:
+Would update loaf.toml:
   [project.scripts]
   main = "src/main.incn"
 
@@ -310,7 +310,7 @@ The result is an ordinary project:
 
 ```text
 weather_core/
-  Loaf.toml
+  loaf.toml
   src/lib.incn
   src/main.incn
   tests/test_cli.incn
@@ -410,7 +410,7 @@ For the walkthrough above, the provider-side descriptor could be packaged as ord
 
 ```text
 app-cli/
-  Loaf.toml
+  loaf.toml
   mixes/
     cli.toml
   templates/
@@ -478,7 +478,7 @@ A **starter profile** is a named descriptor that can create a new project or ini
 
 A **mix** is a named descriptor that applies one reusable project concern to an existing project. A starter profile may include mixes.
 
-A **project mutation** is a planned change to project files, `Loaf.toml`, dependency declarations, env definitions, scripts, generated docs, or other explicit artifacts owned by the project.
+A **project mutation** is a planned change to project files, `loaf.toml`, dependency declarations, env definitions, scripts, generated docs, or other explicit artifacts owned by the project.
 
 A **starter catalog** is a source of starter and mix descriptors. V1 implementations must support built-in descriptors. They may also support explicit local descriptor paths. Future source kinds may include git references, package-provided descriptors, public catalog sources, and private catalog sources.
 
@@ -511,7 +511,7 @@ This RFC adds the following lifecycle commands and flags:
 
 `oven starter show` and `oven mix show` must report the descriptor source, required Incan constraint, descriptor dependencies, included mixes, planned manifest effects, declared files, and known conflicts if evaluated in a project context.
 
-`oven mix add` requires a project root. If no `Loaf.toml` is found, it must fail with a diagnostic suggesting `oven init` or `oven new`.
+`oven mix add` requires a project root. If no `loaf.toml` is found, it must fail with a diagnostic suggesting `oven init` or `oven new`.
 
 `oven add <pkg>` remains the RFC 034 package dependency command. If the added package advertises mixes, the CLI should report those mixes and show the corresponding `oven mix add <mix-id>` command, but it must not apply project setup as part of plain dependency addition.
 
@@ -637,7 +637,7 @@ The enabled list is provenance and tooling state. It does not replace explicit d
 
 Mix provenance must preserve the descriptor source kind, source identity, selected descriptor version or content hash when available, provider package when applicable, applied mix id, expanded transitive mix graph, and the Incan version used to apply the descriptor. When available, it should also preserve publisher identity, integrity/signature state, yanking or revocation state, catalog trust tier, and the top-level user request that caused transitive mixes to be applied.
 
-The compact `enabled = [...]` form is sufficient for human-readable manifest summaries, but tools that support refresh, status, or security review need access to the richer provenance record. That richer record may live in `Loaf.toml`, a sidecar state file, or a future lock/state artifact, but it must be explicit project tooling state rather than inferred from generated files.
+The compact `enabled = [...]` form is sufficient for human-readable manifest summaries, but tools that support refresh, status, or security review need access to the richer provenance record. That richer record may live in `loaf.toml`, a sidecar state file, or a future lock/state artifact, but it must be explicit project tooling state rather than inferred from generated files.
 
 If a mix is already recorded as enabled, `oven mix add <mix-id>` should be idempotent. It may revalidate that the expected project shape is still present, but it must not duplicate manifest entries or files.
 
@@ -693,7 +693,7 @@ Implementations must provide a machine-readable dry-run format for the full muta
 
 ### Lockfile interaction
 
-Starter and mix application may update `Loaf.toml`, but it must not silently rewrite `Oven.lock` unless the command documents and exposes that behavior. The default behavior should leave lockfile updates to the next `oven lock`, `oven bake`, or `oven test` flow governed by RFC 020.
+Starter and mix application may update `loaf.toml`, but it must not silently rewrite `Oven.lock` unless the command documents and exposes that behavior. The default behavior should leave lockfile updates to the next `oven lock`, `oven bake`, or `oven test` flow governed by RFC 020.
 
 If a descriptor includes dependency changes and the project is in a locked or frozen mode, the CLI must report that lockfile refresh is required rather than pretending the project remains fully locked.
 
@@ -741,7 +741,7 @@ Diagnostics should prefer actionable conflict explanations over generic "templat
 
 ### Relationship to RFCs 015 and 117
 
-RFC 015 remains the historical source of the baseline lifecycle ideas. RFC 117 prospectively supersedes its manifest filename, discovery, lock, and environment-configuration placement. This RFC adds richer starter selection and mix application on top of the `Loaf.toml` project model without reviving the old manifest contract.
+RFC 015 remains the historical source of the baseline lifecycle ideas. RFC 117 prospectively supersedes its manifest filename, discovery, lock, and environment-configuration placement. This RFC adds richer starter selection and mix application on top of the `loaf.toml` project model without reviving the old manifest contract.
 
 The RFC 015 default scaffold remains valid and should stay small. Starter profiles are the place for opinionated project shapes.
 
@@ -834,9 +834,9 @@ Rejected because imports should not mutate projects or create hidden configurati
 
 Rejected because it overloads dependency addition with project mutation. RFC 034 defines `oven add <pkg>` as the package workflow, analogous to `cargo add`. It should be safe to add a dependency without creating source files or scripts. Packages may advertise mixes and the CLI may suggest them after adding the dependency, but applying mix setup belongs to `oven mix add`.
 
-### Store all starter behavior in `Loaf.toml`
+### Store all starter behavior in `loaf.toml`
 
-Rejected because starters often need file templates, docs, and sample tests. `Loaf.toml` should record project metadata and applied mix provenance, not become a large embedded template archive.
+Rejected because starters often need file templates, docs, and sample tests. `loaf.toml` should record project metadata and applied mix provenance, not become a large embedded template archive.
 
 ### Add mix removal in v1
 
@@ -860,7 +860,7 @@ The same mutation plan should power dry-run output, human diagnostics, and machi
 
 ## Layers affected
 
-- **Manifest schema / configuration validation:** `Loaf.toml` should allow mix provenance under `[oven.mixes]`; starter-applied env, script, dependency, and project metadata changes must validate under RFCs 020, 073, 076, and 117.
+- **Manifest schema / configuration validation:** `loaf.toml` should allow mix provenance under `[oven.mixes]`; starter-applied env, script, dependency, and project metadata changes must validate under RFCs 020, 073, 076, and 117.
 - **CLI / tooling:** `oven starter`, `oven mix`, `oven new --starter`, `oven init --starter`, `oven mix add`, `oven mix diff`, and `oven mix update` are new lifecycle tooling surfaces. They must support inspection, dry-run planning, conflict diagnostics, deterministic application, and review-first descriptor-version updates.
 - **LSP / IDE tooling:** editor-facing tools should consume machine-readable starter, mix, mutation-plan, file-role, and action metadata from the lifecycle layer. They may expose completions, code actions, project diagnostics, and run/debug affordances, but they must not fork descriptor semantics.
 - **Agentic tooling:** agent-facing tools may consume mix provenance, file roles, and agent guidance metadata to select relevant skills or workflows, but starter/mix descriptors remain descriptive and must not execute agents implicitly.

--- a/workspaces/docs-site/docs/RFCs/076_project_mutation_policy_and_recovery.md
+++ b/workspaces/docs-site/docs/RFCs/076_project_mutation_policy_and_recovery.md
@@ -9,7 +9,7 @@
     - RFC 034 (`incan.pub` package registry)
     - RFC 074 (template rendering and boilerplate provenance)
     - RFC 075 (starter profiles and capability packs)
-    - RFC 117 (`Loaf.toml` and Oven's language-neutral project model)
+    - RFC 117 (`loaf.toml` and Oven's language-neutral project model)
     - RFC 118 (Incan and Oven command-line surfaces)
 - **Issue:** https://github.com/encero-systems/incan/issues/404
 - **RFC PR:** —
@@ -328,7 +328,7 @@ The same policy result should power terminal diagnostics, machine-readable JSON,
 
 ## Layers affected
 
-- **Manifest schema / configuration validation:** project tooling needs a place to describe project-local policy and record policy-related audit metadata, whether in a typed `Loaf.toml` policy table or an explicit tool-owned policy state artifact. `Oven.lock` is not a general policy store.
+- **Manifest schema / configuration validation:** project tooling needs a place to describe project-local policy and record policy-related audit metadata, whether in a typed `loaf.toml` policy table or an explicit tool-owned policy state artifact. `Oven.lock` is not a general policy store.
 - **CLI / tooling:** lifecycle commands must evaluate policy before applying template, starter, capability, update, reset, refresh, or recovery mutations.
 - **LSP / IDE tooling:** editor-facing tools should surface policy outcomes, blocked mutation reasons, review requirements, and recovery actions from machine-readable lifecycle output.
 - **Package and catalog integration:** registries and catalogs may provide source identity, integrity, yanking, revocation, advisory, compatibility, and trust-tier metadata that policy can consume.
@@ -337,7 +337,7 @@ The same policy result should power terminal diagnostics, machine-readable JSON,
 
 ## Unresolved questions
 
-- Should project-local mutation policy live in a typed `Loaf.toml` table or an explicit tool-owned policy state artifact, and which audit facts belong in receipts rather than either location?
+- Should project-local mutation policy live in a typed `loaf.toml` table or an explicit tool-owned policy state artifact, and which audit facts belong in receipts rather than either location?
 - What is the minimum useful policy syntax for v1?
 - Which risk categories should be standardized in v1, and which should remain extension labels?
 - Should policy support explicit reviewer or owner requirements, or should it only emit categories for external review systems to interpret?

--- a/workspaces/docs-site/docs/RFCs/078_tool_execution_and_typed_workflow_actions.md
+++ b/workspaces/docs-site/docs/RFCs/078_tool_execution_and_typed_workflow_actions.md
@@ -12,7 +12,7 @@
     - RFC 077 (workspace and multi-package projects)
     - RFC 079 (`incan.pub` artifact graph)
     - RFC 080 (AI assets and agent metadata)
-    - RFC 117 (`Loaf.toml` and Oven's language-neutral project model)
+    - RFC 117 (`loaf.toml` and Oven's language-neutral project model)
     - RFC 118 (Incan and Oven command-line surfaces)
 - **Issue:** https://github.com/encero-systems/incan/issues/406
 - **RFC PR:** —
@@ -263,7 +263,7 @@ Rejected because install-time hooks are difficult to review and policy-gate. Pro
 
 ## Implementation architecture
 
-The recommended implementation shape is to build an action registry from built-ins, `Loaf.toml` project and workspace data, package metadata, starter/capability descriptors, and AI assets. `oven action list` and IDE tooling consume this registry. `oven action run` resolves source, inherited workspace scope, env, policy, target context, and execution mode before invoking anything. RFC 118 may expose an Incan convenience that delegates downward to this operation, but it must not resolve or execute actions independently.
+The recommended implementation shape is to build an action registry from built-ins, `loaf.toml` project and workspace data, package metadata, starter/capability descriptors, and AI assets. `oven action list` and IDE tooling consume this registry. `oven action run` resolves source, inherited workspace scope, env, policy, target context, and execution mode before invoking anything. RFC 118 may expose an Incan convenience that delegates downward to this operation, but it must not resolve or execute actions independently.
 
 ## Layers affected
 

--- a/workspaces/docs-site/docs/RFCs/081_language_shaped_dsl_embeddings.md
+++ b/workspaces/docs-site/docs/RFCs/081_language_shaped_dsl_embeddings.md
@@ -1,20 +1,20 @@
 # RFC 081: Language-shaped DSL embeddings
 
-- **Status:** Draft
+- **Status:** Planned
 - **Created:** 2026-04-27
 - **Author(s):** Danny Meijer (@dannymeijer)
 - **Related:**
-    - RFC 027 (`incan-vocab` block registration and desugaring)
+    - RFC 027 (`incan-vocab` block registration and desugaring — this RFC supersedes its Rust-only desugarer-authoring model through implementation)
     - RFC 040 (scoped DSL surface forms)
     - RFC 045 (scoped DSL symbol surfaces)
-- **Issue:** —
+- **Issue:** https://github.com/encero-systems/incan/issues/555
 - **RFC PR:** —
 - **Written against:** v0.3
 - **Shipped in:** —
 
 ## Summary
 
-This RFC captures the language-embedding design track for DSLs that need to look like established languages or language fragments: CSS, HTML, XML, Ruby, JavaScript, TypeScript, Java, Kotlin, Groovy, and similar surfaces. The goal is not to make those syntaxes part of ordinary Incan. The goal is to define when an explicit DSL block may opt into descriptor-gated token forms, lexical submodes, and language-shaped ambiguity rules without leaking them into core Incan parsing.
+This RFC captures the language-embedding design track for DSLs that need to look like established languages or language fragments: CSS, HTML, XML, Ruby, JavaScript, TypeScript, Java, Kotlin, Groovy, and similar surfaces. The goal is not to make those syntaxes part of ordinary Incan, and it is not for Incan itself to build, ship, or standardize support for any of them. The goal is to define when an explicit DSL block may opt into descriptor-gated token forms, lexical submodes, and language-shaped ambiguity rules without leaking them into core Incan parsing, so that a downstream author can build a CSS-shaped, HTML-shaped, or similarly language-shaped DSL on top of it. This RFC also redesigns the vocab/desugar authoring layer so both existing scoped-surface DSLs and the language-shaped DSLs this RFC introduces author their desugarer or lowering hook in Incan.
 
 ## Motivation
 
@@ -31,7 +31,8 @@ Putting all of that in RFC 040 would collapse two compiler-layer concerns into o
 - Preserve core Incan tokenization and parsing outside eligible DSL positions.
 - Define how embedded language fragments expose typed syntax artifacts to desugarers, formatters, diagnostics, and LSP tooling.
 - Support narrow product-specific template/style fragments without requiring a full implementation of every target language.
-- Provide a compatibility target for CSS, HTML, XML, Ruby, JavaScript, TypeScript, Java, Kotlin, Groovy, and similar language-shaped DSLs.
+- Ensure the mechanism is expressive enough that a downstream author could build a CSS-shaped, HTML/XML-shaped, Ruby-shaped, JavaScript/TypeScript-shaped, or JVM-family-shaped (Java, Kotlin, Groovy) embedding, without Incan itself defining, shipping, or guaranteeing any of those specific language surfaces.
+- Redesign the vocab/desugar authoring layer so both existing scoped-surface DSLs (RFC 040, RFC 045) and the language-shaped DSLs this RFC introduces can author their desugarer or lowering hook in Incan, compiled by the replacement backend directly to the existing WASM desugarer-artifact contract.
 
 ## Non-Goals
 
@@ -104,6 +105,16 @@ This RFC does not reserve global syntax. It reserves descriptor space for explic
 
 Accepted embedded fragments are DSL-owned syntax artifacts. Their runtime meaning is supplied by the owning DSL's desugarer or lowering hook, not by core Incan evaluation.
 
+### Desugarer authoring
+
+This RFC redesigns the vocab/desugar authoring layer RFC 027 established. Both existing scoped-surface DSLs (RFC 040, RFC 045) and the language-shaped DSLs this RFC introduces must be able to author their desugarer or lowering hook in Incan. The replacement backend must compile an Incan-authored desugarer directly to the existing WASM artifact contract the compiler already loads at a fixed ABI entrypoint; the artifact format and loading mechanism must not change, only the authoring source does.
+
+Authoring a desugarer directly in Rust against a bespoke Rust API is retired. New and updated desugarers must be authored in Incan; an Incan-authored desugarer that needs an existing Rust crate must reach it through Incan's own Rust interop rather than through a parallel Rust-native authoring surface. Maintaining two authoring models for the same artifact contract is unjustified once Incan-to-WASM compilation and Rust interop both exist.
+
+Already-compiled, already-published vocab-companion WASM artifacts must continue to load and run unchanged. This redesign changes the recommended authoring source for new and updated desugarers, not the artifact contract already-published packages rely on.
+
+This redesign supersedes RFC 027's Rust-only desugarer-authoring model through implementation rather than by amending RFC 027's document; RFC 027 remains an unmodified historical record.
+
 ### Interaction with existing features
 
 RFC 040 remains the base model for scoped ownership, positive eligibility, misuse diagnostics, and descriptor identity. RFC 045 remains the home for scoped identifier-level meaning. This RFC extends those ideas to token forms and lexical submodes that cannot be modeled honestly as ordinary operator-like glyphs.
@@ -120,12 +131,15 @@ This RFC is additive. Code that does not import and use a DSL with language-shap
 
 3. Treat foreign-looking syntax as strings. Rejected as the only model because strings hide structure from diagnostics, formatting, LSP, desugaring, and policy.
 
+4. Keep both the Rust-native and the Incan-authored desugarer-authoring paths available for new work. Rejected because Incan's own Rust interop already lets an Incan-authored desugarer reach into an existing Rust crate when needed, so a parallel Rust-native authoring surface duplicates capability without adding any reach the Incan path lacks.
+
 ## Drawbacks
 
 - Descriptor-gated lexical modes increase parser, formatter, and LSP complexity.
 - Embedded language fragments can make source files visually dense if overused.
 - Partial language-shaped implementations may create user confusion if they look like a full external language but intentionally support only a subset.
 - Tooling must make ownership visible enough that readers can tell where ordinary Incan ends and the DSL-owned surface begins.
+- Retiring the Rust-authored desugarer path depends on the v0.6 replacement backend being mature enough to compile arbitrary Incan-authored desugarer logic to the WASM artifact contract. A backend gap during the v0.6 transition could leave a desugarer author without a working authoring path until the backend covers the surface they need.
 
 ## Layers affected
 
@@ -135,14 +149,13 @@ This RFC is additive. Code that does not import and use a DSL with language-shap
 - **Formatter** — must format language-shaped fragments from structured artifacts or preserve source layout where the DSL declares itself layout-sensitive.
 - **LSP / tooling** — must expose ownership, highlighting, hover, diagnostics, and completions across ordinary Incan and embedded submodes.
 - **Docs / examples** — must clearly distinguish narrow product-specific fragments from full language-compatible embeddings.
+- **Vocab / desugarer tooling** — must support compiling Incan-authored desugarers through the replacement backend to the existing WASM artifact contract, and must retire the Rust-native authoring surface for new work without breaking already-published artifacts.
 
-## Unresolved questions
+## Design Decisions
 
-- Which embedded surfaces should be standardized first: CSS-like style fragments, HTML/XML-like markup fragments, or script/type-expression fragments?
-- How much of a target language grammar may a DSL claim before it must identify itself as a partial subset?
-- Should descriptor declarations name external language compatibility levels, or should every embedded surface be described only in Incan-owned terms?
-- How should formatter fallback behave when a DSL provides tokenization but not a full formatter?
-- What is the smallest template/style fragment needed before full language-shaped embedding work is planned?
-
-<!-- Rename this section to "Design Decisions" once all questions have been resolved.
-     An RFC cannot move from Draft to Planned until no unresolved questions remain. -->
+- **No embedded surface is prioritized or standardized by this RFC:** RFC 081 defines the descriptor-gated lexical-mode mechanism only; it does not build, ship, or commit to CSS, HTML, XML, Ruby, JavaScript, TypeScript, Java, Kotlin, or Groovy support itself. Any concrete language-shaped embedding is authored by a downstream vocab package using this mechanism, on that package's own timeline. The original question of which surface to standardize first does not apply -- there is nothing for this RFC to sequence.
+- **No compiler-enforced partial-subset threshold:** a descriptor can only ever claim the token forms and submodes it explicitly enumerates (Reference-level explanation), so a DSL cannot silently appear to support more of a target grammar than it actually implements -- unrecognized syntax is a parse error, not a silent misinterpretation. Whether a partial implementation communicates its own scope to users is a documentation/branding concern for the downstream package, not a mechanism-level requirement this RFC imposes.
+- **Descriptors are described only in Incan-owned terms:** a descriptor names the token forms and lexical submodes it accepts using vocabulary this RFC itself defines. It must not name or claim a formal external-language compatibility level -- doing so would make Incan responsible for guaranteeing source-compatible external-grammar coverage, which the Non-Goals already exclude.
+- **No third formatter fallback state:** typed-artifact production is mandatory for every accepted token form or submode (Reference-level explanation), and that mandatory artifact is exactly the structured input the formatter already requires. "Tokenization without a full formatter" is not a state the mechanism can produce. The formatter has exactly the two modes Layers Affected already states: format from the structured artifact, or preserve source layout verbatim for a DSL that declares itself layout-sensitive.
+- **No minimum fragment is planned by this RFC:** for the same reason as the first decision, there is no "full language-shaped embedding work" for this RFC to plan a minimal precursor to; that planning belongs to whichever downstream project builds a concrete embedding.
+- **The vocab/desugar authoring layer is redesigned to be Incan-authored:** see "Desugarer authoring" in Design details for the full contract. Both existing scoped-surface DSLs and this RFC's language-shaped DSLs author their desugarer in Incan through the replacement backend; the Rust-native authoring surface is retired, superseding RFC 027's model through implementation without amending RFC 027 itself. Already-published WASM artifacts keep working unchanged; only the authoring source for new and updated desugarers is affected.

--- a/workspaces/docs-site/docs/RFCs/090_typed_cli_framework.md
+++ b/workspaces/docs-site/docs/RFCs/090_typed_cli_framework.md
@@ -12,7 +12,7 @@
     - RFC 073 (environment matrices and toolchain constraints)
     - RFC 083 (symbol and method aliases)
     - RFC 089 (`std.environ` runtime environment access)
-    - RFC 117 (`Loaf.toml` and Oven's language-neutral project model)
+    - RFC 117 (`loaf.toml` and Oven's language-neutral project model)
     - RFC 118 (Incan and Oven command-line surfaces)
 - **Issue:** https://github.com/encero-systems/incan/issues/87
 - **RFC PR:** —

--- a/workspaces/docs-site/docs/RFCs/090_typed_cli_framework.md
+++ b/workspaces/docs-site/docs/RFCs/090_typed_cli_framework.md
@@ -1,12 +1,13 @@
 # RFC 090: typed CLI framework
 
-- **Status:** Draft
+- **Status:** Planned
 - **Created:** 2026-05-06
 - **Author(s):** Danny Meijer (@dannymeijer)
 - **Related:**
     - RFC 015 (hatch-like tooling and project lifecycle CLI)
     - RFC 019 (test runner, CLI, and ecosystem)
     - RFC 021 (model field metadata and schema-safe aliases)
+    - RFC 024 (extensible derive protocol)
     - RFC 033 (`ctx` typed configuration context)
     - RFC 063 (`std.process` process spawning and command execution)
     - RFC 073 (environment matrices and toolchain constraints)
@@ -26,7 +27,7 @@ This RFC introduces `std.cli`, a typed model-first framework for authoring comma
 ## Core model
 
 1. **A CLI spec is typed data:** command structure is declared with ordinary Incan enums, models, reusable fields, descriptions, and defaults rather than a stringly parser builder.
-2. **Parsing produces a command value:** `std.cli.parse[T](argv)` validates an argument vector and returns `Result[T, CliError]`, where `T` is the command enum or model that describes the CLI.
+2. **Parsing produces a command value:** `std.cli.parse[T](argv)` validates an argument vector and returns `Result[T, CliError]`, where `T` is a command model or enum that has derived `CliArgs` or `CliCommand` (see "CLI eligibility is a derived trait, not an ambient marker").
 3. **One spec drives every surface:** parse behavior, help text, usage text, completions metadata, validation errors, command descriptions, and optional dispatch helpers must all lower to the same underlying CLI spec.
 4. **Metadata stays small:** the CLI framework should reuse ordinary `description` text and define only the extra keys required for command-line shape, while the field type, default, optionality, and collection shape remain the source of truth for parsing.
 5. **Command execution is separate:** this RFC parses current-program arguments and renders CLI outcomes; child process spawning remains owned by `std.process`.
@@ -53,6 +54,7 @@ This also helps library and application tests. A CLI program should be testable 
 - Standardize exit code mapping for success, usage errors, and application failures.
 - Keep command handlers independent from parsing so CLI logic is easy to unit test.
 - Allow command presentation metadata to live in a typed sidecar spec without requiring new enum syntax.
+- Generate shell completion scripts for bash, zsh, fish, and PowerShell from the same spec used for parsing and help.
 
 ## Non-Goals
 
@@ -61,7 +63,7 @@ This also helps library and application tests. A CLI program should be testable 
 - Replacing Oven project lifecycle env execution, matrix execution, or `oven env run` behavior from RFCs 073 and 117.
 - Replacing direct runtime environment access from RFC 089.
 - Defining terminal UI widgets, progress bars, prompts, interactive menus, curses-style interfaces, or rich text styling.
-- Defining shell completion script generation in full detail, though the spec should preserve enough structure for a later RFC or extension to add it.
+- Defining dynamic, context-aware, or custom completion callbacks for open-ended values (for example completing a `Path` field against the real filesystem, or completing a value from a live remote lookup). Static completions derived from the spec itself — command names, subcommand names, option/flag spellings, and enum-typed value choices — are in scope; runtime-dependent completion logic is not.
 - Defining a general application dependency-injection framework.
 - Making decorator CLI authoring a separate parser system.
 - Adding enum-variant metadata syntax as a special case for CLI only.
@@ -74,6 +76,7 @@ A command-line program starts with a typed command shape. A single-command progr
 ```incan
 from std.cli import parse
 
+@derive(CliArgs)
 model ServeArgs:
     host [description="Address to bind"]: str = "127.0.0.1"
     port [description="TCP port to listen on", short="p", value_name="PORT"]: int = 8000
@@ -89,15 +92,18 @@ For a multi-command program, an enum defines the command set and each variant ca
 ```incan
 from std.cli import parse
 
+@derive(CliArgs)
 model ServeArgs:
     host [description="Address to bind"]: str = "127.0.0.1"
     port [description="TCP port to listen on", short="p", value_name="PORT"]: int = 8000
     reload [description="Restart when source files change"]: bool = false
 
+@derive(CliArgs)
 model BuildArgs:
     release [description="Build optimized artifacts"]: bool = false
     output [description="Write artifacts to this path", short="o", value_name="PATH"]: Path | None = None
 
+@derive(CliCommand)
 enum ToolCommand:
     Serve(ServeArgs)
     Build(BuildArgs)
@@ -198,6 +204,7 @@ Reusable field contracts from RFC 087 compose with CLI argument models. A reusab
 ```incan
 field port [description="TCP port to listen on"]: int = 8000
 
+@derive(CliArgs)
 model ServeArgs:
     host [description="Address to bind"]: str = "127.0.0.1"
     field port [short="p", value_name="PORT"]
@@ -209,6 +216,7 @@ The imported `port` field supplies the canonical field name, type, default, and 
 Environment fallbacks use the same string-boundary parsing rules as command-line arguments:
 
 ```incan
+@derive(CliArgs)
 model DeployArgs:
     token [description="API token for deployment", env="API_TOKEN", secret=true]: SecretStr
     region [description="Deployment region", env="APP_REGION"]: str = "eu-west-1"
@@ -216,31 +224,72 @@ model DeployArgs:
 
 If `--token` is omitted, parsing may consult `API_TOKEN`. If the token is still absent or fails validation, the parser returns a `CliError` rather than letting the handler discover the problem later. Handlers do not have to know whether a value came from an option, a positional argument, a default, or an environment fallback unless the program explicitly asks for provenance metadata. The ordinary result is just a typed command value.
 
+### CLI eligibility is a derived trait, not an ambient marker
+
+`parse[T]` and `spec_for[T]` only accept a type that has explicitly derived `CliArgs` (for a single-command model) or `CliCommand` (for a multi-command enum):
+
+```incan
+trait CliArgs:
+    ...
+
+trait CliCommand:
+    ...
+
+@derive(CliArgs)
+model ServeArgs:
+    ...
+
+@derive(CliCommand)
+enum ToolCommand:
+    ...
+```
+
+`@derive(CliArgs)`/`@derive(CliCommand)` are not new compiler-internal derives in the shape of `Debug`/`Eq`/`Clone` (which are Rust proc macros with no Incan-expressible body). They are ordinary RFC 024 `__derives__` modules: `CliArgs`/`CliCommand` trait bodies authored in plain Incan, using RFC 021's `Model.__fields__() -> List[FieldInfo]` reflection to inspect a model's fields or an enum's variants at derive time — the same pattern RFC 024's own `SqlSchema` example already demonstrates for a different derivable trait. No new compiler-internal trait-generation logic is needed; `std.cli` is a library consumer of two mechanisms this project has already shipped, not a third compiler-magic derive path.
+
+This does require `FieldInfo` to carry more than it does today. RFC 021 already reserves an `extra: dict[str, str]` slot on `FieldInfo` for exactly this kind of consumer-specific metadata, but nothing populates it yet. `std.cli`'s `__derives__` body reads its CLI-specific bracket keys (`option`, `short`, `positional`, `value_name`) out of `extra`, so populating that reserved slot for the compiler's own field reflection is part of this RFC's own scope — not an amendment to RFC 021 (which stays untouched and Implemented), but the first real use of an extension point RFC 021 already built for this. `FieldInfo` does not need to expose a field's actual default *value*: `parse[T]`'s generated command value only passes fields it actually resolved (from CLI arguments or an environment fallback) to the model constructor, and omits everything else, letting the model's own ordinary default application handle the rest — exactly like any other Incan constructor call. `has_default: bool`, already part of `FieldInfo`, is all `CliArgs`'s derive body needs to know whether omission is legal.
+
+This split matters for the metadata keys too. `option`, `short`, `positional`, and `value_name` are meaningful only on a `CliArgs`/`CliCommand`-derived type and are diagnosed if present on a field of a type that hasn't derived one; `env` and `secret` are general-purpose model field metadata usable on any model regardless of CLI derivation (see "Relationship to field metadata and reusable fields").
+
 ## Reference-level explanation
 
 ### Module surface
 
-`std.cli` must provide a core parsing and rendering surface:
+`std.cli` must provide a core parsing and rendering surface. Every function taking a command type `T` is declared twice, bound on `CliArgs` and on `CliCommand` respectively, since Incan's generic bounds are intersection-only and there is no union-bound syntax to express "T implements either trait" in one declaration. The concrete `T` at a call site (a `@derive(CliArgs)` model or a `@derive(CliCommand)` enum) resolves which declaration applies, the same multi-instantiation dispatch RFC 025 already establishes for this shape of problem:
 
 ```incan
-def parse[T](argv: list[str]) -> Result[T, CliError]
-def parse_from[T](argv: list[str], config: CliParseConfig = CliParseConfig()) -> Result[T, CliError]
-def spec_for[T]() -> Result[CliSpec[T], CliSpecError]
-def render_help[T](program_name: str | None = None) -> Result[str, CliSpecError]
+def parse[T with CliArgs](argv: list[str]) -> Result[T, CliError]
+def parse[T with CliCommand](argv: list[str]) -> Result[T, CliError]
+
+def parse_from[T with CliArgs](argv: list[str], config: CliParseConfig = CliParseConfig()) -> Result[T, CliError]
+def parse_from[T with CliCommand](argv: list[str], config: CliParseConfig = CliParseConfig()) -> Result[T, CliError]
+
+def spec_for[T with CliArgs]() -> Result[CliSpec[T], CliSpecError]
+def spec_for[T with CliCommand]() -> Result[CliSpec[T], CliSpecError]
+
+def render_help[T with CliArgs](program_name: str | None = None) -> Result[str, CliSpecError]
+def render_help[T with CliCommand](program_name: str | None = None) -> Result[str, CliSpecError]
+
+def render_completions[T with CliArgs](shell: Shell) -> Result[str, CliSpecError]
+def render_completions[T with CliCommand](shell: Shell) -> Result[str, CliSpecError]
+
 def render_error(error: CliError, style: CliRenderStyle = CliRenderStyle.default()) -> str
 def exit_code_for(result: CliOutcome) -> int
-def run_cli[T](argv: list[str], handler: Callable[[T], Result[int, E] | int]) -> int
+
+def run_cli[T with CliArgs](argv: list[str], handler: Callable[[T], Result[int, E] | int]) -> int
+def run_cli[T with CliCommand](argv: list[str], handler: Callable[[T], Result[int, E] | int]) -> int
 ```
 
-The exact helper names may change before this RFC moves to Planned, but the committed surface must include typed parse, spec derivation, help rendering, error rendering, and exit-code mapping.
+`Shell` is a plain enum (`Bash`, `Zsh`, `Fish`, `PowerShell`). `render_completions[T]` draws entirely from the same `CliSpec` every other renderer already uses — no second spec, no completion-specific derive.
+
+The exact helper names may change before this RFC moves to Planned, but the committed surface must include typed parse, spec derivation, help rendering, completion rendering, error rendering, and exit-code mapping.
 
 ### CLI spec derivation
 
-`spec_for[T]` must derive a CLI spec from a supported command type `T`.
+`spec_for[T]` must derive a CLI spec from a supported command type `T`. `T` must have derived `CliArgs` or `CliCommand`; a type that has not is rejected at the `spec_for[T]`/`parse[T]` call site as a compile-time bound-not-satisfied error, not a runtime diagnostic.
 
-A model type may describe a single-command CLI. Its fields become options, flags, or positional arguments according to the rules in this RFC.
+A model type that has derived `CliArgs` may describe a single-command CLI. Its fields become options, flags, or positional arguments according to the rules in this RFC.
 
-An enum type may describe a multi-command CLI. Each variant becomes a subcommand. A variant with a payload model uses that model as the subcommand argument shape. A payload-free variant is a subcommand with no additional arguments. A variant with unsupported payload shape must be rejected at spec derivation time.
+An enum type that has derived `CliCommand` may describe a multi-command CLI. Each variant becomes a subcommand. A variant with a payload model uses that model as the subcommand argument shape; that payload model must itself have derived `CliArgs`. A payload-free variant is a subcommand with no additional arguments. A variant with unsupported payload shape, or a payload model that has not derived `CliArgs`, must be rejected at spec derivation time.
 
 Field metadata may customize CLI presentation and input sources, but type information remains authoritative. Metadata must not cause a field typed as `int` to parse as `str`, a required field to silently become optional, or a non-collection field to accept repeated values unless a future RFC defines that behavior.
 
@@ -252,18 +301,25 @@ This RFC must not add bracket metadata to enum variants. Current enum syntax alr
 
 `std.cli` must not reuse RFC 021 `alias` as the spelling for command-line option aliases. Field `alias` is a wire/schema name and participates in model construction, field access, destructuring, and descriptor metadata. Command-line spellings live in the CLI parser namespace and must not change ordinary model member resolution.
 
-RFC 087 reusable field contracts may appear in CLI argument models. When a model imports a reusable field, the imported field's canonical name, type, default, description, and validation contract are available to the CLI spec. A local model use may add CLI presentation metadata such as `short`, `option`, `positional`, `env`, or `value_name` without changing the reusable field contract itself.
+RFC 087 reusable field contracts may appear in CLI argument models. When a model imports a reusable field, the imported field's canonical name, type, default, description, and validation contract are available to the CLI spec. A local model use may add CLI presentation metadata such as `short`, `option`, `positional`, or `value_name` without changing the reusable field contract itself.
 
 If a reusable field and a local model use both provide the same CLI-specific metadata key, the local model use must win. This allows one domain field such as `port` to be reused across several commands while each command chooses its own short option or positional behavior.
 
-The CLI-specific metadata set should be small:
+The metadata set splits into two groups, matching whether it needs `CliArgs`/`CliCommand` to mean anything at all:
+
+CLI-specific, meaningful only on a field of a `CliArgs`/`CliCommand`-derived type and diagnosed otherwise:
 
 - `option`: override the long option spelling without leading dashes;
 - `short`: provide one short option character without a leading dash;
 - `positional`: mark a field as positional;
-- `env`: name an environment fallback;
-- `value_name`: display name for usage and help;
-- `secret`: suppress value display in diagnostics and help-rendered defaults.
+- `value_name`: display name for usage and help.
+
+General-purpose model field metadata, usable on any field regardless of CLI derivation, in the same way `description` already is:
+
+- `env`: name an environment fallback, useful beyond CLI parsing for any typed configuration value (for example an RFC 033 `ctx` model) that wants "fall back to this environment variable" independent of ever being parsed as CLI args;
+- `secret`: suppress value display in diagnostics and rendered defaults, useful for any sensitive field (a config model's password, a stored token) regardless of whether the containing type is ever used as CLI args.
+
+`std.cli` reuses `env` and `secret` for its own environment-fallback and diagnostic-redaction behavior rather than owning them, the same relationship it already has with `description`. A field using an `option`, `short`, `positional`, or `value_name` key on a type that has not derived `CliArgs` or `CliCommand` must be diagnosed: these four keys are only meaningful on a derived type, and the diagnostic should suggest adding the missing `@derive`.
 
 Aliases, deprecations, hidden commands, grouping, shell completion annotations, prompts, and rich terminal formatting are outside this RFC unless Draft discussion proves they are required for the core contract.
 
@@ -377,6 +433,18 @@ Hidden fields and hidden commands are deferred until a follow-up extension defin
 Help rendering must be deterministic for a given spec.
 
 The parser must reserve `--help` for help by default. A command may not define its own conflicting `--help` option unless an explicit parser configuration disables automatic help.
+
+### Shell completion
+
+`render_completions[T](shell: Shell)` must generate a completion script from the same spec used by parsing and help, for each of `Shell.Bash`, `Shell.Zsh`, `Shell.Fish`, and `Shell.PowerShell`.
+
+Completions must cover: command and subcommand names, long and short option spellings, and enum-typed value choices. These are static facts already present in the derived `CliSpec`; generation must not require any metadata beyond what `spec_for[T]` already produces.
+
+Completion generation must not invoke dynamic or context-aware logic (filesystem lookups, remote calls, running the program itself) to produce candidates. A field whose value cannot be statically enumerated from the spec (for example a `Path` or a plain `str`) completes with no candidates rather than a runtime-dependent guess; per-field custom completion callbacks are out of scope for this RFC (see Non-Goals).
+
+Completion output must be deterministic for a given spec, matching help rendering's own determinism requirement.
+
+Secret fields must not appear as completable values; a secret option's own name may still complete normally.
 
 ### Errors and diagnostics
 
@@ -501,6 +569,22 @@ Rejected because it solves token access but not CLI quality. Users would still h
 
 Rejected as the primary surface because it duplicates information already present in typed Incan declarations. A builder may still be useful as a lower-level escape hatch, but it should not be the user-facing center of gravity.
 
+### CLI eligibility as a plain decorator marker
+
+Rejected. An earlier shape used a bare `@cli.args`/`@cli.command` decorator purely as a checked marker with no generated behavior — functionally adequate for gating `parse[T]`, but an inert annotation that carries no substance and forecloses ever attaching real methods to a CLI-shaped type without a later redesign. `@derive(CliArgs)`/`@derive(CliCommand)` generating a real trait implementation, using the same derive convention `@derive(Debug, Eq, Clone)` already establishes, costs nothing extra today and leaves room to attach real trait methods later without revisiting the eligibility mechanism.
+
+### Ambient eligibility via import
+
+Rejected. Making any model automatically CLI-eligible merely by importing `std.cli` somewhere in the file would be ambient, implicit behavior with no local signal at the declaration site — exactly the kind of inference this RFC's model-first philosophy and the rest of this project's design principles avoid. Eligibility must be visible at the type's own declaration.
+
+### A dedicated `cli.args` declaration form
+
+Open, deferred past this RFC. A form such as `cli.args ServeArgs:` (declaring the model with CLI-specific vocabulary directly, rather than an ordinary `model` plus `@derive`) would read more locally but is new syntax or vocab surface that must justify itself beyond a nicer example, the same bar this RFC already applies to the dedicated CLI DSL alternative below. `@derive(CliArgs)` is the answer for this RFC's committed contract; a future RFC may reconsider dedicated declaration syntax once real usage shows the derive form is too indirect.
+
+### Attach command descriptions via RFC 032 value-enum assignment instead of a sidecar
+
+Considered and rejected for this RFC, worth revisiting when a general enum-variant metadata RFC exists. The proposed shape was `Serve(ServeArgs) = cli.command(description="...")`, reusing RFC 032's `enum Name(str|int): Variant = literal` value-assignment syntax so a command's description could live directly on its variant instead of in a separate `cli.spec[...]` sidecar. This does not work today on two independent grounds: RFC 032 makes payload-carrying variants and value-assignment mutually exclusive (an explicit Non-Goal, enforced by the parser), and even without that conflict, RFC 032 only accepts a `str`/`int` literal as the assigned value, not a function call — Incan has no `const fn` concept (a function provably pure/deterministic enough to fold into a compile-time constant), so `cli.command(...)` cannot be treated as a literal today regardless of the payload restriction. Separately from both syntactic blockers, RFC 032's value slot is conceptually the enum's wire/backing representation (its `str`/`int` identity for serialization, comparison, FFI), not a general per-variant metadata slot — even a hypothetical relaxed literal rule would be reusing the wrong feature for this. The right future vehicle is the general enum-variant metadata RFC this RFC's own "Relationship to field metadata and reusable fields" section already points at ("a later RFC that defines enum-variant metadata generally"), not an expansion of RFC 032's narrower, already-shipped scope. RFC 032 is `Implemented` and is not retroactively amended.
+
 ### Dedicated CLI DSL
 
 Open. A DSL such as `cli ToolCli for ToolCommand:` would make command descriptions and presentation metadata more local than a const sidecar while still avoiding enum-variant metadata. The cost is a new syntax or vocab surface that must justify itself beyond one nicer example. If accepted, the DSL must lower to the same `CliSpec` as the typed sidecar and must not create a second parser model.
@@ -519,7 +603,7 @@ Rejected. Dogfooding is valuable, but forcing compiler CLI migration into this R
 - Metadata-driven behavior can become opaque if the accepted metadata keys are too broad or poorly named, so this RFC keeps the metadata set intentionally small.
 - Help rendering and diagnostic quality require polish; a technically correct parser with weak messages would not meet this RFC's goal.
 - Deriving behavior from types creates pressure to define parse paths for more types than this RFC should commit to.
-- Shell completion and rich terminal output are attractive follow-ons, but including them too early would make the first contract too large.
+- Shell completion adds four separate script-generation targets (bash, zsh, fish, PowerShell) to implement and keep correct as shells evolve their own completion conventions; rich terminal output stays out of scope to bound this RFC's surface.
 
 ## Implementation architecture
 
@@ -527,25 +611,24 @@ Rejected. Dogfooding is valuable, but forcing compiler CLI migration into this R
 
 ## Layers affected
 
-- **Stdlib / runtime (`incan_stdlib`)**: new `std.cli` module, parser entry points, error types, help rendering, and exit-code helpers.
-- **Typechecker / symbol resolution**: CLI spec derivation must validate supported command enum and model shapes, metadata keys, option spelling collisions, defaults, and parse paths.
-- **Metadata / descriptors**: field and variant metadata must preserve CLI-specific keys in a checked form that the parser and renderer can consume.
+- **Stdlib / runtime (`incan_stdlib`)**: new `std.cli` module, parser entry points, error types, help rendering, shell completion rendering for bash/zsh/fish/PowerShell, and exit-code helpers.
+- **Typechecker / symbol resolution**: CLI spec derivation must validate supported command enum and model shapes, metadata keys, option spelling collisions, and parse paths; must reject `parse[T]`/`spec_for[T]` calls where `T` has derived neither `CliArgs` nor `CliCommand` (ordinary RFC 025 multi-instantiation bound checking, no CLI-specific typechecker logic required beyond that); must diagnose CLI-specific metadata keys (`option`, `short`, `positional`, `value_name`) used on a field of a type that has derived neither trait. `@derive(CliArgs)`/`@derive(CliCommand)` themselves are RFC 024 `__derives__` modules with Incan-authored bodies, not new typechecker-level derive-generation code.
+- **Metadata / descriptors**: RFC 021's `FieldInfo.extra: dict[str, str]` reserved slot must actually be populated with a field's bracket-metadata keys during reflection, so `std.cli`'s Incan-authored derive body can read `option`/`short`/`positional`/`value_name`/`env`/`secret` back out through `__fields__()`. This is the first real consumer of that reserved slot, not a new descriptor mechanism.
 - **Emission / runtime handoff**: generated programs need a stable way to pass the current argument vector into Incan `main` or equivalent CLI entry points.
 - **Formatter**: no new syntax is required, but examples and metadata-heavy model declarations should format predictably.
 - **LSP / tooling**: completions and hovers should understand `std.cli` metadata keys, command specs, and parse errors where practical.
 - **Docs / examples**: tutorials should show parse-test-handler structure and clarify the boundaries with `std.process`, `std.environ`, and project lifecycle commands.
 
-## Unresolved questions
+## Design decisions
 
-- Should the CLI metadata keys be exactly `option`, `short`, `positional`, `env`, `value_name`, and `secret`, or should any of those be renamed before Planned?
-- Should command presentation metadata use the const sidecar form, a dedicated CLI DSL, or both as equivalent frontends to `CliSpec`?
-- Should positional fields be opt-in only with `positional=true`, or should required scalar fields without defaults become positionals by convention?
-- What exact numeric exit codes should be standardized for usage errors and application errors?
-- Should `bool` fields with default `true` support automatic `--no-name` negation, require explicit metadata, or be rejected?
-- Which target types are guaranteed to have CLI parse paths in the committed surface?
-- Should `std.cli` define a public `CliSpec` builder escape hatch now, or keep spec construction derived-only until concrete escape-hatch needs appear?
-- Should command and option aliases beyond `short` be deferred, or is long-alias support required by this RFC's contract?
-- Should automatic shell completion metadata be part of this RFC's accepted contract or explicitly left to a follow-up RFC?
-
-<!-- Rename this section to "Design Decisions" once all questions have been resolved.
-     An RFC cannot move from Draft to Planned until no unresolved questions remain. -->
+- **CLI eligibility is the `CliArgs`/`CliCommand` derived traits, not a bare marker or ambient inference:** `parse[T]`/`spec_for[T]`/`render_help[T]`/`run_cli[T]` each declare two bound overloads, `T with CliArgs` and `T with CliCommand`, dispatched per RFC 025's existing multi-instantiation mechanism (Incan's generic bounds are intersection-only; there is no union-bound syntax, so one declaration cannot accept "either trait"). This also gives the LSP an unambiguous, local signal at the type's own declaration site, without needing to trace `parse[T]` call sites across module or package boundaries to know a model is CLI-shaped. An ambient-by-import mechanism was considered and rejected (see "Alternatives considered").
+- **`@derive(CliArgs)`/`@derive(CliCommand)` are RFC 024 `__derives__` modules, not new compiler-internal derive logic:** unlike `Debug`/`Eq`/`Clone` (Rust proc macros with no Incan-expressible body), `CliArgs`/`CliCommand` are ordinary trait bodies authored in plain Incan, using RFC 021's `Model.__fields__() -> List[FieldInfo]` reflection — the same pattern RFC 024's own `SqlSchema` example already demonstrates. `std.cli` is a library consumer of two already-shipped mechanisms, not a third compiler-magic derive path; this was a real correction caught during this pass, not the original framing. This requires actually populating RFC 021's reserved-but-empty `FieldInfo.extra: dict[str, str]` slot with a field's bracket-metadata keys during reflection — the first real consumer of an extension point RFC 021 already built, not an amendment to RFC 021 (which stays untouched and `Implemented`). `FieldInfo` does not need to expose a field's actual default value: `parse[T]`'s generated command value omits any field it didn't resolve from CLI/env and lets the model's own ordinary default application handle it, so `has_default: bool` (already in `FieldInfo`) is sufficient.
+- **The metadata key set splits into CLI-specific and general-purpose groups, resolving the original naming question without renaming anything:** `option`, `short`, `positional`, and `value_name` remain CLI-specific — meaningful, and diagnosed as a probable missing-`@derive` mistake when absent, only on a field of a `CliArgs`/`CliCommand`-derived type. `env` and `secret` become general-purpose model field metadata, usable on any model regardless of CLI derivation, exactly as `description` already is — `std.cli` reuses them rather than owning them. This split was motivated by genuinely broader utility beyond CLI parsing: an RFC 033 `ctx` typed configuration model has the same "fall back to this environment variable" and "don't display this value" needs independent of ever being parsed as CLI args. No key names changed; the six original names all stay.
+- **The const sidecar (`cli.spec[ToolCommand](...)`) is the only committed command-presentation mechanism:** a dedicated CLI DSL and a dedicated `cli.args`/reused-value-enum declaration form were all considered (see "Alternatives considered") and stay explicitly open/deferred, not spec'd by this RFC. Each would need new syntax or vocab surface to justify itself beyond a nicer-looking example; the sidecar already does the job without that cost. Command descriptions living directly on enum variants — via RFC 032's value-enum assignment or a future dedicated syntax — remains a real, worth-revisiting direction once a general enum-variant metadata RFC exists to own it properly, rather than reusing or loosening RFC 032's narrower, already-shipped wire-representation feature.
+- **Positional fields stay strictly opt-in:** `positional=true` is the only way a field becomes positional; a required scalar field with no default never becomes positional by convention. Matches this RFC's existing default (scalar fields become named options) and the explicit-over-inference instinct applied throughout this pass — two structurally identical fields could legitimately need different treatment, which convention-based inference can't express.
+- **Exit codes: `0` success, `2` usage error, `1` application error**, matching the widely-recognized Unix convention (bash, Python's `argparse`, GNU tools) this RFC's own Prior Art section already gestures at.
+- **A `negate` metadata key, not automatic `--no-*` generation, for default-`true` bool fields:** a `bool` field defaulting to `true` needs an explicit `negate=true` to generate its `--no-<name>` spelling; there is no implicit negation and no rejection of default-`true` bool fields outright. This is a fifth CLI-specific metadata key (joining `option`/`short`/`positional`/`value_name`), chosen over forcing users to invert a field's polarity (e.g. renaming `color: bool = true` to `no_color: bool = false`) just to satisfy the parser.
+- **The guaranteed CLI parse-path type list is already fully specified** by the "String-boundary parsing and validation" section: `str`, `int` (plus sized integers with overflow/underflow rejection), `float`, `Path`, `bool`, enum values, validated newtypes (covering types like `SecretStr`), `Option[T]`, and collection fields, with the rules composing for nested cases rather than needing per-combination entries. This closes the question; no new type support was added.
+- **No `CliSpec` builder API, now or later:** manual `CliSpec` construction without deriving it from a model is not a compiler-provided fluent/chained builder (`.builder().option(...).build()`) — that shape is borrowed Rust/Java idiom, not native Incan. If manual construction is ever needed, `CliSpec` is an ordinary constructible value using normal Incan value-construction syntax, the same as any other model. This is not "defer the builder until a need appears" — there is no builder pattern to defer.
+- **Long aliases beyond `short` stay deferred**, per this RFC's own existing "outside this RFC unless Draft discussion proves required" language for aliases. No guide-level example has needed a second long spelling for one field; nothing demonstrated the need.
+- **Shell completion is designed and committed now, not deferred to a follow-up RFC.** Initially framed as out of scope purely for contract-size reasons — corrected mid-pass as a "north star first, don't pre-assign versions" mistake, the same principle already applied to RFC 117/118/119: settle the design now, decide implementation phasing (which shells ship first, which release) separately. `render_completions[T](shell: Shell)` generates static completions (command/subcommand names, option spellings, enum-typed value choices) entirely from the existing `CliSpec`, for `Bash`, `Zsh`, `Fish`, and `PowerShell`. Dynamic/context-aware completion callbacks for open-ended values (filesystem paths, remote lookups) remain explicitly out of scope — a genuinely different, runtime-dependent feature, not a scope cut for size alone.

--- a/workspaces/docs-site/docs/RFCs/097_rust_hosted_incan_caller.md
+++ b/workspaces/docs-site/docs/RFCs/097_rust_hosted_incan_caller.md
@@ -13,7 +13,7 @@
     - RFC 043 (Rust trait implementation from Incan)
     - RFC 079 (`incan.pub` artifact graph)
     - RFC 092 (interactive runtime stdlib contracts)
-    - RFC 117 (`Loaf.toml` and Oven's language-neutral project model)
+    - RFC 117 (`loaf.toml` and Oven's language-neutral project model)
     - RFC 119 (Oven-native Rust build facets and Cargo interoperation)
     - #656 (Rust-facing ABI and Incan package compatibility direction)
     - #975 (Oven: Cargo-free Incan/Rust toolchain)
@@ -78,7 +78,7 @@ The end-state should be simple: an application team writes domain logic, policy,
 - This RFC does not require Cargo to resolve or compile an Incan package before a Rust host can call it.
 - This RFC does not require every Incan public export to be Rust-callable by default.
 - This RFC does not define registry publication mechanics beyond compatibility with RFC 034 and RFC 079.
-- This RFC does not define `Loaf.toml`, `Oven.lock`, or the `*.loaf` asset format; it consumes the project, asset-identity, and receipt contract from RFC 117.
+- This RFC does not define `loaf.toml`, `Oven.lock`, or the `*.loaf` asset format; it consumes the project, asset-identity, and receipt contract from RFC 117.
 - This RFC does not define the full implementation of async runtime internals, host capability enforcement, or telemetry backends.
 - This RFC does not guarantee that every Rust type imported through `rust::` can automatically cross back into a host Rust application without an adapter.
 

--- a/workspaces/docs-site/docs/RFCs/104_ambient_runtime_capabilities_and_receipts.md
+++ b/workspaces/docs-site/docs/RFCs/104_ambient_runtime_capabilities_and_receipts.md
@@ -1,6 +1,6 @@
 # RFC 104: Ambient Runtime Capabilities and Receipts
 
-- **Status:** Draft
+- **Status:** Planned
 - **Created:** 2026-05-24
 - **Author(s):** Danny Meijer (@dannymeijer)
 - **Related:**
@@ -65,6 +65,9 @@ The key design constraint is usability. This RFC must not turn ordinary Incan in
 - Make receipts consumable by RFC 102 semantic inspection, RFC 078 typed actions, RFC 093 telemetry, RFC 076 policy, CI, LSP, docs tooling, and agents.
 - Align typed action dry-runs and runtime reports so declared capability requirements can be compared with actual receipt emission.
 - Keep ordinary source readable and low ceremony.
+- Make capability identities checked symbols, resolved from where they are declared, rather than string literals a caller can misspell or a package can spoof.
+- Let the compiler statically verify that a typed action's declared capabilities match what its body actually calls, so a mismatch is a compile-time diagnostic rather than a runtime capability denial discovered later.
+- Allow a host to supply a capability ceiling that bounds an invocation's effective grants regardless of what that invocation requests, so an untrusted or agent-driven caller cannot widen its own authority.
 
 ## Non-Goals
 
@@ -77,7 +80,7 @@ The key design constraint is usability. This RFC must not turn ordinary Incan in
 - This RFC does not replace `std.telemetry`, `std.logging`, diagnostics, or semantic inspection.
 - This RFC does not require every package to publish capability metadata.
 - This RFC does not allow libraries to grant themselves host authority.
-- This RFC does not define the final CLI flag spelling for governed runs or reports.
+- This RFC does not define global CLI flags unrelated to capability grants and reports, such as verbosity, color, or profile selection.
 - This RFC does not define a secret-value type; it only requires receipts to preserve sensitivity and redaction metadata from the owning subsystem.
 
 ## Guide-level explanation
@@ -149,43 +152,50 @@ Granted capabilities:
   host.http.request
 ```
 
-Library authors should be able to participate without depending on stdlib-private hooks. A package can define a domain capability:
+Library authors should be able to participate without depending on stdlib-private hooks. A package can define a domain capability, declared inside its own module tree so its identity comes from where it lives rather than from a string the author types:
 
 ```incan
-capability example.policy.evaluate:
+# declared inside the package's own `policy` submodule
+capability evaluate:
     description = "Evaluate an input against a policy"
-    emits = "policy.evaluation"
+    requires = [host.fs.read]
 ```
 
-The exact declaration syntax is unresolved. The important contract is that packages can publish stable capability identities, descriptions, receipt schemas, and relationships to host capabilities.
+This resolves to a fully-qualified identity such as `example_lib.policy.evaluate`, namespaced by the declaring package's own registered identity so two packages can never collide on the same name. `requires` documents that evaluating a policy needs `host.fs.read` to load the policy file; it does not grant that authority by implication -- see "Import, request, grant, and use."
 
-Library code can then emit a receipt through a low-ceremony boundary:
+Library code can then emit a receipt through a low-ceremony boundary, referencing the capability as a checked symbol rather than a string:
 
 ```incan
+from example_lib.capabilities import policy_evaluate
 from std.runtime import receipts
 
 def evaluate(policy: Policy, input: Input) -> Decision:
-    with receipts.event("example.policy.evaluate", subject=policy.id):
+    with receipts.event(policy_evaluate, subject=policy.id):
         return policy.evaluate(input)
 ```
 
-For common entrypoints, typed actions can declare the capabilities they require:
+For common entrypoints, typed actions declare the capabilities they require the same way:
 
 ```incan
-@action(caps=["example.policy.evaluate", "host.model.invoke"])
+from example_lib.capabilities import policy_evaluate
+from std.runtime import host
+
+@action(caps=[policy_evaluate, host.model.invoke])
 def review(input: ReviewInput) -> ReviewReport:
     ...
 ```
 
-Granting a domain capability does not automatically let a package bypass host policy. If `example.policy.evaluate` needs `host.fs.read` to load a policy file, that relationship must be visible in metadata and accepted by the runtime or host policy. Libraries can name and explain authority; the runtime grants authority.
+Granting a domain capability does not automatically let a package bypass host policy. `policy_evaluate` declares that it `requires` `host.fs.read`, but that relationship is inspectable documentation the runtime and host policy can check and warn against when it is missing -- it is never an implicit grant. Libraries can name and explain authority; the runtime grants authority.
 
 ## Reference-level explanation
 
 ### Capability identities
 
-A capability identity must be a stable string. The exact naming grammar is unresolved, but this RFC reserves the `host.*` namespace for host authority capabilities owned by the Incan toolchain and runtime.
+A capability identity must be a checked symbol, not a string literal that source code writes out by hand. A capability declaration's fully-qualified identity must be derived from where it is declared, the same way any other Incan symbol's fully-qualified path is derived from its declaration site rather than from a string the author types. A package capability declared inside a package's own module tree resolves to `<package_identity>.<module_path>.<name>`, where `<package_identity>` is the package's own registered identity (the same identity a registry already enforces as unique), never a prefix the author writes literally. Two packages must never collide on the same capability name, because the namespace segment is derived from an identity the registry already guarantees is unique, not from an author-chosen string.
 
-Initial host capability families should include:
+`host.*` is reserved for capabilities owned by the Incan toolchain and runtime. It must use the same declaration mechanism as package capabilities -- a `capability` declaration with the same fully-qualified-identity-from-location rule -- except that only the compiler's own bundled `std.runtime` source may declare under it. A package that attempts to declare a capability under `host.*` must be rejected with a reserved-namespace diagnostic, the same enforcement class as a package trying to claim another package's registered identity. There is exactly one capability-declaration mechanism in this RFC; `host.*` capabilities look fixed because `std.runtime`'s source is fixed between releases, not because host and package capabilities are two different kinds of thing.
+
+The minimum stable host capability set for this RFC is exactly:
 
 - `host.env.read`
 - `host.fs.read`
@@ -197,9 +207,9 @@ Initial host capability families should include:
 - `host.model.invoke`
 - `host.tool.invoke`
 
-Implementations may define narrower capabilities such as scoped filesystem paths, hostnames, methods, or model families, but the broad families must remain understandable in diagnostics and reports.
+This set must not be extensible by packages. A package that needs narrower or additional authority defines its own capability and, where applicable, declares which of these host capabilities it `requires` -- see "Capability declarations."
 
-Package-defined capabilities must be namespaced so two packages cannot accidentally define the same authority name. Package-defined capabilities may describe domain operations, typed actions, generated artifacts, policy checks, workflow steps, or library-specific effects.
+A capability reference at a use site (an `@action(caps=[...])` list, a `receipts.event(...)` call, an `--allow` grant) must resolve against the declaration the same way an import resolves against a definition. A misspelled or nonexistent capability reference must be an unresolved-symbol compile error, not a runtime capability-denial diagnostic discovered later.
 
 ### Import, request, grant, and use
 
@@ -209,6 +219,8 @@ A package, action, function, descriptor, or runtime operation may request capabi
 
 When an operation requiring a capability is invoked in governed mode and the capability is not granted, the operation must fail before performing the authority-bearing behavior. The diagnostic must identify the required capability and should include the source span, import/module/function path, and a suggested grant spelling when available.
 
+A host may also supply a capability ceiling: a maximum grant set sourced from outside the invocation itself, such as a policy file a harness writes before starting an agent or CI job. The effective grant for any invocation must be the intersection of its ceiling, if one is supplied, and whatever it requests via `--allow` or a typed action's declared caps -- never their union. An invocation cannot widen its own authority by requesting more than its ceiling allows; it can only receive less. This applies uniformly to host and package capabilities alike. The exact mechanism for supplying a ceiling is illustrative, not normative; what is normative is that a ceiling source exists, is distinct from per-invocation requests, and is enforced as an intersection. Whether that source is itself protected from tampering by the process it bounds is an operating-system/sandbox concern this RFC does not define -- see Non-Goals.
+
 ### Runtime modes
 
 The runtime should support at least these conceptual modes:
@@ -217,32 +229,38 @@ The runtime should support at least these conceptual modes:
 - `observe`: operations run normally and receipts are emitted.
 - `governed`: operations require granted capabilities and receipts are emitted.
 
-The exact CLI spelling is not normative. A natural user-facing shape is:
+The user-facing shape is:
 
 ```text
 incan run app.incn --report json
 incan run app.incn --allow host.env.read,host.http.request --report json
 ```
 
-The default mode for ordinary local development is unresolved. The default must not surprise users by silently exporting data or sending reports to remote services.
+`incan run` defaults to `permissive`: ordinary local development stays ordinary, and nothing is denied or exported without an explicit flag. `incan test` defaults to `governed` with nothing pre-granted, so a test that unexpectedly reaches the real filesystem or network fails with a capability diagnostic instead of silently succeeding -- the same test-isolation property most test frameworks already enforce by convention, made structural here instead. A typed action runs under whatever mode and grants its invoking context provides (a CI job's explicit `--allow`, a host's policy-selected grant set); this RFC does not define a third default distinct from `incan run` and `incan test`, since actions are never invoked in a vacuum.
 
 ### Capability declarations
 
-A capability declaration should include:
+Capability declarations live in source, as a first-class `capability` declaration form -- not in package manifest metadata, generated descriptors, or capability packs. This is required, not a style preference: deriving a capability's fully-qualified identity from its declaration location (see "Capability identities") only works if the declaration site is something the compiler resolves, the same way it resolves a function or type declaration.
 
-- stable identity;
-- human-readable description;
-- owning package or toolchain component;
-- capability kind, such as host, library, action, artifact, or policy;
-- optional implied or requested capabilities;
-- optional scope schema, such as path, hostname, method, model, artifact kind, or action id;
-- receipt event kinds emitted by the capability;
-- redaction and sensitivity rules for receipt attributes;
-- docs and diagnostic labels.
+A capability declaration must include:
 
-Capability declarations may live in source, package metadata, manifest metadata, generated descriptors, or capability packs. Wherever they live, RFC 102 semantic inspection must be able to expose them as project facts.
+- a human-readable description;
+- an optional `scope` schema: a typed set of named scope dimensions the capability accepts, such as `tenant: str` or `path: str`. A grant may constrain zero or more of a capability's declared scope dimensions; a grant referencing a scope key the capability did not declare is a checked error, not a silently ignored key;
+- an optional `requires` list of other capabilities (checked symbol references, typically host capabilities) whose authority this capability's implementation needs.
 
-Package-defined capabilities must not grant host authority by implication alone. If a domain capability requests or implies `host.fs.read`, the runtime must resolve that relationship through host policy before allowing filesystem reads.
+```incan
+capability refund:
+    description = "Issue a refund for a captured charge"
+    scope:
+        tenant: str
+    requires = [host.http.request]
+```
+
+RFC 102 semantic inspection must be able to expose capability declarations, their scope schemas, and their `requires` relationships as project facts.
+
+Package-defined capabilities must not grant host authority by implication alone. `requires` documents that a domain capability's implementation needs a host capability; it is metadata the runtime, host policy, and the static check in "Typed action alignment" can inspect and warn against when missing, but granting the domain capability never automatically grants the capabilities it `requires`. Those must always be granted separately.
+
+Scope values are never written into a static declaration such as `@action(caps=[...])` -- a static declaration only names which capabilities, generically, an action needs. Scope values bind at grant time (`--allow example_lib.policy.refund:tenant=acct_a`) and are checked against the actual attributes of the operation being performed at the moment it happens, independent of whatever the calling code decided. This holds for both host and package capabilities: a scoped `host.http.request` grant is checked against the real outbound host at the point `std.http` makes the request, not against anything decided when the action was defined.
 
 ### Receipts
 
@@ -283,6 +301,8 @@ Reports may include artifact references, span trees, telemetry correlation ids, 
 
 Reports must not include raw secret values or sensitive payloads unless a separate, explicit reveal policy approves that exposure.
 
+Report output reuses the existing `--report`/`--report-output` contract `incan build` already established, rather than defining a new one: `--report json` writes to stdout by default, and `--report-output <PATH>` redirects it to a file. Receipts and run reports use a numeric `schema_version`, matching the same convention already used by `incan check --format json`, `incan build --report json`, and other existing JSON report surfaces; this RFC does not define a new versioning scheme.
+
 ### Typed action alignment
 
 Typed actions from RFC 078 provide the expected authority contract before execution. A typed action may declare required capabilities, optional capabilities, receipt schemas, mutation categories, network or model access, input and output artifacts, replay expectations, and non-plannable behavior. Those declarations are static metadata; they do not grant authority.
@@ -291,21 +311,37 @@ When a typed action runs under this RFC, the run report must preserve the action
 
 Dry-run output from RFC 078 and run reports from this RFC should use compatible capability identities, action identities, risk categories, redaction markers, artifact identities, and replay classifications. A user, CI job, LSP client, or agent should be able to read the dry-run plan, run the action, and compare the actual receipts without interpreting separate schemas.
 
+The declared-versus-actual comparison this section already requires for runtime reports must also happen statically, before a typed action ever runs. The typechecker must resolve every call inside an `@action`-decorated function body, union the host and package capabilities those calls require (via the existing stdlib-to-host-capability mapping in "Relationship to stdlib modules" and via any called capability's own `requires` metadata), and compare that computed set against the function's declared `caps=[...]` list:
+
+- if the body requires a capability the declaration omits, this is a compile error ("incomplete action caps"), not a warning -- an action whose declared caps are incomplete is guaranteed to fail at runtime the first time a governed run reaches the undeclared operation, so catching it statically is strictly better than discovering it as a runtime denial;
+- if the declaration lists a capability the body never actually uses, this is a warning, matching the non-error default this section already establishes for runtime-observed unused declarations, not a new stricter policy for the static case.
+
+This diagnostic must be available through the same channel as any other typechecker diagnostic, including LSP, so it is visible while authoring the decorator, not only at build time. An editor may offer a quick fix that inserts a missing capability into the declared list, the same shape as a quick fix for a missing import.
+
 ### Replay classification
 
-Each receipt and run report should classify replayability. Initial replay classifications should include:
+Each receipt and run report must classify replayability. This RFC requires four classifications for the first implementation, each motivated by an operation this RFC already describes:
 
-- `deterministic`: the operation can be replayed from recorded local inputs.
-- `fixture-required`: replay requires recorded fixtures or test doubles.
-- `external`: replay depends on external systems and cannot be exact without a recording.
-- `unavailable`: replay is not supported for this operation.
-- `redacted`: replay data exists but is intentionally hidden or incomplete.
+- `deterministic`: the operation can be replayed from recorded local inputs, such as a filesystem write whose output is fully determined by its recorded arguments.
+- `external`: replay depends on an external system and cannot be exact without a recording, such as an HTTP call to a partner API whose response can change between calls.
+- `fixture-required`: replay requires a recorded fixture or test double, such as the same HTTP call made under `incan test`'s default governed, ungranted mode.
+- `redacted`: replay data existed but was intentionally not persisted, such as a receipt whose attributes were redacted before reaching a sink.
+
+`unavailable` (replay is not supported for this operation) remains a trivial always-available fallback classification and needs no further design work in this RFC.
 
 This RFC does not require the runtime to implement full replay. It requires the runtime to avoid dishonest replay claims.
 
 ### Budgets
 
 Capability grants may include budgets. Budgets are optional constraints over granted authority, such as maximum request count, maximum bytes written, allowed path roots, allowed hosts, allowed process names, timeout limits, model-token limits, or artifact count.
+
+Budgets are expressed through the same grant syntax as scope, not a separate mechanism, using a reserved `budget.` key prefix alongside a capability's own scope keys:
+
+```text
+--allow "host.http.request:host=partner.example.com,budget.max_requests=100"
+```
+
+CLI grants, package metadata, and typed action declarations all use this same `budget.<key>=<value>` shape wherever a budget needs to be expressed; there is no separate budget-specific declaration form.
 
 If a budget is exhausted in governed mode, the runtime must deny the operation before performing it where practical and must emit a denial receipt. If the operation cannot be prevented before partial work occurs, the receipt must describe the partial state honestly.
 
@@ -350,9 +386,9 @@ Pure computation, parsing, formatting, local model construction, and in-memory t
 
 ### Syntax
 
-This RFC intentionally does not require new syntax. Capability declarations may eventually use source syntax, declaration metadata, package metadata, or manifest descriptors. The required contract is capability identity, declaration, grant, enforcement, receipt emission, and inspection.
+This RFC requires new syntax: `capability` is a first-class declaration form, with an optional `scope` schema and an optional `requires` list, as shown in "Capability declarations." This is necessary, not merely convenient -- a capability's fully-qualified identity being derived from its declaration location, rather than typed by the author, only works if the declaration is real source syntax the compiler resolves.
 
-Illustrative source syntax such as `capability example.policy.evaluate:` is non-normative.
+`host.*` capabilities use the same declaration form; only `std.runtime`'s own bundled source may declare under that reserved namespace.
 
 ### Semantics
 
@@ -430,26 +466,25 @@ Generated build artifacts and run reports should be ordinary artifacts that RFC 
 ## Layers affected
 
 - **Stdlib / Runtime (`incan_stdlib`)**: host-boundary modules need capability checks, receipt emission, redaction handling, and report integration.
-- **Tooling / CLI**: run, test, action, and build commands need report output, governed-mode grants, denial diagnostics, and machine-readable schemas.
+- **Tooling / CLI**: run, test, action, and build commands need report output, governed-mode grants, denial diagnostics, machine-readable schemas, and host-ceiling resolution.
 - **Package metadata**: packages need a way to publish capability declarations and receipt schemas.
 - **Typechecker / Semantic metadata**: static capability declarations and action requirements should be exposed as checked metadata where available.
 - **IR Lowering / Backend**: source spans and semantic identities should be preserved well enough for receipts to point back to source and semantic objects.
 - **LSP / Docs tooling**: editors and docs can surface capability declarations, required grants, denial diagnostics, and report artifacts.
 - **Policy / CI / Agents**: policy and automation can consume capability declarations, action dry-runs, receipt schemas, and actual receipts to decide whether runs, actions, generated artifacts, or proposed changes are acceptable.
 
-## Unresolved questions
+## Design Decisions
 
-- What is the exact grammar for capability identities?
-- Should capability declarations live in source syntax, declaration metadata, package manifests, or all of them?
-- What should the default run mode be for `incan run`, `incan test`, and typed actions?
-- What is the minimum stable host capability set?
-- How should scoped grants be represented for paths, hosts, methods, models, tools, and artifacts?
-- Should package-defined capabilities be allowed to imply host capabilities automatically when a user grants the package capability, or should host grants always be listed separately?
-- What is the first stable receipt schema version?
-- How should receipt sinks be configured, and where should reports be written by default?
-- Which replay classifications are required for the first implementation?
-- How should telemetry export represent receipts without making telemetry a dependency of receipt generation?
-- How should capability budgets be expressed in CLI, package metadata, and typed action declarations?
-
-<!-- Rename this section to "Design Decisions" once all questions have been resolved.
-     An RFC cannot move from Draft to Planned until no unresolved questions remain. -->
+- **Capability identities are checked symbols, not strings:** a capability's fully-qualified identity is derived from where it is declared (package or toolchain identity plus module path), never typed by the author. Two packages cannot collide on a capability name because the namespace segment comes from an identity a registry already enforces as unique. A capability reference at a use site resolves like an import; a misspelled or nonexistent reference is a compile error, not a runtime surprise.
+- **Capability declarations live in source**, as a first-class `capability` declaration form, because deriving identity from declaration location requires the declaration to be real, compiler-resolved syntax rather than manifest or metadata.
+- **Default run modes:** `incan run` defaults to `permissive`; `incan test` defaults to `governed` with nothing pre-granted, enforcing the same test-isolation property most test frameworks already assume by convention. Typed actions run under whatever mode and grants their invoking context provides; there is no third default.
+- **Minimum stable host capability set is exactly the nine already proposed** in Reference-level explanation (`host.env.read`, `host.fs.read`, `host.fs.write`, `host.process.spawn`, `host.http.request`, `host.clock.read`, `host.random`, `host.model.invoke`, `host.tool.invoke`), fixed and not package-extensible.
+- **Scoped grants:** a capability declares its own typed `scope` schema (host capabilities via `std.runtime`'s own declarations, package capabilities via their own). Scope values bind at grant time, never in a static declaration such as `@action(caps=[...])`, and are checked against the real operation's attributes at the moment it happens, independent of the declaring code.
+- **No implicit host-capability grants:** a package capability's `requires` list documents which host capabilities its implementation needs, for tooling and policy to inspect, but granting the package capability never automatically grants what it requires. Those must always be listed and granted separately.
+- **Receipt/report schema versioning is not this RFC's decision to make** -- it is already established product convention. Receipts and run reports use a numeric `schema_version`, matching `incan check`, `incan build`, and other existing JSON report surfaces exactly. There is no starting version number for this RFC to bless.
+- **Report output reuses `incan build`'s existing `--report`/`--report-output` contract** rather than defining a new one.
+- **Four required replay classifications** for the first implementation: `deterministic`, `external`, `fixture-required`, `redacted`. `unavailable` remains a trivial fallback needing no further design.
+- **Telemetry export is confirmed orthogonal** to receipt generation, per this RFC's existing text: receipts remain available to local reports and policy regardless of whether `std.telemetry` is configured; telemetry is a second consumer of the same stream, not a dependency of producing it.
+- **Capability budgets use the same grant syntax as scope**, via a reserved `budget.<key>=<value>` prefix, in CLI grants, package metadata, and typed action declarations alike -- no separate budget declaration form.
+- **Typed actions get a static caps-completeness check**, extending "Typed action alignment" from a runtime-only comparison to a compile-time one: the typechecker resolves every call in an `@action`-decorated body, unions the capabilities it actually requires, and diffs that against the declared `caps=[...]` list. A missing required capability is a compile error; an unused declared capability is a warning, matching the non-error default this RFC already gives runtime-observed unused declarations. The diagnostic is available through LSP the same way any other typechecker diagnostic is, including a quick fix to insert a missing capability.
+- **Host-supplied capability ceilings bound effective grants via intersection, never union:** a host may supply a maximum grant set sourced from outside the invocation itself -- for example, a harness-written policy file for an agent or CI job. The effective grant for any invocation is always the intersection of its ceiling and what it requests; an invocation can only receive less than its ceiling, never more, regardless of what it asks for. This RFC defines the ceiling as a distinct grant source and the intersection rule; it does not define how the ceiling's own source is protected from tampering, which is an operating-system/sandbox concern already excluded by this RFC's Non-Goals.

--- a/workspaces/docs-site/docs/RFCs/105_architect_rule_engine.md
+++ b/workspaces/docs-site/docs/RFCs/105_architect_rule_engine.md
@@ -9,7 +9,7 @@
     - RFC 070 (Result combinators)
     - RFC 088 (iterator adapter surface)
     - RFC 096 (declaration metadata blocks)
-    - RFC 117 (`Loaf.toml` and Oven's language-neutral project model)
+    - RFC 117 (`loaf.toml` and Oven's language-neutral project model)
     - RFC 118 (Incan and Oven command-line surfaces)
 - **Issue:** https://github.com/encero-systems/incan/issues/663
 - **RFC PR:** -
@@ -414,7 +414,7 @@ Experimental peer-baseline analysis is a later consumer of the same fact and que
 
 - What is the default profile for `incan architect .`: architecture-only, architecture plus safety, or all stable rules?
 - What suppression syntax should Incan use for architect findings, and should it share vocabulary with compiler diagnostic suppressions?
-- Should baselines live in a typed `Loaf.toml` table, a separate versioned baseline artifact, or generated project-tooling state? They must not be folded into `Oven.lock` merely because a project uses Oven.
+- Should baselines live in a typed `loaf.toml` table, a separate versioned baseline artifact, or generated project-tooling state? They must not be folded into `Oven.lock` merely because a project uses Oven.
 - Where should peer-group metadata live, and which membership or boundary declarations belong in source, package metadata, or local tooling state?
 - Which peer-signature facts are stable and useful enough to expose without turning names, paths, or aggregate similarity into semantic authority?
 - How should a project review, accept, version, and retire an experimental baseline or intentional outlier without allowing a scan to rewrite its own comparison set?

--- a/workspaces/docs-site/docs/RFCs/107_type_directed_library_apis.md
+++ b/workspaces/docs-site/docs/RFCs/107_type_directed_library_apis.md
@@ -1,17 +1,20 @@
 # RFC 107: Type-directed library APIs and compile-time type tokens
 
-- **Status:** Draft
+- **Status:** Planned
 - **Created:** 2026-06-03
 - **Author(s):** Danny Meijer (@dannymeijer)
 - **Related:**
+    - RFC 017 (validated newtypes with implicit coercion)
+    - RFC 025 (multi-instantiation trait dispatch)
     - RFC 028 (overload-based dispatch)
     - RFC 036 (user-defined decorators)
     - RFC 048 (contract-backed models emit and tooling)
     - RFC 054 (explicit call-site generic arguments)
     - RFC 083 (symbol and method aliases)
+    - RFC 089 (`std.environ`)
     - RFC 098 (native associated types)
 - **Issue:** https://github.com/encero-systems/incan/issues/752
-- **RFC PR:** https://github.com/encero-systems/incan/pull/751
+- **RFC PR:** —
 - **Written against:** v0.3
 - **Shipped in:** —
 
@@ -115,12 +118,20 @@ target: Type[float] = float
 targets: list[Type[int]] = [int]
 ```
 
-The same API family should also support generic spelling when the library declares how `T` maps to its result type. A typed cast API should not need helper families or broad unions just because the caller prefers explicit call-site generics:
+The same API family should also support generic spelling when the library declares how `T` maps to its result type. A typed cast API should not need helper families or broad unions just because the caller prefers explicit call-site generics. The library declares one overload body per admitted `T`, keyed on the type parameter itself rather than on a value-position argument, and the compiler selects among them the same way it already selects trait implementations by type argument:
 
 ```incan
+def cast[T: int](expr: ColumnExpr) -> IntColumnExpr:
+    return IntColumnExpr(source=expr.name)
+
+def cast[T: float](expr: ColumnExpr) -> FloatColumnExpr:
+    return FloatColumnExpr(source=expr.name)
+
 amount = cast[int](col("amount"))
 price = cast[float](col("price"))
 ```
+
+This does not require a parallel `cast(expr, target: Type[int])` overload to exist; the value-position and generic spellings may coexist, but neither is required by the other.
 
 Aliases preserve the overload set. A compatibility spelling does not need wrapper overloads:
 
@@ -161,7 +172,7 @@ safe = safe_cast(col("safe"), float)
 
 `Type[T]` names a compiler-backed token whose payload is the checked type `T`. `Type[T]` is a type in the source type system. Values of this type are not user-constructed objects; they are introduced by expected-type checking when a visible type name appears in a value position that expects `Type[T]`.
 
-An implementation must support `Type[int]`, `Type[float]`, `Type[str]`, and `Type[bool]`. An implementation must support `Type[Model]` for visible model types. This RFC must settle whether enum tokens, trait tokens, type alias tokens, constrained scalar tokens, and associated type projection tokens are admitted before it can move from Draft to Planned.
+An implementation must support `Type[int]`, `Type[float]`, `Type[str]`, and `Type[bool]`. An implementation must support `Type[Model]` for visible model types. An implementation must also admit enum tokens, trait tokens, type-alias tokens, constrained-scalar tokens, and associated-type projection tokens in the same v0.6 pass; see Design Decisions.
 
 `Type[T]` token values may be passed to functions, bound to variables, returned from functions, and stored in collections when the expected type is explicitly `Type[...]`. These operations preserve type evidence only; they must not imply ordinary runtime type-object behavior. `Type[T]` tokens must not support equality, ordering, hashing, serialization, pattern matching, field access, method dispatch, or arbitrary introspection unless this RFC explicitly admits that operation before it becomes Planned.
 
@@ -190,7 +201,7 @@ amount = cast[int](col("amount"))
 price = cast[float](col("price"))
 ```
 
-The result type of `cast[float](...)` must be the library-specific float result type, not a broad union of every possible cast result. The mapping from source type argument to result type may be expressed through associated output types, constrained overloads, type functions, or another explicit mechanism settled by this RFC before it becomes Planned. Whatever mechanism is chosen must compose with aliases, decorators, package manifests, generated docs, and public reexports.
+The result type of `cast[float](...)` must be the library-specific float result type, not a broad union of every possible cast result. The mapping from source type argument to result type must be expressed through type-parameter-constrained overloads: one overload body per admitted `T`, selected the same way overload resolution already selects trait implementations by type argument under RFC 025's multi-instantiation dispatch model. This mechanism must compose with aliases, decorators, package manifests, generated docs, and public reexports; see Design Decisions.
 
 Type-directed return mapping must not be inferred from function names. A library must declare the mapping in a checked, inspectable way so metadata, docs, LSP, and package consumers see the same callable surface.
 
@@ -200,7 +211,7 @@ An alias of an overload set must preserve the overload set and canonical impleme
 
 Public reexports must preserve the same callable surface. A consumer importing through a facade must see the same overloads, type-token parameters, aliases, decorators, and return types as a consumer importing from the declaring module.
 
-Alias spelling is still useful at the user boundary. Diagnostics, hovers, and generated docs may display the alias name at the call site, but canonical decorator side effects and registry metadata must default to the aliased implementation identity. If alias-local metadata overrides are admitted, RFC 107 must define the override rules before it becomes Planned.
+Alias spelling is still useful at the user boundary. Diagnostics, hovers, and generated docs may display the alias name at the call site, but canonical decorator side effects and registry metadata must default to the aliased implementation identity. Alias-local metadata overrides must not be admitted; see Design Decisions.
 
 ### Decorators and callable metadata
 
@@ -330,12 +341,9 @@ Backends should treat type tokens as zero-sized compile-time evidence unless a r
 - **Formatter**: should preserve ordinary call syntax and type annotations; no special formatting beyond existing type syntax is expected.
 - **LSP / Tooling**: should show type-token overloads, selected overloads, mapping explanations, alias targets, facade/reexport invariants, and degraded-state warnings in completion, hover, signature help, generated API docs, semantic inspection, and diagnostics.
 
-## Unresolved questions
+## Design Decisions
 
-- Should enum tokens, trait tokens, type alias tokens, constrained scalar tokens, and associated type projection tokens be admitted together or in staged increments?
-- What is the right mechanism for precise `cast[T](expr)`-style return specialization inside RFC 107: associated output types, type functions, constrained overloads, or something else?
-- Which type-alias token identities remain visible in docs and diagnostics, and which normalize to target types for semantic compatibility?
-- Should alias-local metadata overrides exist, or should aliases always preserve canonical decorated implementation identity while displaying alias spelling only at call sites?
-
-<!-- Rename this section to "Design Decisions" once all questions have been resolved.
-     An RFC cannot move from Draft to Planned until no unresolved questions remain. -->
+- **Token kinds are admitted together:** enum tokens, trait tokens, type-alias tokens, constrained-scalar tokens, and associated-type projection tokens are admitted in the same v0.6 pass as the required primitive (`int`, `float`, `str`, `bool`) and visible-model tokens, not staged into a later increment.
+- **Return-mapping mechanism is type-parameter-constrained overloads:** `cast[T](expr)`-style return specialization is resolved through ordinary overload resolution keyed on the compile-time type argument `T` itself, reusing the multi-instantiation trait dispatch model from RFC 025 (implemented, v0.3). A library declares one overload body per admitted `T`; the compiler selects among them the same way it already selects trait implementations by type argument. This does not require a parallel value-position `cast(expr, target: Type[T])` overload to exist -- the two spellings may coexist, but neither is required by the other -- and it introduces no new type-level construct. Associated output types (an RFC 098-style `type Output` binding on a generic trait implementation, mirroring Rust's `Add<Rhs>::Output`) remain a plausible future spelling once RFC 098 (native associated types, milestone 0.7) ships generally, but they are not this RFC's mechanism and are not a blocking dependency for v0.6. A dedicated type-function construct was considered and rejected as unnecessary net-new machinery for a problem Rust and Python both already solve without one.
+- **Type-alias tokens normalize fully; newtype tokens stay distinct:** a plain type alias (`type UserId = str`, structural, not a `newtype`) normalizes to its target type -- through the full alias chain, not one hop -- for both assignability and `Type[T]` overload dispatch. The alias spelling is retained only as display provenance in diagnostics, hovers, and generated docs, mirroring RFC 083's existing alias-identity rule. Two overloads keyed on different aliases of the same underlying type (for example `Type[UserId]` and `Type[ProductId]`, both aliasing `int`) are a duplicate-overload compile error, not independently selectable; `newtype` remains the correct tool when distinct dispatchable identity is wanted. When `T` is a newtype, construction through a `Type[T]` token goes through the newtype's `from_underlying` validated-conversion hook (RFC 017, implemented), consistent with the existing precedent in `std.environ.get_as[T]` (RFC 089, implemented) -- a `Type[T]` token must never bypass newtype validation.
+- **No alias-local metadata overrides:** aliases always preserve canonical decorated implementation identity -- decorator side effects, registry metadata, and `func.__name__` default to the aliased implementation, never to alias-local overrides. Alias spelling is display-only at the call site in diagnostics, hovers, and generated docs. This matches RFC 083's "aliases are not wrappers" rule without introducing a `Type[T]`-specific exception.

--- a/workspaces/docs-site/docs/RFCs/117_loaf_toml_and_oven_project_model.md
+++ b/workspaces/docs-site/docs/RFCs/117_loaf_toml_and_oven_project_model.md
@@ -1,6 +1,6 @@
 # RFC 117: `Loaf.toml` and Oven's language-neutral project model
 
-- **Status:** Draft
+- **Status:** Planned
 - **Created:** 2026-08-04
 - **Author(s):** Danny Meijer (@dannymeijer)
 - **Related:**
@@ -22,7 +22,7 @@
     - RFC 116 (typed C ABI interop)
     - RFC 118 (Incan and Oven command-line surfaces)
     - RFC 119 (Oven-native Rust build facets and Cargo interoperation)
-- **Issue:** [#1009](https://github.com/encero-systems/incan/issues/1009)
+- **Issue:** [#1063](https://github.com/encero-systems/incan/issues/1063)
 - **RFC PR:** —
 - **Written against:** v0.5
 - **Target scope:** v0.6 design and implementation planning; this is not a shipment claim.
@@ -32,7 +32,7 @@
 
 This RFC replaces `incan.toml` with `Loaf.toml` as the sole authored manifest for an Oven-managed project. A `Loaf.toml` may describe one project, a rooted workspace, or a virtual workspace. Its package, target, lock, cache, and receipt model is language-neutral. Incan and Rust are the built-in authored source facets in v0.6; checked C interop remains under `[interop.c]`; later foreign integrations require their own explicit interop RFC rather than becoming ambient source languages.
 
-`[project]` remains the familiar metadata table. `[workspace]` remains the explicit repository-coordination table. Dependencies use one typed graph whose unit kind and origin are explicit when the defaults are insufficient: Incan Loaf packages default to `incan.pub`, Rust crates default to crates.io, and foreign/system requirements use Oven-managed capability providers. Oven resolves authored intent into `Oven.lock`, then bakes the selected target into immutable, verified `*.loaf` assets and receipts. Cargo remains a deliberately explicit compatibility mode for repositories that have no `Loaf.toml`; it is never inferred as part of a Loaf build.
+`[project]` remains the familiar metadata table. `[workspace]` remains the explicit repository-coordination table. Dependencies use one typed graph whose unit kind and origin are explicit when the defaults are insufficient: Incan Loaf packages default to `incan.pub`, Rust crates default to crates.io, and foreign/system requirements use Oven-managed providers. Oven resolves authored intent into `Oven.lock`, then bakes the selected target into immutable, verified `*.loaf` assets and receipts. Cargo remains a deliberately explicit compatibility mode for repositories that have no `Loaf.toml`; it is never inferred as part of a Loaf build.
 
 This RFC also rehomes the authored configuration boundaries of existing environment, matrix, action, workspace, provider, and interop RFCs. It does not define the final command spelling or a general-purpose task shell.
 
@@ -45,7 +45,7 @@ Read this RFC as thirteen foundations:
 3. **A workspace is an optional hierarchy:** `[workspace]` declares explicit members and shared policy. A root with both `[project]` and `[workspace]` is a rooted workspace; a root with only `[workspace]` is virtual. Members may form explicit structural child groups, but the root remains the sole authority for resolution, locking, registry trust, target policy, and receipts.
 4. **The package graph is language-neutral:** every dependency is one logical requirement with a typed provider contract. The author does not choose a separate Incan-versus-Rust dependency table.
 5. **Origins are configurable:** Loaf packages default to `incan.pub`; crates default to crates.io. A project may explicitly select registered private registries, Git, path, or other supported controlled sources.
-6. **Provider semantics stay visible:** an `incan.pub` package contributes checked Incan semantic/provider facts, a Cargo ecosystem crate contributes Rust interop and implementation requirements, and a system/foreign capability contributes a verified target requirement. Oven must not flatten those differences or expose backend details as public Incan API.
+6. **Provider semantics stay visible:** an `incan.pub` package contributes checked Incan semantic/provider facts, a Cargo ecosystem crate contributes Rust interop and implementation requirements, and a system/foreign provider contributes a verified target requirement. Oven must not flatten those differences or expose backend details as public Incan API.
 7. **Core source facets are convention-first and unambiguous:** a conventional single-language project uses the ordinary `src/` layout. A mixed or nonstandard project declares non-overlapping `[incan.source]` and `[rust.source]` roots; `.incn` and `.rs` files never compete within one undiscriminated source root. C source inputs, headers, shims, and artifacts remain deliberate `[interop.c]` concerns. A Loaf never implicitly consumes a neighbouring `Cargo.toml`.
 8. **Targets have three scopes:** a Loaf declares supported target/interface combinations; a workspace declares shared delivery policy; a bake invocation chooses one concrete target, carrier, profile, and feature closure that produces a target-bound `*.loaf` asset.
 9. **Plans precede effects:** resolution, import, installation, or the presence of a file must not execute package code. Oven exposes a plan before baking and records the actual execution in a receipt.
@@ -69,7 +69,7 @@ Oven is more than a package resolver. It must plan target-specific C ABI, JNI, P
 - Replace `incan.toml` with `Loaf.toml` wholesale before Incan 1.0.
 - Preserve `[project]` as the familiar package-metadata surface.
 - Preserve rooted and virtual workspace forms using optional `[workspace]`.
-- Give Incan packages, Rust crates, and foreign/system capabilities one dependency grammar while retaining their distinct resolver and linkage contracts.
+- Give Incan packages, Rust crates, and foreign/system providers one dependency grammar while retaining their distinct resolver and linkage contracts.
 - Make `incan.pub` the default origin for Loaf packages and crates.io the default origin for Rust crates, while allowing registered alternative registries and explicit sources.
 - Define safe discovery when `Loaf.toml` and `Cargo.toml` coexist.
 - Permit explicitly declared hierarchical sub-Loaves under one inherited root-workspace authority.
@@ -285,11 +285,11 @@ headers = ["interop/include/vision.h"]
 requires = ["vision-runtime"]
 
 [targets.ios]
-platform = "aarch64-apple-ios"
+platforms = ["aarch64-apple-ios"]
 carrier = "framework"
 
 [targets.android]
-platform = "aarch64-linux-android"
+platforms = ["aarch64-linux-android"]
 carrier = "jni-library"
 ```
 
@@ -367,11 +367,11 @@ Every dependency requirement has a **unit kind** and an **origin**.
 | ------------ | ----------------------------------- | --------------------------------------------------------------------------- | ----------------------------------------------- |
 | `loaf`       | `incan.pub`                         | checked Incan semantic/provider facts and public package features           | a Cargo crate or generated Rust source contract |
 | `crate`      | crates.io                           | Rust interop metadata and backend implementation/linkage requirements       | a public Incan feature namespace by accident    |
-| `capability` | Oven-managed system/foreign catalog | target-specific library, SDK, toolchain, runtime, or deployment requirement | an ambient host discovery result                |
+| `provider`   | Oven-managed system/foreign catalog | target-specific library, SDK, toolchain, runtime, or deployment requirement | an ambient host discovery result                |
 
 An entry may override its default origin through a registered registry, Git, path, or another supported source form. The resolved provider contract determines the legal source forms; a Loaf registry must not be accepted as a Cargo registry merely because it has a URL.
 
-Project features remain additive public Loaf capabilities as defined by RFC 114. They may enable optional Loaf dependencies and request public features from Loaf dependencies. A project may explicitly request a provider-specific crate feature as part of a crate dependency requirement, but that request is not exposed as a public project feature unless the project explicitly maps it through its public feature definition. Cargo feature names, generated crate names, and backend module paths remain implementation details.
+Project features remain additive public Loaf features as defined by RFC 114. They may enable optional Loaf dependencies and request public features from Loaf dependencies. A project may explicitly request a provider-specific crate feature as part of a crate dependency requirement, but that request is not exposed as a public project feature unless the project explicitly maps it through its public feature definition. Cargo feature names, generated crate names, and backend module paths remain implementation details.
 
 Workspace inheritance remains explicit. A workspace may own a dependency identity and members may opt into it. A member may refine only the usage properties RFC 114 and the selected dependency kind allow; it may not silently replace the source, registry, package identity, or trust policy selected by the workspace.
 
@@ -381,7 +381,7 @@ Workspace inheritance remains explicit. A workspace may own a dependency identit
 2. Additional registries are registered through Oven-controlled user or organization configuration, never by an unreviewed dependency or an implicit network lookup.
 3. A registry registration must declare a stable identity, unit kind/protocol, endpoint/index, and trust policy. Credentials are referenced from secure user/organization storage rather than copied into project files.
 4. A Loaf or workspace may allow-list registered registry identities. It may select an allowed alias but may not define credentials, rebind an alias, or weaken a user/organization trust policy.
-5. The lock records canonical registry identity, protocol, exact resolved package/crate/capability identity, version, immutable digest, source reference, and signature/trust outcome. An alias alone is insufficient for reproducibility or audit.
+5. The lock records canonical registry identity, protocol, exact resolved package/crate/provider identity, version, immutable digest, source reference, and signature/trust outcome. An alias alone is insufficient for reproducibility or audit.
 6. Resolution in locked or offline mode must not query an unrecorded registry, substitute an ambient local package, or accept a source with different trust facts.
 
 RFC 034 remains the protocol and publication authority for `incan.pub`; this RFC defines how `incan.pub` participates in the generic Loaf graph. A future Cargo-registry adapter must respect Cargo registry identity and integrity semantics without making Cargo the authority for a Loaf bake.
@@ -425,7 +425,7 @@ The resolver may fetch, verify, and stage immutable declared inputs according to
 Every execution edge in a bake must belong to one of these categories:
 
 1. **Oven-managed provider operation:** a known provider kind performs typed work, such as compiling declared Rust sources, verifying C headers, compiling a declared C/C++ shim, or materializing a selected SDK component.
-2. **Declared generator operation:** a generator has typed inputs, outputs, provider identity, target constraints, capability requirements, and generated-output ownership. It may not overwrite authored source through an ordinary bake.
+2. **Declared generator operation:** a generator is a typed Incan (or `rust::`-interop) function with typed inputs, outputs, declaring-package identity, target constraints, capability requirements, and generated-output ownership. It may not overwrite authored source through an ordinary bake.
 3. **Explicit workflow action:** an action from RFC 078 is selected by the user or an authorized tool and is evaluated under RFC 076 policy before execution.
 
 An extension must have a versioned, typed schema and a known provider/action identity. Unknown extension kinds are invalid; they are not a generic `[tool.*]` escape hatch. A provider or action may advertise a required capability, network requirement, external executable, or mutation class, but it must not gain authority merely by being selected as a dependency.
@@ -447,7 +447,7 @@ The following authored concepts move into `Loaf.toml` under Oven ownership. Thei
 
 RFC 015 is implemented, so RFC 117 supersedes its `incan.toml` discovery and `[tool.incan.envs]` configuration placement. RFCs 073, 076, and 078 are still Draft and must be amended to name the new Loaf tables and terminology rather than preserving legacy configuration compatibility.
 
-The initial table roots are `[envs]`, `[actions]`, `[policy]`, `[capabilities]`, and `[templates]`. Their dedicated RFCs own the detailed schema and semantics. No `[oven.*]` prefix is needed: a `Loaf.toml` is already Oven's authored project document, and roots should name their semantic domain instead. They must remain explicit, scoped, inspectable, and free of implicit lifecycle execution. RFC 118 owns whether users invoke those semantics through `incan`, `oven`, aliases, or another command arrangement.
+The initial table roots are `[envs]`, `[actions]`, `[policy]`, `[mixes]`, and `[templates]`. Their dedicated RFCs own the detailed schema and semantics. No `[oven.*]` prefix is needed: a `Loaf.toml` is already Oven's authored project document, and roots should name their semantic domain instead. They must remain explicit, scoped, inspectable, and free of implicit lifecycle execution. RFC 118 owns whether users invoke those semantics through `incan`, `oven`, aliases, or another command arrangement.
 
 ### Standard environments
 
@@ -475,7 +475,7 @@ Project scaffolding must generate a valid, minimal `Loaf.toml` and include the f
 
 RFC 116's current `[oven.interop]` shape is package-owned requirement data, not a record of a host toolchain already selected. Under this RFC it moves to the Loaf-level `[interop]` namespace: C declarations use `[interop.c]`. The file name changes from `incan.toml` to `Loaf.toml`; the ownership boundary does not.
 
-The interop envelope must be binding-kind neutral. It represents declared headers, shims, foreign artifacts, toolchain/SDK capabilities, target variants, carrier requirements, lock identities, plan inputs, generated verification records, artifact staging, and receipts. It does not make C pointer types, C ownership, JNI handles, Python reference counts, or another runtime's safety rules universal. Each binding-kind RFC continues to define its own source vocabulary and checking rules. Loaf-facing configuration uses precise terms such as `interop.c`, `host`, `target`, and declared linker artifact form; it does not introduce a catch-all `native` configuration namespace. Existing RFC 116 source syntax remains historical until a future language-level proposal changes it.
+The interop envelope must be binding-kind neutral. It represents declared headers, shims, foreign artifacts, toolchain/SDK provider requirements, target variants, carrier requirements, lock identities, plan inputs, generated verification records, artifact staging, and receipts. It does not make C pointer types, C ownership, JNI handles, Python reference counts, or another runtime's safety rules universal. Each binding-kind RFC continues to define its own source vocabulary and checking rules. Loaf-facing configuration uses precise terms such as `interop.c`, `host`, `target`, and declared linker artifact form; it does not introduce a catch-all `native` configuration namespace. Existing RFC 116 source syntax remains historical until a future language-level proposal changes it.
 
 ### Locks and derived state
 
@@ -506,7 +506,7 @@ Loaf.toml
 ├── [envs]                    RFC 073, rehomed by RFC 117
 ├── [actions]                 RFC 078, rehomed by RFC 117
 ├── [policy]                  RFC 076, rehomed by RFC 117
-├── [capabilities]            RFC 075, governed by RFC 076
+├── [mixes]                   RFC 075, governed by RFC 076
 ├── [templates]               RFC 074, governed by RFC 076
 ├── [incan.source]            built-in Incan source facet
 ├── [rust.source] / [rust.*]  built-in Rust source facet; RFC 119 owns exceptions
@@ -642,7 +642,7 @@ RFC 117 is ready to move beyond Draft when its normative rules and updated relat
 
 ### Phase 2: Typed graph, registries, and lock
 
-- Normalize Loaf, crate, and capability dependencies into one resolver-owned graph.
+- Normalize Loaf, crate, and provider dependencies into one resolver-owned graph.
 - Implement default origins, registered registry identities, workspace allow-lists, integrity/trust facts, and the `Oven.lock` format.
 - Amend RFC 034 integration and retain RFC 114's public-feature/provider boundaries.
 
@@ -671,16 +671,13 @@ RFC 117 is ready to move beyond Draft when its normative rules and updated relat
 - **Built-in source facets:** Incan and Rust are the v0.6 built-in authored source facets. Simple one-language projects use `src/` by convention. Mixed or nonstandard projects use `[incan.source]` and `[rust.source]` with non-overlapping roots; the compiler diagnoses co-located `.incn` and `.rs` source files instead of imposing precedence. Rust exceptions remain beneath `rust.*`.
 - **Deliberate interop boundary:** C remains behind the existing `[interop.c]` facade, including any authored C shim root. `[interop.*]` is reserved for later concrete integrations such as JNI or Python; v0.6 does not define a plugin system, automatic foreign-tool discovery, or generic foreign-source execution.
 - **Precise C configuration terminology:** Loaf configuration names C interop, host, target, and linker artifact form directly. It does not use `native` as an interop configuration keyword or a generic foreign-language category. Any change to RFC 116's existing source-level binding spelling requires a later language proposal rather than a retroactive edit to that closed RFC.
-
-## Unresolved questions
-
-1. What is the final compact TOML syntax for typed dependency entries and provider-specific feature requests, while preserving the unit-kind/origin distinction?
-2. Which detailed environment matrix and action/policy subtable shapes are needed under the settled direct semantic roots without weakening the standard-environment or explicit-effect boundaries?
-3. Which generated-input declarations and compact `rust.*` exception fields are necessary for the first 0.6 implementation, beyond the settled core source-root syntax?
-4. How should an organization distribute and administer trusted registry registrations without letting a checked-out project overwrite user or organization trust policy?
-5. Which target/carrier combinations and named delivery-policy grammar constitute the first 0.6 proof set?
-6. What is the smallest typed generator/provider extension API that supports real code generation and native shims without becoming a generic script hook?
-7. Which `*.loaf` container or wire format, registry transport, and multi-asset publication protocol best carries the already-reserved immutable target-bound identity without changing its authored/lock/receipt contract?
-8. What precise inspection meaning, if any, should cold, warm, and hot Loaves have after the Oven's cache and lifecycle model is settled?
-
-<!-- Rename this section to "Design Decisions" once all questions have been resolved. -->
+- **`provider` is the third dependency unit kind, not `capability`:** the `[dependencies]` unit kind for target-specific library, SDK, toolchain, runtime, or deployment requirements is named `provider`, matching the vocabulary this RFC already uses pervasively ("provider semantics," "Oven-managed provider operation") rather than inventing a fourth word. `capability` is reserved: RFC 104 already owns it for checked runtime-authority grants, and reusing it here for a build-time provisioning concept created a real three-way terminology collision with RFC 104's runtime capabilities and RFC 075's project-scaffolding descriptor (also renamed, to `mix`, for the same reason). The `[capabilities]` table root this RFC reserved for RFC 075's descriptor-enablement record is renamed to `[mixes]` to match.
+- **Provider-kind dependencies have a full and a bare form:** a `provider`-kind requirement that needs real version or feature constraints is declared as an ordinary `[dependencies]` entry, the same shape as `loaf` and `crate` entries: `vision-runtime = { provider = "vision-runtime", version = ">=2.0" }`. A `provider`-kind requirement that only needs to exist, with no constraints, may instead be referenced bare from the owning domain table that needs it, for example `[interop.c].requires = ["vision-runtime"]`. The bare form is implicit shorthand that resolves against a fuller `[dependencies]` declaration when one is present; the two are not competing syntaxes. This mirrors the "simple shorthand plus full explicit form, both valid" shape RFC 118 uses for its CLI surface.
+- **Detailed environment/action/policy subtable shapes belong to their owning RFCs:** RFC 117 reserves and rehomes the top-level `[envs]`, `[actions]`, and `[policy]` table roots (see "Environments and actions"), but the detailed subtable schema beneath each root is RFC 073's, RFC 078's, and RFC 076's own decision, respectively. RFC 117 does not need to specify those shapes to reach Planned; it only needs the roots and the standard-environment/explicit-effect boundaries it already defines to hold.
+- **Compact `rust.*` exception fields belong to RFC 119:** the core source-root contract (`[incan.source]`, `[rust.source]`, non-overlapping roots, convention-first defaults) is this RFC's own settled surface. The detailed native-Rust facet grammar, including generated-input declarations and the compact `rust.*` exception fields, is RFC 119's work, as this RFC's own "Rust source facet" section already states.
+- **Target declarations use `[targets.<name>]` blocks with a list-only `platforms` field and a toolchain-owned `carrier` field:** `platforms` is always a list of literal Rust target triples (for example `aarch64-apple-ios`), reusing Rust's own target vocabulary instead of inventing a parallel one, and matching this RFC's existing list-only convention for `members`/`targets`. `carrier` is a single value naming the deliverable form (static library, framework, JNI shared library, Python wheel, executable, Rust-host caller projection, or another declared family). Carrier kinds are toolchain-owned and extensible only across releases: a new carrier kind lands through an official RFC (RFC 119 for Rust-hosted carriers, a future RFC for others), never through package-defined extension. Whether a given platform/carrier combination is valid (for example, `framework` only makes sense for Apple platforms) is not this RFC's concern; it is owned by whichever RFC defines that carrier kind. Tooling support for validating combinations and offering editor autocomplete is tracked separately (issue #1064) and is not required for this RFC to reach Planned.
+- **`*.loaf` wire/container format stays out of scope, as already stated in Non-Goals:** this RFC reserves the identity a future artifact-format RFC must carry — project/facet, target, carrier, profile, resolved-graph identity, payload digest, and receipt identity — but does not define the container, registry transport, or multi-asset publication protocol itself. Asking this RFC to also settle the wire format was a category error: Non-Goals already assigns it to a dedicated RFC.
+- **Cold/warm/hot Loaf states stay out of scope, as already stated in Non-Goals and Terminology:** this RFC's Terminology section already flags that their precise state semantics are intentionally not specified here. Giving them normative inspection meaning is a future Oven cache/lifecycle RFC's decision, not a gap in this RFC's own model.
+- **Registry trust distribution/administration is out of scope:** this RFC defines the registration contract — registries are declared in Oven-controlled user or organization configuration outside the project, and a Loaf or workspace may only allow-list from what is already registered, never define, rebind, or weaken trust (see "Registry registration and trust"). That non-overwrite guarantee already holds without any additional distribution mechanism, because a project has no registration authority at all. How an organization gets the same trusted-registry configuration onto every developer machine and CI runner — through existing device-management tooling, a self-hosted convention, or another means the operator chooses — is an operational concern for whoever runs the registry, not a capability this RFC or Oven itself needs to provide. `incan.pub` remains the trusted, secure default origin for the open ecosystem; that trust is RFC 034's responsibility.
+- **Generators are ordinary typed Incan functions, not a bespoke plugin format:** a generator is not a new sandboxed runtime, wire protocol, or component model. It is a typed Incan (or `rust::`-interop) function with a declared input/output signature that Oven resolves and calls as part of planning or baking, reusing the same execution substrate Incan's own interactive and notebook ambitions already require rather than inventing a second one. Its capability needs — network access, filesystem beyond its declared outputs, a live database, or any other ambient authority — are ordinary RFC 104 capability grants like any other code path; there is no generator-specific security model, because RFC 104 already owns "what can this code touch" regardless of who is asking. A generator's output may legitimately vary between two otherwise-identical builds when it consults an external, changing source; that variability is a capability its declaring package consciously requests and its consumer consciously grants, not a defect this RFC needs to guard against. A generator's declared outputs remain generated, ownership-tracked files that an ordinary bake must not overwrite authored source with.
+- **Providers remain closed and toolchain-owned, not a third-party extension point:** unlike generators, providers (compiling Rust, verifying C headers, materializing an SDK component) are deep native toolchain integrations that Oven implements itself, not expressible as a typed function signature. A new provider kind lands only through an official RFC, the same governance already settled for carrier kinds.

--- a/workspaces/docs-site/docs/RFCs/117_loaf_toml_and_oven_project_model.md
+++ b/workspaces/docs-site/docs/RFCs/117_loaf_toml_and_oven_project_model.md
@@ -128,10 +128,10 @@ Loaf.toml + declared sources + declared inputs
 - A **`loaves/` group** is the repository convention for non-root workspace members. It may be nested, for example `loaves/stdlib/web/`; its path is not a dependency, publication, or Rust-crate identity.
 - A **Doughball** is Oven's internal representation of the selected sources, declared dependencies, features, interop inputs, and policy before target shaping.
 - A **Loaf** is the resolved logical build unit Oven obtains by shaping a Doughball for a selected package facet and target-compatible plan.
-- A **`*.loaf` asset** is the immutable, verified, target-bound build and distribution asset emitted by a bake. It carries the selected Loaf identity, target/carrier/profile, resolved-graph identity, payload digest, and receipt identity. Its archive or wire format is outside this RFC.
-- To **bake** is the operation that executes a resolved plan for a selected target/carrier/profile and produces a `*.loaf` asset plus a receipt. "Bake" is a verb, not a required artifact type.
+- A **`*.loaf` asset** is the immutable, verified, target-bound build and distribution asset emitted by a bake of a loaf-shaped carrier. It carries the selected Loaf identity, target/carrier/profile, resolved-graph identity, payload digest, and receipt identity. Its archive or wire format is outside this RFC.
+- To **bake** is the operation that executes a resolved plan for a selected target/carrier/profile and produces a build artifact plus a receipt. "Bake" is a verb, not a required artifact type. The produced artifact's packaging depends on the selected carrier's shape (see below): a loaf-shaped carrier yields a `*.loaf` asset, a terminal carrier yields a plain build artifact. Both shapes still go through the same plan, policy decision, and receipt; only downstream-reuse packaging differs.
 - **Cold**, **warm**, and **hot** Loaves may be shown by Oven's internal inspection and cache-status UX. Their precise state semantics are intentionally not specified here.
-- A **carrier** is the target deliverable form: for example, a static library, framework, JNI shared library, Python wheel, Rust-host caller projection, executable, or another declared artifact family.
+- A **carrier** is the target deliverable form: for example, a static library, framework, JNI shared library, Python wheel, Rust-host caller projection, executable, or another declared artifact family. Every carrier has a **shape**: **loaf-shaped** carriers (static library, framework, JNI shared library, Python wheel, Rust-host caller projection) produce a `*.loaf` asset meant for another Oven consumer to depend on or reuse; the **terminal** carrier `executable` produces a plain build artifact meant to be run or deployed directly, never depended on as a package. A carrier's shape is fixed by whichever RFC defines that carrier kind, not chosen per invocation.
 
 ## Guide-level explanation
 
@@ -297,7 +297,7 @@ This example is intentionally schematic. `[interop]` is Loaf-owned requirement d
 
 ### Baking and inspecting
 
-Before Oven performs external work, it can show a plan containing selected members, dependencies, providers, target, carrier, profile, capabilities, declared inputs/outputs, and expected effect classes. Baking executes only that plan and emits a target-bound `*.loaf` asset plus a receipt.
+Before Oven performs external work, it can show a plan containing selected members, dependencies, providers, target, carrier, profile, capabilities, declared inputs/outputs, and expected effect classes. Baking executes only that plan and emits a target-bound build artifact plus a receipt — a `*.loaf` asset for a loaf-shaped carrier, or a plain build artifact for a terminal carrier such as `executable`.
 
 The exact CLI spelling is intentionally outside this RFC. The semantic operation is:
 
@@ -407,6 +407,21 @@ The resolved plan must distinguish:
 
 An explicit invocation has the highest selection precedence but cannot override package support or workspace policy. A workspace delivery policy may narrow a project choice but cannot make a package claim an unsupported target. An unqualified local bake may choose a deterministic host-development target and profile, and the receipt must record that choice. Publication or deployment must require an explicit target/carrier or named delivery policy; it must not silently publish a host-default artifact.
 
+### Carrier shape and bake output
+
+A carrier's **shape** determines what packaging, if any, a bake of it produces:
+
+| Carrier                     | Shape       | Bake output                                                 |
+| ---------------------------- | ----------- | -------------------------------------------------------------- |
+| static library                | loaf-shaped | `*.loaf` asset, verified and reusable by another Oven bake     |
+| framework                     | loaf-shaped | `*.loaf` asset, verified and reusable by another Oven bake     |
+| JNI shared library             | loaf-shaped | `*.loaf` asset, verified and reusable by another Oven bake     |
+| Python wheel                  | loaf-shaped | `*.loaf` asset, verified and reusable by another Oven bake     |
+| Rust-host caller projection    | loaf-shaped | `*.loaf` asset, verified and reusable by another Oven bake     |
+| executable                    | terminal    | plain build artifact, no `.loaf` packaging                     |
+
+A loaf-shaped carrier's output is meant for another Oven consumer to depend on or reuse: it is the shape a package published for downstream consumption needs. A terminal carrier's output is meant to be run or deployed directly and is never depended on as a package, so packaging it as a reusable `*.loaf` would carry no meaning — nothing will ever declare a dependency on it. Both shapes go through the same plan, policy decision, and receipt; shape changes packaging for downstream reuse, not plan rigor, policy gating, or audit requirements. A future carrier RFC declares its own carrier's shape alongside its other properties; shape is fixed per carrier kind, not selectable per invocation.
+
 ### Plans, effects, extensions, and receipts
 
 Oven uses the following boundary:
@@ -483,7 +498,7 @@ The interop envelope must be binding-kind neutral. It represents declared header
 
 The lock must include every semantic or physical input whose change can alter checking, linking, target compatibility, generated output, or the baked artifact closure. It must not contain credentials, mutable cache paths, arbitrary environment values, or unreviewed host discovery output.
 
-`*.loaf` is the immutable, target-bound distribution/build asset derived from the lock and the selected bake plan. It must identify its project/facet, target, carrier, profile, resolved graph identity, payload digest, and receipt identity; it is not an editable project manifest or a replacement lockfile. The artifact store, provider payload store, staged deployment files, generated Rust, target intermediates, and receipts are separate from the lock. They are inspectable and may be content-addressed, but they are not user-authored package configuration or semantic authority.
+`*.loaf` is the immutable, target-bound distribution/build asset derived from the lock and the selected bake plan for a loaf-shaped carrier. It must identify its project/facet, target, carrier, profile, resolved graph identity, payload digest, and receipt identity; it is not an editable project manifest or a replacement lockfile. A bake of a terminal carrier such as `executable` instead produces a plain build artifact identified by the same lock and receipt, without `.loaf` packaging (see "Carrier shape and bake output"). The artifact store, provider payload store, staged deployment files, generated Rust, target intermediates, and receipts are separate from the lock. They are inspectable and may be content-addressed, but they are not user-authored package configuration or semantic authority.
 
 ### Future registry-supplied warm reuse
 
@@ -681,3 +696,4 @@ RFC 117 is ready to move beyond Draft when its normative rules and updated relat
 - **Registry trust distribution/administration is out of scope:** this RFC defines the registration contract — registries are declared in Oven-controlled user or organization configuration outside the project, and a Loaf or workspace may only allow-list from what is already registered, never define, rebind, or weaken trust (see "Registry registration and trust"). That non-overwrite guarantee already holds without any additional distribution mechanism, because a project has no registration authority at all. How an organization gets the same trusted-registry configuration onto every developer machine and CI runner — through existing device-management tooling, a self-hosted convention, or another means the operator chooses — is an operational concern for whoever runs the registry, not a capability this RFC or Oven itself needs to provide. `incan.pub` remains the trusted, secure default origin for the open ecosystem; that trust is RFC 034's responsibility.
 - **Generators are ordinary typed Incan functions, not a bespoke plugin format:** a generator is not a new sandboxed runtime, wire protocol, or component model. It is a typed Incan (or `rust::`-interop) function with a declared input/output signature that Oven resolves and calls as part of planning or baking, reusing the same execution substrate Incan's own interactive and notebook ambitions already require rather than inventing a second one. Its capability needs — network access, filesystem beyond its declared outputs, a live database, or any other ambient authority — are ordinary RFC 104 capability grants like any other code path; there is no generator-specific security model, because RFC 104 already owns "what can this code touch" regardless of who is asking. A generator's output may legitimately vary between two otherwise-identical builds when it consults an external, changing source; that variability is a capability its declaring package consciously requests and its consumer consciously grants, not a defect this RFC needs to guard against. A generator's declared outputs remain generated, ownership-tracked files that an ordinary bake must not overwrite authored source with.
 - **Providers remain closed and toolchain-owned, not a third-party extension point:** unlike generators, providers (compiling Rust, verifying C headers, materializing an SDK component) are deep native toolchain integrations that Oven implements itself, not expressible as a typed function signature. A new provider kind lands only through an official RFC, the same governance already settled for carrier kinds.
+- **Carriers have a shape, and a terminal carrier's bake output is not a `*.loaf`:** found while working RFC 118's command-surface decisions and folded back here, since carrier semantics are this RFC's job, not RFC 118's. A `*.loaf`'s entire value proposition, as this RFC's own "Future registry-supplied warm reuse" section describes it, is reuse by another Oven consumer. A terminal artifact such as an executable — for example a data pipeline's final ETL binary — is never depended on as a package by anything, so packaging it as a reusable `*.loaf` carries no meaning. Every carrier therefore has a fixed **shape**: loaf-shaped carriers (static library, framework, JNI shared library, Python wheel, Rust-host caller projection) bake to a `*.loaf` asset; the terminal carrier (`executable`) bakes to a plain build artifact with no `.loaf` packaging. Both shapes still go through the same plan, policy decision, and receipt; shape changes only downstream-reuse packaging, not plan rigor or audit requirements. See "Carrier shape and bake output."

--- a/workspaces/docs-site/docs/RFCs/117_loaf_toml_and_oven_project_model.md
+++ b/workspaces/docs-site/docs/RFCs/117_loaf_toml_and_oven_project_model.md
@@ -1,4 +1,4 @@
-# RFC 117: `Loaf.toml` and Oven's language-neutral project model
+# RFC 117: `loaf.toml` and Oven's language-neutral project model
 
 - **Status:** Planned
 - **Created:** 2026-08-04
@@ -30,9 +30,9 @@
 
 ## Summary
 
-This RFC replaces `incan.toml` with `Loaf.toml` as the sole authored manifest for an Oven-managed project. A `Loaf.toml` may describe one project, a rooted workspace, or a virtual workspace. Its package, target, lock, cache, and receipt model is language-neutral. Incan and Rust are the built-in authored source facets in v0.6; checked C interop remains under `[interop.c]`; later foreign integrations require their own explicit interop RFC rather than becoming ambient source languages.
+This RFC replaces `incan.toml` with `loaf.toml` as the sole authored manifest for an Oven-managed project. A `loaf.toml` may describe one project, a rooted workspace, or a virtual workspace. Its package, target, lock, cache, and receipt model is language-neutral. Incan and Rust are the built-in authored source facets in v0.6; checked C interop remains under `[interop.c]`; later foreign integrations require their own explicit interop RFC rather than becoming ambient source languages.
 
-`[project]` remains the familiar metadata table. `[workspace]` remains the explicit repository-coordination table. Dependencies use one typed graph whose unit kind and origin are explicit when the defaults are insufficient: Incan Loaf packages default to `incan.pub`, Rust crates default to crates.io, and foreign/system requirements use Oven-managed providers. Oven resolves authored intent into `Oven.lock`, then bakes the selected target into immutable, verified `*.loaf` assets and receipts. Cargo remains a deliberately explicit compatibility mode for repositories that have no `Loaf.toml`; it is never inferred as part of a Loaf build.
+`[project]` remains the familiar metadata table. `[workspace]` remains the explicit repository-coordination table. Dependencies use one typed graph whose unit kind and origin are explicit when the defaults are insufficient: Incan Loaf packages default to `incan.pub`, Rust crates default to crates.io, and foreign/system requirements use Oven-managed providers. Oven resolves authored intent into `Oven.lock`, then bakes the selected target into immutable, verified `*.loaf` assets and receipts. Cargo remains a deliberately explicit compatibility mode for repositories that have no `loaf.toml`; it is never inferred as part of a Loaf build.
 
 This RFC also rehomes the authored configuration boundaries of existing environment, matrix, action, workspace, provider, and interop RFCs. It does not define the final command spelling or a general-purpose task shell.
 
@@ -40,7 +40,7 @@ This RFC also rehomes the authored configuration boundaries of existing environm
 
 Read this RFC as thirteen foundations:
 
-1. **One authored manifest:** `Loaf.toml` is the only Incan/Oven project manifest. `incan.toml` is not read as a compatibility format.
+1. **One authored manifest:** `loaf.toml` is the only Incan/Oven project manifest. `incan.toml` is not read as a compatibility format.
 2. **A familiar project table:** `[project]` owns package identity and publication metadata. The filename carries the Loaf vocabulary; the metadata table remains ordinary and legible.
 3. **A workspace is an optional hierarchy:** `[workspace]` declares explicit members and shared policy. A root with both `[project]` and `[workspace]` is a rooted workspace; a root with only `[workspace]` is virtual. Members may form explicit structural child groups, but the root remains the sole authority for resolution, locking, registry trust, target policy, and receipts.
 4. **The package graph is language-neutral:** every dependency is one logical requirement with a typed provider contract. The author does not choose a separate Incan-versus-Rust dependency table.
@@ -52,7 +52,7 @@ Read this RFC as thirteen foundations:
 10. **Named environments and actions are explicit Loaf intent:** the standard `dev`, `test`, `lint`, and `docs` environments always exist; authored environment and typed-action configuration moves out of `[tool.incan.*]` and into the Loaf model. Environments select named, reproducible command contexts; they do not silently change a production bake.
 11. **Derived state is separate:** `Oven.lock`, immutable `*.loaf` assets, the artifact store, selected host toolchains, caches, staged outputs, generated code, and receipts are not authored Loaf configuration.
 12. **Distribution assets are verifiable and future-reusable:** a `*.loaf` asset is immutable and target-bound. It identifies the selected project/facet, target, carrier, profile, resolved graph, payload digest, and receipt; those facts reserve the compatibility boundary through which a future `incan.pub` consumer can safely reuse a pre-warmed asset rather than rebuild it. Its wire or bundle format is intentionally deferred.
-13. **Cargo compatibility is explicit:** a directory with only `Cargo.toml` may be run by Oven in Cargo-compatibility mode. A directory containing `Loaf.toml` is a Loaf project; Cargo files there are ignored with a diagnostic unless the user explicitly invokes Cargo compatibility.
+13. **Cargo compatibility is explicit:** a directory with only `Cargo.toml` may be run by Oven in Cargo-compatibility mode. A directory containing `loaf.toml` is a Loaf project; Cargo files there are ignored with a diagnostic unless the user explicitly invokes Cargo compatibility.
 
 ## Motivation
 
@@ -60,22 +60,22 @@ The current `incan.toml` correctly introduced project identity, dependency decla
 
 That assumption is constraining in both directions. An Incan-authored package may need a Rust crate, a C ABI library, a C++ shim, a target SDK, or a later JNI/Python carrier without ceasing to be one package. A Rust-authored project that elects to use Oven should be able to adopt the same package, target, receipt, and workspace model without being forced to rewrite its sources into Incan. Cargo must remain runnable where Cargo is explicitly authoritative, but Cargo's implicit build scripts, proc macros, target conventions, and workspace semantics must not become accidental Loaf semantics.
 
-The same pressure exists at the repository root. A separate `Oven.toml` would distinguish package metadata from workspace orchestration, but introduces two canonical files and an ownership/discovery boundary without a demonstrated capability need. Cargo already demonstrates that one manifest can express a root package, a virtual workspace, or both. `Loaf.toml` can do the same when its table scopes are explicit.
+The same pressure exists at the repository root. A separate `Oven.toml` would distinguish package metadata from workspace orchestration, but introduces two canonical files and an ownership/discovery boundary without a demonstrated capability need. Cargo already demonstrates that one manifest can express a root package, a virtual workspace, or both. `loaf.toml` can do the same when its table scopes are explicit.
 
 Oven is more than a package resolver. It must plan target-specific C ABI, JNI, Python, Rust-host, and future carrier builds; select and verify toolchains; materialize controlled environments; protect shared artifact stores; and describe exactly what happened. That requires a manifest that captures desired inputs, not hidden host discovery or arbitrary execution.
 
 ## Goals
 
-- Replace `incan.toml` with `Loaf.toml` wholesale before Incan 1.0.
+- Replace `incan.toml` with `loaf.toml` wholesale before Incan 1.0.
 - Preserve `[project]` as the familiar package-metadata surface.
 - Preserve rooted and virtual workspace forms using optional `[workspace]`.
 - Give Incan packages, Rust crates, and foreign/system providers one dependency grammar while retaining their distinct resolver and linkage contracts.
 - Make `incan.pub` the default origin for Loaf packages and crates.io the default origin for Rust crates, while allowing registered alternative registries and explicit sources.
-- Define safe discovery when `Loaf.toml` and `Cargo.toml` coexist.
+- Define safe discovery when `loaf.toml` and `Cargo.toml` coexist.
 - Permit explicitly declared hierarchical sub-Loaves under one inherited root-workspace authority.
 - Keep source-language choice out of the package identity while avoiding implicit Cargo participation.
 - Define a target model that distinguishes platform target, deployable carrier, profile, and delivery policy.
-- Distinguish authored intent (`Loaf.toml`), resolved graph (`Oven.lock`), and immutable target-bound distribution assets (`*.loaf`) without making any of them hidden state.
+- Distinguish authored intent (`loaf.toml`), resolved graph (`Oven.lock`), and immutable target-bound distribution assets (`*.loaf`) without making any of them hidden state.
 - Make plans, declared effects, selected inputs, output artifacts, and receipts inspectable.
 - Rehome environment/matrix/action configuration ownership to Oven without re-specifying the semantics already owned by RFCs 073 and 078.
 - Rehome package-level C ABI configuration from `[oven.interop]` into `[interop]`, a direct semantic root that future binding kinds may share, while retaining RFC 116 as the owner of C safety semantics.
@@ -102,8 +102,8 @@ Oven is more than a package resolver. It must plan target-specific C ABI, JNI, P
 
 Closed RFCs remain historical records and are not retroactively edited. This RFC explicitly supersedes the following decisions for implementations that adopt the Loaf/Oven project model:
 
-- **RFC 013 and RFC 031:** separate authored `[dependencies]` and `[rust-dependencies]` tables, and the assumption that a consumer's dependency graph is authored as Cargo wiring. `Loaf.toml` has one typed dependency graph; provider-specific Rust requirements remain visible facts rather than a second authoring domain.
-- **RFC 015:** `incan.toml` as the project manifest, nearest-manifest root discovery, project generation that writes `incan.toml`, and `[tool.incan.envs]` as the environment-configuration home. `Loaf.toml` is the sole authored manifest, while environment semantics remain owned by their dedicated RFCs.
+- **RFC 013 and RFC 031:** separate authored `[dependencies]` and `[rust-dependencies]` tables, and the assumption that a consumer's dependency graph is authored as Cargo wiring. `loaf.toml` has one typed dependency graph; provider-specific Rust requirements remain visible facts rather than a second authoring domain.
+- **RFC 015:** `incan.toml` as the project manifest, nearest-manifest root discovery, project generation that writes `incan.toml`, and `[tool.incan.envs]` as the environment-configuration home. `loaf.toml` is the sole authored manifest, while environment semantics remain owned by their dedicated RFCs.
 - **RFC 020:** `incan.lock` as the generated resolution identity. The reproducibility and locked/offline requirements remain; their generated artifact is `Oven.lock`.
 - **RFC 077:** a flat workspace that forbids nested workspaces. Explicit membership, rooted and virtual workspace forms, and one shared resolution boundary remain; a member may now declare explicit sub-Loaves within a single inherited root-workspace authority.
 - **RFC 112:** the public lockfile path used by its publication examples. Crash-safe publication and coordination requirements remain unchanged, but the published lockfile is `Oven.lock` and its companion coordination identity follows that name.
@@ -113,10 +113,10 @@ This RFC does not supersede the retained semantic contracts in those RFCs: repro
 
 ## Terminology and mental model
 
-The user-facing contract is intentionally small: authors write `Loaf.toml`; Oven plans and bakes it. The surrounding bread vocabulary is a guide-level model and an Oven inspection affordance, not a second vocabulary users must configure.
+The user-facing contract is intentionally small: authors write `loaf.toml`; Oven plans and bakes it. The surrounding bread vocabulary is a guide-level model and an Oven inspection affordance, not a second vocabulary users must configure.
 
 ```text
-Loaf.toml + declared sources + declared inputs
+loaf.toml + declared sources + declared inputs
   -> Doughball (internal source-and-input mass)
   -> Oven shapes one or more Loaves (resolved logical build units)
   -> Oven bakes a selected Loaf for a selected target
@@ -137,7 +137,7 @@ Loaf.toml + declared sources + declared inputs
 
 ### A single project
 
-An ordinary project needs only `Loaf.toml`:
+An ordinary project needs only `loaf.toml`:
 
 ```toml
 [project]
@@ -163,7 +163,7 @@ This example is mixed, so it names separate roots. An Incan-only project convent
 
 ### A workspace of Loaves
 
-The root `Loaf.toml` can be a project and a workspace:
+The root `loaf.toml` can be a project and a workspace:
 
 ```toml
 [project]
@@ -185,7 +185,7 @@ targets = ["aarch64-apple-ios", "aarch64-linux-android"]
 profile = "release"
 ```
 
-A virtual workspace omits `[project]` and retains `[workspace]`. Every member has its own `Loaf.toml`; no member is inferred merely because it lives under `loaves/` or a nested group beneath it. A Rust-only member remains a Rust crate in its own source facet; `loaves/` is the repository's package hierarchy, not a replacement name for Rust compilation units.
+A virtual workspace omits `[project]` and retains `[workspace]`. Every member has its own `loaf.toml`; no member is inferred merely because it lives under `loaves/` or a nested group beneath it. A Rust-only member remains a Rust crate in its own source facet; `loaves/` is the repository's package hierarchy, not a replacement name for Rust compilation units.
 
 The directory name is a repository convention, not an identity rule. A member can live anywhere inside the workspace root if it is explicitly included by `members`.
 
@@ -195,17 +195,17 @@ A workspace can group members recursively without flattening its repository layo
 
 ```text
 incan/
-├── Loaf.toml                         # root authority and Oven.lock
+├── loaf.toml                         # root authority and Oven.lock
 └── loaves/
     ├── compiler/
-    │   ├── syntax/Loaf.toml
-    │   └── semantics/Loaf.toml
+    │   ├── syntax/loaf.toml
+    │   └── semantics/loaf.toml
     └── stdlib/
-        ├── io/Loaf.toml
-        └── web/Loaf.toml
+        ├── io/loaf.toml
+        └── web/loaf.toml
 ```
 
-If a group itself needs a local member-selection boundary or narrower local requirements, it may declare a structural parent `Loaf.toml` with explicit children. That parent inherits the root's resolved graph, lock, registry trust, target/delivery policy, and receipt boundary. It cannot create a second `Oven.lock`, rebind a registry, widen target policy, or form a second publication authority.
+If a group itself needs a local member-selection boundary or narrower local requirements, it may declare a structural parent `loaf.toml` with explicit children. That parent inherits the root's resolved graph, lock, registry trust, target/delivery policy, and receipt boundary. It cannot create a second `Oven.lock`, rebind a registry, widen target policy, or form a second publication authority.
 
 Membership hierarchy is not a dependency graph. Parent/child placement, a shared workspace, and a selected closure create no runtime, linkage, or publication dependency between packages; those relationships exist only through declared typed dependencies. For example, `incql-core`, `incql-db`, and `incql-datafusion` can remain independently versioned packages whether or not one is structurally nested below another; any dependency between them is explicit in the consuming package's dependency table.
 
@@ -223,7 +223,7 @@ root = "sources/incan"
 root = "sources/rust"
 ```
 
-The roots must not overlap. Generated output is not an authored source root. The root's package/target authority remains in `Loaf.toml`; neither source facet can select a different lock, registry, target, policy, or carrier.
+The roots must not overlap. Generated output is not an authored source root. The root's package/target authority remains in `loaf.toml`; neither source facet can select a different lock, registry, target, policy, or carrier.
 
 C is not a peer top-level source namespace. When a C integration needs authored shim source, it remains behind the deliberate C interop contract:
 
@@ -246,7 +246,7 @@ Rust crate    -> crates.io
 Users or organizations explicitly register additional registries in Oven-controlled user or organization configuration. Registry configuration identifies the registry kind, endpoint/index, trust policy, and a reference to credentials held outside the project.
 
 ```toml
-# Illustrative Oven user/organization configuration, not Loaf.toml.
+# Illustrative Oven user/organization configuration, not loaf.toml.
 [registries.encero]
 kind = "loaf"
 index = "https://packages.encero.dev/index"
@@ -269,7 +269,7 @@ serde = { crate = "serde", registry = "internal-cargo" }
 allow = ["encero", "internal-cargo"]
 ```
 
-The registry alias is convenience, not the security identity. `Oven.lock` records the canonical registry endpoint and protocol, exact package identity, immutable digest, and observed signature/trust result. Credentials never enter `Loaf.toml` or the lock. A project cannot silently register, rebind, or trust a registry on a developer's machine.
+The registry alias is convenience, not the security identity. `Oven.lock` records the canonical registry endpoint and protocol, exact package identity, immutable digest, and observed signature/trust result. Credentials never enter `loaf.toml` or the lock. A project cannot silently register, rebind, or trust a registry on a developer's machine.
 
 ### Declaring C ABI and future carriers
 
@@ -317,7 +317,7 @@ A repository containing only `Cargo.toml` remains runnable by Oven in explicitly
 If both files are present, Oven must continue as a Loaf project and issue a warning equivalent to:
 
 ```text
-Found Loaf.toml and Cargo.toml. Loaf.toml is authoritative; Cargo configuration
+Found loaf.toml and Cargo.toml. loaf.toml is authoritative; Cargo configuration
 was ignored. Use an explicit Cargo-compatibility operation to run Cargo semantics.
 ```
 
@@ -327,7 +327,7 @@ Oven must not parse, merge, or infer dependency, feature, source, workspace, bui
 
 ### Manifest discovery and shapes
 
-1. `Loaf.toml` is the canonical manifest filename. Project-aware discovery walks upward from the working directory or source path to the nearest directory containing it.
+1. `loaf.toml` is the canonical manifest filename. Project-aware discovery walks upward from the working directory or source path to the nearest directory containing it.
 2. A manifest containing `[project]` and no `[workspace]` describes one project.
 3. A manifest containing `[project]` and `[workspace]` describes a rooted workspace. The root project is a member without requiring `"."` in `members`.
 4. A manifest containing `[workspace]` and no `[project]` describes a virtual workspace. It must declare at least one resolved member.
@@ -336,8 +336,8 @@ Oven must not parse, merge, or infer dependency, feature, source, workspace, bui
 7. Membership and parent/child hierarchy are never dependency, linkage, or publication edges. Those edges arise only from declared typed dependency requirements; a path dependency does not imply membership, and membership does not imply a dependency.
 8. The root workspace is the sole authority for the resolved graph, `Oven.lock`, registry trust, workspace delivery policy, and receipt boundary. Child workspace declarations may add local membership and narrow local requirements, but may not create a lock, rebind registries, weaken trust, broaden target policy, or establish an independent publication authority.
 9. A manifest containing neither `[project]` nor `[workspace]` is invalid.
-10. `incan.toml` is not a project manifest after this RFC. A directory that contains it but no `Loaf.toml` must receive a targeted diagnostic rather than legacy parsing.
-11. If a `Loaf.toml` project also contains `Cargo.toml`, Oven must warn and ignore Cargo configuration. The diagnostic must name the ignored file and explain explicit Cargo-compatibility selection.
+10. `incan.toml` is not a project manifest after this RFC. A directory that contains it but no `loaf.toml` must receive a targeted diagnostic rather than legacy parsing.
+11. If a `loaf.toml` project also contains `Cargo.toml`, Oven must warn and ignore Cargo configuration. The diagnostic must name the ignored file and explain explicit Cargo-compatibility selection.
 
 ### Project metadata and source domains
 
@@ -451,7 +451,7 @@ RFC 104 owns capability-enforcement and receipt semantics. RFC 112 owns crash-sa
 
 ### Environments and actions
 
-The following authored concepts move into `Loaf.toml` under Oven ownership. Their table roots are intentionally typed and reserved; arbitrary `[tool.*]` namespaces do not carry forward:
+The following authored concepts move into `loaf.toml` under Oven ownership. Their table roots are intentionally typed and reserved; arbitrary `[tool.*]` namespaces do not carry forward:
 
 | Concept                                       | Semantic owner | Oven responsibility                                                            |
 | --------------------------------------------- | -------------- | ------------------------------------------------------------------------------ |
@@ -462,7 +462,7 @@ The following authored concepts move into `Loaf.toml` under Oven ownership. Thei
 
 RFC 015 is implemented, so RFC 117 supersedes its `incan.toml` discovery and `[tool.incan.envs]` configuration placement. RFCs 073, 076, and 078 are still Draft and must be amended to name the new Loaf tables and terminology rather than preserving legacy configuration compatibility.
 
-The initial table roots are `[envs]`, `[actions]`, `[policy]`, `[mixes]`, and `[templates]`. Their dedicated RFCs own the detailed schema and semantics. No `[oven.*]` prefix is needed: a `Loaf.toml` is already Oven's authored project document, and roots should name their semantic domain instead. They must remain explicit, scoped, inspectable, and free of implicit lifecycle execution. RFC 118 owns whether users invoke those semantics through `incan`, `oven`, aliases, or another command arrangement.
+The initial table roots are `[envs]`, `[actions]`, `[policy]`, `[mixes]`, and `[templates]`. Their dedicated RFCs own the detailed schema and semantics. No `[oven.*]` prefix is needed: a `loaf.toml` is already Oven's authored project document, and roots should name their semantic domain instead. They must remain explicit, scoped, inspectable, and free of implicit lifecycle execution. RFC 118 owns whether users invoke those semantics through `incan`, `oven`, aliases, or another command arrangement.
 
 ### Standard environments
 
@@ -484,11 +484,11 @@ mdbook = { crate = "mdbook", version = "0.4" }
 
 An environment is a named, reproducible command context. It may select extra development tools and project features, but it must not silently alter the selected target, carrier, profile, provider closure, or release dependency closure of an ordinary bake. `bake` is therefore not a standard environment: a bake records its target, carrier, profile, and feature selection directly in the plan and receipt. Dependencies needed to compile or execute a provider belong to that provider; target-specific dependencies belong to the target. Environment inheritance must diagnose conflicting bindings in the selected closure rather than silently choose one.
 
-Project scaffolding must generate a valid, minimal `Loaf.toml` and include the four standard environments as commented examples. The comments must explain that the defaults already exist and show where test, lint, and documentation dependencies belong; they must not materialize active configuration that merely duplicates the defaults.
+Project scaffolding must generate a valid, minimal `loaf.toml` and include the four standard environments as commented examples. The comments must explain that the defaults already exist and show where test, lint, and documentation dependencies belong; they must not materialize active configuration that merely duplicates the defaults.
 
 ### Interop package envelope
 
-RFC 116's current `[oven.interop]` shape is package-owned requirement data, not a record of a host toolchain already selected. Under this RFC it moves to the Loaf-level `[interop]` namespace: C declarations use `[interop.c]`. The file name changes from `incan.toml` to `Loaf.toml`; the ownership boundary does not.
+RFC 116's current `[oven.interop]` shape is package-owned requirement data, not a record of a host toolchain already selected. Under this RFC it moves to the Loaf-level `[interop]` namespace: C declarations use `[interop.c]`. The file name changes from `incan.toml` to `loaf.toml`; the ownership boundary does not.
 
 The interop envelope must be binding-kind neutral. It represents declared headers, shims, foreign artifacts, toolchain/SDK provider requirements, target variants, carrier requirements, lock identities, plan inputs, generated verification records, artifact staging, and receipts. It does not make C pointer types, C ownership, JNI handles, Python reference counts, or another runtime's safety rules universal. Each binding-kind RFC continues to define its own source vocabulary and checking rules. Loaf-facing configuration uses precise terms such as `interop.c`, `host`, `target`, and declared linker artifact form; it does not introduce a catch-all `native` configuration namespace. Existing RFC 116 source syntax remains historical until a future language-level proposal changes it.
 
@@ -510,10 +510,10 @@ This is not a promise that one published binary works on every machine, nor that
 
 ### Manifest ownership map
 
-`Loaf.toml` is the authored envelope. Existing RFCs continue to own the meaning of their respective content:
+`loaf.toml` is the authored envelope. Existing RFCs continue to own the meaning of their respective content:
 
 ```text
-Loaf.toml
+loaf.toml
 ├── [project]                 RFC 117
 ├── [workspace]               RFC 117; prospectively supersedes RFC 077's flat-workspace restriction
 ├── dependencies/features     RFC 117 + RFC 114
@@ -545,8 +545,8 @@ The Rust facet is the language-neutral planner contract for Rust-authored or mix
 
 Cargo compatibility has two valid states:
 
-1. **Cargo project:** a directory has `Cargo.toml` and no `Loaf.toml`. An explicitly selected Oven Cargo-compatibility operation delegates to Cargo. Cargo retains authority over its manifest and side effects.
-2. **Loaf project:** a directory has `Loaf.toml`, with or without `Cargo.toml`. Oven uses only the Loaf graph. Cargo is not an implicit source of build policy.
+1. **Cargo project:** a directory has `Cargo.toml` and no `loaf.toml`. An explicitly selected Oven Cargo-compatibility operation delegates to Cargo. Cargo retains authority over its manifest and side effects.
+2. **Loaf project:** a directory has `loaf.toml`, with or without `Cargo.toml`. Oven uses only the Loaf graph. Cargo is not an implicit source of build policy.
 
 There is no mixed automatic state. In particular, Oven must not merge dependency tables, inherit Cargo workspace membership, execute a discovered `build.rs`, or allow a Cargo feature to silently change a Loaf's public feature API.
 
@@ -570,20 +570,20 @@ Diagnostics must distinguish configuration errors, unsupported target/carrier co
 
 This RFC is intentionally breaking and should land before Incan 1.0.
 
-- `incan.toml` is replaced wholesale with `Loaf.toml`.
+- `incan.toml` is replaced wholesale with `loaf.toml`.
 - `incan.lock` is replaced with `Oven.lock`.
 - Existing implemented project/workspace/environment code must be updated to discover and write the new schema; it must not retain a legacy `incan.toml` parser.
 - Existing Draft RFCs that refer to `[tool.incan.*]` must be amended before their implementation is scheduled.
 - Existing project authors must explicitly adopt the Loaf contract; a raw rename is valid only when the resulting tables satisfy the new schema.
 - Cargo-only repositories require no adoption to be runnable in explicit Cargo-compatibility mode.
 
-The tool should emit a targeted diagnostic when it finds `incan.toml` without `Loaf.toml`, but it must not silently interpret the old file. This keeps the authority transition explicit and avoids supporting every interaction between old Incan configuration, Cargo configuration, and the new Oven model.
+The tool should emit a targeted diagnostic when it finds `incan.toml` without `loaf.toml`, but it must not silently interpret the old file. This keeps the authority transition explicit and avoids supporting every interaction between old Incan configuration, Cargo configuration, and the new Oven model.
 
 ## Alternatives considered
 
-### Add `Oven.toml` beside `Loaf.toml`
+### Add `Oven.toml` beside `loaf.toml`
 
-Rejected for now. A separate root file makes the package-versus-workspace vocabulary literal, but it creates two canonical documents, discovery precedence, and synchronization questions. A single `Loaf.toml` with explicit `[project]` and `[workspace]` scopes supports single projects, rooted workspaces, and virtual workspaces without losing capability. A future RFC may introduce a separate file only if independently versioned workspace policy demonstrates a real need.
+Rejected for now. A separate root file makes the package-versus-workspace vocabulary literal, but it creates two canonical documents, discovery precedence, and synchronization questions. A single `loaf.toml` with explicit `[project]` and `[workspace]` scopes supports single projects, rooted workspaces, and virtual workspaces without losing capability. A future RFC may introduce a separate file only if independently versioned workspace policy demonstrates a real need.
 
 ### Keep `incan.toml` and add Loaf concepts inside it
 
@@ -613,13 +613,13 @@ Rejected. Unconstrained tool tables make the canonical manifest a dumping ground
 
 - This is a breaking pre-1.0 configuration change touching project creation, discovery, documentation, workspaces, locking, environments, package resolution, interop, and tooling.
 - Typed dependencies and registered registries are more explicit than one string version requirement; good defaults and concise syntax are necessary for everyday use.
-- A strict Cargo boundary means Rust projects that adopt `Loaf.toml` cannot rely on arbitrary Cargo manifest behavior without an explicit supported Oven provider/action model.
+- A strict Cargo boundary means Rust projects that adopt `loaf.toml` cannot rely on arbitrary Cargo manifest behavior without an explicit supported Oven provider/action model.
 - Plans, policies, and receipts impose vocabulary and implementation work beyond a simple compiler wrapper.
-- One manifest filename means a virtual workspace has a `Loaf.toml` without a `[project]` table. The explicit table scopes must make that form obvious.
+- One manifest filename means a virtual workspace has a `loaf.toml` without a `[project]` table. The explicit table scopes must make that form obvious.
 
 ## Layers affected
 
-- **Manifest discovery and validation** — must recognize only `Loaf.toml`, validate rooted/virtual workspace shapes, reject unknown or conflicting scope, and diagnose legacy or coexisting manifests precisely.
+- **Manifest discovery and validation** — must recognize only `loaf.toml`, validate rooted/virtual workspace shapes, reject unknown or conflicting scope, and diagnose legacy or coexisting manifests precisely.
 - **Workspace resolution** — must preserve explicit membership, shared lock ownership, scoped command selection, and typed dependency inheritance while replacing `incan.toml` paths and tables.
 - **Provider and dependency resolution** — must normalize typed dependencies, apply default origins, resolve registered registries, preserve provider-specific semantics, verify trust/integrity, and construct one session-owned plan.
 - **Source and backend planning** — must discover one conventional built-in source facet, require `[incan.source]` and `[rust.source]` for mixed or nonstandard roots, diagnose ambiguous mixed roots, define the bounded Rust facet needed to plan Rust compilation, and prevent Cargo conventions from participating in Loaf planning.
@@ -628,13 +628,13 @@ Rejected. Unconstrained tool tables make the canonical manifest a dumping ground
 - **Locking, stores, and publication** — must rename the canonical lock to `Oven.lock`, preserve deterministic whole-workspace resolution, reserve immutable target-bound `*.loaf` identities, and keep locks, receipts, caches, and publication artifacts distinct.
 - **Cargo compatibility adapter** — must run Cargo only when explicitly selected, report its mode and side-effect boundary, and never act as a fallback inside a Loaf build.
 - **CLI and inspection** — must expose manifest shape, plan, target selection, registry/trust facts, effects, `*.loaf` assets, and receipts; RFC 118 owns final binary/subcommand spelling and alias behavior.
-- **Documentation, templates, LSP, and IDEs** — must create, discover, edit, display, and diagnose `Loaf.toml` consistently without making generated Rust or hidden backend state the public model.
+- **Documentation, templates, LSP, and IDEs** — must create, discover, edit, display, and diagnose `loaf.toml` consistently without making generated Rust or hidden backend state the public model.
 
 ## Acceptance criteria
 
 RFC 117 is ready to move beyond Draft when its normative rules and updated related RFCs establish all of the following:
 
-- A standalone project, rooted workspace, and virtual workspace have unambiguous `Loaf.toml` examples and discovery rules.
+- A standalone project, rooted workspace, and virtual workspace have unambiguous `loaf.toml` examples and discovery rules.
 - The dependency grammar distinguishes unit kind from origin and explains defaults, source overrides, features, integrity, and trust.
 - The `incan.pub` and crates.io defaults, explicit registry registration, project allow-list, credential boundary, and lock identity are defined precisely enough to implement.
 - An Incan-only, Rust-only, and mixed Incan/Rust Loaf have defined source-root behavior: simple projects are convention-first, mixed roots use `[incan.source]` and `[rust.source]`, ambiguous co-located `.incn`/`.rs` sources diagnose, and no implicit Cargo participation occurs.
@@ -650,7 +650,7 @@ RFC 117 is ready to move beyond Draft when its normative rules and updated relat
 
 ### Phase 1: Manifest and workspace authority
 
-- Introduce `Loaf.toml` discovery and validation; remove `incan.toml` discovery from project-aware operations.
+- Introduce `loaf.toml` discovery and validation; remove `incan.toml` discovery from project-aware operations.
 - Implement rooted and virtual workspace shapes, explicit member selection, and precise coexisting-Cargo diagnostics.
 - Support nested `loaves/` groups, retaining explicit membership and allowing a structural parent manifest only when it has real child-selection or local-requirement work to do.
 - Update project creation, documentation, LSP/IDE manifest discovery, and fixtures.
@@ -669,7 +669,7 @@ RFC 117 is ready to move beyond Draft when its normative rules and updated relat
 
 ### Phase 4: Environment and action rehoming
 
-- Amend and implement the `Loaf.toml` configuration location for RFC 073 environments/matrices and RFC 078 typed actions.
+- Amend and implement the `loaf.toml` configuration location for RFC 073 environments/matrices and RFC 078 typed actions.
 - Materialize the standard `dev`, `test`, `lint`, and `docs` environments; support explicit inheritance, environment dependency closure, conflict diagnostics, and commented scaffold defaults.
 - Make Oven materialization, scope selection, dry-run, and policy gating consume the same project/workspace plan without allowing an environment to change an ordinary bake implicitly.
 
@@ -682,7 +682,7 @@ RFC 117 is ready to move beyond Draft when its normative rules and updated relat
 ## Design decisions
 
 - **Loafified-package distribution advantage:** the long-term `incan.pub` value proposition is a verified, target-compatible pre-warmed Loaf closure that Oven can reuse across consumers after compatibility and trust verification. It is not universal-binary distribution, an implicit network effect, or a v0.6 release requirement. The v0.6 package/lock/receipt model must nevertheless preserve the identities needed to make it a later registry capability rather than a new authority model.
-- **Nested Loaf topology:** `loaves/` is the conventional home for all non-root workspace member projects, including Rust-only members. It supports arbitrary nested groups such as `loaves/stdlib/web`; paths are never implicit membership, dependency, linkage, or publication edges. A group gains a `Loaf.toml` only when it needs a real structural parent contract, and it always inherits the root authority.
+- **Nested Loaf topology:** `loaves/` is the conventional home for all non-root workspace member projects, including Rust-only members. It supports arbitrary nested groups such as `loaves/stdlib/web`; paths are never implicit membership, dependency, linkage, or publication edges. A group gains a `loaf.toml` only when it needs a real structural parent contract, and it always inherits the root authority.
 - **Built-in source facets:** Incan and Rust are the v0.6 built-in authored source facets. Simple one-language projects use `src/` by convention. Mixed or nonstandard projects use `[incan.source]` and `[rust.source]` with non-overlapping roots; the compiler diagnoses co-located `.incn` and `.rs` source files instead of imposing precedence. Rust exceptions remain beneath `rust.*`.
 - **Deliberate interop boundary:** C remains behind the existing `[interop.c]` facade, including any authored C shim root. `[interop.*]` is reserved for later concrete integrations such as JNI or Python; v0.6 does not define a plugin system, automatic foreign-tool discovery, or generic foreign-source execution.
 - **Precise C configuration terminology:** Loaf configuration names C interop, host, target, and linker artifact form directly. It does not use `native` as an interop configuration keyword or a generic foreign-language category. Any change to RFC 116's existing source-level binding spelling requires a later language proposal rather than a retroactive edit to that closed RFC.

--- a/workspaces/docs-site/docs/RFCs/118_incan_and_oven_command_line_surfaces.md
+++ b/workspaces/docs-site/docs/RFCs/118_incan_and_oven_command_line_surfaces.md
@@ -1,6 +1,6 @@
 # RFC 118: Incan and Oven command-line surfaces
 
-- **Status:** Draft
+- **Status:** Planned
 - **Created:** 2026-08-04
 - **Author(s):** Danny Meijer (@dannymeijer)
 - **Related:**
@@ -86,10 +86,14 @@ Within a discovered `Loaf.toml` project, project-scale execution is not a second
 ```text
 incan run                 # shallow alias to the selected Oven run/bake plan
 incan test                # shallow alias to the selected Oven test plan and scheduler
+incan build                   # shallow alias to `oven build` (terminal-carrier bake, e.g. executable)
+incan check                # in-Loaf: compiler diagnostics plus read-only Oven plan diagnostics
 incan run --direct tool.incn  # explicit direct-source escape hatch
 ```
 
-`incan run` and `incan test` inside a Loaf forward project selection to Oven. Oven resolves the same dependencies, target, carrier, profile, policy, scheduler, artifacts, and receipt that it would for the corresponding `oven` operation. Incan contributes source collection and semantic diagnostics; it does not create build state, choose a separate target, or issue a second receipt. `--direct` is explicit because a nearby manifest must not silently turn deliberate scratch execution into a project bake.
+`incan run`, `incan test`, and `incan build` inside a Loaf forward project selection to Oven. Oven resolves the same dependencies, target, carrier, profile, policy, scheduler, artifacts, and receipt that it would for the corresponding `oven` operation. Incan contributes source collection and semantic diagnostics; it does not create build state, choose a separate target, or issue a second receipt. `incan check` extends its existing direct-source behavior with read-only Oven plan diagnostics (unmet dependencies, invalid target/carrier) without becoming a second resolver. `--direct` is explicit because a nearby manifest must not silently turn deliberate scratch execution into a project bake.
+
+There is no `incan bake` alias. Baking a loaf-shaped carrier packages a `*.loaf` asset for another Oven consumer to depend on — a deliberate, project-level publishing action in the same register as `oven publish`, not the kind of instinctive direct-language action `incan` aliases exist to shorten. `oven bake` remains `oven`-only.
 
 ### Use Oven for project work
 
@@ -97,6 +101,7 @@ incan run --direct tool.incn  # explicit direct-source escape hatch
 oven init
 oven add stdlib-web
 oven add --crate serde
+oven build --target aarch64-apple-ios
 oven plan --target aarch64-apple-ios --carrier framework
 oven bake --target aarch64-apple-ios --carrier framework
 oven test --workspace
@@ -108,6 +113,39 @@ oven publish
 ```
 
 These commands operate on a selected Loaf or workspace closure. They discover `Loaf.toml`, resolve the typed dependency graph, apply inherited workspace authority, and report a plan before effects where policy requires it.
+
+### `oven build` and `oven bake` are not the same operation
+
+RFC 117 gives every carrier a shape: a loaf-shaped carrier (static library, framework, JNI shared library, Python wheel, Rust-host caller projection) bakes to a `*.loaf` asset meant for another Oven consumer to depend on; the terminal carrier (`executable`) bakes to a plain build artifact meant to be run or deployed directly and never depended on as a package. `oven build` and `oven bake` name that distinction instead of hiding it behind a `--carrier` flag choice:
+
+```text
+oven build                  # terminal carriers only (e.g. executable); plain build artifact, no .loaf packaging
+oven bake                   # loaf-shaped carriers only; produces a *.loaf asset for downstream reuse
+```
+
+Both commands resolve the same underlying plan, policy decision, and receipt; they differ only in which carrier shapes they accept and what they name the output. `oven build --carrier framework` and `oven bake --carrier executable` are each a carrier/command mismatch and must fail with a diagnostic naming the correct command, rather than silently producing the other command's output shape. A project whose declared targets have no terminal carrier has nothing for `oven build` to build, and must fail with a diagnostic explaining that rather than falling back to a loaf-shaped default.
+
+### `oven add` is shorthand; every noun gets its own full command family
+
+`oven add <pkg>` is the most common project-mutation operation, so it is a bare shorthand for `oven dependency add <pkg>`, the same ergonomic reasoning as `cargo add` or `npm install`. `dependency` is not special beyond earning that one shortcut: it still gets its own full, explicit, discoverable subcommand family, the same shape every other noun gets:
+
+```text
+oven add stdlib-web              # shorthand for `oven dependency add stdlib-web`
+oven dependency add stdlib-web   # same operation, spelled explicitly
+oven dependency add --crate serde
+oven dependency add --provider vision-runtime --version ">=2.0"
+oven dependency list
+oven dependency remove stdlib-web
+
+oven mix add cli
+oven mix list
+oven mix show cli
+oven mix status
+oven mix diff cli --to 1.6.0
+oven mix update cli --to 1.6.0
+```
+
+Only `dependency` gets the bare-verb shortcut; `mix` and future nouns do not collapse into `oven add`/`oven update`, because a mix id and a package name could otherwise collide under one ambiguous bare verb. This mirrors Docker's `docker run`/`docker ps` shortcuts coexisting with the full `docker container run`/`docker container ls` form: one proven, real-world precedent for "simple shorthand plus full explicit form, both valid, no runtime ambiguity about what a bare verb operates on."
 
 ### Inspecting semantic and operational facts
 
@@ -140,9 +178,9 @@ Cargo compatibility is a clearly selected mode for a directory with `Cargo.toml`
 | Parsing, checking, formatting, compiler diagnostics                                | `incan`         | `check`, `fmt`                                           |
 | Language services and semantic products                                            | `incan`         | `lsp`, `inspect`, `codegraph`, `architect`               |
 | Manifest and workspace selection                                                   | `oven`          | `init`, `new`, member selection                          |
-| Dependency, lock, and registry lifecycle                                           | `oven`          | `add`, `remove`, `update`, `lock`, `registry`, `publish` |
-| Target, carrier, provider, and artifact lifecycle                                  | `oven`          | `plan`, `bake`, `run`, `test`, `inspect`                 |
-| Environments, typed actions, project mutations                                     | `oven`          | `env`, `action`, `starter`, `capability`                 |
+| Dependency, lock, and registry lifecycle                                           | `oven`          | `add` (shorthand for `dependency add`), `dependency`, `remove`, `update`, `lock`, `registry`, `publish` |
+| Target, carrier, provider, and artifact lifecycle                                  | `oven`          | `plan`, `build`, `bake`, `run`, `test`, `inspect`        |
+| Environments, typed actions, project mutations                                     | `oven`          | `env`, `action`, `starter`, `mix`                        |
 | Cargo compatibility                                                                | `oven`          | `cargo`                                                  |
 
 An operation that changes dependency resolution, registry trust, a lock, generated project state, selected toolchain/provider, target output, or execution receipt belongs to Oven even when the selected sources are entirely Incan.
@@ -179,7 +217,7 @@ RFC 118 does not require every canonical Oven operation to have an Incan alias. 
 - conceal an explicit Cargo compatibility operation; or
 - turn an Oven effect into an unplanned Incan compiler side effect.
 
-Inside a discovered Loaf, `incan run` and `incan test` are required shallow aliases. They must produce the same Oven plan identity, scheduler decision, selected target/carrier/profile, `*.loaf` asset where applicable, and receipt as the canonical Oven operation. A direct `incan run` in that directory requires `--direct`; the explicit flag makes the absence of Oven planning visible.
+Inside a discovered Loaf, `incan run`, `incan test`, and `incan build` are required shallow aliases; `incan check` is a required read-only extension of its existing direct-source behavior. `run`, `test`, and `build` must produce the same Oven plan identity, scheduler decision, selected target/carrier/profile, build artifact where applicable, and receipt as the canonical Oven operation. `incan build` follows `oven build`'s own carrier restriction: it is a terminal-carrier-only alias and must fail with a diagnostic, not silently package a `*.loaf`, if the selected project has no terminal carrier. A direct `incan run` in that directory requires `--direct`; the explicit flag makes the absence of Oven planning visible. There is no `incan bake` alias (see "`oven build` and `oven bake` are not the same operation"): packaging a `*.loaf` for downstream reuse is a deliberate project-publishing action, not a direct-language convenience, so it stays `oven`-only.
 
 The remaining alias set is intentionally deferred until the first native Incan CLI vertical slice proves which conveniences improve direct language use rather than making the ownership boundary less legible.
 
@@ -247,12 +285,10 @@ Rejected. It would allow Cargo workspace discovery and side effects to leak into
 - **Diagnostics:** commands must name whether failure occurred in direct-source mode, Loaf/Oven mode, or explicit Cargo-compatibility mode, and identify the selected manifest or target where relevant.
 - **Not implicit:** neither command surface may infer Cargo behavior from an adjacent manifest, execute an action during resolution, or hide the delegation path that produced a receipt.
 
-## Unresolved questions
+## Design decisions
 
-1. Which shallow Incan-to-Oven aliases beyond the required in-Loaf `run` and `test` demonstrably improve direct language workflows without weakening the ownership boundary?
-2. Should `oven` support a single-command spelling such as `oven bake`, or retain a compatibility alias such as `oven build` for Cargo familiarity?
-3. What exact command hierarchy and output contract should `oven registry` use for registration, credentials, trust inspection, and publishing?
-4. How should global flags for JSON output, color, verbosity, profile, target, and project selection be shared while preserving each command's authority?
-5. What evidence would justify an Incan-authored Oven CLI while preserving the Rust operational-core boundary and unchanged command/receipt contract?
-
-<!-- Rename this section to "Design Decisions" once all questions have been resolved. An RFC cannot move from Draft to Planned until no unresolved questions remain. -->
+- **`oven build` and `oven bake` are two commands, not one spelling choice:** RFC 117 gives every carrier a fixed shape (loaf-shaped or terminal); `build` and `bake` name that split instead of hiding it behind a `--carrier` flag. `oven build` is terminal-carrier-only and produces a plain build artifact; `oven bake` is loaf-shaped-carrier-only and produces a `*.loaf` asset for downstream reuse. Both resolve the same underlying plan/policy/receipt; a carrier/command mismatch (`oven build --carrier framework`, `oven bake --carrier executable`) fails with a diagnostic naming the correct command rather than silently producing the other command's output shape. There is no `oven build`-as-Cargo-compatibility-alias: it is the terminal-carrier command in its own right, not a synonym for `oven bake`.
+- **The required in-Loaf alias set is `run`, `test`, `build`, and `check`:** `run`, `test`, and `build` are shallow aliases producing the same Oven plan identity, target/carrier/profile, artifact, and receipt as the canonical `oven` operation; `incan build` inherits `oven build`'s terminal-carrier restriction rather than silently packaging a `*.loaf`. `incan check` extends its existing direct-source behavior with read-only Oven plan diagnostics (unmet dependencies, invalid target/carrier) without becoming a second resolver. There is deliberately no `incan bake`: packaging a `*.loaf` for another consumer to depend on is a deliberate project-publishing action in the same register as `oven publish`, not the kind of instinctive direct-language convenience `incan` aliases exist to shorten — it stays `oven`-only, and the remaining alias set beyond this four stays deferred to the first native Incan CLI vertical slice, per this RFC's existing "Alias rules" language.
+- **`oven registry` covers local registration and trust inspection only, no login/credential command:** `oven registry add/list/remove` manage local registration fields (kind, endpoint/index, trust policy) exactly as RFC 117 already defines them; `oven registry inspect <name>` reports trust policy, protocol, signature/integrity state, and allow-list usage. There is no `oven registry login` or other credential-acquisition command in this RFC. Credentials are referenced from secure user/organization storage, per RFC 117's already-settled model; how a credential gets into that storage is either RFC 034's job for the default `incan.pub` registry (which already owns its protocol and publication authority) or the registry operator's own concern for any other registry, per RFC 117's Q4 resolution. Inventing a generic login verb here would mean designing credential acquisition for registries this RFC has no visibility into.
+- **Global flags are a shared naming/behavior convention, not shared code:** `incan` and `oven` use the same flag names and semantics for `--format json`, `--color`/`--no-color`, `-v`/`--verbose`, `--profile <name>`, `--target <triple>`, and project-selection flags, documented once and followed by both. This is ordinary consistency discipline for two entry points in one distribution, the same reasoning `git`/`git-lfs` or `docker`/`docker-compose` already apply — it does not require a shared flag-parsing dependency or any new mechanism, and does not interact with the delegation boundary this RFC defines elsewhere.
+- **Evidence bar for an Incan-authored Oven CLI:** this RFC already leaves the Oven CLI's implementation language non-normative ("may change without changing command behavior or receipt semantics"), and RFC 117 already requires authored Rust in Incan's own tooling to have "a demonstrated Incan limitation and a tracked removal path." For the Oven CLI specifically, that evidence is: (1) RFC 090's `std.cli` has reached the same maturity bar this RFC already sets for the native Incan CLI; (2) a full command/receipt parity suite demonstrates identical plans, diagnostics, and receipts between the existing Rust CLI and the candidate Incan-authored one across real projects, proving the unchanged-contract requirement rather than assuming it; (3) the rewrite consumes only the same public, language-neutral Oven API any third-party Incan program could already call, with no special or internal access, proving the API boundary this RFC defines is real; and (4) no meaningful startup or latency regression, since a CLI is a high-frequency, latency-sensitive surface regardless of implementation language. None of these are met today; this is a future possibility this RFC leaves open, not a v0.7 commitment.

--- a/workspaces/docs-site/docs/RFCs/118_incan_and_oven_command_line_surfaces.md
+++ b/workspaces/docs-site/docs/RFCs/118_incan_and_oven_command_line_surfaces.md
@@ -11,7 +11,7 @@
     - RFC 105 (`incan architect` rule engine)
     - RFC 106 (compiler-backed agent context graph)
     - RFC 116 (typed C ABI interop)
-    - RFC 117 (`Loaf.toml` and Oven's language-neutral project model)
+    - RFC 117 (`loaf.toml` and Oven's language-neutral project model)
     - RFC 119 (Oven-native Rust build facets and Cargo interoperation)
 - **Issue:** [#1010](https://github.com/encero-systems/incan/issues/1010)
 - **RFC PR:** —
@@ -21,7 +21,7 @@
 
 ## Summary
 
-This RFC defines two command surfaces delivered in one Incan installation. `incan` is the language and semantic-tooling command: it is deliberately Python-shaped for direct source use, modules, REPL work, formatting, language-server work, semantic inspection, codegraph, and architect analysis. `oven` is the project, package, environment, target, registry, and artifact-lifecycle command: it is deliberately Cargo-shaped for `Loaf.toml` workspaces, planning, baking, locking, testing, actions, and publication.
+This RFC defines two command surfaces delivered in one Incan installation. `incan` is the language and semantic-tooling command: it is deliberately Python-shaped for direct source use, modules, REPL work, formatting, language-server work, semantic inspection, codegraph, and architect analysis. `oven` is the project, package, environment, target, registry, and artifact-lifecycle command: it is deliberately Cargo-shaped for `loaf.toml` workspaces, planning, baking, locking, testing, actions, and publication.
 
 The surfaces are not peer orchestrators. Incan may delegate downward to the Oven API when a semantic command needs a project plan or build work. Oven must not invoke the Incan CLI, expose Incan semantic subcommands, or learn Cargo behavior through Incan. Oven consumes compiler service APIs and owns its own operational plan, policy, cache, receipt, and provider lifecycle.
 
@@ -29,7 +29,7 @@ The surfaces are not peer orchestrators. Incan may delegate downward to the Oven
 
 1. **One installation, two surfaces:** installing Incan provides the compiler/runtime, Oven core and providers, `incan`, and `oven`. Oven is not a separately installed product.
 2. **`incan` is semantic and source-oriented:** outside a Loaf it owns direct-file and module execution, checking, formatting, REPL/LSP operation, compiler diagnostics, semantic inspection, `codegraph`, and `architect`. Inside a Loaf, its approved project-scale conveniences remain shallow calls to Oven.
-3. **`oven` is project-oriented:** it owns `Loaf.toml` discovery, workspaces, dependency resolution, registry trust, environments, targets, carriers, plans, baking, locks, artifacts, receipts, publication, and explicit Cargo compatibility.
+3. **`oven` is project-oriented:** it owns `loaf.toml` discovery, workspaces, dependency resolution, registry trust, environments, targets, carriers, plans, baking, locks, artifacts, receipts, publication, and explicit Cargo compatibility.
 4. **Cargo familiarity is deliberate but bounded:** Oven may use recognizable Cargo-shaped verbs such as `add`, `update`, `lock`, `test`, and `publish`; it does not promise Cargo's implicit workspace, build-script, proc-macro, or manifest semantics for a Loaf.
 5. **Incan familiarity is deliberate but bounded:** Incan may use familiar direct-source affordances such as a file argument, `-m`, `-c`, and a REPL. It must not grow a second dependency resolver, environment manager, cache, or package lifecycle model.
 6. **Delegation is downward only:** an Incan command may request work from the Oven API. Oven may call compiler service APIs, but it must never shell out to or route its behavior through the Incan CLI.
@@ -55,7 +55,7 @@ This separation also protects the architecture. Incan's semantic products—diag
 
 ## Non-Goals
 
-- Defining `Loaf.toml`, `Oven.lock`, dependency resolution, target/carrier semantics, artifact format, or interop safety rules; RFC 117 and the corresponding interop RFCs own those contracts.
+- Defining `loaf.toml`, `Oven.lock`, dependency resolution, target/carrier semantics, artifact format, or interop safety rules; RFC 117 and the corresponding interop RFCs own those contracts.
 - Creating a second resolver, environment manager, cache, registry/trust model, or package lifecycle in the Incan CLI.
 - Requiring the Oven CLI itself to be implemented in Incan by v0.7, or allowing its implementation language to change the Oven API/receipt contract.
 - Inferring or emulating Cargo workspace, build-script, proc-macro, or manifest semantics in a Loaf command.
@@ -77,11 +77,11 @@ incan codegraph export --format json
 incan architect src/
 ```
 
-These commands are about source, language behavior, and semantic facts. A direct-file invocation does not require a `Loaf.toml` project. When a semantic command is given a Loaf project, it may ask Oven for the selected dependency/provider context, but the compiler remains the authority for semantic results.
+These commands are about source, language behavior, and semantic facts. A direct-file invocation does not require a `loaf.toml` project. When a semantic command is given a Loaf project, it may ask Oven for the selected dependency/provider context, but the compiler remains the authority for semantic results.
 
 ### Use shallow Incan conveniences inside a Loaf
 
-Within a discovered `Loaf.toml` project, project-scale execution is not a second build system:
+Within a discovered `loaf.toml` project, project-scale execution is not a second build system:
 
 ```text
 incan run                 # shallow alias to the selected Oven run/bake plan
@@ -112,7 +112,7 @@ oven update
 oven publish
 ```
 
-These commands operate on a selected Loaf or workspace closure. They discover `Loaf.toml`, resolve the typed dependency graph, apply inherited workspace authority, and report a plan before effects where policy requires it.
+These commands operate on a selected Loaf or workspace closure. They discover `loaf.toml`, resolve the typed dependency graph, apply inherited workspace authority, and report a plan before effects where policy requires it.
 
 ### `oven build` and `oven bake` are not the same operation
 
@@ -166,7 +166,7 @@ oven cargo test
 oven cargo build --release
 ```
 
-Cargo compatibility is a clearly selected mode for a directory with `Cargo.toml` and no `Loaf.toml`. Cargo remains authoritative, including its own side effects. If both files exist, normal Oven commands use `Loaf.toml`, warn that Cargo was ignored, and require explicit Cargo compatibility to run Cargo semantics.
+Cargo compatibility is a clearly selected mode for a directory with `Cargo.toml` and no `loaf.toml`. Cargo remains authoritative, including its own side effects. If both files exist, normal Oven commands use `loaf.toml`, warn that Cargo was ignored, and require explicit Cargo compatibility to run Cargo semantics.
 
 ## Reference-level explanation
 
@@ -234,14 +234,14 @@ RFC 090 owns `std.cli`, the framework for applications authored in Incan. It doe
 ### Release boundaries
 
 - **v0.5:** retains the current bounded RFC 116 interop release work and its existing `incan.toml` contract; this RFC does not backport a Loaf transition into that release.
-- **v0.6:** RFC 117 introduces `Loaf.toml`, `Oven.lock`, hierarchical sub-Loaves, and the language-neutral project model.
+- **v0.6:** RFC 117 introduces `loaf.toml`, `Oven.lock`, hierarchical sub-Loaves, and the language-neutral project model.
 - **v0.7:** this RFC introduces the canonical command-surface split over the v0.6 Oven API and project model.
 
 ## Compatibility and migration
 
 This RFC does not require a separate Oven installation or a second lockfile format. It is intentionally incompatible with a model in which every project operation remains an `incan` command and owns its own package behavior.
 
-Direct Incan source commands remain usable without a project manifest. Inside a discovered Loaf, project-scale `incan run` and `incan test` use Oven as specified above; `incan run --direct` is the explicit direct-source alternative. Oven project commands require `Loaf.toml`, except explicit Cargo compatibility. Existing 0.5 `incan.toml` behavior is governed by the RFC 117 cutover; it is not preserved as a CLI compatibility parser.
+Direct Incan source commands remain usable without a project manifest. Inside a discovered Loaf, project-scale `incan run` and `incan test` use Oven as specified above; `incan run --direct` is the explicit direct-source alternative. Oven project commands require `loaf.toml`, except explicit Cargo compatibility. Existing 0.5 `incan.toml` behavior is governed by the RFC 117 cutover; it is not preserved as a CLI compatibility parser.
 
 ## Alternatives considered
 
@@ -280,7 +280,7 @@ Rejected. It would allow Cargo workspace discovery and side effects to leak into
 
 ## Inspectability and tooling surface
 
-- **Artifacts and metadata:** `Loaf.toml`, `Oven.lock`, selected plan, target-bound `*.loaf` assets, execution receipt, compiler diagnostics, semantic inspection facts, codegraph records, and architect findings expose the chosen authority.
+- **Artifacts and metadata:** `loaf.toml`, `Oven.lock`, selected plan, target-bound `*.loaf` assets, execution receipt, compiler diagnostics, semantic inspection facts, codegraph records, and architect findings expose the chosen authority.
 - **Inspection commands:** `oven inspect` reports operational plan/store/receipt facts; `incan inspect`, `incan codegraph`, and `incan architect` report checked semantic facts.
 - **Diagnostics:** commands must name whether failure occurred in direct-source mode, Loaf/Oven mode, or explicit Cargo-compatibility mode, and identify the selected manifest or target where relevant.
 - **Not implicit:** neither command surface may infer Cargo behavior from an adjacent manifest, execute an action during resolution, or hide the delegation path that produced a receipt.

--- a/workspaces/docs-site/docs/RFCs/119_oven_native_rust_build_facets_and_cargo_interoperation.md
+++ b/workspaces/docs-site/docs/RFCs/119_oven_native_rust_build_facets_and_cargo_interoperation.md
@@ -11,7 +11,7 @@
     - RFC 043 (Rust trait implementation from Incan)
     - RFC 097 (Rust-hosted Incan caller)
     - RFC 114 (compiled providers, SDK components, and package features)
-    - RFC 117 (`Loaf.toml` and Oven's language-neutral project model)
+    - RFC 117 (`loaf.toml` and Oven's language-neutral project model)
     - RFC 118 (Incan and Oven command-line surfaces)
     - #975 (Oven: Cargo-free Incan/Rust toolchain)
     - #990 (governed `std.process` for Oven execution)
@@ -26,7 +26,7 @@
 
 RFC 117 establishes a language-neutral Loaf project model, but it deliberately does not specify enough Rust build behavior to replace Cargo as the normal authority for an explicitly supported Rust project. This RFC defines that next layer: Oven-native Rust build facets, an Oven-owned crate graph and direct-`rustc` plan, controlled build-time providers, Rust test and IDE projections, and explicit Cargo interoperation.
 
-Oven consumes crates.io and registered Cargo-compatible sources through the typed `crate` provider contract. It does not publish Loaves or `*.loaf` assets to crates.io. `Loaf.toml` remains the sole authored project manifest, `Oven.lock` remains the resolved graph, and a bake emits immutable target-bound `*.loaf` assets plus receipts. Cargo remains runnable only through explicit Cargo-compatibility mode; an existing Cargo project must explicitly opt into Loaf adoption and is never silently merged into an Oven project.
+Oven consumes crates.io and registered Cargo-compatible sources through the typed `crate` provider contract. It does not publish Loaves or `*.loaf` assets to crates.io. `loaf.toml` remains the sole authored project manifest, `Oven.lock` remains the resolved graph, and a bake emits immutable target-bound `*.loaf` assets plus receipts. Cargo remains runnable only through explicit Cargo-compatibility mode; an existing Cargo project must explicitly opt into Loaf adoption and is never silently merged into an Oven project.
 
 ## Core model
 
@@ -38,7 +38,7 @@ Oven consumes crates.io and registered Cargo-compatible sources through the type
 6. **Host and target are different build domains:** build scripts, procedural macros, and compiler plugins execute for the build host; libraries, binaries, test subjects, and carriers are compiled for the selected target. Oven plans and locks both domains separately.
 7. **Rust test work is first-class:** unit tests, integration tests, doctests, examples, and benchmarks are explicit build/run roles, not side effects of a generic `rustc` invocation. They use RFC 117's named environments: `test` by default for test roles and `docs` by default for documentation roles.
 8. **IDE projection is derived and warm-reusing:** Oven materializes a Rust-analyzer-compatible project projection from one explicit inspection selection. It first reuses every receipt-compatible pre-warmed `*.loaf` asset and provider/artifact closure, including across equivalent clean worktrees or implementation slices; the lightweight local projection then describes that selected graph. Switching an editor selection never implies rebuilding every target, dependency, or provider, and the projection does not create or require a synthetic authoritative `Cargo.toml`.
-9. **Cargo is an explicit interoperation boundary:** `oven cargo ...` invokes Cargo as Cargo-authoritative compatibility mode. Explicit adoption may import selected facts into a new `Loaf.toml`, but no directory with both manifests receives mixed semantics.
+9. **Cargo is an explicit interoperation boundary:** `oven cargo ...` invokes Cargo as Cargo-authoritative compatibility mode. Explicit adoption may import selected facts into a new `loaf.toml`, but no directory with both manifests receives mixed semantics.
 10. **The Rust core remains narrow but real:** as decided by RFC 118, Oven's operational core/API owns planning, resolution, policy, stores, leases, provider execution, and crash-safe publication in Rust. Its public API is language-neutral and does not leak Rust borrows.
 11. **Incan-first authoring remains policy:** a Rust facet makes Rust projects and explicitly justified mixed work supportable. It does not authorize new Rust in Incan products without a demonstrated limitation and tracked removal path.
 12. **Native compatibility is proved, not implied:** the supported Rust envelope is defined by an executable conformance corpus. Unsupported Cargo behavior produces a precise diagnostic or requires explicit Cargo mode.
@@ -49,7 +49,7 @@ RFC 117 makes an Oven-native Rust project architecturally possible: it has an au
 
 Cargo is valuable because it solves those practical concerns for a large Rust ecosystem. But it is not a sufficient authority for a project that includes Incan sources, checked interop, target carriers, governed actions, receipts, persistent stores, and Incan package publication. Oven should not hide Cargo under a different command name; it must own its build graph and make any Cargo interoperation explicit.
 
-The right v0.8 objective is therefore neither “emulate every Cargo behavior” nor “rewrite Rust as Incan.” It is a bounded native-Rust contract that builds serious selected Rust Loaves, consumes the ordinary crate ecosystem, produces target-bound `*.loaf` assets, and makes its limits inspectable. Cargo remains available for compatibility while that envelope expands through evidence.
+The right objective is therefore neither “emulate every Cargo behavior” nor “rewrite Rust as Incan.” It is a bounded native-Rust contract that builds serious selected Rust Loaves, consumes the ordinary crate ecosystem, produces target-bound `*.loaf` assets, and makes its limits inspectable. Cargo remains available for compatibility while that envelope expands through evidence.
 
 ## Goals
 
@@ -68,7 +68,7 @@ The right v0.8 objective is therefore neither “emulate every Cargo behavior”
 - Publishing Oven-native Loaves, `*.loaf` assets, or normal Oven packages to crates.io.
 - Making `Cargo.toml`, `Cargo.lock`, Cargo workspace discovery, Cargo build profiles, or arbitrary Cargo command behavior part of ordinary Loaf semantics.
 - Supporting every Cargo crate on day one, or claiming compatibility from source discovery alone.
-- Implicitly importing, merging, or executing a neighbouring Cargo project after `Loaf.toml` exists.
+- Implicitly importing, merging, or executing a neighbouring Cargo project after `loaf.toml` exists.
 - Defining the `*.loaf` archive/wire format, Incan registry transport protocol, or whether `bakery.io` becomes an Incan registry endpoint or alias.
 - Redefining RFC 097's Rust-host caller ABI, RFC 116's C ABI safety contract, RFC 117's project authority, or RFC 118's command ownership.
 - Moving Oven's operational core/API into Incan. RFC 118's justified Rust exception remains in force.
@@ -77,7 +77,7 @@ The right v0.8 objective is therefore neither “emulate every Cargo behavior”
 
 ### An Oven-native Rust Loaf
 
-An explicitly Rust-authored project adopts Oven by authoring `Loaf.toml`, not by placing Cargo configuration beside Rust sources and hoping it is inferred:
+An explicitly Rust-authored project adopts Oven by authoring `loaf.toml`, not by placing Cargo configuration beside Rust sources and hoping it is inferred:
 
 ```toml
 [project]
@@ -149,18 +149,18 @@ oven cargo test
   Cargo compatibility mode: Cargo.toml is authoritative.
 
 oven adopt cargo --manifest ./Cargo.toml
-  Explicit adoption: inspect/import selected source facts, write or propose Loaf.toml,
+  Explicit adoption: inspect/import selected source facts, write or propose loaf.toml,
   then make future Oven operations Loaf-authoritative.
 
 oven bake
-  Oven-native mode: Loaf.toml and Oven.lock are authoritative; Cargo files are ignored.
+  Oven-native mode: loaf.toml and Oven.lock are authoritative; Cargo files are ignored.
 ```
 
 `oven adopt cargo` is illustrative command spelling. The important rule is explicit re-authoring: a user chooses to cross the boundary, sees the proposed Loaf contract and unsupported Cargo behavior, and accepts the resulting project state. Oven does not treat every checked-out `Cargo.toml` as a latent Loaf.
 
 ### Publishing and consuming
 
-Oven-native packages publish to Incan's registry ecosystem. The configured public endpoint may eventually be branded `bakery.io`, but registry identity and trust remain explicit Oven configuration rather than a hard-coded domain in `Loaf.toml`.
+Oven-native packages publish to Incan's registry ecosystem. The configured public endpoint may eventually be branded `bakery.io`, but registry identity and trust remain explicit Oven configuration rather than a hard-coded domain in `loaf.toml`.
 
 Oven can consume a crate from crates.io because Rust libraries are part of the world it interoperates with. That is not reciprocal authority: an Oven-native package is not automatically a crates.io package. If a future product needs a Cargo-consumable publication projection, it must be a separately specified bridge with explicit provenance to a selected `*.loaf` asset.
 
@@ -223,10 +223,10 @@ Oven can consume a crate from crates.io because Rust libraries are part of the w
 
 ### Cargo compatibility and explicit adoption
 
-1. `oven cargo ...` is an explicit compatibility operation for a directory with `Cargo.toml` and no `Loaf.toml`. Cargo remains authoritative for its manifest, lock, build scripts, procedural macros, profiles, workspace discovery, and side effects. Oven records that it ran Cargo mode and may retain a wrapper receipt; it does not reinterpret Cargo results as an Oven-native lock.
-2. A directory that contains `Loaf.toml` is always a Loaf project for normal Oven operations. A neighbouring Cargo manifest is diagnosed and ignored.
-3. Adoption is an explicit user-requested transformation. It may parse Cargo metadata as input, propose a `Loaf.toml`, enumerate unsupported or policy-sensitive behavior, and write project state only after the mutation/policy rules of RFC 076 approve it.
-4. Adoption must never leave an implicit mixed state. Once a user accepts the Loaf contract, future Oven-native operations use `Loaf.toml` and `Oven.lock`; continuing to run Cargo requires an explicit Cargo operation.
+1. `oven cargo ...` is an explicit compatibility operation for a directory with `Cargo.toml` and no `loaf.toml`. Cargo remains authoritative for its manifest, lock, build scripts, procedural macros, profiles, workspace discovery, and side effects. Oven records that it ran Cargo mode and may retain a wrapper receipt; it does not reinterpret Cargo results as an Oven-native lock.
+2. A directory that contains `loaf.toml` is always a Loaf project for normal Oven operations. A neighbouring Cargo manifest is diagnosed and ignored.
+3. Adoption is an explicit user-requested transformation. It may parse Cargo metadata as input, propose a `loaf.toml`, enumerate unsupported or policy-sensitive behavior, and write project state only after the mutation/policy rules of RFC 076 approve it.
+4. Adoption must never leave an implicit mixed state. Once a user accepts the Loaf contract, future Oven-native operations use `loaf.toml` and `Oven.lock`; continuing to run Cargo requires an explicit Cargo operation.
 5. Cargo-compatible caller packages remain RFC 097 interoperability projections. They may consume selected outputs, but must not cause Cargo to resolve, compile, or select the Incan implementation graph.
 
 ### Supported-envelope conformance
@@ -253,7 +253,7 @@ The matrix is a compatibility statement, not a one-time benchmark. It must run o
 
 RFC 117 owns one manifest authority, one typed dependency graph, target policy, registry trust, `Oven.lock`, `*.loaf` identity, and the rule that a discovered Cargo file is ignored in Loaf mode. This RFC supplies the detailed Rust planner and provider contract that RFC 117 intentionally leaves open. It does not create a second Rust manifest or make a Rust facet an exception to workspace authority.
 
-The illustrative `rust.*` tables in this RFC are source-facet data within `Loaf.toml`, not a return to one manifest per implementation language. `[rust.source]` names a mixed or nonstandard Rust root, and other `rust.*` tables carry compact Rust-specific exceptions. No `[oven.rust]` prefix is needed: `Loaf.toml` is already the Oven-managed project document. Incan uses the parallel built-in `[incan.source]` root; C remains behind `[interop.c]` rather than becoming a peer top-level source namespace.
+The illustrative `rust.*` tables in this RFC are source-facet data within `loaf.toml`, not a return to one manifest per implementation language. `[rust.source]` names a mixed or nonstandard Rust root, and other `rust.*` tables carry compact Rust-specific exceptions. No `[oven.rust]` prefix is needed: `loaf.toml` is already the Oven-managed project document. Incan uses the parallel built-in `[incan.source]` root; C remains behind `[interop.c]` rather than becoming a peer top-level source namespace.
 
 ### Relationship to RFC 118
 
@@ -360,6 +360,7 @@ Rejected. It would revive implicit Cargo semantics, surprise build-script/proc-m
 - **Proc-macro compatibility:** a proc macro is a foreign Rust compiler feature. Oven compiles it for the build host and lets the selected `rustc` load and invoke it through the normal ABI, matching Cargo behavior. Oven improves graph/artifact reuse without caching individual expansions or changing macro execution semantics; stricter containment is governed-policy behavior only.
 - **IDE selection, provenance, and warm reuse:** an editor uses one visible Oven inspection selection, defaulting to `dev` and the Loaf-selected or host-native target. Oven first reuses receipt-compatible pre-warmed Loaf/provider/artifact closures across equivalent clean worktrees and implementation slices, then derives a small local standard Rust project descriptor plus an Oven provenance sidecar. The descriptor is a compatibility export, not authority; it neither triggers every target build nor duplicates dependency output.
 - **Editor-side macro execution:** an Oven-owned inspection session may expand procedural macros only under explicit observe, governed, or permissive policy and records session-level macro/toolchain/policy status separately from bake receipts. A third-party editor that consumes the compatibility descriptor is never presented as governed Oven execution.
+- **Splitting a project's declarations across different build outputs is done by physically separating Loaves, not by tagging individual declarations:** this RFC's bake model already lets one compilation unit produce multiple `*.loaf` assets when different carriers are selected (see "Native linkage, carriers, and cross compilation"), but that is the same code packaged multiple ways, not different code per output. A project that genuinely needs different subsets of its own source in different outputs (for example, browser-facing code and server-facing code in one logical project) expresses that as separate Loaves under RFC 117's workspace model — the same idiom Rust uses (separate crates in a workspace) and Python uses (separate sub-packages), not a novel Incan mechanism. This RFC does not add a declaration-level tagging or attribute system for routing individual functions or modules into different carrier outputs from a single Loaf; RFC 117's existing workspace/member model already provides the separation, with a shared common Loaf as a dependency when code needs to be reused across the split. This closes the gap left by RFC 092's rejection using a mechanism this RFC already has, not a new one.
 
 ## Unresolved questions
 

--- a/workspaces/docs-site/docs/RFCs/119_oven_native_rust_build_facets_and_cargo_interoperation.md
+++ b/workspaces/docs-site/docs/RFCs/119_oven_native_rust_build_facets_and_cargo_interoperation.md
@@ -1,6 +1,6 @@
 # RFC 119: Oven-native Rust build facets and Cargo interoperation
 
-- **Status:** Draft
+- **Status:** Planned
 - **Created:** 2026-08-04
 - **Author(s):** Danny Meijer (@dannymeijer)
 - **Related:**
@@ -19,7 +19,7 @@
 - **Issue:** [#1012](https://github.com/encero-systems/incan/issues/1012)
 - **RFC PR:** —
 - **Written against:** v0.5
-- **Target scope:** v0.8 design and implementation planning; this is not a shipment claim.
+- **Target scope:** v0.6 design and implementation planning; this is not a shipment claim.
 - **Shipped in:** —
 
 ## Summary
@@ -69,7 +69,7 @@ The right objective is therefore neither “emulate every Cargo behavior” nor 
 - Making `Cargo.toml`, `Cargo.lock`, Cargo workspace discovery, Cargo build profiles, or arbitrary Cargo command behavior part of ordinary Loaf semantics.
 - Supporting every Cargo crate on day one, or claiming compatibility from source discovery alone.
 - Implicitly importing, merging, or executing a neighbouring Cargo project after `loaf.toml` exists.
-- Defining the `*.loaf` archive/wire format, Incan registry transport protocol, or whether `bakery.io` becomes an Incan registry endpoint or alias.
+- Defining the `*.loaf` archive/wire format or Incan registry transport protocol.
 - Redefining RFC 097's Rust-host caller ABI, RFC 116's C ABI safety contract, RFC 117's project authority, or RFC 118's command ownership.
 - Moving Oven's operational core/API into Incan. RFC 118's justified Rust exception remains in force.
 
@@ -160,7 +160,7 @@ oven bake
 
 ### Publishing and consuming
 
-Oven-native packages publish to Incan's registry ecosystem. The configured public endpoint may eventually be branded `bakery.io`, but registry identity and trust remain explicit Oven configuration rather than a hard-coded domain in `loaf.toml`.
+Oven-native packages publish to Incan's registry ecosystem. `incan.pub` is the public endpoint for the foreseeable future; registry identity and trust remain explicit Oven configuration rather than a hard-coded domain in `loaf.toml`.
 
 Oven can consume a crate from crates.io because Rust libraries are part of the world it interoperates with. That is not reciprocal authority: an Oven-native package is not automatically a crates.io package. If a future product needs a Cargo-consumable publication projection, it must be a separately specified bridge with explicit provenance to a selected `*.loaf` asset.
 
@@ -270,7 +270,7 @@ RFC 097 defines a Rust-host caller facet and its stable ABI/package metadata. RF
 
 ### Publication authority
 
-An Oven-native package's publication identity is a Loaf registry identity. `incan.pub` is the current default; a future `bakery.io` endpoint or alias must be registered and trusted through Oven configuration. Crates.io is a Rust crate source, not an Oven-native publish target.
+An Oven-native package's publication identity is a Loaf registry identity. `incan.pub` is the default and only registered endpoint for the foreseeable future. Crates.io is a Rust crate source, not an Oven-native publish target.
 
 ## Alternatives considered
 
@@ -361,12 +361,33 @@ Rejected. It would revive implicit Cargo semantics, surprise build-script/proc-m
 - **IDE selection, provenance, and warm reuse:** an editor uses one visible Oven inspection selection, defaulting to `dev` and the Loaf-selected or host-native target. Oven first reuses receipt-compatible pre-warmed Loaf/provider/artifact closures across equivalent clean worktrees and implementation slices, then derives a small local standard Rust project descriptor plus an Oven provenance sidecar. The descriptor is a compatibility export, not authority; it neither triggers every target build nor duplicates dependency output.
 - **Editor-side macro execution:** an Oven-owned inspection session may expand procedural macros only under explicit observe, governed, or permissive policy and records session-level macro/toolchain/policy status separately from bake receipts. A third-party editor that consumes the compatibility descriptor is never presented as governed Oven execution.
 - **Splitting a project's declarations across different build outputs is done by physically separating Loaves, not by tagging individual declarations:** this RFC's bake model already lets one compilation unit produce multiple `*.loaf` assets when different carriers are selected (see "Native linkage, carriers, and cross compilation"), but that is the same code packaged multiple ways, not different code per output. A project that genuinely needs different subsets of its own source in different outputs (for example, browser-facing code and server-facing code in one logical project) expresses that as separate Loaves under RFC 117's workspace model — the same idiom Rust uses (separate crates in a workspace) and Python uses (separate sub-packages), not a novel Incan mechanism. This RFC does not add a declaration-level tagging or attribute system for routing individual functions or modules into different carrier outputs from a single Loaf; RFC 117's existing workspace/member model already provides the separation, with a shared common Loaf as a dependency when code needs to be reused across the split. This closes the gap left by RFC 092's rejection using a mechanism this RFC already has, not a new one.
+- **`rust.*` exceptions describe one Loaf's own single compilation unit, never an additional crate:** `[rust.source]`, and any other `rust.*` field, may only describe exceptions for the Rust unit that Loaf's own convention-first root would otherwise identify — a nonstandard root, crate type, edition, or non-default name for that one unit — plus additional *build roles* sharing that same unit, such as extra binaries alongside one library (Cargo's `[[bin]]` pattern). There is no `[rust.crates.<name>]`-style table for declaring a second, independently identified crate inside one Loaf's manifest. A genuinely separate Rust crate — most commonly a procedural-macro crate, which Rust's own compiler requires to be a distinct crate from anything that uses it — is a sibling Loaf under RFC 117's workspace model, referenced as an ordinary `loaf`-kind dependency with a `path` origin override:
 
-## Unresolved questions
+    ```toml
+    # myproject/loaf.toml
+    [workspace]
+    members = ["loaves/incan_derive"]
 
-1. Which compact exception declarations are needed for nonconventional Rust crates, feature-gated targets, and target predicates without turning the convention-first facet into a restatement of Cargo's manifest surface?
-2. Which governed compiler-process containment backends meet the policy/receipt contract on supported build hosts without changing the Cargo-equivalent observe-mode behavior?
-3. What evidence should promote a crate/provider class from Cargo-only compatibility to Oven-native support?
-4. If a public “Bakery” registry endpoint is introduced, should it be an alias of the current Incan registry identity or a separately registered registry kind?
+    [dependencies]
+    incan_derive = { loaf = "incan_derive", path = "loaves/incan_derive" }
+
+    [rust.source]
+    root = "sources/rust"
+    ```
+
+    ```toml
+    # myproject/loaves/incan_derive/loaf.toml
+    [project]
+    name = "incan_derive"
+
+    [rust]
+    crate-type = ["proc-macro"]
+    ```
+
+    The sibling crate is `loaf`-kind, not `crate`-kind, even though its content is entirely Rust: per RFC 117's own language-neutral model, `crate`-kind is for consuming the *external* Rust ecosystem (crates.io or a registered Cargo-compatible source), while `loaf`-kind is for this project's own package graph regardless of implementation language. Target predicates *within* one compilation unit (ordinary `#[cfg(...)]` source-level conditionals) remain native Rust and need no manifest declaration at all; this RFC already commits to passing the selected target through so `rustc`'s own `cfg` evaluation works unmodified.
+- **Governed-mode containment delegates to existing platform-native primitives; Oven does not implement its own sandboxing:** on Linux, containment uses Landlock or delegates to an established userspace sandboxing tool such as bubblewrap rather than hand-rolled namespace/seccomp wiring; on macOS, `sandbox-exec`/Seatbelt profiles; on Windows, AppContainer or Job Objects. These are security-audited, already-existing primitives; Oven integrates with them rather than authoring new OS-level containment code, the same "reuse existing infrastructure" reasoning behind this RFC's proc-macro and generator decisions elsewhere. Where a build host has no viable primitive for a selected policy, governed mode is refused outright rather than silently weakened or emulated, exactly as this RFC's reference text already requires ("if the host cannot enforce the selected policy without changing behavior, Oven denies the governed operation"). Observe mode's Cargo-equivalent behavior is unaffected by this choice: observe mode records effects without enforcing containment, so it has no platform-primitive dependency at all.
+- **The native-mode conformance bar is the price of a real benefit, not friction for its own sake, and that benefit is native-mode-only:** Oven-native's value over plain Cargo is not "compiles any single cold build faster" — a native bake still invokes the same `rustc` Cargo would. The concrete payoff is avoiding *redundant* rebuild work across environments: reusing a receipt-compatible pre-warmed Loaf/provider/artifact closure across equivalent clean worktrees, CI runners, and implementation slices (see "IDE selection, provenance, and warm reuse") gives a significant speed advantage over raw Cargo under warm circumstances, on top of the receipted, auditable, unified Incan+Rust project model Cargo cannot offer at all. Neither benefit is available in Cargo-compatibility mode: `oven cargo ...` is Cargo being fully authoritative over its own manifest, lock, and side effects, with no Oven-owned graph, receipt, or content-addressed store to reuse against. A project keeping `Cargo.toml` and wrapping it with `oven cargo` gets Cargo's own native performance characteristics, not Oven's — the reuse and receipt benefits require adopting `loaf.toml`.
+- **Crate/provider promotion from Cargo-only to Oven-native reuses the existing conformance-corpus mechanism rather than a new process:** a crate or provider class graduates when (1) every build-time directive it emits is covered by the already-known directive vocabulary (see "Build scripts, procedural macros, and generated inputs") with no unknown directive falling back to a passthrough, (2) it is added to the conformance corpus with a passing artifact/receipt-equivalence proof against the same crate built through Cargo-compatibility mode, and (3) governed-mode containment succeeds on every supported build host if its build-time work needs host access at all. This is deliberately the same "compatibility statement, not a one-time benchmark" mechanism this RFC already commits to running on every relevant change, applied at crate/provider grain rather than only at the project-shape grain the existing conformance matrix covers. Most real-world `build.rs` usage (`rerun-if-changed`, `cfg` emission, ordinary link-lib/link-search) is expected to already fall within the known vocabulary; the bar mainly excludes exotic, undemonstrated build-time patterns, not the mainstream ecosystem.
+- **No speculative naming for a future registry endpoint:** `incan.pub` is the registry for the foreseeable future. This RFC does not name, brand, or reserve a hypothetical second public endpoint; an unregistered domain speculatively mentioned in earlier drafts is removed rather than carried forward as a design question.
 
 <!-- Rename this section to "Design Decisions" once all questions have been resolved. An RFC cannot move from Draft to Planned until no unresolved questions remain. -->

--- a/workspaces/docs-site/docs/RFCs/closed/implemented/005_rust_interop.md
+++ b/workspaces/docs-site/docs/RFCs/closed/implemented/005_rust_interop.md
@@ -316,7 +316,7 @@ Reason: generated programs are Rust-to-Rust call paths, and preserving native pa
 
 4. **Non-native target behavior (`wasm32`, etc.)**
 
-Decision: target-specific interop constraints are out of RFC 005 scope and must be specified in target/toolchain RFCs (e.g., [RFC 092](../../092_interactive_runtime_stdlib_contracts.md) or a dedicated target-constraints RFC).
+Decision: target-specific interop constraints are out of RFC 005 scope and must be specified in target/toolchain RFCs (e.g., [RFC 092](../rejected/092_interactive_runtime_stdlib_contracts.md) or a dedicated target-constraints RFC).
 
 Reason: interop validity is target-dependent (runtime availability, crate support, panic model), so policy belongs in the target model rather than the base Rust interop contract.
 

--- a/workspaces/docs-site/docs/RFCs/closed/rejected/092_interactive_runtime_stdlib_contracts.md
+++ b/workspaces/docs-site/docs/RFCs/closed/rejected/092_interactive_runtime_stdlib_contracts.md
@@ -1,6 +1,6 @@
 # RFC 092: Interactive Runtime Stdlib Contracts
 
-- **Status:** Draft
+- **Status:** Rejected
 - **Created:** 2026-05-07
 - **Author(s):** Danny Meijer (@dannymeijer)
 - **Related:**
@@ -176,13 +176,12 @@ The recommended internal architecture is to keep the runtime manifest separate f
 - **Stdlib / Runtime (`incan_stdlib`)**: provides runtime target, artifact, host, input/accessibility, and diagnostics contracts.
 - **LSP / Tooling**: surfaces target/capability diagnostics, generated-boundary spans, asset references, and unsupported-host warnings.
 
-## Unresolved questions
+## Rejection rationale
 
-- Are runtime target declarations library calls, project metadata, decorators, or a dedicated syntax form?
-- What is the minimum manifest format that is stable enough for downstream consumers while still allowing compiler internals to evolve?
-- Which host capabilities belong in the first browser target, and which remain target-specific extensions?
-- How should capability denial be reported: compile-time error, build-time target mismatch, runtime diagnostic, or a mix based on target?
-- How much server/client region information must be explicit in source versus derived from imports, handlers, and target configuration?
+RFC 092 set out to define Incan-owned stdlib contracts for interactive runtime consumers -- target manifests, host capability boundaries, execution regions, and packaging metadata. On review, its actual normative surface duplicated or overreached into ground already covered elsewhere:
 
-<!-- Rename this section to "Design Decisions" once all questions have been resolved.
-     An RFC cannot move from Draft to Planned until no unresolved questions remain. -->
+- Capability authority (browser or otherwise) is already fully covered by RFC 104's general, package-namespaced capability mechanism. No `host.browser.*` or similar toolchain-reserved namespace is needed.
+- Marking functions for different compilation targets (server-side, client-side, or any future split) is already supported by RFC 036's user-defined decorators, combined with existing compiler introspection (`incan inspect codegraph`). No new Incan-core "region" concept is needed.
+- Producing multiple artifacts from one project is already the shape of RFC 117-119's target/carrier/profile model -- a completed bake already emits one or more target-bound `*.loaf` assets according to the selected roles and carriers. Whether a carrier can someday be selected by a declaration-level criterion rather than only by role is a narrow, generic question for that model to answer if and when it becomes concrete, not a reason for a separate interactive-runtime RFC to exist.
+
+This RFC's actual driving motivation -- a native, Omerus-backed interactive runtime target -- remains real, but Omerus does not yet have a concrete API surface to design against. Rejecting this RFC rather than leaving it open avoids Incan's core language and stdlib pre-committing to browser- or native-specific vocabulary before a real downstream consumer's design exists to validate it. This note is the only carried-forward record of that intent; if and when Omerus's own design solidifies, its actual needs should be designed there, not resurrected from this RFC's speculative shape.

--- a/workspaces/docs-site/docs/design_records/0001_gpu_target_capability_deferred.md
+++ b/workspaces/docs-site/docs/design_records/0001_gpu_target_capability_deferred.md
@@ -15,7 +15,7 @@ sources:
 
 ## Context
 
-[RFC 092](../RFCs/092_interactive_runtime_stdlib_contracts.md) defines the Incan-owned standard-library and artifact contracts needed by interactive runtime consumers. GPU target capability and graphics contracts are not required for that work, Incan v0.6's self-hosting direction, Oven authority, the direct-HIR backend cutover, or the first interactive runtime target.
+[RFC 092](../RFCs/closed/rejected/092_interactive_runtime_stdlib_contracts.md) defined the Incan-owned standard-library and artifact contracts needed by interactive runtime consumers (subsequently rejected; covered by RFC 104/036/117-119). GPU target capability and graphics contracts are not required for that work, Incan v0.6's self-hosting direction, Oven authority, the direct-HIR backend cutover, or the first interactive runtime target.
 
 [Issue #1041](https://github.com/encero-systems/incan/issues/1041) records the need for a separate, consumer-backed design before Incan admits a GPU capability family. Keeping that work inside RFC 092 would expand its scope without a concrete consumer and could prematurely constrain later graphics work.
 
@@ -55,6 +55,6 @@ This record derives from RFC 092, issue #1041, and the design-record proposal de
 
 ## References
 
-- [RFC 092: Interactive Runtime Stdlib Contracts](../RFCs/092_interactive_runtime_stdlib_contracts.md)
+- [RFC 092: Interactive Runtime Stdlib Contracts](../RFCs/closed/rejected/092_interactive_runtime_stdlib_contracts.md) (rejected)
 - [Issue #1041: GPU target capability and graphics contracts](https://github.com/encero-systems/incan/issues/1041)
 - [PR #1044: Add design doc deferring GPU target capability to v0.8](https://github.com/encero-systems/incan/pull/1044)

--- a/workspaces/docs-site/docs/roadmap.md
+++ b/workspaces/docs-site/docs/roadmap.md
@@ -115,7 +115,7 @@ Core tracking issues:
 - [#225](https://github.com/encero-systems/incan/issues/225): semantic facts adoption on backend cutover paths.
 - [#656](https://github.com/encero-systems/incan/issues/656): Rust-facing ABI and Cargo-native Incan package direction.
 - [#752](https://github.com/encero-systems/incan/issues/752): RFC 107 type-directed library APIs and compile-time type tokens.
-- [RFC 092](RFCs/092_interactive_runtime_stdlib_contracts.md): interactive runtime stdlib contracts.
+- [RFC 092](RFCs/closed/rejected/092_interactive_runtime_stdlib_contracts.md): interactive runtime stdlib contracts (rejected, covered by RFC 104/036/117-119).
 - [RFC 093](RFCs/093_std_telemetry_opentelemetry_observability.md): `std.telemetry`.
 - [RFC 094](RFCs/094_context_managers.md): context managers.
 - [RFC 107](RFCs/107_type_directed_library_apis.md): type-directed library APIs and compile-time type tokens.
@@ -201,7 +201,7 @@ The 1.0 milestone consolidates the post-cutover compiler architecture, ABI/packa
 - Testing surface: see [RFC 018] / [RFC 019] / [RFC 004].
 - Tooling and first-contact: install, starter, diagnostics, explain, codegraph, artifact inspection, and build reports are the immediate release surface.
 - Rust interop: see [RFC 005] / [RFC 013] and the [Rust Interop guide](language/how-to/rust_interop.md). Rust-hosted consumption should be reframed through ABI and Cargo-native package direction instead of generated Rust as the public semantic path.
-- Web and interactive runtime: see the [Web Framework guide](language/tutorials/web_framework.md), [RFC 092](RFCs/092_interactive_runtime_stdlib_contracts.md), and related runtime/DSL RFCs.
+- Web and interactive runtime: see the [Web Framework guide](language/tutorials/web_framework.md), [RFC 092](RFCs/closed/rejected/092_interactive_runtime_stdlib_contracts.md) (rejected, covered by RFC 104/036/117-119), and related runtime/DSL RFCs.
 - Standard library: stdlib work is allowed in the backend-foundation lane where it helps real programs and dogfood paths validate compiler/runtime direction.
 
 ## Deferred / Later

--- a/workspaces/docs-site/docs/tooling/explanation/oven_alpha.md
+++ b/workspaces/docs-site/docs/tooling/explanation/oven_alpha.md
@@ -266,7 +266,7 @@ The publisher pays the compatibility cost once. Oven fingerprints the inputs tha
 <p>Alpha boundary</p>
 <h2 id="oven-boundary-title">Early by design. Explicit by default.</h2>
 <span>Oven Alpha proves the maintained Incan workflow and the repository's own compiler suite. It does not yet claim:</span>
-<ul><li>general Cargo compatibility for arbitrary Rust workspaces;</li><li>every build script, procedural macro, target, or platform dependency shape;</li><li>compressed or remotely distributed <code>.loaf</code> bundles;</li><li>the authored <code>Loaf.toml</code>, resolved <code>Oven.lock</code>, workspace, or registry model proposed for later work; or</li><li>broad ecosystem readiness from external-library bake-offs.</li></ul>
+<ul><li>general Cargo compatibility for arbitrary Rust workspaces;</li><li>every build script, procedural macro, target, or platform dependency shape;</li><li>compressed or remotely distributed <code>.loaf</code> bundles;</li><li>the authored <code>loaf.toml</code>, resolved <code>Oven.lock</code>, workspace, or registry model proposed for later work; or</li><li>broad ecosystem readiness from external-library bake-offs.</li></ul>
 <small>Those belong to 0.6-and-later releases and RFC work. If the Alpha envelope cannot authorize a normal command, Oven explains the miss and stops.</small>
 </div>
 <div class="inc-oven-closing__visual" role="img" aria-label="Incus keeping watch beside the glowing Oven">

--- a/workspaces/docs-site/docs/whitepapers/incan_ecosystem_north_star.md
+++ b/workspaces/docs-site/docs/whitepapers/incan_ecosystem_north_star.md
@@ -526,7 +526,7 @@ These are the decisions that most affect the final shape:
 The whitepaper stands on its own as the ecosystem direction. The concrete branch-out work lives in seven focused RFCs:
 
 - [RFC 074: template rendering and boilerplate provenance](../RFCs/074_template_rendering_and_boilerplate_provenance.md) defines how static provider-side templates become validated project files and how provenance, ownership, update, and reset behavior work.
-- [RFC 075: starter profiles and capability packs](../RFCs/075_starter_profiles_and_capability_packs.md) defines explicit project recipes for starters and capabilities, including mutation plans, applicability, file roles, actions, and agent guidance metadata.
+- [RFC 075: starter profiles and mixes](../RFCs/075_starter_profiles_and_capability_packs.md) defines explicit project recipes for starters and mixes, including mutation plans, applicability, file roles, actions, and agent guidance metadata.
 - [RFC 076: project mutation policy and recovery](../RFCs/076_project_mutation_policy_and_recovery.md) defines receiver-side policy, risk classification, approval, quarantine, advisory handling, and recovery for project mutations.
 - [RFC 077: workspace and multi-package projects](../RFCs/closed/implemented/077_workspace_and_multi_package_projects.md) defines workspace topology, member selection, shared lock and policy state, and workspace-scoped mutations.
 - [RFC 078: tool execution and typed workflow actions](../RFCs/078_tool_execution_and_typed_workflow_actions.md) defines typed actions, tool sources, execution modes, dry-run behavior, and policy-gated workflow execution.


### PR DESCRIPTION
## Summary

Decision-closure pass moving eight RFCs from Draft to Planned (or Rejected), plus a terminology-only rename on a ninth (stays Draft):

- **RFC 107** (type-directed library APIs) → **Planned**.
- **RFC 081** (language-shaped DSL embeddings) → **Planned**.
- **RFC 104** (ambient runtime capabilities and receipts) → **Planned**.
- **RFC 092** (interactive runtime stdlib contracts) → **Rejected**. Everything it needed is already covered by RFC 104's capability model, RFC 036's existing decorators, and RFC 117-119's target/carrier/bake model.
- **RFC 075** (starter profiles) — stays Draft. Terminology-only rename: "capability pack" → "mix", resolving a three-way word collision with RFC 104 (runtime capabilities) and RFC 117 (dependency unit kind).
- **RFC 117** (`loaf.toml` and Oven's project model) → **Planned**. All 8 questions resolved: `capability` dependency unit kind renamed `provider`; target/carrier grammar settled; generators are ordinary typed Incan functions governed by RFC 104 capabilities. Later amended with a carrier **shape** split (loaf-shaped vs. terminal) after a concrete scenario showed a terminal executable shouldn't be packaged as a reusable `*.loaf`.
- **RFC 118** (Incan and Oven command-line surfaces) → **Planned**. All 5 questions resolved, riding on RFC 117's carrier-shape split: `oven build`/`oven bake` are two distinct commands; `oven registry` covers local registration/inspection only.
- **RFC 119** (Oven-native Rust build facets and Cargo interoperation) → **Planned**. All 4 questions resolved plus a carried-forward item from the RFC 092 rejection audit.
- **RFC 090** (`std.cli` typed CLI framework) → **Planned**. All 9 questions resolved, including a real architecture correction: `CliArgs`/`CliCommand` are RFC 024 `__derives__` modules using RFC 021's field reflection, not new compiler-internal derive logic.
- Repo-wide `Loaf.toml` → `loaf.toml` rename (case-only filenames are a cross-platform footgun on case-sensitive filesystems/CI).
- Fixes three broken links left dangling by RFC 092's move to `closed/rejected/`.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [x] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: none yet — these are RFC design documents, not implementations. Future implementation work will follow the settled `loaf.toml`, `provider`, `mix`, `oven build`/`oven bake`, and `std.cli` surfaces documented here.
- **Internals**: RFC decision-closure only; no compiler, stdlib, or tooling code changed.
- **Risks**: none — docs-only change, no code paths affected.

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `mkdocs build --strict` run and passing after every content change across all touched RFCs, including the RFC 092 broken-link fixes.
- RFC 119's commit history was squashed (3 commits → 1) at the maintainer's request; `git diff` verified byte-identical final content against a backup branch before the backup was discarded, confirming no content was lost in the squash.
- All three original decision-closure branches (D-language, D-runtime, D-oven) were combined onto this one via clean cherry-picks (no conflicts — no file overlap between tracks) at the maintainer's request, so the full set lands as one PR.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): [RFC 075](workspaces/docs-site/docs/RFCs/075_starter_profiles_and_capability_packs.md), [RFC 081](workspaces/docs-site/docs/RFCs/081_language_shaped_dsl_embeddings.md), [RFC 090](workspaces/docs-site/docs/RFCs/090_typed_cli_framework.md), [RFC 092](workspaces/docs-site/docs/RFCs/closed/rejected/092_interactive_runtime_stdlib_contracts.md), [RFC 104](workspaces/docs-site/docs/RFCs/104_ambient_runtime_capabilities_and_receipts.md), [RFC 107](workspaces/docs-site/docs/RFCs/107_type_directed_library_apis.md), [RFC 117](workspaces/docs-site/docs/RFCs/117_loaf_toml_and_oven_project_model.md), [RFC 118](workspaces/docs-site/docs/RFCs/118_incan_and_oven_command_line_surfaces.md), [RFC 119](workspaces/docs-site/docs/RFCs/119_oven_native_rust_build_facets_and_cargo_interoperation.md)

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [ ] I added/updated tests where it materially reduces regressions

Refs #752, #555, #662, #558, #1063, #1010, #1012, #87
