### PR TITLE
chore - commit Claude Code hooks/skills, add fleet-audit and doc-sync tooling

### DIFF
--- a/.agents/skills/add-learning/SKILL.md
+++ b/.agents/skills/add-learning/SKILL.md
@@ -56,6 +56,21 @@ Guidelines:
 
 Add the bullet to the appropriate section in `.agents/learnings.md`. Maintain alphabetical or logical ordering within the section.
 
+### Step 3.5: Spot-check 1-2 existing entries in the same section
+
+`.agents/learnings.md` is never mechanically checked against the code it describes — the only thing that catches a stale learning is an agent noticing while already in that section. So do that noticing on purpose, every time:
+
+- While you're in the section from Step 1, pick 1-2 other entries that name a concrete file path, function, struct, or pattern (not every entry does — skip pure-principle ones).
+- Quickly confirm the named thing still exists and the described behavior still matches (a `grep`/`Read` is usually enough — this is a spot-check, not a re-audit).
+- If an entry is stale (the file moved, the function was renamed, the described behavior changed), do **not** silently delete or rewrite it. Mark it in place so the correction itself is visible:
+
+  ```markdown
+  - **Concept in 3-5 words**: ~~Original explanation~~ **[SUPERSEDED YYYY-MM-DD]**: what's true now, and why the original stopped applying (link the RFC/issue/commit that changed it if there is one).
+  ```
+
+  This keeps a record that the learning was wrong and got corrected — which is more useful to a future agent than a silent edit, and is itself worth an `/add-learning` note if the *reason* it went stale is a generalizable lesson on its own.
+- If nothing in your quick check turns out stale, don't add noise — no need to annotate entries that are still accurate.
+
 ### Step 4: Verify
 
 Read back the file to confirm:
@@ -63,3 +78,4 @@ Read back the file to confirm:
 - The new bullet is in the right section
 - It doesn't duplicate an existing learning
 - It's generalizable (would help with future work, not just the current task)
+- Step 3.5 happened — either something got marked `[SUPERSEDED ...]` or you confirmed the spot-checked entries are still accurate

--- a/.agents/skills/fleet-audit/SKILL.md
+++ b/.agents/skills/fleet-audit/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: fleet-audit
+description: Report which local git worktrees under tmp/ are safe to close, need a human look, or are explicitly protected. Use when the user says /fleet-audit, asks what worktrees can be cleaned up, or wants a status check across all Ralph-loop/spike worktrees before running closeout on any of them.
+---
+
+# Fleet Audit — Incan Worktrees
+
+## Purpose
+
+`/fleet-audit` gives a read-only, fleet-wide status report across every worktree under the shared `tmp/` root — something `closeout` deliberately does not do, since `closeout` only acts on one PR/branch at a time. This skill never removes, moves, or modifies anything. It exists to tell you (or an orchestrator deciding what to hand to `closeout`) what's actually going on before anyone touches a worktree.
+
+## When to use this vs `closeout`
+
+- Use `fleet-audit` first, to see the whole picture.
+- Use `closeout` second, worktree by worktree, only on things `fleet-audit` reported as `safe-to-close` — and still verify PR-merged status yourself per `closeout`'s own rules before removing anything.
+- Never use `fleet-audit`'s output as authorization to force-remove anything. It classifies; it does not approve deletion.
+
+## How it works
+
+Runs `~/Development/encero/.agents-state/scripts/fleet_audit.py`, which:
+
+1. Lists every worktree via `git worktree list --porcelain`.
+2. Skips (reports as `protected`) any worktree with a `.agents/state/KEEP` marker file — that marker means a human already decided this one is not up for evaluation, full stop.
+3. For everything else, checks: branch ancestry against `origin/main`, matching GitHub PR state via `gh pr list` (catches squash/rebase merges the ancestor check alone would miss), uncommitted **tracked** file edits specifically (not just untracked build junk), and Ralph-loop slice status via the same parsing Codex's session hook already uses (`~/.codex/hooks/ralph_state_impl.py`'s `summarize_state`).
+4. Classifies each as `protected`, `safe-to-close`, or `needs-review`, with a one-line reason.
+
+## Workflow
+
+1. Run:
+
+   ```bash
+   python3 ~/Development/encero/.agents-state/scripts/fleet_audit.py --repo-root . --repo-slug encero-systems/incan
+   ```
+
+   If that script or the private workspace state root (`~/Development/encero/.agents-state/`) doesn't exist on this machine, say so plainly and stop — do not attempt to reimplement the logic inline.
+
+2. Present the report grouped by status, exactly as the script outputs it. Do not editorialize the `protected` group — those are closed questions.
+3. For `safe-to-close` entries, note that the next step is a human-approved `closeout` run per worktree, not automatic removal.
+4. For `needs-review` entries, summarize the *reason* field per worktree so the user can decide quickly (tracked edits vs. non-terminal loop state vs. no signal at all) rather than re-reading the whole report.
+5. If asked to mark something as protected on the spot, write a one-line reason to `<worktree>/.agents/state/KEEP` (create `.agents/state/` first if it doesn't exist) — do not mark something protected without a reason.
+
+## Output format
+
+```md
+## Fleet Audit — <date>
+
+### Protected (N)
+- <worktree>: <reason>
+
+### Safe to close (N)
+- <worktree> (branch): <reason> — run /closeout to remove
+
+### Needs review (N)
+- <worktree> (branch): <reason>
+```

--- a/.agents/skills/ralph-loop/SKILL.md
+++ b/.agents/skills/ralph-loop/SKILL.md
@@ -442,6 +442,7 @@ When code is ready:
 - produce a concise done summary
 - draft the commit message with `write-commit-message`
 - draft the PR description with `create-pr-description`
+- append one line to `.agents/state/findings-ledger.md` (a symlink into a private, non-git location — see `AGENTS.md`) if this loop's integration review (step 6) surfaced a real defect, regression, or scope gap that got fixed before shipping: `- YYYY-MM-DD | ralph-loop | <loop_id>: <what was found> | <what changed>`. Skip this for a loop that shipped clean with nothing notable to record, and skip silently if the ledger file doesn't exist in this workspace.
 
 For RFC-driven work, only the parent loop drafts or owns the final PR description. Child loops must not produce PRs of their own.
 

--- a/.agents/skills/review-orchestrate/SKILL.md
+++ b/.agents/skills/review-orchestrate/SKILL.md
@@ -226,6 +226,16 @@ A `review-orchestrate` run is invalid if any of the following is true:
 
 If subagents cannot be used, do not pretend this skill ran successfully. Fall back explicitly to `/review` and say that `review-orchestrate` could not be honored.
 
+## Findings ledger
+
+When the canonical report's `## Findings` section is non-empty at the end of a run, or when this run confirms findings from a prior run are now `fixed`, append one line per materially distinct finding (not per worker slice) to `.agents/state/findings-ledger.md` (a symlink into a private, non-git location — see `AGENTS.md`):
+
+```
+- YYYY-MM-DD | review-orchestrate | <one-line finding, e.g. "F2: env overlays inspectable but not executable"> | <what changed, or "pending">
+```
+
+Skip this for a run that closes with zero open findings. If `.agents/state/findings-ledger.md` doesn't exist, skip silently rather than creating it yourself.
+
 ## Relationship to other skills
 
 - Use `orchestrate-parallel-work` as the worker-spawning substrate when delegation is justified.

--- a/.agents/skills/review/SKILL.md
+++ b/.agents/skills/review/SKILL.md
@@ -391,3 +391,18 @@ The default verification bar for a strong review is:
 - `make pre-commit`
 
 If either command was not run, say so explicitly in the final review report and treat that as residual risk rather than silently claiming the branch is clean.
+
+## Findings ledger
+
+`.agents/state/review-report.md` is per-worktree and gets overwritten by the next run (Step 11). To keep a durable record of what review actually catches over time, append one line to `.agents/state/findings-ledger.md` (a symlink into a private, non-git location — see `AGENTS.md`) whenever this run:
+
+- concludes with at least one 🔴 blocker or 🟡 warning, or
+- confirms a *previous* run's blocker/warning is now resolved.
+
+Format, appended not rewritten:
+
+```
+- YYYY-MM-DD | review | <one-line finding> | <what changed, or "pending" if not yet fixed>
+```
+
+Skip the ledger entirely for a clean pass with nothing to report — it should stay a record of real findings, not a heartbeat log. If `.agents/state/findings-ledger.md` doesn't exist (e.g. this workspace layout wasn't set up), skip this step silently rather than creating it yourself.

--- a/.claude/agents/test-suite.md
+++ b/.claude/agents/test-suite.md
@@ -1,0 +1,95 @@
+<!-- Claude Code mirror of .agents/test-suite.md (Codex's canonical copy, model: composer-1.5). -->
+<!-- Same process/content; only the `model:` field differs because Claude Code and Codex don't share a model namespace. -->
+<!-- If you change the process below, update .agents/test-suite.md too. -->
+---
+name: test-suite
+model: sonnet
+description: Incan compiler test orchestrator. Use proactively when code changes need validation, when the user asks to run tests, check for regressions, or validate before a PR. Analyzes the diff, runs targeted tests, checks snapshots and clippy, and reports results.
+---
+
+You are a test orchestrator for the Incan compiler. When invoked, you analyze the current changes and run the right tests automatically.
+
+## Process
+
+1. Run `git diff --name-only main...HEAD` to identify changed files.
+2. Map changed paths to test commands using the table below.
+3. Run targeted tests first (most specific), then broaden. Stop on failure.
+4. If codegen-affecting files changed, check for snapshot drift.
+5. Run `cargo clippy --all-targets --all-features -- -D warnings`.
+6. Report a structured summary.
+
+## Path-to-test mapping
+
+| Changed path pattern | Command |
+|---|---|
+| `crates/incan_syntax/src/parser/` | `cargo test -p incan_syntax --lib parser::tests` |
+| `src/frontend/typechecker/` | `cargo test -p incan --lib typechecker::tests` |
+| `src/backend/ir/lower/` | `cargo test --test codegen_snapshot_tests` |
+| `src/backend/ir/emit/` | `cargo test --test codegen_snapshot_tests` |
+| `src/backend/ir/codegen.rs` | `cargo test --test codegen_snapshot_tests --test integration_tests` |
+| `src/backend/ir/conversions.rs` | `cargo test --test codegen_snapshot_tests` |
+| `src/backend/project/` | `cargo test --test integration_tests` |
+| `src/cli/` | `cargo test --test integration_tests` |
+| `src/format/` | `cargo test --test property_tests --test integration_tests` |
+| `crates/incan_core/` | `cargo test --test semantic_core_parity --test semantic_core_parity_strings` |
+| `crates/incan_stdlib/` | `cargo test --test codegen_snapshot_tests --test integration_tests` |
+| `crates/incan_derive/` | `cargo test --test codegen_snapshot_tests` |
+| `tests/codegen_snapshots/*.incn` | `cargo test --test codegen_snapshot_tests` |
+| `tests/fixtures/` | `cargo test --test integration_tests` |
+| `tests/*.rs` | `cargo test --test <filename_without_ext>` |
+| `src/lsp/` | No automated tests — inform the user |
+
+## Snapshot handling
+
+If snapshots need updating, ask the user before running:
+
+```bash
+INSTA_UPDATE=1 cargo test --test codegen_snapshot_tests
+```
+
+Show the diff of updated snapshots for review.
+
+## Output format
+
+```
+## Test Results
+
+### Targeted tests
+- ✅/❌ <category> (N passed, N failed)
+
+### Failures
+<test name> — <error summary>
+
+### Snapshot changes
+<list or "none">
+
+### Clippy
+✅ Clean / ❌ N warnings
+
+### Coverage gaps
+<suggestions for missing test coverage>
+```
+
+## Coverage gap detection
+
+Flag (as suggestions, not failures) when:
+
+- New parser syntax has no parser unit test
+- New typechecker validation has no valid + invalid test case
+- New codegen path has no snapshot test
+- New diagnostic has no fixture in `tests/fixtures/invalid/`
+- Changed CLI behavior has no integration test
+
+## Full sweep mode
+
+If the user says "full sweep", "full run", "task completion", or "pre-PR validation", run the complete gate:
+
+1. `make pre-commit` — full local gate (full checks + smoke-test-fast)
+2. `make smoke-test` — builds release, runs all examples with timeout, runs benchmarks
+3. Report any failures from either step
+
+This is the final validation before a PR. Do not run full sweep by default — only when explicitly requested.
+
+## Quick mode
+
+If the user says "quick" or "fast", run only the most specific unit tests for the changed module, codegen snapshots if applicable, and clippy.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,54 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 scripts/claude_hooks/dispatch.py",
+            "timeout": 15,
+            "statusMessage": "Checking Ralph-loop state (shared policy with Codex)"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 scripts/claude_hooks/dispatch.py",
+            "timeout": 15,
+            "statusMessage": "Loading Ralph-loop context (shared policy with Codex)"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash|Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 scripts/claude_hooks/dispatch.py",
+            "timeout": 15,
+            "statusMessage": "Checking Ralph-loop hygiene (shared policy with Codex)"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 scripts/claude_hooks/dispatch.py",
+            "timeout": 15,
+            "statusMessage": "Checking Ralph-loop closeout (shared policy with Codex)"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,9 @@ yarn-error.log*
 pnpm-debug.log*
 
 # Local AI agent instructions
-.claude/
+# .claude/settings.json (project hooks/policy) and .claude/agents/* are committed
+# and shared; only personal per-machine overrides are ignored.
+.claude/settings.local.json
 .agents/state/*
 !.agents/state/.gitkeep
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ Incan is a Python-like language that compiles to Rust. The compiler itself is wr
 [`.github/ISSUE_TEMPLATE/`]: .github/ISSUE_TEMPLATE/
 [`.agents/learnings.md`]: .agents/learnings.md
 
-Skills, learnings, and agent notes live under **this repository’s** `.agents/` directory (committed here).
+Skills (`.agents/skills/`) and learnings (`.agents/learnings.md`) live under **this repository’s** `.agents/` directory and are committed here. Working state and review-run artifacts (`.agents/state/`) live in the same directory but are **not** committed — they're gitignored, per-machine scratch, except `.agents/state/findings-ledger.md` which is a symlink into a private workspace-level log (see `.agents/skills/review/SKILL.md` and `.agents/skills/ralph-loop/SKILL.md` for how it's used).
 
 ## General Workflow
 
@@ -217,17 +217,61 @@ Key directories:
 
 ### Skills
 
-Skills are reusable workflows in `.agents/skills/`. Use them by name when the task matches:
+Skills are reusable workflows in `.agents/skills/`. Use them by name when the task matches. This table is checked against `.agents/skills/` by `make agents-doc-sync` (part of `make pre-commit-fast`) -- if you add or remove a skill, update this table in the same change or the local gate will fail.
 
-| Skill           | Trigger                           | What it does                                                                                                                            |
-| --------------- | --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `/start-work`   | Starting work on an issue or RFC  | Creates branch, gathers context from issue/RFC, checks learnings; does **not** commit (maintainer-only commits unless explicitly asked) |
-| `/test`         | Writing tests for a change        | Guides test selection, provides correct patterns per compiler stage                                                                     |
-| `/review`       | Code review, PR review            | Runs the full Incan-aware review checklist                                                                                              |
-| `/write-rfc`    | Drafting a new RFC                | Scaffolds an RFC with correct structure and conventions                                                                                 |
-| `/review-rfc`   | Checking an RFC before submission | Validates formatting, structure, content, and status-specific rules                                                                     |
-| `/bump-rfc`     | Promoting an RFC status           | Handles Draft -> Planned -> In Progress -> Done transitions                                                                             |
-| `/add-learning` | Recording a reusable insight      | Appends to learnings file with correct format and topic grouping                                                                        |
+**Core workflow**
+
+| Skill | Trigger | What it does |
+| --- | --- | --- |
+| `/start-work` | Starting work on an issue or RFC | Creates branch, gathers context from issue/RFC, checks learnings; does **not** commit (maintainer-only commits unless explicitly asked) |
+| `/create-plan` | Drafting an implementation plan before coding | TDD-oriented plan with doc updates and verification commands for encero-workspace repos |
+| `/test` | Writing tests for a change | Guides test selection, provides correct patterns per compiler stage |
+| `/write-commit-message` | Drafting a commit message | Formats `chore\|bugfix\|feature - <issue_id(s)> <description>` per workspace convention |
+| `/create-pr-description` | Drafting a PR description | Fills in the repo's PR template from the current git diff |
+| `/yeet-pr` | Publishing local changes to GitHub | Commits/pushes/opens a review-ready or draft PR per repo commit-message and PR-description conventions |
+| `/create-github-issue` | Filing a GitHub issue | Drafts title/body using the target repo's issue templates |
+| `/closeout` | Cleaning up after a merged PR | Removes task-owned worktrees/branches, prunes refs, reports dirty or ambiguous leftovers |
+| `/fleet-audit` | Checking what worktrees can be cleaned up | Fleet-wide report of protected/safe-to-close/needs-review worktrees under `tmp/`; never deletes anything itself |
+
+**Review and repair**
+
+| Skill | Trigger | What it does |
+| --- | --- | --- |
+| `/review` | Code review, PR review | Runs the full Incan-aware review checklist |
+| `/fix` | Repairing review findings | Fixes actionable in-scope findings, usually after `/review` |
+| `/review-and-fix` | Autonomous review + repair loop | Runs review, fixes findings, re-reviews until clean or blocked |
+| `/loop` | Looping named skills until clean | Thin orchestrator that reruns a detector/repair skill pair (e.g. `/review` `/fix`) until clean or blocked |
+| `/review-orchestrate` | Broad, multi-agent review | Runs specialized reviewer roles in parallel, merges into one canonical report |
+| `/review-architecture` | Architecture-specific review pass | Layering, crate boundaries, single-source-of-truth, registry-driven behavior |
+| `/review-code-smells` | Maintainability-specific review pass | Duplication, awkward indirection, dead code, naming, Boy Scout opportunities |
+| `/review-docs-claims` | Docs-truth review pass | User-facing docs/CLI text for truthfulness, prose quality, RFC leakage |
+| `/review-incan-source-quality` | Incan-source readability review pass | Checks `.incn` code reads like well-written Python, not Rust-shaped scaffolding |
+| `/review-rust-prose` | Rust comment/rustdoc review pass | Prose-comment quality, rustdoc accuracy, manual line-wrap smells |
+| `/review-scope` | Scope-completeness review pass | Checks the change actually matches the intended issue/RFC/branch scope |
+| `/review-test-style` | Test-style review pass | Result-returning patterns, panic helpers, unwrap/expect use, obvious coverage gaps |
+| `/flag-compiler-bug` | Suspecting a compiler defect mid-task | Minimizes the repro, checks for duplicates, files via `/create-github-issue` |
+
+**RFC lifecycle**
+
+| Skill | Trigger | What it does |
+| --- | --- | --- |
+| `/write-rfc` | Drafting a new RFC | Scaffolds an RFC with correct structure and conventions |
+| `/review-rfc` | Checking an RFC before submission | Validates formatting, structure, content, and status-specific rules |
+| `/bump-rfc` | Promoting an RFC status | Handles Draft -> Planned -> In Progress -> Implemented transitions |
+
+**Multi-agent orchestration**
+
+| Skill | Trigger | What it does |
+| --- | --- | --- |
+| `/orchestrate-parallel-work` | Delegating to parallel sub-agents | Splits a task into non-overlapping, worktree-isolated slices with orchestrator-led integration |
+| `/ralph-loop` | High-thoroughness autonomous implementation | Plan/do/check/act loop across worker worktrees through to ship-ready commit/PR artifacts |
+
+**Other**
+
+| Skill | Trigger | What it does |
+| --- | --- | --- |
+| `/add-learning` | Recording a reusable insight | Appends to learnings file with correct format and topic grouping |
+| `/hello-world` | Trivial example/smoke-test request | Says hello world; not part of the real workflow, used to sanity-check the skill mechanism itself |
 
 ### Agents
 

--- a/Makefile
+++ b/Makefile
@@ -185,6 +185,15 @@ rustdoc-gate:
 rustdoc-gate-ci:
 	@python3 scripts/check_changed_rustdocs.py
 
+.PHONY: agents-doc-sync  ## quality - Check AGENTS.md's skill table matches .agents/skills/ (local only, not CI)
+agents-doc-sync:
+	@echo "\033[1mChecking AGENTS.md skill table against .agents/skills/...\033[0m"
+	@python3 scripts/check_agents_doc_sync.py
+
+.PHONY: agents-doc-sync-ci
+agents-doc-sync-ci:
+	@python3 scripts/check_agents_doc_sync.py
+
 .PHONY: cargo-deny  ## quality - Run cargo-deny policy checks
 cargo-deny:
 	@echo "\033[1mRunning cargo-deny...\033[0m"
@@ -219,12 +228,16 @@ pre-commit-fast:
 	$(MAKE) -s rustdoc-gate-ci; \
 	echo "\033[32mDONE\033[0m"; \
 	t2=$$(date +%s); \
+	printf "\033[1mChecking AGENTS.md skill table...\033[0m "; \
+	$(MAKE) -s agents-doc-sync-ci; \
+	echo "\033[32mDONE\033[0m"; \
+	t2b=$$(date +%s); \
 	echo "\033[1mRunning cargo check (fast gate)...\033[0m"; \
 	$(MAKE) -s check-fast-ci; \
 	echo "\033[32mDONE\033[0m"; \
 	t3=$$(date +%s); \
 	echo "\033[32m✓ Pre-commit checks passed (fast)\033[0m"; \
-	echo "\033[36mPhase timing:\033[0m fmt-check=$$((t1-start))s, rustdoc=$$((t2-t1))s, check=$$((t3-t2))s, total=$$((t3-start))s"
+	echo "\033[36mPhase timing:\033[0m fmt-check=$$((t1-start))s, rustdoc=$$((t2-t1))s, agents-doc-sync=$$((t2b-t2))s, check=$$((t3-t2b))s, total=$$((t3-start))s"
 
 .PHONY: pre-commit-full-gate  ## quality - Full local gate core: fmt-check + tests + clippy + cargo-deny with phase timing
 pre-commit-full-gate:
@@ -238,6 +251,10 @@ pre-commit-full-gate:
 	$(MAKE) -s rustdoc-gate-ci; \
 	echo "\033[32mDONE\033[0m"; \
 	t2=$$(date +%s); \
+	printf "\033[1mChecking AGENTS.md skill table...\033[0m "; \
+	$(MAKE) -s agents-doc-sync-ci; \
+	echo "\033[32mDONE\033[0m"; \
+	t2b=$$(date +%s); \
 	echo "\033[1mRunning tests...\033[0m"; \
 	$(MAKE) -s test-oven; \
 	echo "\033[32mDONE\033[0m"; \
@@ -251,7 +268,7 @@ pre-commit-full-gate:
 	echo "\033[32mDONE\033[0m"; \
 	t5=$$(date +%s); \
 	echo "\033[32m✓ Pre-commit checks passed (full)\033[0m"; \
-	echo "\033[36mPhase timing:\033[0m fmt-check=$$((t1-start))s, rustdoc=$$((t2-t1))s, tests=$$((t3-t2))s, lint=$$((t4-t3))s, deny=$$((t5-t4))s, total=$$((t5-start))s"
+	echo "\033[36mPhase timing:\033[0m fmt-check=$$((t1-start))s, rustdoc=$$((t2-t1))s, agents-doc-sync=$$((t2b-t2))s, tests=$$((t3-t2b))s, lint=$$((t4-t3))s, deny=$$((t5-t4))s, total=$$((t5-start))s"
 
 .PHONY: pre-commit  ## quality - Full local gate: pre-commit-full-gate + smoke-test-fast
 pre-commit:

--- a/scripts/check_agents_doc_sync.py
+++ b/scripts/check_agents_doc_sync.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Check that AGENTS.md's "Available Skills and Agents" table matches the
+actual contents of .agents/skills/.
+
+This exists because AGENTS.md's skill table silently drifted from the real
+skill set before (documenting 7 of 27 skills at one point) with nothing
+catching it. Run locally via `make agents-doc-sync` / as part of
+`make pre-commit-fast`; deliberately not wired into remote CI.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+AGENTS_MD = REPO_ROOT / "AGENTS.md"
+SKILLS_DIR = REPO_ROOT / ".agents" / "skills"
+
+# Skills that are internal building blocks, not meant to be invoked by name
+# and therefore not expected to appear in the user-facing table. Empty for
+# now -- every skill under .agents/skills/ is user-invocable today.
+DOC_EXEMPT_SKILLS: set[str] = set()
+
+
+def actual_skills() -> set[str]:
+    return {
+        child.name
+        for child in SKILLS_DIR.iterdir()
+        if child.is_dir() and (child / "SKILL.md").exists()
+    }
+
+
+def documented_skills() -> set[str]:
+    text = AGENTS_MD.read_text()
+    # Capture everything between "### Skills" and the next heading, so this
+    # doesn't stop early at a blank line inside the section (e.g. the intro
+    # sentence before the table).
+    match = re.search(r"### Skills\n(.*?)\n#{1,3} ", text, re.DOTALL)
+    if not match:
+        return set()
+    section = match.group(1)
+    # Row cells look like `| \`/skill-name\`   | ... |`
+    return set(re.findall(r"`/([a-z-]+)`", section))
+
+
+def main() -> int:
+    if not AGENTS_MD.exists():
+        print(f"missing {AGENTS_MD}", file=sys.stderr)
+        return 1
+    if not SKILLS_DIR.is_dir():
+        print(f"missing {SKILLS_DIR}", file=sys.stderr)
+        return 1
+
+    actual = actual_skills() - DOC_EXEMPT_SKILLS
+    documented = documented_skills()
+
+    undocumented = sorted(actual - documented)
+    stale = sorted(documented - actual)
+
+    if not undocumented and not stale:
+        return 0
+
+    if undocumented:
+        print("skills present in .agents/skills/ but missing from AGENTS.md's skill table:")
+        for name in undocumented:
+            print(f"  {name}")
+    if stale:
+        print("skills documented in AGENTS.md's skill table but no longer present in .agents/skills/:")
+        for name in stale:
+            print(f"  {name}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/claude_hooks/dispatch.py
+++ b/scripts/claude_hooks/dispatch.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Claude Code hook dispatcher for this repo.
+
+Reuses this maintainer's existing Codex hook scripts (~/.codex/hooks/) so
+Claude Code and Codex enforce the same Ralph-loop hygiene and Incan/Rust-
+boundary review policy from one source of truth, instead of drifting apart
+as two hand-maintained copies.
+
+Fails open, silently, if ~/.codex/hooks isn't present on this machine -- e.g.
+a collaborator who clones this repo but doesn't run Codex. This hook exists
+to keep tools in sync for people who already run both; it must not become a
+hard dependency on Codex for everyone else, and it must never block a turn
+just because it couldn't reach its own dependency.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+RALPH_DISPATCH = Path.home() / ".codex" / "hooks" / "ralph_state.py"
+
+
+def main() -> int:
+    if not RALPH_DISPATCH.exists():
+        return 0
+
+    raw = sys.stdin.read()
+
+    try:
+        result = subprocess.run(
+            [sys.executable, str(RALPH_DISPATCH)],
+            input=raw,
+            capture_output=True,
+            text=True,
+            timeout=25,
+            check=False,
+        )
+    except Exception as exc:
+        sys.stderr.write(f"claude_hooks/dispatch.py: failed open ({exc})\n")
+        return 0
+
+    stdout = result.stdout.strip()
+    if not stdout:
+        return 0
+
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError:
+        return 0
+
+    sys.stdout.write(json.dumps(payload))
+
+    # The underlying Codex scripts emit the flat {"decision": "block", "reason": ...}
+    # shape on stdout for a Stop-hook block, which Claude Code's Stop hook also
+    # accepts directly. Also satisfy the exit-code-2 + stderr contract as cheap
+    # redundancy, since that detail wasn't independently confirmed at write time --
+    # see the note in .claude/settings.json history / commit message.
+    if payload.get("decision") == "block":
+        reason = payload.get("reason") or "blocked by shared Codex/Claude hook policy"
+        sys.stderr.write(reason + "\n")
+        return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Decision-closure pass moving four RFCs from Draft to Planned (RFC 117, 118, 119, 090), plus a terminology-only rename on a fifth (RFC 075, stays Draft) and a repo-wide `Loaf.toml` → `loaf.toml` filename-case rename. Completes the D-oven track (117/118/119) and adds `std.cli` (090) as pre-work for RFC 118's v0.7 shipment.

- **RFC 075** (stays Draft) — "capability pack" → "mix", resolving a three-way word collision with RFC 104 (runtime capabilities) and RFC 117 (dependency unit kind).
- **RFC 117** → **Planned**. All 8 questions resolved: `capability` dependency unit kind renamed `provider`; target/carrier grammar settled; generators are ordinary typed Incan functions governed by RFC 104 capabilities. Later amended with a carrier **shape** split (loaf-shaped vs. terminal) after a concrete scenario showed a terminal executable shouldn't be packaged as a reusable `*.loaf`.
- **RFC 118** → **Planned**. All 5 questions resolved, riding on RFC 117's carrier-shape split: `oven build`/`oven bake` are two distinct commands; `oven registry` covers local registration/inspection only.
- **RFC 119** → **Planned**. All 4 questions resolved plus a carried-forward item from an earlier RFC 092 audit. Governed-mode containment delegates to existing platform-native sandboxing.
- **RFC 090** → **Planned**. All 9 questions resolved, including a real architecture correction: `CliArgs`/`CliCommand` are RFC 024 `__derives__` modules using RFC 021's field reflection, not new compiler-internal derive logic.
- Repo-wide `Loaf.toml` → `loaf.toml` rename (case-only filenames are a cross-platform footgun on case-sensitive filesystems/CI).

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [x] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: none yet — these are RFC design documents, not implementations. Future implementation work will follow the settled `loaf.toml`, `provider`, `mix`, `oven build`/`oven bake`, and `std.cli` surfaces documented here.
- **Internals**: RFC decision-closure only; no compiler, stdlib, or tooling code changed.
- **Risks**: none — docs-only change, no code paths affected.

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `mkdocs build --strict` run and passing after every content change across all touched RFCs.
- RFC 119's commit history was squashed (3 commits → 1) at the maintainer's request; `git diff` verified byte-identical final content against a backup branch before the backup was discarded, confirming no content was lost in the squash.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): [RFC 075](workspaces/docs-site/docs/RFCs/075_starter_profiles_and_capability_packs.md), [RFC 117](workspaces/docs-site/docs/RFCs/117_loaf_toml_and_oven_project_model.md), [RFC 118](workspaces/docs-site/docs/RFCs/118_incan_and_oven_command_line_surfaces.md), [RFC 119](workspaces/docs-site/docs/RFCs/119_oven_native_rust_build_facets_and_cargo_interoperation.md), [RFC 090](workspaces/docs-site/docs/RFCs/090_typed_cli_framework.md)

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [ ] I added/updated tests where it materially reduces regressions

Closes #1063, Closes #1010, Closes #1012, Closes #87
