### PR TITLE
chore - bump to v0.5.0-rc6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1436,7 +1436,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.5.0-rc5"
+version = "0.5.0-rc6"
 dependencies = [
  "blake2",
  "blake3",
@@ -1493,7 +1493,7 @@ dependencies = [
 
 [[package]]
 name = "incan_codegraph"
-version = "0.5.0-rc5"
+version = "0.5.0-rc6"
 dependencies = [
  "serde",
  "serde_json",
@@ -1501,14 +1501,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.5.0-rc5"
+version = "0.5.0-rc6"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.5.0-rc5"
+version = "0.5.0-rc6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1517,14 +1517,14 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.5.0-rc5"
+version = "0.5.0-rc6"
 dependencies = [
  "incan_core",
 ]
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.5.0-rc5"
+version = "0.5.0-rc6"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1532,7 +1532,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.5.0-rc5"
+version = "0.5.0-rc6"
 dependencies = [
  "axum",
  "incan_core",
@@ -1546,7 +1546,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.5.0-rc5"
+version = "0.5.0-rc6"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1568,7 +1568,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.5.0-rc5"
+version = "0.5.0-rc6"
 dependencies = [
  "axum",
  "incan_stdlib",
@@ -3136,7 +3136,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.5.0-rc5"
+version = "0.5.0-rc6"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.5.0-rc5"
+version = "0.5.0-rc6"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.93"

--- a/workspaces/release/npm/package.json
+++ b/workspaces/release/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@incan/toolchain",
-  "version": "0.5.0-rc5",
+  "version": "0.5.0-rc6",
   "description": "Command shims for the Incan toolchain",
   "license": "Apache-2.0",
   "homepage": "https://incan.io",

--- a/workspaces/release/pip/pyproject.toml
+++ b/workspaces/release/pip/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "incan"
-version = "0.5.0rc5"
+version = "0.5.0rc6"
 description = "Thin installer package for the Incan toolchain"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/workspaces/release/pip/src/incan_toolchain/__init__.py
+++ b/workspaces/release/pip/src/incan_toolchain/__init__.py
@@ -1,4 +1,4 @@
 """Thin Python installer package for the Incan toolchain."""
 
 __all__ = ["__version__"]
-__version__ = "0.5.0rc5"
+__version__ = "0.5.0rc6"


### PR DESCRIPTION
## Summary

Bumps workspace, npm, and pip release metadata to `0.5.0-rc6`.

rc5 validated the pip path end to end in a clean-room container (install → toolchain provisioning → `incan new`/`run`/`test`/`build --release`), but its npm leg failed with `E413 Payload Too Large` from the per-platform payload packages. #1109 restored the reference-shim model; rc6 exists to validate that against the real registry.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / maintenance
- [ ] Documentation
- [x] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: release artifacts and installer/package metadata identify as `v0.5.0-rc6`.
- **Internals**: root `Cargo.toml` (single source of truth), `Cargo.lock` workspace members, npm `package.json`, pip `pyproject.toml` and `__init__.py`.
- **Risks**: none beyond ordinary version-bump surface.

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `make pre-commit-fast` (format, rustdoc gate, check) clean
- `git grep` confirms no tracked rc5 references remain outside generated build output

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions