### PR TITLE
bugfix - bump hardcoded 0.5.x version-compatibility fixtures onto the 0.6.x line

### DIFF
--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -5614,7 +5614,7 @@ fn requires_incan_allows_compatible_project_commands() -> Result<(), Box<dyn std
         r#"[project]
 name = "compatible_toolchain_guard"
 version = "0.1.0"
-requires-incan = ">=0.5.0-0,<0.6.0"
+requires-incan = ">=0.6.0-0,<0.7.0"
 
 [project.scripts]
 main = "src/main.incn"

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1621,7 +1621,7 @@ fn lifecycle_new_version_and_env_commands_work() -> Result<(), Box<dyn std::erro
     assert!(initial_manifest.contains(r#"description = "A generated greeting app""#));
     assert!(initial_manifest.contains(r#"authors = ["Danny <danny@example.com>"]"#));
     assert!(initial_manifest.contains(r#"license = "MIT""#));
-    assert!(initial_manifest.contains(r#"requires-incan = ">=0.5.0-0,<0.6.0""#));
+    assert!(initial_manifest.contains(r#"requires-incan = ">=0.6.0-0,<0.7.0""#));
     assert!(project_dir.join("src/main.incn").exists());
     assert!(project_dir.join("tests/test_main.incn").exists());
 
@@ -7866,8 +7866,8 @@ async def main() -> None:
             r#"{
   "schema_version": 2,
   "sdk_id": "incan",
-  "sdk_version": "0.5.0",
-  "compiler_requirement": ">=0.5.0-dev.6,<0.6.0",
+  "sdk_version": "0.6.0",
+  "compiler_requirement": ">=0.6.0-dev.0,<0.7.0",
   "provider_codegen_revision": 4,
   "components": {},
   "profiles": {"default": []}

--- a/tests/toolchain_installer_tests.rs
+++ b/tests/toolchain_installer_tests.rs
@@ -377,8 +377,8 @@ fn write_fixture_sdk_provider_seed(root: &Path, profile: &str) -> Result<PathBuf
     let inventory = serde_json::json!({
         "schema_version": 2,
         "sdk_id": "incan-fixture",
-        "sdk_version": "0.5.0",
-        "compiler_requirement": ">=0.5.0-dev.6,<0.6.0",
+        "sdk_version": "0.6.0",
+        "compiler_requirement": ">=0.6.0-dev.0,<0.7.0",
         "provider_codegen_revision": incan::version::SDK_PROVIDER_CODEGEN_REVISION,
         "components": inventory_components,
         "profiles": {


### PR DESCRIPTION
## Summary

The workspace version moved to `0.6.0-dev.0` (`a7a91c702`) without updating four test fixtures that hardcode a compiler-requirement/`requires-incan` string checked against the *active* compiler. This is the same class of drift PR #1127 found and fixed for `crates/incan_stdlib/stdlib/sdk-components.toml` — flagged there as a separate, pre-existing gap rather than folded in blindly. This PR fixes the remaining occurrences in test fixtures.

Root cause in each case: `semver`'s prerelease-matching rule means a bare `<0.6.0`/`<0.7.0` upper bound never matches a `0.6.0-dev.N` compiler on its own — the lower bound has to explicitly name the `0.6.x` line (`>=0.6.0-dev.0` / `>=0.6.0-0`), the same fix `#1127` already applied to `sdk-components.toml`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: none — test-only fixtures.
- **Internals**: bumped four hardcoded fixture strings across three test files onto the `0.6.x` line:
  - `tests/cli_integration.rs::requires_incan_allows_compatible_project_commands` — a fixture manifest's `requires-incan` no longer matched the active compiler; `incan lock` failed instead of succeeding as the test expects.
  - `tests/integration_tests.rs::lifecycle_new_version_and_env_commands_work` — asserted the exact `0.5.x` string that `incan new`'s already-dynamic `default_requires_incan_constraint()` (`src/cli/commands/init.rs`) correctly no longer produces. That production code was never wrong; only the test's expected literal was stale.
  - `tests/integration_tests.rs::codegen_tests::explicit_stale_sdk_inventory_fails_closed` — a deliberately stale fixture's `compiler_requirement` was *also* incompatible with the active compiler (on top of its intentional `provider_codegen_revision` mismatch), so the compiler rejected it for the wrong reason before the test's targeted assertion could run.
  - `tests/toolchain_installer_tests.rs::toolchain_archive_packager_writes_archive_checksum_and_release_metadata` — its self-contained fake SDK inventory fixture hit the same invalid-SDK-inventory rejection.
- **Risks**: none — every deliberately-incompatible fixture (`>999.0.0`, `schema_version: 1` legacy shape, the `provider_codegen_revision` mismatch itself) was left untouched; only genuinely-stale "should be compatible" literals were bumped.

## Testing / verification

- [x] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `make test` (the full Oven-orchestrated compiler suite, with proper SDK/Loaf prewarming — a bare `cargo test --test <name>` skips that environment setup and produces dozens of unrelated failures, which is a dead end, not a regression) now shows **zero** failures in any of the four tests this PR targets.
- The suite's one remaining failure, `oven::legacy_cargo::tests::cargo_monitor_counts_the_whole_private_publisher_staging_root`, is a pre-existing timing-sensitive assertion (`started.elapsed() < Duration::from_secs(2)`) about legacy-Cargo staging-capacity monitoring — unrelated to version literals, reproduces in isolation, and is reported here as residual risk rather than fixed in this PR.
- `make fmt`, `cargo clippy --test toolchain_installer_tests --test cli_integration --test integration_tests -- -D warnings`, and the rustdoc gate all pass.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Related: #987, #1127
