### PR TITLE
bugfix - stop hashing compiler-owned path dependencies on every cache load

### DIFF
--- a/crates/rust_inspect/src/cache_resolve.rs
+++ b/crates/rust_inspect/src/cache_resolve.rs
@@ -65,11 +65,26 @@ pub(crate) fn dependency_manifest_dir_from_manifest(root: &Path, crate_name: &st
         })
 }
 
-/// Return every local path-dependency directory declared directly in the workspace root manifest.
+/// Compiler-injected support crates share this package-name prefix in every generated Cargo manifest (`incan_derive`,
+/// `incan_stdlib`, and each `incan_stdlib_<component>` SDK component). They are never a project author's own
+/// interop dependency, so [`path_dependency_dirs_from_manifest`] excludes them; see that function's docs for why.
+const COMPILER_OWNED_CRATE_NAME_PREFIX: &str = "incan_";
+
+/// Return every local path-dependency directory declared directly in the workspace root manifest, excluding the
+/// compiler's own injected support crates.
 ///
 /// `Cargo.lock` records a locked version for a `path = "..."` dependency but no content checksum, so it cannot
 /// detect an edit to the dependency's own source. Callers use this to fold path-dependency contents into a cache
 /// fingerprint that would otherwise treat an edited local crate as unchanged.
+///
+/// Every generated project's manifest also carries `path = "..."` dependencies the compiler injects for its own
+/// runtime support (`incan_derive`, `incan_stdlib`, and the `incan_stdlib_<component>` SDK components) rather than
+/// anything the project author wrote. Those are excluded by package-name prefix: they are not editable through
+/// ordinary project use, their own staleness is already covered by the toolchain/SDK identity that selects their
+/// path in the first place, and walking them (the stdlib alone spans well over a hundred files) on every cache load
+/// for every generated project turns an occasional-edit staleness check into the dominant cost of the whole test
+/// suite. The prefix is a deliberate, environment-agnostic proxy for "compiler-owned": unlike an env-var-based
+/// check, it holds the same in a development checkout, a CI test harness, and an installed toolchain alike.
 ///
 /// Mirrors [`dependency_manifest_dir_from_manifest`]'s table coverage (ordinary, target-specific, and
 /// `{ workspace = true }`-inherited dependency tables) so a path dependency declared through any of those shapes
@@ -113,6 +128,10 @@ pub(crate) fn path_dependency_dirs_from_manifest(root: &Path) -> Vec<PathBuf> {
             } else {
                 declaration
             };
+            let package_name = resolved.get("package").and_then(toml::Value::as_str).unwrap_or(key);
+            if package_name.starts_with(COMPILER_OWNED_CRATE_NAME_PREFIX) {
+                return None;
+            }
             let path = resolved.get("path")?.as_str()?;
             root.join(path).canonicalize().ok()
         })

--- a/crates/rust_inspect/src/cache_tests.rs
+++ b/crates/rust_inspect/src/cache_tests.rs
@@ -421,6 +421,36 @@ fn workspace_fingerprint_changes_when_path_dependency_source_changes() -> Result
     Ok(())
 }
 
+/// The compiler injects `incan_derive`/`incan_stdlib`/`incan_stdlib_<component>` path dependencies into every
+/// generated project. Editing their source (a rare, compiler-development-only scenario) must not force every
+/// generated project's fingerprint to walk the whole stdlib tree on every cache load; excluded by package-name
+/// prefix regardless of the dependency's own directory size.
+#[test]
+fn workspace_fingerprint_ignores_compiler_owned_path_dependencies() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let dep_dir = tmp.path().join("incan_stdlib");
+    fs::create_dir_all(dep_dir.join("src"))?;
+    fs::write(
+        dep_dir.join("Cargo.toml"),
+        "[package]\nname = \"incan_stdlib\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )?;
+    fs::write(dep_dir.join("src/lib.rs"), "pub fn hello() -> i32 { 1 }\n")?;
+    fs::write(
+        tmp.path().join("Cargo.toml"),
+        "[package]\nname = \"probe\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[dependencies]\nincan_stdlib = { path = \"incan_stdlib\" }\n",
+    )?;
+
+    let before = workspace_fingerprint(tmp.path())?;
+    fs::write(dep_dir.join("src/lib.rs"), "pub fn hello() -> i32 { 2 }\n")?;
+    let after = workspace_fingerprint(tmp.path())?;
+
+    assert_eq!(
+        before, after,
+        "editing a compiler-owned incan_* path dependency must not change the workspace fingerprint"
+    );
+    Ok(())
+}
+
 /// Malformed on-disk cache payloads are ignored instead of poisoning later lookups.
 #[test]
 fn malformed_disk_cache_is_treated_as_miss() -> Result<(), Box<dyn std::error::Error>> {

--- a/src/cli/commands/oven.rs
+++ b/src/cli/commands/oven.rs
@@ -100,9 +100,12 @@ pub const OVEN_COMPILER_TEST_JOBS_ENV: &str = "INCAN_OVEN_COMPILER_TEST_JOBS";
 /// the complete worker pool indefinitely on one host-specific child process.
 ///
 /// Constrained hosted MSRV runners can require more than fifteen minutes for the two largest integration roots even
-/// though prepared reference-machine replay remains inside the five-minute suite budget. Keep a deterministic
-/// per-root ceiling, but calibrate it with enough headroom that slow hardware is not misreported as a test failure.
-const OVEN_COMPILER_TEST_ROOT_TIMEOUT: Duration = Duration::from_secs(30 * 60);
+/// though prepared reference-machine replay remains inside the five-minute suite budget. The unsharded release
+/// evidence workflow (`oven_evidence.yml`) runs every root in one job rather than the four-way split the ordinary
+/// CI workflow uses, so its two largest roots (`cli_integration`, `integration_tests`) have repeatedly needed more
+/// than thirty minutes under real hosted-runner contention. Keep a deterministic per-root ceiling, but calibrate it
+/// with enough headroom that slow hardware is not misreported as a test failure.
+const OVEN_COMPILER_TEST_ROOT_TIMEOUT: Duration = Duration::from_secs(60 * 60);
 
 /// Inputs for `incan oven import`.
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Summary

The `Oven Release Evidence` workflow has failed on every push to `release/v0.5` since the branch was cut, with increasingly severe symptoms. Root-caused it properly this time (a first pass just widened the timeout — that was a workaround, not a fix, and rightly rejected).

**The actual bug:** `#1076`'s `rust_inspect` path-dependency cache-fingerprint fix hashes every `path = "..."` dependency in a generated project's `Cargo.toml` to detect edits to local interop crates. But every generated project's manifest *also* carries path dependencies the compiler injects for its own runtime support — `incan_derive`, `incan_stdlib`, and each `incan_stdlib_<component>` SDK component — alongside anything the project author actually wrote. That fix treated all of them alike.

Each test in `cli_integration.rs`/`integration_tests.rs` spawns a fresh `incan` subprocess, and nearly every one of them touches the stdlib. So every one of those ~400 combined tests independently re-walked the compiler's own support-crate trees on cache load — turning an occasional-edit staleness check into the dominant cost of the two largest test binaries, and pushing them past the (already-raised-once) timeout.

**The fix:** exclude path dependencies whose package name starts with `incan_` from the fingerprint walk. They are never a project author's own dependency, are not editable through ordinary project use, and their own staleness is already covered by the toolchain/SDK identity that selects their path in the first place.

Also keeps the earlier timeout raise (30 → 60 minutes) as a safety net for genuine hosted-runner variance, now that it's backed by an actual fix rather than standing in for one.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: None for ordinary users — `rust_inspect`'s disk-cache staleness detection for genuine user-authored path dependencies (the original `#1076` fix) is unaffected and still covered by a passing regression test. Only the compiler's own injected support-crate dependencies are excluded from the walk.
- **Internals**: `crates/rust_inspect/src/cache_resolve.rs::path_dependency_dirs_from_manifest` now skips any dependency whose resolved package name starts with `incan_` before it's added to the fingerprint walk. Added `workspace_fingerprint_ignores_compiler_owned_path_dependencies` to lock in the exclusion, alongside the existing `workspace_fingerprint_changes_when_path_dependency_source_changes` which proves genuine local dependencies are still tracked.
- **Risks**: A hand-authored interop crate literally named with an `incan_` prefix would no longer trigger cache invalidation on edit — an extremely unlikely naming collision, and a much smaller miss than the severe regression this fixes.

## Testing / verification

- [x] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- Measured the actual generated-project manifests: `crates/incan_stdlib` and `crates/incan_derive` are small (~1MB excluding `target/`, which is already excluded), but the fingerprint walk ran on every cache load for every one of ~400 subprocess-spawned tests — the cost is in call frequency and per-file syscall overhead, not raw bytes, which the previous fix didn't account for.
- `cargo test -p rust_inspect --lib` — 48 passed, including both the new exclusion test and the original path-dependency staleness test (still passing, confirming no regression to the intended `#1076` fix).
- `cargo check --workspace`, `cargo clippy --workspace --all-targets`, `make fmt`, rustdoc gate, `make pre-commit-fast` — all clean.

## Docs impact

- [x] No docs changes needed

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions