### PR TITLE
chore - bump to v0.5.0-rc5 and show 1-based Oven replay shard names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,7 +332,7 @@ jobs:
         run: make test-oven-pr-regressions
 
   oven-linux-replay:
-    name: Oven Linux replay (${{ matrix.partition }}/4)
+    name: Oven Linux replay (${{ matrix.display }}/4)
     runs-on: ubuntu-latest
     needs:
       - changes
@@ -340,8 +340,14 @@ jobs:
     if: ${{ needs.changes.outputs.docs_only != 'true' }}
     strategy:
       fail-fast: false
+      # `partition` is the 0-based index the Makefile and artifact names consume; `display` exists only because
+      # GitHub expressions cannot compute `partition + 1` for a human-facing 1-based job name.
       matrix:
-        partition: [0, 1, 2, 3]
+        include:
+          - { partition: 0, display: 1 }
+          - { partition: 1, display: 2 }
+          - { partition: 2, display: 3 }
+          - { partition: 3, display: 4 }
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1436,7 +1436,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.5.0-rc4"
+version = "0.5.0-rc5"
 dependencies = [
  "blake2",
  "blake3",
@@ -1493,7 +1493,7 @@ dependencies = [
 
 [[package]]
 name = "incan_codegraph"
-version = "0.5.0-rc4"
+version = "0.5.0-rc5"
 dependencies = [
  "serde",
  "serde_json",
@@ -1501,14 +1501,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.5.0-rc4"
+version = "0.5.0-rc5"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.5.0-rc4"
+version = "0.5.0-rc5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1517,14 +1517,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.5.0-rc4"
+version = "0.5.0-rc5"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.5.0-rc4"
+version = "0.5.0-rc5"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1532,7 +1532,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.5.0-rc4"
+version = "0.5.0-rc5"
 dependencies = [
  "axum",
  "incan_core",
@@ -1546,7 +1546,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.5.0-rc4"
+version = "0.5.0-rc5"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1568,7 +1568,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.5.0-rc4"
+version = "0.5.0-rc5"
 dependencies = [
  "axum",
  "incan_stdlib",
@@ -3136,7 +3136,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.5.0-rc4"
+version = "0.5.0-rc5"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.5.0-rc4"
+version = "0.5.0-rc5"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.93"

--- a/workspaces/release/npm/package.json
+++ b/workspaces/release/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@incan/toolchain",
-  "version": "0.5.0-rc4",
+  "version": "0.5.0-rc5",
   "description": "Command shims for the Incan toolchain",
   "license": "Apache-2.0",
   "homepage": "https://incan.io",
@@ -14,9 +14,9 @@
     "install-incan": "bin/install-incan.js"
   },
   "optionalDependencies": {
-    "@incan/toolchain-linux-x64": "0.5.0-rc4",
-    "@incan/toolchain-darwin-x64": "0.5.0-rc4",
-    "@incan/toolchain-darwin-arm64": "0.5.0-rc4"
+    "@incan/toolchain-linux-x64": "0.5.0-rc5",
+    "@incan/toolchain-darwin-x64": "0.5.0-rc5",
+    "@incan/toolchain-darwin-arm64": "0.5.0-rc5"
   },
   "files": [
     "README.md",

--- a/workspaces/release/pip/pyproject.toml
+++ b/workspaces/release/pip/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "incan"
-version = "0.5.0rc4"
+version = "0.5.0rc5"
 description = "Thin installer package for the Incan toolchain"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/workspaces/release/pip/src/incan_toolchain/__init__.py
+++ b/workspaces/release/pip/src/incan_toolchain/__init__.py
@@ -1,4 +1,4 @@
 """Thin Python installer package for the Incan toolchain."""
 
 __all__ = ["__version__"]
-__version__ = "0.5.0rc4"
+__version__ = "0.5.0rc5"


### PR DESCRIPTION
## Summary

Bumps the workspace, npm, and pip release metadata from rc4 to rc5. The rc4 tag exercised the release pipeline for the first time on v0.5 and failed in packaging before publishing anywhere; with the registry prewarm (#1105), the IncQL/Oven fixes (#1104), and the formula assertion alignment (#1106) merged, rc5 is the next validation tag.

Also renames the Oven Linux replay CI jobs from 0-based `(0/4)`..`(3/4)` to 1-based `(1/4)`..`(4/4)`. The 0-based `partition` value stays authoritative for the Makefile partition index and artifact names; a paired `display` matrix value exists only because GitHub expressions cannot compute `partition + 1` in a job name.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / maintenance
- [ ] Documentation
- [x] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: release artifacts and installer/package metadata identify as `v0.5.0-rc5`.
- **Internals**: version strings in the root `Cargo.toml` (single source of truth), `Cargo.lock` workspace members, npm `package.json` (root + three platform packages), pip `pyproject.toml` and `__init__.py`; one CI job-name matrix change.
- **Risks**: none beyond ordinary version-bump surface.

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `make pre-commit-fast` (format, rustdoc gate, check) clean
- `git grep` confirms no tracked rc4 references remain outside generated build output

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions