### PR TITLE
bugfix - teach the CI-shape guardrail the paired partition/display replay matrix

### DIFF
--- a/tests/toolchain_installer_tests.rs
+++ b/tests/toolchain_installer_tests.rs
@@ -1171,7 +1171,10 @@ fn compiler_suite_action_composes_baker_guarded_runner_and_storage_evidence() ->
             && workflow.contains("oven-linux-replay")
             && workflow.contains("actions/cache/save@v5")
             && workflow.contains("fail-on-cache-miss: true")
-            && workflow.contains("partition: [0, 1, 2, 3]")
+            && workflow.contains("{ partition: 0, display: 1 }")
+            && workflow.contains("{ partition: 1, display: 2 }")
+            && workflow.contains("{ partition: 2, display: 3 }")
+            && workflow.contains("{ partition: 3, display: 4 }")
             && workflow.matches("timeout-minutes: 20").count() >= 4
             && workflow.matches("Install WASI target for vocab desugarers").count() == 6
             && !workflow.contains("make test-oven-focused"),


### PR DESCRIPTION
## Summary

The workflow-shape guardrail (`compiler_suite_action_composes_baker_guarded_runner_and_storage_evidence`) pinned the replay matrix's literal spelling (`partition: [0, 1, 2, 3]`). The 1-based job-name rename in #1107 restructured that matrix into paired `{ partition, display }` include entries, so the guardrail now fails on the release branch (Oven Linux replay 4/4). This asserts all four pairs instead, preserving the original guarantee — four receipt partitions replay — and additionally pinning the 0-based/1-based pairing.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [x] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: none; test-only expectation alignment.
- **Internals**: one assertion block in `tests/toolchain_installer_tests.rs`.
- **Risks**: none.

## Testing / verification

- [x] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `cargo test --test toolchain_installer_tests compiler_suite_action_composes_baker_guarded_runner_and_storage_evidence` passes locally (this guardrail reads workflow files directly and needs no suite harness).

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions