### PR TITLE
bugfix - align the remaining formula assertion with the wrapped SDK-inventory guard

### DIFF
--- a/tests/toolchain_installer_tests.rs
+++ b/tests/toolchain_installer_tests.rs
@@ -1407,9 +1407,15 @@ fn toolchain_release_assets_are_prepared_by_central_manifest_program() -> Result
     assert!(formula.contains(
         r#"odie "could not find incan binary in archive; staged files: #{staged_file_sample}" if incan_bin.nil?"#
     ));
-    assert!(formula.contains(
-        r#"odie "could not find SDK provider inventory in archive; staged files: #{staged_file_sample}" unless sdk_inventory.exist?"#
-    ));
+    // The SDK-inventory guard is emitted in the wrapped `unless ... end` form: its one-line trailing-`unless`
+    // spelling exceeded brew audit's line-length limit (the same v0.4 tap-only hand-fix this generator now owns).
+    assert!(formula.contains("unless sdk_inventory.exist?"));
+    assert!(
+        formula.contains(
+            r#"odie "could not find SDK provider inventory in archive; staged files: #{staged_file_sample}""#
+        )
+    );
+    assert!(!formula.contains(r#"" unless sdk_inventory.exist?"#));
     assert!(formula.contains("could not find SDK provider inventory in archive"));
     assert!(formula.contains("libexec.install Dir[\"*\"]"));
     assert!(formula.contains("bin.write_exec_script libexec/\"bin/incan\""));


### PR DESCRIPTION
## Summary

Follow-up to #1105: the audit-clean formula backport updated the platform-selection and version assertions in `toolchain_installer_tests` but missed a second assertion further down that still expected the SDK-inventory `odie` in its one-line trailing-`unless` spelling. The generator now emits it wrapped in `unless ... end` (the brew audit line-length fix), so the release-branch suite fails on that assertion (Oven Linux replay shard 3). This aligns the assertion with the emitted shape and rejects the old spelling.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: none; test-only assertion alignment.
- **Internals**: one assertion block in `tests/toolchain_installer_tests.rs`.
- **Risks**: none beyond test coverage semantics.

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `cargo check --test toolchain_installer_tests` clean; the test itself requires the suite harness environment and is validated by the Oven Linux replay shards on this PR.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions