### PR TITLE
feature - execute first replacement Body IR vertical (#988)

### DIFF
--- a/crates/incan_core/src/lib.rs
+++ b/crates/incan_core/src/lib.rs
@@ -46,6 +46,43 @@ pub enum NumericOp {
     GtEq,
 }
 
+/// Evaluate Python-style integer floor division for non-zero operands.
+///
+/// The result rounds toward negative infinity, unlike Rust's truncation toward zero. Callers must reject a zero
+/// divisor and the unrepresentable `i64::MIN // -1` result before calling this function.
+#[inline]
+pub fn python_floor_div_i64(dividend: i64, divisor: i64) -> i64 {
+    let quotient = dividend / divisor;
+    let remainder = dividend % divisor;
+    if remainder == 0 {
+        return quotient;
+    }
+    if divisor > 0 {
+        if remainder < 0 { quotient - 1 } else { quotient }
+    } else if remainder > 0 {
+        quotient - 1
+    } else {
+        quotient
+    }
+}
+
+/// Evaluate Python-style integer modulo for a non-zero divisor.
+///
+/// The returned remainder has the divisor's sign. Unlike floor division, `i64::MIN % -1` is representable and is
+/// therefore defined here as zero; callers must still reject a zero divisor before calling this function.
+#[inline]
+pub fn python_mod_i64(dividend: i64, divisor: i64) -> i64 {
+    if dividend == i64::MIN && divisor == -1 {
+        return 0;
+    }
+    let remainder = dividend % divisor;
+    if (remainder > 0 && divisor < 0) || (remainder < 0 && divisor > 0) {
+        remainder + divisor
+    } else {
+        remainder
+    }
+}
+
 /// Classify the exponent for `**` so policy can decide `Int` vs `Float` results.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PowExponentKind {
@@ -192,6 +229,15 @@ pub fn needs_float_promotion(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn python_integer_division_and_modulo_preserve_signed_semantics() {
+        assert_eq!(python_floor_div_i64(7, -3), -3);
+        assert_eq!(python_floor_div_i64(-7, 3), -3);
+        assert_eq!(python_mod_i64(7, -3), -2);
+        assert_eq!(python_mod_i64(-7, 3), 2);
+        assert_eq!(python_mod_i64(i64::MIN, -1), 0);
+    }
 
     #[test]
     fn test_div_always_float() {

--- a/crates/incan_stdlib/src/num.rs
+++ b/crates/incan_stdlib/src/num.rs
@@ -36,47 +36,7 @@
 /// ```
 use crate::errors::{raise_value_error, raise_zero_division};
 use core::fmt;
-
-// --- Numeric kernels (hot) ---------------------------------------------------------------------
-//
-// These are implemented in `incan_stdlib` (rather than calling into `incan_core`) so they can be
-// inlined aggressively into generated binaries without requiring LTO.
-
-#[inline(always)]
-fn py_mod_i64_impl(a: i64, b: i64) -> i64 {
-    debug_assert!(b != 0);
-    // Fast path for the dominant benchmark/runtime shape (`a >= 0`, `b > 0`).
-    // For this domain, Rust `%` already matches Python modulo semantics.
-    //
-    // TODO(perf): Teach lowering/codegen to emit native `%` directly when positivity is proven,
-    //             so hot loops can bypass helper calls entirely.
-    if a >= 0 && b > 0 {
-        return a % b;
-    }
-    // Use `wrapping_rem` to avoid the extra overflow guard Rust emits for `i64::MIN % -1`.
-    // (We still panic on division by zero at the wrapper layer for consistent Python-like errors.)
-    let r = a.wrapping_rem(b);
-    // Python semantics: remainder has the sign of the divisor.
-    if (r > 0 && b < 0) || (r < 0 && b > 0) { r + b } else { r }
-}
-
-#[inline]
-fn py_floor_div_i64_impl(a: i64, b: i64) -> i64 {
-    debug_assert!(b != 0);
-    let q = a / b;
-    let r = a % b;
-    // Python semantics: quotient rounds toward negative infinity.
-    if r == 0 {
-        return q;
-    }
-    if b > 0 {
-        if r < 0 { q - 1 } else { q }
-    } else if r > 0 {
-        q - 1
-    } else {
-        q
-    }
-}
+use incan_core::{python_floor_div_i64, python_mod_i64};
 
 #[inline]
 fn py_mod_f64_impl(a: f64, b: f64) -> f64 {
@@ -119,6 +79,18 @@ fn non_negative_i64_or_overflow(value: u64, fn_name: &str) -> i64 {
         Ok(value) => value,
         Err(_) => raise_value_error(&format!("{fn_name} result overflows Incan int")),
     }
+}
+
+/// Apply shared signed floor-division semantics after refusing inputs unrepresentable in Incan's `i64` carrier.
+#[inline]
+fn checked_python_floor_div_i64(dividend: i64, divisor: i64) -> i64 {
+    if divisor == 0 {
+        raise_zero_division();
+    }
+    if dividend == i64::MIN && divisor == -1 {
+        raise_value_error("integer floor division result overflows Incan int");
+    }
+    python_floor_div_i64(dividend, divisor)
 }
 
 // --- Generic helpers and sealed traits ---------------------------------------------------------
@@ -333,7 +305,7 @@ impl PyModImpl<i64> for i64 {
     type Output = i64;
     #[inline]
     fn py_mod(self, rhs: i64) -> Self::Output {
-        py_mod_i64_impl(self, rhs)
+        python_mod_i64(self, rhs)
     }
 }
 
@@ -365,7 +337,7 @@ impl PyFloorDivImpl<i64> for i64 {
     type Output = i64;
     #[inline]
     fn py_floor_div(self, rhs: i64) -> Self::Output {
-        py_floor_div_i64_impl(self, rhs)
+        checked_python_floor_div_i64(self, rhs)
     }
 }
 
@@ -403,12 +375,17 @@ impl PyFloorDivImpl<f64> for f64 {
 
 // --- Compatibility wrappers (existing API) ----------------------------------------------------
 
+/// Python-style floor division for integers.
+///
+/// Rounds toward negative infinity and raises the standard zero-division failure when the divisor is zero.
+///
+/// ## Panics
+///
+/// Raises `ValueError` when the mathematical quotient cannot fit Incan's signed `i64` carrier, including
+/// `i64::MIN // -1`.
 #[inline]
 pub fn py_floor_div_i64(a: i64, b: i64) -> i64 {
-    if b == 0 {
-        raise_zero_division();
-    }
-    py_floor_div_i64_impl(a, b)
+    checked_python_floor_div_i64(a, b)
 }
 
 /// Python-style floor division for floats.
@@ -451,7 +428,7 @@ pub fn py_mod_i64(a: i64, b: i64) -> i64 {
     if b == 0 {
         raise_zero_division();
     }
-    py_mod_i64_impl(a, b)
+    python_mod_i64(a, b)
 }
 
 /// Python-style modulo for floats.
@@ -879,6 +856,12 @@ mod tests {
         assert!(approx_eq(py_floor_div(-7.0_f64, 3.0_f64), -3.0));
         assert!(approx_eq(py_floor_div(7.0_f64, -3.0_f64), -3.0));
         assert!(approx_eq(py_floor_div(-7.0_f64, -3.0_f64), 2.0));
+    }
+
+    #[test]
+    #[should_panic(expected = "ValueError: integer floor division result overflows Incan int")]
+    fn test_py_floor_div_i64_refuses_an_unrepresentable_quotient() {
+        let _ = py_floor_div_i64(i64::MIN, -1);
     }
 
     #[test]

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -43,6 +43,7 @@
 pub(crate) mod c_abi;
 pub mod ir;
 pub mod project;
+pub mod replacement;
 pub mod selection;
 
 // Re-export the unified codegen entrypoint

--- a/src/backend/replacement/mod.rs
+++ b/src/backend/replacement/mod.rs
@@ -1,0 +1,776 @@
+//! Direct execution of the deliberately narrow #988 Body-IR replacement profile.
+//!
+//! This module consumes [`incan_semantics_core::BodyIrModule`] directly. It never reads generated Rust, never
+//! delegates a requested replacement execution to [`crate::backend::ir`], and rejects every operation outside the
+//! first free-function profile with the original Body-IR source span. The profile is intentionally limited to
+//! scalar local values, arithmetic, compiler-owned string concatenation, branches, normalized loops, returns, and
+//! assertions; packages, Rust interop, callable values, generators, destructuring, and projections remain visible
+//! refusals for later #988 extensions.
+
+use std::collections::BTreeMap;
+
+use incan_semantics_core::body_ir::{
+    BinOp, Body, BodyIrModule, Callee, Constant, HelperOp, IterProtocol, LocalId, LocalOrigin, Operand, OwnershipFact,
+    Place, Rvalue, Statement, StatementKind, UnOp,
+};
+use incan_semantics_core::{AbiV0RuntimeRequirement, HirSourceSpan};
+
+use crate::backend::selection::digest_output;
+
+/// Bounded instruction count for one replacement execution.
+///
+/// The first profile deliberately executes normalized loops rather than translating them to native code. Keeping a
+/// deterministic bound turns an accidental infinite loop into an explicit unavailable result instead of allowing a
+/// test or CLI invocation to hang without a receipt.
+const MAX_EXECUTION_STEPS: usize = 100_000;
+
+/// One scalar value supported by the first replacement-execution profile.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReplacementValue {
+    /// An Incan `int` value.
+    Int(i64),
+    /// An Incan `bool` value.
+    Bool(bool),
+    /// An owned Incan `str` value.
+    Str(String),
+    /// An Incan floating-point literal, retained so unsupported float operations refuse honestly.
+    Float(String),
+    /// An Incan `None`/unit value.
+    Unit,
+    /// A list retained only long enough to make a subsequent projection refusal attributable to that projection.
+    List(Vec<ReplacementValue>),
+    /// A normalized builtin range iterator for the selected range-`for` control-flow case.
+    Range { next: i64, end: i64, step: i64 },
+}
+
+impl ReplacementValue {
+    /// Render a deterministic source-observable result spelling for receipts and legacy runtime comparison.
+    pub fn observable_text(&self) -> String {
+        match self {
+            Self::Int(value) => value.to_string(),
+            Self::Bool(value) => value.to_string(),
+            Self::Str(value) => value.clone(),
+            Self::Float(value) => value.clone(),
+            Self::Unit => "None".to_string(),
+            Self::List(values) => {
+                let items = values.iter().map(Self::observable_text).collect::<Vec<_>>();
+                format!("[{}]", items.join(", "))
+            }
+            Self::Range { next, end, step } => format!("range({next}, {end}, {step})"),
+        }
+    }
+}
+
+/// One Body-IR place read observed while executing the replacement profile.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OwnershipRead {
+    /// The original Incan source span of the statement containing the read.
+    pub span: HirSourceSpan,
+    /// The compiler-owned ownership fact the executor honored.
+    pub fact: OwnershipFact,
+    /// Whether lowering identified this read as the local's last use.
+    pub last_use: bool,
+}
+
+/// Successful replacement execution evidence for one free function.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReplacementExecution {
+    /// The function's source-level return value.
+    pub value: ReplacementValue,
+    /// Deterministic Body-IR snapshot retained as proof of the consumed input.
+    pub body_snapshot: String,
+    /// Every ownership decision observed during execution, in execution order.
+    pub ownership_reads: Vec<OwnershipRead>,
+    /// Runtime/helper requirements carried through from the consumed Body IR.
+    pub runtime_requirements: Vec<AbiV0RuntimeRequirement>,
+    /// Content identity of the actual Body-IR snapshot, ownership facts, requirements, and observed result.
+    pub output_identity: String,
+}
+
+/// A visible refusal or runtime outcome from the replacement executor.
+#[derive(Debug, thiserror::Error)]
+pub enum ReplacementExecutionError {
+    /// The requested free function was absent from the typed Body-IR module.
+    #[error("replacement backend has no free function named `{name}` to execute")]
+    MissingFunction {
+        /// The requested source-level function name.
+        name: String,
+    },
+    /// The caller supplied a different number of arguments than the Body IR declares.
+    #[error("replacement backend cannot execute `{name}`: expected {expected} arguments, got {actual}")]
+    ArgumentCount {
+        /// Function selected for execution.
+        name: String,
+        /// Parameter count from Body IR.
+        expected: usize,
+        /// Argument count supplied by the caller.
+        actual: usize,
+    },
+    /// A Body-IR construct lies outside the declared first replacement profile.
+    #[error(
+        "replacement backend does not support {description} at original Incan source span {span_start}..{span_end}"
+    )]
+    Unsupported {
+        /// Construct or semantic fact the first profile cannot execute.
+        description: String,
+        /// Original Incan source span carried by Body IR.
+        span: HirSourceSpan,
+        /// Start byte offset duplicated for typed error formatting.
+        span_start: usize,
+        /// End byte offset duplicated for typed error formatting.
+        span_end: usize,
+    },
+    /// A selected operation reached a source-observable runtime failure.
+    #[error("replacement backend runtime failure at original Incan source span {span_start}..{span_end}: {detail}")]
+    RuntimeFailure {
+        /// Source-observable runtime-failure description.
+        detail: String,
+        /// Original Incan source span carried by Body IR.
+        span: HirSourceSpan,
+        /// Start byte offset duplicated for typed error formatting.
+        span_start: usize,
+        /// End byte offset duplicated for typed error formatting.
+        span_end: usize,
+    },
+}
+
+impl ReplacementExecutionError {
+    /// Return the original Incan source location when this outcome arose from Body IR.
+    pub const fn primary_span(&self) -> Option<HirSourceSpan> {
+        match self {
+            Self::Unsupported { span, .. } | Self::RuntimeFailure { span, .. } => Some(*span),
+            Self::MissingFunction { .. } | Self::ArgumentCount { .. } => None,
+        }
+    }
+}
+
+/// Execute one named, free-function Body IR body with concrete scalar arguments.
+///
+/// The caller must already have parsed and typechecked the source before constructing `module`; this boundary only
+/// consumes Body IR and refuses unsupported operations rather than rerunning frontend or generated-Rust semantics.
+pub fn execute_free_function(
+    module: &BodyIrModule,
+    name: &str,
+    args: &[ReplacementValue],
+) -> Result<ReplacementExecution, ReplacementExecutionError> {
+    let body = module
+        .bodies
+        .iter()
+        .find(|body| body.name == name)
+        .ok_or_else(|| ReplacementExecutionError::MissingFunction { name: name.to_string() })?;
+    if body.is_generator() {
+        return Err(unsupported("generator body", body.span));
+    }
+    if body.param_locals.len() != args.len() {
+        return Err(ReplacementExecutionError::ArgumentCount {
+            name: name.to_string(),
+            expected: body.param_locals.len(),
+            actual: args.len(),
+        });
+    }
+
+    let mut executor = BodyExecutor::new(body, args);
+    let flow = executor.execute_block(&body.block)?;
+    let value = match flow {
+        Flow::Return(value) => value.unwrap_or(ReplacementValue::Unit),
+        Flow::Next => ReplacementValue::Unit,
+        Flow::Break | Flow::Continue => {
+            return Err(unsupported("loop control outside a normalized loop", body.span));
+        }
+    };
+    let body_snapshot = body.render_snapshot();
+    let ownership_summary = executor
+        .ownership_reads
+        .iter()
+        .map(|read| format!("{}:{}:{}", read.span.start, ownership_label(read.fact), read.last_use))
+        .collect::<Vec<_>>()
+        .join("|");
+    let requirements_summary = format!("{:?}", body.runtime_requirements);
+    let output_identity = digest_output(&[
+        body_snapshot.as_str(),
+        value.observable_text().as_str(),
+        ownership_summary.as_str(),
+        requirements_summary.as_str(),
+    ]);
+    Ok(ReplacementExecution {
+        value,
+        body_snapshot,
+        ownership_reads: executor.ownership_reads,
+        runtime_requirements: body.runtime_requirements.clone(),
+        output_identity,
+    })
+}
+
+/// Mutable interpreter state for one Body-IR execution.
+struct BodyExecutor {
+    locals: BTreeMap<LocalId, ReplacementValue>,
+    local_bindings: BTreeMap<LocalId, (Option<String>, LocalOrigin)>,
+    ownership_reads: Vec<OwnershipRead>,
+    steps: usize,
+}
+
+impl BodyExecutor {
+    /// Bind the already-typechecked call arguments to their Body-IR parameter locals.
+    fn new(body: &Body, args: &[ReplacementValue]) -> Self {
+        let locals = body.param_locals.iter().copied().zip(args.iter().cloned()).collect();
+        let local_bindings = body
+            .locals
+            .iter()
+            .map(|local| (local.id, (local.name.clone(), local.origin)))
+            .collect();
+        Self {
+            locals,
+            local_bindings,
+            ownership_reads: Vec::new(),
+            steps: 0,
+        }
+    }
+
+    /// Execute one normalized Body-IR block until it falls through or produces control flow.
+    fn execute_block(
+        &mut self,
+        block: &incan_semantics_core::body_ir::Block,
+    ) -> Result<Flow, ReplacementExecutionError> {
+        for statement in &block.stmts {
+            self.record_step(statement.span)?;
+            match self.execute_statement(statement)? {
+                Flow::Next => {}
+                flow => return Ok(flow),
+            }
+        }
+        Ok(Flow::Next)
+    }
+
+    /// Execute one Body-IR statement without consulting generated Rust or the legacy backend.
+    fn execute_statement(&mut self, statement: &Statement) -> Result<Flow, ReplacementExecutionError> {
+        match &statement.kind {
+            StatementKind::Assign { place, rvalue } => {
+                let local = bare_local(place, statement.span)?;
+                let value = self.evaluate_rvalue(rvalue, statement.span)?;
+                self.assign_local(local, value);
+                Ok(Flow::Next)
+            }
+            StatementKind::Call {
+                destination,
+                callee,
+                args,
+                may_panic: _,
+            } => self.execute_call(destination.as_ref(), callee, args, statement.span),
+            StatementKind::Drop { local } => {
+                let _ = self.locals.remove(local);
+                Ok(Flow::Next)
+            }
+            StatementKind::If {
+                cond,
+                then_block,
+                else_block,
+            } => {
+                if self.evaluate_operand(cond, statement.span)?.into_bool(statement.span)? {
+                    self.execute_block(then_block)
+                } else if let Some(else_block) = else_block {
+                    self.execute_block(else_block)
+                } else {
+                    Ok(Flow::Next)
+                }
+            }
+            StatementKind::Loop { body } => self.execute_loop(body, statement.span),
+            StatementKind::Break { value: Some(_) } => Err(unsupported("value-carrying loop break", statement.span)),
+            StatementKind::Break { value: None } => Ok(Flow::Break),
+            StatementKind::Continue => Ok(Flow::Continue),
+            StatementKind::Return { value } => Ok(Flow::Return(
+                value
+                    .as_ref()
+                    .map(|value| self.evaluate_operand(value, statement.span))
+                    .transpose()?,
+            )),
+            StatementKind::Assert {
+                cond,
+                message,
+                may_panic: _,
+            } => {
+                if self.evaluate_operand(cond, statement.span)?.into_bool(statement.span)? {
+                    Ok(Flow::Next)
+                } else {
+                    let detail = match message {
+                        Some(message) => format!(
+                            "assertion failed: {}",
+                            self.evaluate_operand(message, statement.span)?.observable_text()
+                        ),
+                        None => "assertion failed".to_string(),
+                    };
+                    Err(runtime_failure(detail, statement.span))
+                }
+            }
+            StatementKind::Expr { value } => {
+                let _ = self.evaluate_operand(value, statement.span)?;
+                Ok(Flow::Next)
+            }
+            StatementKind::IterNext {
+                destination,
+                iterator,
+                protocol: IterProtocol::Builtin,
+            } => self.execute_range_next(destination, iterator, statement.span),
+            StatementKind::Yield { .. } => Err(unsupported("generator yield", statement.span)),
+            StatementKind::TryPropagate { .. } => Err(unsupported("try propagation", statement.span)),
+            StatementKind::IterNext { .. } => Err(unsupported("non-range iteration", statement.span)),
+            StatementKind::Unsupported { description } => Err(unsupported(description, statement.span)),
+        }
+    }
+
+    /// Evaluate a compiler-owned helper call in the first execution profile.
+    fn execute_call(
+        &mut self,
+        destination: Option<&Place>,
+        callee: &Callee,
+        args: &[Operand],
+        span: HirSourceSpan,
+    ) -> Result<Flow, ReplacementExecutionError> {
+        let destination = destination.ok_or_else(|| unsupported("discarded string-concatenation result", span))?;
+        let local = bare_local(destination, span)?;
+        let value = match callee {
+            Callee::Helper(HelperOp::StrConcat) => {
+                let [left, right] = args else {
+                    return Err(unsupported("string-concatenation call arity", span));
+                };
+                let left = self.evaluate_operand(left, span)?.into_string(span)?;
+                let right = self.evaluate_operand(right, span)?.into_string(span)?;
+                ReplacementValue::Str(format!("{left}{right}"))
+            }
+            Callee::Function(name) if name == "range" => self.evaluate_range(args, span)?,
+            _ => return Err(unsupported(format!("call to {}", callee_label(callee)), span)),
+        };
+        self.assign_local(local, value);
+        Ok(Flow::Next)
+    }
+
+    /// Materialize the builtin `range` call that Body IR retains before its normalized loop.
+    fn evaluate_range(
+        &mut self,
+        args: &[Operand],
+        span: HirSourceSpan,
+    ) -> Result<ReplacementValue, ReplacementExecutionError> {
+        let values = args
+            .iter()
+            .map(|argument| self.evaluate_operand(argument, span))
+            .collect::<Result<Vec<_>, _>>()?;
+        let ints = values
+            .iter()
+            .map(|value| match value {
+                ReplacementValue::Int(value) => Ok(*value),
+                value => Err(unsupported(format!("range argument using {}", value_kind(value)), span)),
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let (next, end, step) = match ints.as_slice() {
+            [end] => (0, *end, 1),
+            [start, end] => (*start, *end, 1),
+            [start, end, step] if *step != 0 => (*start, *end, *step),
+            [_, _, 0] => return Err(runtime_failure("range step cannot be zero".to_string(), span)),
+            _ => return Err(unsupported("range call arity", span)),
+        };
+        Ok(ReplacementValue::Range { next, end, step })
+    }
+
+    /// Poll one builtin range iterator and express exhaustion as the Body-IR loop break it represents.
+    fn execute_range_next(
+        &mut self,
+        destination: &Place,
+        iterator: &Operand,
+        span: HirSourceSpan,
+    ) -> Result<Flow, ReplacementExecutionError> {
+        let Operand::Place(iterator) = iterator else {
+            return Err(unsupported("non-place range iterator", span));
+        };
+        let iterator_local = bare_local(&iterator.place, span)?;
+        self.ownership_reads.push(OwnershipRead {
+            span,
+            fact: iterator.fact,
+            last_use: iterator.last_use,
+        });
+        let value = match self.locals.get_mut(&iterator_local) {
+            Some(ReplacementValue::Range { next, end, step })
+                if (*step > 0 && *next < *end) || (*step < 0 && *next > *end) =>
+            {
+                let value = *next;
+                *next += *step;
+                value
+            }
+            Some(ReplacementValue::Range { .. }) => return Ok(Flow::Break),
+            Some(value) => return Err(unsupported(format!("iteration over {}", value_kind(value)), span)),
+            None => {
+                return Err(runtime_failure(
+                    "read of an unavailable range iterator".to_string(),
+                    span,
+                ));
+            }
+        };
+        self.assign_local(bare_local(destination, span)?, ReplacementValue::Int(value));
+        Ok(Flow::Next)
+    }
+
+    /// Assign a Body-IR local while retaining the first profile's source-binding equivalence.
+    ///
+    /// Body IR v0 records source assignment sites as fresh locals even though later condition reads can still point
+    /// at the original local. For the selected free-function profile, equal user-binding names denote the same
+    /// source binding; update those aliases together rather than allowing a generated local id to create stale
+    /// source reads. Shadowing remains unsupported until Body IR carries an explicit binding-equivalence fact.
+    fn assign_local(&mut self, local: LocalId, value: ReplacementValue) {
+        let Some((Some(name), LocalOrigin::UserBinding)) = self.local_bindings.get(&local) else {
+            self.locals.insert(local, value);
+            return;
+        };
+        let aliases = self
+            .local_bindings
+            .iter()
+            .filter_map(|(candidate, (candidate_name, origin))| {
+                (matches!(origin, LocalOrigin::UserBinding) && candidate_name.as_deref() == Some(name.as_str()))
+                    .then_some(*candidate)
+            })
+            .collect::<Vec<_>>();
+        for alias in aliases {
+            self.locals.insert(alias, value.clone());
+        }
+    }
+
+    /// Execute one normalized Body-IR loop and propagate only non-local control flow outward.
+    fn execute_loop(
+        &mut self,
+        body: &incan_semantics_core::body_ir::Block,
+        span: HirSourceSpan,
+    ) -> Result<Flow, ReplacementExecutionError> {
+        loop {
+            match self.execute_block(body)? {
+                Flow::Next | Flow::Continue => {}
+                Flow::Break => return Ok(Flow::Next),
+                Flow::Return(value) => return Ok(Flow::Return(value)),
+            }
+            if self.steps >= MAX_EXECUTION_STEPS {
+                return Err(runtime_failure(
+                    format!("normalized loop exceeded the {MAX_EXECUTION_STEPS}-step replacement profile limit"),
+                    span,
+                ));
+            }
+        }
+    }
+
+    /// Evaluate an assignment rvalue supported by the initial profile.
+    fn evaluate_rvalue(
+        &mut self,
+        rvalue: &Rvalue,
+        span: HirSourceSpan,
+    ) -> Result<ReplacementValue, ReplacementExecutionError> {
+        match rvalue {
+            Rvalue::Use(operand) => self.evaluate_operand(operand, span),
+            Rvalue::UnaryOp(operator, operand) => self.evaluate_unary(*operator, operand, span),
+            Rvalue::BinaryOp(operator, left, right) => self.evaluate_binary(*operator, left, right, span),
+            Rvalue::Aggregate(incan_semantics_core::body_ir::AggregateKind::List, values) => values
+                .iter()
+                .map(|value| self.evaluate_operand(value, span))
+                .collect::<Result<Vec<_>, _>>()
+                .map(ReplacementValue::List),
+            Rvalue::Aggregate(kind, _) => Err(unsupported(format!("{} aggregate", aggregate_label(kind)), span)),
+            Rvalue::Format(_) => Err(unsupported("f-string", span)),
+            Rvalue::Closure { .. } => Err(unsupported("callable value", span)),
+            Rvalue::Match { .. } => Err(unsupported("match expression", span)),
+        }
+    }
+
+    /// Evaluate a scalar unary operation.
+    fn evaluate_unary(
+        &mut self,
+        operator: UnOp,
+        operand: &Operand,
+        span: HirSourceSpan,
+    ) -> Result<ReplacementValue, ReplacementExecutionError> {
+        let value = self.evaluate_operand(operand, span)?;
+        match (operator, value) {
+            (UnOp::Neg, ReplacementValue::Int(value)) => Ok(ReplacementValue::Int(-value)),
+            (UnOp::Not, ReplacementValue::Bool(value)) => Ok(ReplacementValue::Bool(!value)),
+            (UnOp::Invert, ReplacementValue::Int(value)) => Ok(ReplacementValue::Int(!value)),
+            (operator, value) => Err(unsupported(
+                format!("{} applied to {}", unary_label(operator), value_kind(&value)),
+                span,
+            )),
+        }
+    }
+
+    /// Evaluate a scalar arithmetic, comparison, or boolean operation.
+    fn evaluate_binary(
+        &mut self,
+        operator: BinOp,
+        left: &Operand,
+        right: &Operand,
+        span: HirSourceSpan,
+    ) -> Result<ReplacementValue, ReplacementExecutionError> {
+        let left = self.evaluate_operand(left, span)?;
+        let right = self.evaluate_operand(right, span)?;
+        match (operator, left, right) {
+            (BinOp::Add, ReplacementValue::Int(left), ReplacementValue::Int(right)) => {
+                Ok(ReplacementValue::Int(left + right))
+            }
+            (BinOp::Sub, ReplacementValue::Int(left), ReplacementValue::Int(right)) => {
+                Ok(ReplacementValue::Int(left - right))
+            }
+            (BinOp::Mul, ReplacementValue::Int(left), ReplacementValue::Int(right)) => {
+                Ok(ReplacementValue::Int(left * right))
+            }
+            (BinOp::FloorDiv, ReplacementValue::Int(_), ReplacementValue::Int(0))
+            | (BinOp::Mod, ReplacementValue::Int(_), ReplacementValue::Int(0))
+            | (BinOp::Div, ReplacementValue::Int(_), ReplacementValue::Int(0)) => {
+                Err(runtime_failure("division or modulo by zero".to_string(), span))
+            }
+            (BinOp::FloorDiv, ReplacementValue::Int(left), ReplacementValue::Int(right)) => {
+                Ok(ReplacementValue::Int(left.div_euclid(right)))
+            }
+            (BinOp::Mod, ReplacementValue::Int(left), ReplacementValue::Int(right)) => {
+                Ok(ReplacementValue::Int(left.rem_euclid(right)))
+            }
+            (BinOp::Eq, left, right) => Ok(ReplacementValue::Bool(left == right)),
+            (BinOp::Ne, left, right) => Ok(ReplacementValue::Bool(left != right)),
+            (BinOp::Lt, ReplacementValue::Int(left), ReplacementValue::Int(right)) => {
+                Ok(ReplacementValue::Bool(left < right))
+            }
+            (BinOp::Le, ReplacementValue::Int(left), ReplacementValue::Int(right)) => {
+                Ok(ReplacementValue::Bool(left <= right))
+            }
+            (BinOp::Gt, ReplacementValue::Int(left), ReplacementValue::Int(right)) => {
+                Ok(ReplacementValue::Bool(left > right))
+            }
+            (BinOp::Ge, ReplacementValue::Int(left), ReplacementValue::Int(right)) => {
+                Ok(ReplacementValue::Bool(left >= right))
+            }
+            (BinOp::And, ReplacementValue::Bool(left), ReplacementValue::Bool(right)) => {
+                Ok(ReplacementValue::Bool(left && right))
+            }
+            (BinOp::Or, ReplacementValue::Bool(left), ReplacementValue::Bool(right)) => {
+                Ok(ReplacementValue::Bool(left || right))
+            }
+            (operator, left, right) => Err(unsupported(
+                format!(
+                    "{} between {} and {}",
+                    binary_label(operator),
+                    value_kind(&left),
+                    value_kind(&right)
+                ),
+                span,
+            )),
+        }
+    }
+
+    /// Read one constant or local place while applying its recorded ownership decision.
+    fn evaluate_operand(
+        &mut self,
+        operand: &Operand,
+        span: HirSourceSpan,
+    ) -> Result<ReplacementValue, ReplacementExecutionError> {
+        match operand {
+            Operand::Constant(constant) => Ok(constant_value(constant)),
+            Operand::Place(place_operand) => {
+                let local = bare_local(&place_operand.place, span)?;
+                self.ownership_reads.push(OwnershipRead {
+                    span,
+                    fact: place_operand.fact,
+                    last_use: place_operand.last_use,
+                });
+                match place_operand.fact {
+                    OwnershipFact::Copy => self
+                        .locals
+                        .get(&local)
+                        .cloned()
+                        .filter(ReplacementValue::is_copy_shaped)
+                        .ok_or_else(|| unsupported("copy of a non-copy or unavailable local", span)),
+                    OwnershipFact::Move => self
+                        .locals
+                        .remove(&local)
+                        .ok_or_else(|| runtime_failure("read of a moved or dropped local".to_string(), span)),
+                    OwnershipFact::Clone | OwnershipFact::Borrow | OwnershipFact::MutBorrow => self
+                        .locals
+                        .get(&local)
+                        .cloned()
+                        .ok_or_else(|| runtime_failure("read of an unavailable local".to_string(), span)),
+                    OwnershipFact::Unknown => Err(unsupported("unknown ownership fact", span)),
+                }
+            }
+        }
+    }
+
+    /// Record one executed statement and enforce the bounded-profile step limit.
+    fn record_step(&mut self, span: HirSourceSpan) -> Result<(), ReplacementExecutionError> {
+        self.steps = self.steps.saturating_add(1);
+        if self.steps > MAX_EXECUTION_STEPS {
+            return Err(runtime_failure(
+                format!("replacement profile exceeded the {MAX_EXECUTION_STEPS}-step execution limit"),
+                span,
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl ReplacementValue {
+    /// Return whether a value can honor a Body-IR `Copy` read without duplicating owned state.
+    const fn is_copy_shaped(&self) -> bool {
+        matches!(self, Self::Int(_) | Self::Bool(_) | Self::Unit)
+    }
+
+    /// Return this value as a boolean, refusing a type-shape mismatch at the original source location.
+    fn into_bool(self, span: HirSourceSpan) -> Result<bool, ReplacementExecutionError> {
+        match self {
+            Self::Bool(value) => Ok(value),
+            value => Err(unsupported(
+                format!("boolean condition using {}", value_kind(&value)),
+                span,
+            )),
+        }
+    }
+
+    /// Return this value as an owned string, refusing an incompatible helper call at the original source location.
+    fn into_string(self, span: HirSourceSpan) -> Result<String, ReplacementExecutionError> {
+        match self {
+            Self::Str(value) => Ok(value),
+            value => Err(unsupported(
+                format!("string operation using {}", value_kind(&value)),
+                span,
+            )),
+        }
+    }
+}
+
+/// Control flow propagated between normalized blocks.
+enum Flow {
+    /// Ordinary fallthrough.
+    Next,
+    /// Break from the innermost normalized loop.
+    Break,
+    /// Continue the innermost normalized loop.
+    Continue,
+    /// Return from the selected free function.
+    Return(Option<ReplacementValue>),
+}
+
+/// Return one bare local id, refusing fields, indexes, and slices in the first profile.
+fn bare_local(place: &Place, span: HirSourceSpan) -> Result<LocalId, ReplacementExecutionError> {
+    if place.projection.is_empty() {
+        Ok(place.local)
+    } else {
+        Err(unsupported("place projection", span))
+    }
+}
+
+/// Construct a source-span-preserving unsupported-profile error.
+fn unsupported(description: impl Into<String>, span: HirSourceSpan) -> ReplacementExecutionError {
+    ReplacementExecutionError::Unsupported {
+        description: description.into(),
+        span,
+        span_start: span.start,
+        span_end: span.end,
+    }
+}
+
+/// Construct a source-span-preserving runtime-failure error.
+fn runtime_failure(detail: String, span: HirSourceSpan) -> ReplacementExecutionError {
+    ReplacementExecutionError::RuntimeFailure {
+        detail,
+        span,
+        span_start: span.start,
+        span_end: span.end,
+    }
+}
+
+/// Render one ownership fact without relying on generated-Rust implementation details.
+const fn ownership_label(fact: OwnershipFact) -> &'static str {
+    match fact {
+        OwnershipFact::Copy => "copy",
+        OwnershipFact::Move => "move",
+        OwnershipFact::Clone => "clone",
+        OwnershipFact::Borrow => "borrow",
+        OwnershipFact::MutBorrow => "mut_borrow",
+        OwnershipFact::Unknown => "unknown",
+    }
+}
+
+/// Render a narrow unsupported-call label for diagnostics.
+fn callee_label(callee: &Callee) -> String {
+    match callee {
+        Callee::Function(name) => format!("function `{name}`"),
+        Callee::Method(name) => format!("method `{name}`"),
+        Callee::Helper(helper) => format!("runtime helper `{}`", helper_label(*helper)),
+    }
+}
+
+/// Render a compiler-owned helper name without depending on generated-Rust spellings.
+const fn helper_label(helper: HelperOp) -> &'static str {
+    match helper {
+        HelperOp::StrConcat => "str_concat",
+        HelperOp::StrEq => "str_eq",
+        HelperOp::StrNe => "str_ne",
+        HelperOp::StrLt => "str_lt",
+        HelperOp::StrLe => "str_le",
+        HelperOp::StrGt => "str_gt",
+        HelperOp::StrGe => "str_ge",
+        HelperOp::ListConcat => "list_concat",
+    }
+}
+
+/// Render an aggregate kind as a compact source-level diagnostic label.
+fn aggregate_label(kind: &incan_semantics_core::body_ir::AggregateKind) -> &'static str {
+    match kind {
+        incan_semantics_core::body_ir::AggregateKind::Tuple => "tuple",
+        incan_semantics_core::body_ir::AggregateKind::List => "list",
+        incan_semantics_core::body_ir::AggregateKind::Dict => "dict",
+        incan_semantics_core::body_ir::AggregateKind::Set => "set",
+        incan_semantics_core::body_ir::AggregateKind::Constructor(_) => "constructor",
+    }
+}
+
+/// Render a unary operator as a compact source-level diagnostic label.
+const fn unary_label(operator: UnOp) -> &'static str {
+    match operator {
+        UnOp::Neg => "negation",
+        UnOp::Not => "boolean negation",
+        UnOp::Invert => "bitwise inversion",
+    }
+}
+
+/// Render a binary operator as a compact source-level diagnostic label.
+const fn binary_label(operator: BinOp) -> &'static str {
+    match operator {
+        BinOp::Add => "addition",
+        BinOp::Sub => "subtraction",
+        BinOp::Mul => "multiplication",
+        BinOp::Div => "division",
+        BinOp::FloorDiv => "floor division",
+        BinOp::Mod => "modulo",
+        BinOp::Eq => "equality comparison",
+        BinOp::Ne => "inequality comparison",
+        BinOp::Lt => "less-than comparison",
+        BinOp::Le => "less-or-equal comparison",
+        BinOp::Gt => "greater-than comparison",
+        BinOp::Ge => "greater-or-equal comparison",
+        BinOp::And => "boolean conjunction",
+        BinOp::Or => "boolean disjunction",
+    }
+}
+
+/// Render one replacement value's dynamic shape for an unsupported-operation diagnostic.
+const fn value_kind(value: &ReplacementValue) -> &'static str {
+    match value {
+        ReplacementValue::Int(_) => "int",
+        ReplacementValue::Bool(_) => "bool",
+        ReplacementValue::Str(_) => "str",
+        ReplacementValue::Float(_) => "float",
+        ReplacementValue::Unit => "unit",
+        ReplacementValue::List(_) => "list",
+        ReplacementValue::Range { .. } => "range",
+    }
+}
+
+/// Convert one Body-IR literal into a first-profile replacement value.
+fn constant_value(constant: &Constant) -> ReplacementValue {
+    match constant {
+        Constant::Int(value) => ReplacementValue::Int(*value),
+        Constant::Bool(value) => ReplacementValue::Bool(*value),
+        Constant::Str(value) => ReplacementValue::Str(value.clone()),
+        Constant::Unit | Constant::None => ReplacementValue::Unit,
+        Constant::Float(value) => ReplacementValue::Float(value.clone()),
+    }
+}

--- a/src/backend/replacement/mod.rs
+++ b/src/backend/replacement/mod.rs
@@ -9,6 +9,10 @@
 
 use std::collections::BTreeMap;
 
+use incan_core::{
+    lang::surface::constructors::{ConstructorId, as_str as constructor_name},
+    python_floor_div_i64, python_mod_i64,
+};
 use incan_semantics_core::body_ir::{
     BinOp, Body, BodyIrModule, Callee, Constant, HelperOp, IterProtocol, LocalId, LocalOrigin, Operand, OwnershipFact,
     Place, Rvalue, Statement, StatementKind, UnOp,
@@ -37,25 +41,19 @@ pub enum ReplacementValue {
     Float(String),
     /// An Incan `None`/unit value.
     Unit,
-    /// A list retained only long enough to make a subsequent projection refusal attributable to that projection.
-    List(Vec<ReplacementValue>),
     /// A normalized builtin range iterator for the selected range-`for` control-flow case.
     Range { next: i64, end: i64, step: i64 },
 }
 
 impl ReplacementValue {
-    /// Render a deterministic source-observable result spelling for receipts and legacy runtime comparison.
+    /// Render a deterministic source-observable result spelling for replacement receipts and CLI output.
     pub fn observable_text(&self) -> String {
         match self {
             Self::Int(value) => value.to_string(),
             Self::Bool(value) => value.to_string(),
             Self::Str(value) => value.clone(),
             Self::Float(value) => value.clone(),
-            Self::Unit => "None".to_string(),
-            Self::List(values) => {
-                let items = values.iter().map(Self::observable_text).collect::<Vec<_>>();
-                format!("[{}]", items.join(", "))
-            }
+            Self::Unit => constructor_name(ConstructorId::None).to_string(),
             Self::Range { next, end, step } => format!("range({next}, {end}, {step})"),
         }
     }
@@ -72,6 +70,31 @@ pub struct OwnershipRead {
     pub last_use: bool,
 }
 
+/// Canonical, machine-readable rendering of one ownership read used in a replacement receipt.
+///
+/// This projection deliberately uses stable source offsets and fact labels rather than Rust `Debug` output, so
+/// receipt identities and CLI reports remain stable when implementation-only derives or field formatting change.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct OwnershipReadProjection {
+    /// Original Incan source span start byte offset.
+    pub span_start: usize,
+    /// Original Incan source span end byte offset.
+    pub span_end: usize,
+    /// Stable compiler-owned ownership fact label.
+    pub fact: &'static str,
+    /// Whether lowering marked this source read as its local's last use.
+    pub last_use: bool,
+}
+
+/// Canonical, machine-readable rendering of one Body-IR runtime requirement used in a replacement receipt.
+///
+/// `requirement` is a stable semantic label, not the Rust `Debug` representation of the internal enum.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct RuntimeRequirementProjection {
+    /// Stable semantic label for the runtime requirement.
+    pub requirement: String,
+}
+
 /// Successful replacement execution evidence for one free function.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReplacementExecution {
@@ -85,6 +108,31 @@ pub struct ReplacementExecution {
     pub runtime_requirements: Vec<AbiV0RuntimeRequirement>,
     /// Content identity of the actual Body-IR snapshot, ownership facts, requirements, and observed result.
     pub output_identity: String,
+}
+
+/// A free-function execution that has passed the bounded #988 profile validator.
+///
+/// The capability retains the exact typed Body IR, source-level function name, and concrete arguments that were
+/// validated. It lets selection/receipt code decide whether direct execution may proceed without rerunning profile
+/// validation or allowing an unvalidated Body IR body to reach the executor.
+pub struct ValidatedFreeFunctionExecution<'module, 'args> {
+    module: &'module BodyIrModule,
+    name: String,
+    args: &'args [ReplacementValue],
+}
+
+impl ReplacementExecution {
+    /// Return the stable ownership evidence bound into this execution's output identity and CLI report.
+    #[must_use]
+    pub fn ownership_evidence(&self) -> Vec<OwnershipReadProjection> {
+        ownership_read_projection(&self.ownership_reads)
+    }
+
+    /// Return the stable runtime-requirement evidence bound into this execution's output identity and CLI report.
+    #[must_use]
+    pub fn runtime_requirement_evidence(&self) -> Vec<RuntimeRequirementProjection> {
+        runtime_requirement_projection(&self.runtime_requirements)
+    }
 }
 
 /// A visible refusal or runtime outcome from the replacement executor.
@@ -135,6 +183,21 @@ pub enum ReplacementExecutionError {
 }
 
 impl ReplacementExecutionError {
+    /// Construct a typed, source-span-preserving refusal for an unsupported source-profile boundary.
+    #[must_use]
+    pub fn unsupported_profile(description: impl Into<String>, span: HirSourceSpan) -> Self {
+        unsupported(description, span)
+    }
+
+    /// Return the stable diagnostic code for this replacement outcome.
+    pub const fn diagnostic_code(&self) -> &'static str {
+        match self {
+            Self::MissingFunction { .. } | Self::ArgumentCount { .. } => "INCAN-R988-ENTRYPOINT",
+            Self::Unsupported { .. } => "INCAN-R988-UNSUPPORTED",
+            Self::RuntimeFailure { .. } => "INCAN-R988-RUNTIME",
+        }
+    }
+
     /// Return the original Incan source location when this outcome arose from Body IR.
     pub const fn primary_span(&self) -> Option<HirSourceSpan> {
         match self {
@@ -142,6 +205,37 @@ impl ReplacementExecutionError {
             Self::MissingFunction { .. } | Self::ArgumentCount { .. } => None,
         }
     }
+}
+
+/// Validate and prepare one Body-IR free function for later direct execution.
+///
+/// This side-effect-free boundary lets callers route availability through #986 selection and receipt logic before
+/// committing to execution. Only [`execute_prevalidated_free_function`] can consume the returned capability.
+pub fn prepare_free_function_execution<'module, 'args>(
+    module: &'module BodyIrModule,
+    name: &str,
+    args: &'args [ReplacementValue],
+) -> Result<ValidatedFreeFunctionExecution<'module, 'args>, ReplacementExecutionError> {
+    let body = named_free_function(module, name)?;
+    validate_single_function_module(module, name)?;
+    if body.is_generator() {
+        return Err(unsupported("generator body", body.span));
+    }
+    if body.param_locals.len() != args.len() {
+        return Err(ReplacementExecutionError::ArgumentCount {
+            name: name.to_string(),
+            expected: body.param_locals.len(),
+            actual: args.len(),
+        });
+    }
+    validate_scalar_arguments(args, body.span)?;
+    validate_binding_identity(body)?;
+    validate_block_profile(&body.block)?;
+    Ok(ValidatedFreeFunctionExecution {
+        module,
+        name: name.to_string(),
+        args,
+    })
 }
 
 /// Execute one named, free-function Body IR body with concrete scalar arguments.
@@ -153,39 +247,35 @@ pub fn execute_free_function(
     name: &str,
     args: &[ReplacementValue],
 ) -> Result<ReplacementExecution, ReplacementExecutionError> {
-    let body = module
-        .bodies
-        .iter()
-        .find(|body| body.name == name)
-        .ok_or_else(|| ReplacementExecutionError::MissingFunction { name: name.to_string() })?;
-    if body.is_generator() {
-        return Err(unsupported("generator body", body.span));
-    }
-    if body.param_locals.len() != args.len() {
-        return Err(ReplacementExecutionError::ArgumentCount {
-            name: name.to_string(),
-            expected: body.param_locals.len(),
-            actual: args.len(),
-        });
-    }
+    let execution = prepare_free_function_execution(module, name, args)?;
+    execute_prevalidated_free_function(execution)
+}
 
-    let mut executor = BodyExecutor::new(body, args);
+/// Execute one free function that has already passed [`prepare_free_function_execution`].
+///
+/// This consumes the validated capability, preserving the rule that callers select the source profile before the
+/// direct Body-IR executor observes a result.
+pub fn execute_prevalidated_free_function(
+    execution: ValidatedFreeFunctionExecution<'_, '_>,
+) -> Result<ReplacementExecution, ReplacementExecutionError> {
+    let body = named_free_function(execution.module, &execution.name)?;
+
+    let mut executor = BodyExecutor::new(body, execution.args);
     let flow = executor.execute_block(&body.block)?;
     let value = match flow {
-        Flow::Return(value) => value.unwrap_or(ReplacementValue::Unit),
+        Flow::Return(value) => match value {
+            Some(value) => value,
+            None => ReplacementValue::Unit,
+        },
         Flow::Next => ReplacementValue::Unit,
         Flow::Break | Flow::Continue => {
             return Err(unsupported("loop control outside a normalized loop", body.span));
         }
     };
+    ensure_scalar_result(&value, body.span)?;
     let body_snapshot = body.render_snapshot();
-    let ownership_summary = executor
-        .ownership_reads
-        .iter()
-        .map(|read| format!("{}:{}:{}", read.span.start, ownership_label(read.fact), read.last_use))
-        .collect::<Vec<_>>()
-        .join("|");
-    let requirements_summary = format!("{:?}", body.runtime_requirements);
+    let ownership_summary = canonical_ownership_summary(&executor.ownership_reads);
+    let requirements_summary = canonical_runtime_requirements_summary(&body.runtime_requirements);
     let output_identity = digest_output(&[
         body_snapshot.as_str(),
         value.observable_text().as_str(),
@@ -201,10 +291,194 @@ pub fn execute_free_function(
     })
 }
 
+/// Locate the requested free-function body without inventing a fallback entrypoint.
+fn named_free_function<'a>(module: &'a BodyIrModule, name: &str) -> Result<&'a Body, ReplacementExecutionError> {
+    module
+        .bodies
+        .iter()
+        .find(|body| body.name == name)
+        .ok_or_else(|| ReplacementExecutionError::MissingFunction { name: name.to_string() })
+}
+
+/// Reject any additional free function because this first CLI profile admits exactly one selected entrypoint body.
+fn validate_single_function_module(module: &BodyIrModule, name: &str) -> Result<(), ReplacementExecutionError> {
+    if let Some(extra) = module.bodies.iter().find(|body| body.name != name) {
+        return Err(unsupported(
+            format!(
+                "additional free function `{}` outside the selected replacement entrypoint",
+                extra.name
+            ),
+            extra.span,
+        ));
+    }
+    Ok(())
+}
+
+/// Reject non-scalar direct API arguments before they can widen the first replacement profile.
+fn validate_scalar_arguments(args: &[ReplacementValue], span: HirSourceSpan) -> Result<(), ReplacementExecutionError> {
+    for argument in args {
+        if !matches!(
+            argument,
+            ReplacementValue::Int(_) | ReplacementValue::Bool(_) | ReplacementValue::Str(_) | ReplacementValue::Unit
+        ) {
+            return Err(unsupported(
+                format!("{} argument in the scalar replacement profile", value_kind(argument)),
+                span,
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Reject repeated user-binding spellings because Body IR v0 cannot distinguish shadowing from reassignment safely.
+fn validate_binding_identity(body: &Body) -> Result<(), ReplacementExecutionError> {
+    let mut declared = BTreeMap::new();
+    for local in &body.locals {
+        if !matches!(local.origin, LocalOrigin::Parameter | LocalOrigin::UserBinding) {
+            continue;
+        }
+        let Some(name) = local.name.as_deref() else {
+            continue;
+        };
+        if declared.insert(name, local.span).is_some() {
+            return Err(unsupported(
+                format!(
+                    "repeated user binding `{name}` (lexical shadowing or reassignment); Body IR v0 does not yet carry binding-equivalence facts for direct execution"
+                ),
+                local.span,
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Validate every statement in one normalized Body-IR block before the direct executor starts.
+fn validate_block_profile(block: &incan_semantics_core::body_ir::Block) -> Result<(), ReplacementExecutionError> {
+    for statement in &block.stmts {
+        validate_statement_profile(statement)?;
+    }
+    Ok(())
+}
+
+/// Validate one statement against the deliberately narrow #988 direct-execution profile.
+fn validate_statement_profile(statement: &Statement) -> Result<(), ReplacementExecutionError> {
+    match &statement.kind {
+        StatementKind::Assign { place, rvalue } => {
+            validate_bare_local(place, statement.span)?;
+            validate_rvalue_profile(rvalue, statement.span)
+        }
+        StatementKind::Call {
+            destination,
+            callee,
+            args,
+            may_panic: _,
+        } => {
+            let destination = destination
+                .as_ref()
+                .ok_or_else(|| unsupported("discarded call result", statement.span))?;
+            validate_bare_local(destination, statement.span)?;
+            validate_call_profile(callee, args, statement.span)
+        }
+        StatementKind::Drop { .. } => Ok(()),
+        StatementKind::If {
+            cond,
+            then_block,
+            else_block,
+        } => {
+            validate_operand_profile(cond, statement.span)?;
+            validate_block_profile(then_block)?;
+            if let Some(else_block) = else_block {
+                validate_block_profile(else_block)?;
+            }
+            Ok(())
+        }
+        StatementKind::Loop { body } => validate_block_profile(body),
+        StatementKind::Break { value: Some(_) } => Err(unsupported("value-carrying loop break", statement.span)),
+        StatementKind::Break { value: None } | StatementKind::Continue => Ok(()),
+        StatementKind::Return { value } => value
+            .as_ref()
+            .map_or(Ok(()), |value| validate_operand_profile(value, statement.span)),
+        StatementKind::Assert {
+            cond,
+            message,
+            may_panic: _,
+        } => {
+            validate_operand_profile(cond, statement.span)?;
+            message
+                .as_ref()
+                .map_or(Ok(()), |message| validate_operand_profile(message, statement.span))
+        }
+        StatementKind::Expr { value } => validate_operand_profile(value, statement.span),
+        StatementKind::IterNext {
+            destination,
+            iterator,
+            protocol: IterProtocol::Builtin,
+        } => {
+            validate_bare_local(destination, statement.span)?;
+            validate_operand_profile(iterator, statement.span)
+        }
+        StatementKind::Yield { .. } => Err(unsupported("generator yield", statement.span)),
+        StatementKind::TryPropagate { .. } => Err(unsupported("try propagation", statement.span)),
+        StatementKind::IterNext { .. } => Err(unsupported("non-range iteration", statement.span)),
+        StatementKind::Unsupported { description } => Err(unsupported(description, statement.span)),
+    }
+}
+
+/// Validate one Body-IR call before the executor dispatches it.
+fn validate_call_profile(
+    callee: &Callee,
+    args: &[Operand],
+    span: HirSourceSpan,
+) -> Result<(), ReplacementExecutionError> {
+    let supported = match callee {
+        Callee::Helper(HelperOp::StrConcat) => true,
+        Callee::Function(name) => name == "range",
+        Callee::Helper(_) | Callee::Method(_) => false,
+    };
+    if !supported {
+        return Err(unsupported(format!("call to {}", callee_label(callee)), span));
+    }
+    for arg in args {
+        validate_operand_profile(arg, span)?;
+    }
+    Ok(())
+}
+
+/// Validate one rvalue before it can be evaluated by the bounded executor.
+fn validate_rvalue_profile(rvalue: &Rvalue, span: HirSourceSpan) -> Result<(), ReplacementExecutionError> {
+    match rvalue {
+        Rvalue::Use(operand) | Rvalue::UnaryOp(_, operand) => validate_operand_profile(operand, span),
+        Rvalue::BinaryOp(_, left, right) => {
+            validate_operand_profile(left, span)?;
+            validate_operand_profile(right, span)
+        }
+        Rvalue::Aggregate(kind, _) => Err(unsupported(format!("{} aggregate", aggregate_label(kind)), span)),
+        Rvalue::Format(_) => Err(unsupported("f-string", span)),
+        Rvalue::Closure { .. } => Err(unsupported("callable value", span)),
+        Rvalue::Match { .. } => Err(unsupported("match expression", span)),
+    }
+}
+
+/// Validate a single operand's place shape and compiler-owned ownership decision.
+fn validate_operand_profile(operand: &Operand, span: HirSourceSpan) -> Result<(), ReplacementExecutionError> {
+    let Operand::Place(place_operand) = operand else {
+        return Ok(());
+    };
+    validate_bare_local(&place_operand.place, span)?;
+    if matches!(place_operand.fact, OwnershipFact::Unknown) {
+        return Err(unsupported("unknown ownership fact", span));
+    }
+    Ok(())
+}
+
+/// Reject projections at the profile boundary while preserving the statement's original source authority.
+fn validate_bare_local(place: &Place, span: HirSourceSpan) -> Result<(), ReplacementExecutionError> {
+    bare_local(place, span).map(|_| ())
+}
+
 /// Mutable interpreter state for one Body-IR execution.
 struct BodyExecutor {
     locals: BTreeMap<LocalId, ReplacementValue>,
-    local_bindings: BTreeMap<LocalId, (Option<String>, LocalOrigin)>,
     ownership_reads: Vec<OwnershipRead>,
     steps: usize,
 }
@@ -213,14 +487,8 @@ impl BodyExecutor {
     /// Bind the already-typechecked call arguments to their Body-IR parameter locals.
     fn new(body: &Body, args: &[ReplacementValue]) -> Self {
         let locals = body.param_locals.iter().copied().zip(args.iter().cloned()).collect();
-        let local_bindings = body
-            .locals
-            .iter()
-            .map(|local| (local.id, (local.name.clone(), local.origin)))
-            .collect();
         Self {
             locals,
-            local_bindings,
             ownership_reads: Vec::new(),
             steps: 0,
         }
@@ -407,28 +675,13 @@ impl BodyExecutor {
         Ok(Flow::Next)
     }
 
-    /// Assign a Body-IR local while retaining the first profile's source-binding equivalence.
+    /// Assign exactly the authoritative Body-IR `LocalId` selected by lowering.
     ///
-    /// Body IR v0 records source assignment sites as fresh locals even though later condition reads can still point
-    /// at the original local. For the selected free-function profile, equal user-binding names denote the same
-    /// source binding; update those aliases together rather than allowing a generated local id to create stale
-    /// source reads. Shadowing remains unsupported until Body IR carries an explicit binding-equivalence fact.
+    /// The profile preflight rejects repeated user-binding names rather than reconstructing scope equivalence from
+    /// spelling. Reassignment is therefore refused until Body IR carries binding-equivalence facts; no name-based
+    /// aliasing is permitted here.
     fn assign_local(&mut self, local: LocalId, value: ReplacementValue) {
-        let Some((Some(name), LocalOrigin::UserBinding)) = self.local_bindings.get(&local) else {
-            self.locals.insert(local, value);
-            return;
-        };
-        let aliases = self
-            .local_bindings
-            .iter()
-            .filter_map(|(candidate, (candidate_name, origin))| {
-                (matches!(origin, LocalOrigin::UserBinding) && candidate_name.as_deref() == Some(name.as_str()))
-                    .then_some(*candidate)
-            })
-            .collect::<Vec<_>>();
-        for alias in aliases {
-            self.locals.insert(alias, value.clone());
-        }
+        self.locals.insert(local, value);
     }
 
     /// Execute one normalized Body-IR loop and propagate only non-local control flow outward.
@@ -462,11 +715,6 @@ impl BodyExecutor {
             Rvalue::Use(operand) => self.evaluate_operand(operand, span),
             Rvalue::UnaryOp(operator, operand) => self.evaluate_unary(*operator, operand, span),
             Rvalue::BinaryOp(operator, left, right) => self.evaluate_binary(*operator, left, right, span),
-            Rvalue::Aggregate(incan_semantics_core::body_ir::AggregateKind::List, values) => values
-                .iter()
-                .map(|value| self.evaluate_operand(value, span))
-                .collect::<Result<Vec<_>, _>>()
-                .map(ReplacementValue::List),
             Rvalue::Aggregate(kind, _) => Err(unsupported(format!("{} aggregate", aggregate_label(kind)), span)),
             Rvalue::Format(_) => Err(unsupported("f-string", span)),
             Rvalue::Closure { .. } => Err(unsupported("callable value", span)),
@@ -519,10 +767,10 @@ impl BodyExecutor {
                 Err(runtime_failure("division or modulo by zero".to_string(), span))
             }
             (BinOp::FloorDiv, ReplacementValue::Int(left), ReplacementValue::Int(right)) => {
-                Ok(ReplacementValue::Int(left.div_euclid(right)))
+                checked_python_floor_division(left, right, span)
             }
             (BinOp::Mod, ReplacementValue::Int(left), ReplacementValue::Int(right)) => {
-                Ok(ReplacementValue::Int(left.rem_euclid(right)))
+                Ok(ReplacementValue::Int(python_mod_i64(left, right)))
             }
             (BinOp::Eq, left, right) => Ok(ReplacementValue::Bool(left == right)),
             (BinOp::Ne, left, right) => Ok(ReplacementValue::Bool(left != right)),
@@ -676,6 +924,87 @@ fn runtime_failure(detail: String, span: HirSourceSpan) -> ReplacementExecutionE
     }
 }
 
+/// Apply Python integer floor division while keeping an unrepresentable direct-execution quotient visible.
+fn checked_python_floor_division(
+    left: i64,
+    right: i64,
+    span: HirSourceSpan,
+) -> Result<ReplacementValue, ReplacementExecutionError> {
+    if left == i64::MIN && right == -1 {
+        return Err(runtime_failure("integer division overflow".to_string(), span));
+    }
+    Ok(ReplacementValue::Int(python_floor_div_i64(left, right)))
+}
+
+/// Reject a return value that would widen the first replacement profile beyond scalar source observables.
+fn ensure_scalar_result(value: &ReplacementValue, span: HirSourceSpan) -> Result<(), ReplacementExecutionError> {
+    match value {
+        ReplacementValue::Int(_) | ReplacementValue::Bool(_) | ReplacementValue::Str(_) | ReplacementValue::Unit => {
+            Ok(())
+        }
+        _ => Err(unsupported(
+            format!("returning {} from the scalar replacement profile", value_kind(value)),
+            span,
+        )),
+    }
+}
+
+/// Project ownership reads into the stable evidence shape shared by identities and CLI reports.
+fn ownership_read_projection(reads: &[OwnershipRead]) -> Vec<OwnershipReadProjection> {
+    reads
+        .iter()
+        .map(|read| OwnershipReadProjection {
+            span_start: read.span.start,
+            span_end: read.span.end,
+            fact: ownership_label(read.fact),
+            last_use: read.last_use,
+        })
+        .collect()
+}
+
+/// Project Body-IR runtime requirements into stable semantic labels shared by identities and CLI reports.
+fn runtime_requirement_projection(requirements: &[AbiV0RuntimeRequirement]) -> Vec<RuntimeRequirementProjection> {
+    requirements
+        .iter()
+        .map(|requirement| RuntimeRequirementProjection {
+            requirement: runtime_requirement_label(requirement),
+        })
+        .collect()
+}
+
+/// Render ownership evidence as one deterministic digest component without relying on `Debug` formatting.
+fn canonical_ownership_summary(reads: &[OwnershipRead]) -> String {
+    ownership_read_projection(reads)
+        .into_iter()
+        .map(|read| {
+            format!(
+                "span={}..{};fact={};last_use={}",
+                read.span_start, read.span_end, read.fact, read.last_use
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("|")
+}
+
+/// Render runtime requirements as one deterministic digest component without relying on `Debug` formatting.
+fn canonical_runtime_requirements_summary(requirements: &[AbiV0RuntimeRequirement]) -> String {
+    runtime_requirement_projection(requirements)
+        .into_iter()
+        .map(|requirement| requirement.requirement)
+        .collect::<Vec<_>>()
+        .join("|")
+}
+
+/// Render one runtime requirement with the semantic labels used in replacement evidence.
+fn runtime_requirement_label(requirement: &AbiV0RuntimeRequirement) -> String {
+    match requirement {
+        AbiV0RuntimeRequirement::RuntimeHelper(name) => format!("runtime_helper({name})"),
+        AbiV0RuntimeRequirement::HostedStd => "hosted_std".to_string(),
+        AbiV0RuntimeRequirement::Allocator => "allocator".to_string(),
+        AbiV0RuntimeRequirement::PanicStrategy => "panic_strategy".to_string(),
+    }
+}
+
 /// Render one ownership fact without relying on generated-Rust implementation details.
 const fn ownership_label(fact: OwnershipFact) -> &'static str {
     match fact {
@@ -759,7 +1088,6 @@ const fn value_kind(value: &ReplacementValue) -> &'static str {
         ReplacementValue::Str(_) => "str",
         ReplacementValue::Float(_) => "float",
         ReplacementValue::Unit => "unit",
-        ReplacementValue::List(_) => "list",
         ReplacementValue::Range { .. } => "range",
     }
 }

--- a/src/backend/selection.rs
+++ b/src/backend/selection.rs
@@ -43,7 +43,7 @@ pub const LEGACY_BACKEND_REVISION: u32 = 1;
 ///
 /// #653 owns actual Body IR execution. This constant exists now so that landing #653 only needs
 /// to bump a revision and flip [`BackendKind::is_implemented`], not invent a new schema field.
-pub const REPLACEMENT_BACKEND_REVISION: u32 = 0;
+pub const REPLACEMENT_BACKEND_REVISION: u32 = 1;
 
 /// Compiler backend that can produce or execute a build unit.
 ///
@@ -54,21 +54,20 @@ pub const REPLACEMENT_BACKEND_REVISION: u32 = 0;
 pub enum BackendKind {
     /// The current Rust-source-emission pipeline (`IrCodegen`, `src/backend/ir/`).
     Legacy,
-    /// The Body IR replacement backend tracked by #653. Not yet implemented: selecting it always
-    /// produces an explicit, visible outcome (a refusal or a declared fallback), never a silent
-    /// legacy execution.
+    /// The Body IR replacement backend tracked by #653. Its first executable #988 profile is intentionally partial;
+    /// unsupported source is refused visibly instead of falling back to the legacy backend.
     Replacement,
 }
 
 impl BackendKind {
     /// Whether this backend can actually execute a compilation today.
     ///
-    /// Only [`BackendKind::Legacy`] is implemented until #653 lands. Callers must consult this
-    /// (or pass the equivalent fact into [`resolve_execution`]) instead of assuming a requested
-    /// backend can run.
+    /// Both backends have an executable implementation. The replacement backend still accepts only its declared
+    /// #988 Body-IR profile, so callers must validate source support at the replacement boundary rather than using
+    /// this capability bit as a claim of full language coverage.
     #[must_use]
     pub fn is_implemented(self) -> bool {
-        matches!(self, BackendKind::Legacy)
+        matches!(self, BackendKind::Legacy | BackendKind::Replacement)
     }
 }
 
@@ -609,10 +608,11 @@ mod tests {
     }
 
     #[test]
-    fn declared_fallback_to_an_unavailable_target_still_refuses() {
-        // A fallback target that is itself unimplemented must never be reported as "executed":
-        // otherwise a build that actually ran legacy could claim the replacement backend
-        // executed cleanly with no fallback (`executed_backend == selected_backend`).
+    fn declared_fallback_to_the_available_replacement_target_resolves_explicitly() -> Result<(), BackendSelectionError>
+    {
+        // #988 makes the replacement implementation available for its declared partial profile. A caller that has
+        // independently found the initially selected execution unavailable may therefore resolve an explicitly
+        // declared replacement target, but source-profile validation still belongs to the replacement executor.
         let selection = select_backend(
             BackendKind::Replacement,
             true,
@@ -620,13 +620,9 @@ mod tests {
             "sha256:source",
             FallbackPolicy::AllowTo(BackendKind::Replacement),
         );
-        let Err(error) = resolve_execution(&selection, false) else {
-            panic!("a fallback target that is itself unavailable must still be refused");
-        };
-        match error {
-            BackendSelectionError::Refused { backend, .. } => assert_eq!(backend, BackendKind::Replacement),
-            other => panic!("expected Refused, got {other:?}"),
-        }
+        let resolved = resolve_execution(&selection, false)?;
+        assert_eq!(resolved, BackendKind::Replacement);
+        Ok(())
     }
 
     #[test]

--- a/src/backend/selection.rs
+++ b/src/backend/selection.rs
@@ -2,11 +2,10 @@
 //!
 //! The v0.6 programme tracked by #652 introduces a second compiler backend (the Body IR
 //! "replacement" backend, tracked by #653) alongside the current Rust-source-emission backend
-//! (`IrCodegen`, `src/backend/ir/`, referred to here as "legacy"). Until the replacement backend
-//! actually lands, a build must still be able to declare, record, and report which backend it
-//! intended to use and which backend it actually ran — so that a legacy result is never mistaken
-//! for a replacement-backend result, and so that a caller who explicitly asks for the replacement
-//! backend gets a visible outcome instead of a silent legacy execution.
+//! (`IrCodegen`, `src/backend/ir/`, referred to here as "legacy"). #988 supplies a deliberately partial direct
+//! Body-IR profile; the selection boundary still declares and records which backend was intended and actually ran,
+//! so a legacy result is never mistaken for replacement execution and an unsupported replacement source remains a
+//! visible refusal rather than a silent legacy execution.
 //!
 //! This module owns two boundary types:
 //!
@@ -39,11 +38,17 @@ pub const BACKEND_SELECTION_SCHEMA_VERSION: u32 = 1;
 /// consumer keying reuse on this revision knows to invalidate.
 pub const LEGACY_BACKEND_REVISION: u32 = 1;
 
-/// Implementation revision of the not-yet-implemented replacement backend.
+/// Implementation revision of the partial Body-IR replacement backend.
 ///
-/// #653 owns actual Body IR execution. This constant exists now so that landing #653 only needs
-/// to bump a revision and flip [`BackendKind::is_implemented`], not invent a new schema field.
+/// #988 provides its first direct-execution profile. Bump this when that profile's observable execution or
+/// receipt-bound semantic evidence changes for previously accepted source.
 pub const REPLACEMENT_BACKEND_REVISION: u32 = 1;
+
+/// Canonical reason for a requested shadow comparison that has no source-observable legacy comparator yet.
+///
+/// This deliberately names the missing comparison boundary, not implementation availability: a direct replacement
+/// executor exists for #988's narrow profile, while generated Rust remains inspection-only and cannot prove parity.
+pub const SHADOW_COMPARISON_UNAVAILABLE_REASON: &str = "no source-observable legacy/replacement comparator is implemented for this profile; generated Rust is not semantic proof";
 
 /// Compiler backend that can produce or execute a build unit.
 ///
@@ -121,8 +126,8 @@ pub enum FallbackPolicy {
 pub enum ShadowComparisonState {
     /// No shadow comparison was requested for this compilation.
     NotRequested,
-    /// A shadow comparison was requested but could not run, with the concrete reason (for
-    /// example, the replacement backend is not implemented yet).
+    /// A shadow comparison was requested but could not run, with the concrete reason (for example, the active
+    /// profile has no source-observable legacy/replacement comparator).
     Unavailable { reason: String },
     /// A shadow comparison ran and the replacement backend's output matched the executed
     /// backend's output under the compilation's comparison rules.
@@ -130,6 +135,20 @@ pub enum ShadowComparisonState {
     /// A shadow comparison ran and the outputs diverged, with a human-readable summary of the
     /// difference.
     Diverged { detail: String },
+}
+
+/// Produce the canonical shadow state for a request that cannot yet run a source-observable comparison.
+///
+/// This preserves the distinction between no request and an explicitly requested but non-green unavailable result.
+#[must_use]
+pub fn unavailable_shadow_comparison(shadow_requested: bool) -> ShadowComparisonState {
+    if shadow_requested {
+        ShadowComparisonState::Unavailable {
+            reason: SHADOW_COMPARISON_UNAVAILABLE_REASON.to_string(),
+        }
+    } else {
+        ShadowComparisonState::NotRequested
+    }
 }
 
 /// Whether the backend that actually executed differed from the one declared in the selection.
@@ -560,7 +579,7 @@ mod tests {
         assert_eq!(selection.compatibility_profile, CompatibilityProfile::Partial);
 
         let Err(error) = resolve_execution(&selection, false) else {
-            panic!("replacement backend is not implemented yet; selection must be refused");
+            panic!("an unavailable replacement source profile must be refused");
         };
         match error {
             BackendSelectionError::Refused { backend, .. } => assert_eq!(backend, BackendKind::Replacement),
@@ -631,9 +650,7 @@ mod tests {
         assert!(selection.shadow_requested);
 
         let executed = resolve_execution(&selection, true)?;
-        let shadow_comparison = ShadowComparisonState::Unavailable {
-            reason: "replacement backend not implemented yet (#653)".to_string(),
-        };
+        let shadow_comparison = unavailable_shadow_comparison(selection.shadow_requested);
         let receipt = finalize_receipt(&selection, executed, "sha256:output", shadow_comparison.clone(), 1)?;
         assert_eq!(receipt.shadow_comparison, shadow_comparison);
         receipt.verify_identity()?;

--- a/src/cli/commands/build.rs
+++ b/src/cli/commands/build.rs
@@ -15,14 +15,17 @@ use std::time::{Duration, Instant};
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 
+use incan_semantics_core::HirSourceSpan;
 use serde::{Deserialize, Serialize};
 
 use crate::backend::project::generator::GENERATED_CARGO_TARGET_DIR_ENV;
 use crate::backend::project::runner::resolved_cargo_executable;
-use crate::backend::replacement::execute_free_function;
+use crate::backend::replacement::{
+    ReplacementExecutionError, execute_prevalidated_free_function, prepare_free_function_execution,
+};
 use crate::backend::selection::{
     BackendExecutionReceipt, BackendKind, BackendSelection, FallbackOutcome, FallbackPolicy, ShadowComparisonState,
-    digest_output, finalize_receipt, resolve_execution, select_backend,
+    digest_output, finalize_receipt, resolve_execution, select_backend, unavailable_shadow_comparison,
 };
 use crate::backend::{IrCodegen, ProjectGenerator};
 use crate::cli::{CliError, CliResult, ExitCode};
@@ -2325,16 +2328,10 @@ fn multi_file_output_identity(main_code: &str, rust_modules: &HashMap<Vec<String
 
 /// Shadow-comparison state for one build's backend execution receipt.
 ///
-/// The replacement backend is not implemented yet (#653), so a requested shadow comparison is
-/// always explicitly `Unavailable` today rather than silently `NotRequested`.
+/// The direct #988 executor has no source-observable legacy comparator yet, so a requested shadow comparison is
+/// explicitly `Unavailable` rather than silently `NotRequested` or inferred from generated Rust.
 fn backend_shadow_comparison(selection: &BackendSelection) -> ShadowComparisonState {
-    if selection.shadow_requested {
-        ShadowComparisonState::Unavailable {
-            reason: "replacement backend not implemented yet (#653)".to_string(),
-        }
-    } else {
-        ShadowComparisonState::NotRequested
-    }
+    unavailable_shadow_comparison(selection.shadow_requested)
 }
 
 /// Declare and resolve a backend selection for one build, before codegen runs (#986).
@@ -2422,6 +2419,13 @@ fn report_backend_fallback(receipt: &crate::backend::selection::BackendExecution
 /// boundary (#986). Oven and other clients consume this without reading private HIR/Body IR.
 const DEFAULT_BACKEND_RECEIPT_RELATIVE_PATH: &str = ".incan/backend/receipt.json";
 
+/// Stable schema marker for the direct Body-IR replacement execution report.
+///
+/// This is distinct from the Oven build-report schema because this path has no generated Rust, artifacts, or Oven
+/// plan to report. Consumers must inspect its backend receipt and direct-execution evidence rather than treating it
+/// as a partial legacy build report.
+const REPLACEMENT_EXECUTION_REPORT_SCHEMA_VERSION: &str = "incan.replacement_execution.v0";
+
 /// Return the compiler-owned project-relative destination for a backend-selection execution receipt.
 fn default_backend_receipt_path(project_root: &Path) -> PathBuf {
     project_root.join(DEFAULT_BACKEND_RECEIPT_RELATIVE_PATH)
@@ -2452,6 +2456,77 @@ fn write_backend_receipt(receipt: &crate::backend::selection::BackendExecutionRe
             path.display()
         ))
     })
+}
+
+/// Convert a typed replacement refusal into the CLI's stable source-location presentation.
+///
+/// `CliError` predates typed frontend diagnostics and carries display text only, so this adapter retains the
+/// replacement diagnostic code, entrypoint path, and original Body-IR span rather than discarding them at the CLI
+/// boundary.
+fn replacement_profile_cli_error(error: ReplacementExecutionError, entrypoint: &Path) -> CliError {
+    match error.primary_span() {
+        Some(span) => CliError::failure(format!(
+            "{}: {error}\nprimary Incan source location: {}:{}..{}",
+            error.diagnostic_code(),
+            entrypoint.display(),
+            span.start,
+            span.end
+        )),
+        None => CliError::failure(format!("{}: {error}", error.diagnostic_code())),
+    }
+}
+
+/// Return the first unsupported source-module boundary with its original Incan source span.
+fn replacement_module_profile_error(program: &crate::frontend::ast::Program) -> Option<ReplacementExecutionError> {
+    if let Some(rust_module) = &program.rust_module_path {
+        return Some(ReplacementExecutionError::unsupported_profile(
+            "Rust interop `rust.module` directive",
+            HirSourceSpan::new(rust_module.span.start, rust_module.span.end),
+        ));
+    }
+    program.declarations.iter().find_map(|declaration| {
+        if matches!(declaration.node, Declaration::Function(_) | Declaration::Docstring(_)) {
+            return None;
+        }
+        let description = if matches!(declaration.node, Declaration::Import(_)) {
+            "import declaration"
+        } else {
+            "non-function top-level declaration"
+        };
+        Some(ReplacementExecutionError::unsupported_profile(
+            description,
+            HirSourceSpan::new(declaration.span.start, declaration.span.end),
+        ))
+    })
+}
+
+/// Refuse one unsupported replacement profile through the canonical #986 selection boundary.
+///
+/// The resolver must reject the availability claim before the profile diagnostic reaches the CLI. If a future
+/// fallback policy resolves it anyway, that is a separate, visible failure rather than implicit legacy execution.
+fn refuse_replacement_profile<T>(
+    selection: &BackendSelection,
+    error: ReplacementExecutionError,
+    entrypoint: &Path,
+) -> CliResult<T> {
+    match resolve_execution(selection, false) {
+        Err(_) => Err(replacement_profile_cli_error(error, entrypoint)),
+        Ok(executed) => Err(CliError::failure(format!(
+            "{}: replacement source-profile refusal cannot execute `{executed:?}` because this CLI exposes no receipt-bound fallback path",
+            error.diagnostic_code()
+        ))),
+    }
+}
+
+/// Resolve an available direct replacement selection through the canonical #986 boundary.
+fn resolve_available_replacement_execution(selection: &BackendSelection) -> CliResult<BackendKind> {
+    match resolve_execution(selection, true) {
+        Ok(BackendKind::Replacement) => Ok(BackendKind::Replacement),
+        Ok(executed) => Err(CliError::failure(format!(
+            "replacement profile selection resolved unexpected backend `{executed:?}`"
+        ))),
+        Err(error) => Err(CliError::failure(error.to_string())),
+    }
 }
 
 /// Execute the first #988 replacement-backend profile directly from typed Body IR.
@@ -2492,15 +2567,15 @@ fn build_replacement_file_report(
             entrypoint.display()
         ))
     })?;
-    if program.rust_module_path.is_some()
-        || program
-            .declarations
-            .iter()
-            .any(|declaration| !matches!(declaration.node, Declaration::Function(_) | Declaration::Docstring(_)))
-    {
-        return Err(CliError::failure(
-            "replacement backend #988 supports one source-only free-function module; imports, packages, Rust interop, models, and top-level values are refused",
-        ));
+    let selection = select_backend(
+        options.backend.requested,
+        options.backend.explicit,
+        options.backend.shadow,
+        digest_output(&[source.as_str()]),
+        options.backend.fallback_policy,
+    );
+    if let Some(error) = replacement_module_profile_error(&program) {
+        return refuse_replacement_profile(&selection, error, &entrypoint);
     }
     let module_path = vec![
         entrypoint
@@ -2518,29 +2593,14 @@ fn build_replacement_file_report(
         ))
     })?;
     let body_ir = build_body_ir_module_v0(&program, &module_path, checker.type_info());
-    let selection = select_backend(
-        options.backend.requested,
-        options.backend.explicit,
-        options.backend.shadow,
-        digest_output(&[source.as_str()]),
-        options.backend.fallback_policy,
-    );
-    let executed = resolve_execution(&selection, BackendKind::Replacement.is_implemented())
-        .map_err(|error| CliError::failure(error.to_string()))?;
-    if executed != BackendKind::Replacement {
-        return Err(CliError::failure(
-            "replacement backend #988 refuses declared fallback execution; run `--backend legacy` explicitly for the legacy backend",
-        ));
-    }
-    let execution =
-        execute_free_function(&body_ir, "main", &[]).map_err(|error| CliError::failure(error.to_string()))?;
-    let shadow_comparison = if selection.shadow_requested {
-        ShadowComparisonState::Unavailable {
-            reason: "#988's source-only free-function build profile has no source-observable legacy entrypoint; shadow comparison is unavailable rather than inferred from generated Rust".to_string(),
-        }
-    } else {
-        ShadowComparisonState::NotRequested
+    let execution_plan = match prepare_free_function_execution(&body_ir, "main", &[]) {
+        Ok(plan) => plan,
+        Err(error) => return refuse_replacement_profile(&selection, error, &entrypoint),
     };
+    let executed = resolve_available_replacement_execution(&selection)?;
+    let execution = execute_prevalidated_free_function(execution_plan)
+        .map_err(|error| replacement_profile_cli_error(error, &entrypoint))?;
+    let shadow_comparison = unavailable_shadow_comparison(selection.shadow_requested);
     let backend_receipt = finalize_receipt(
         &selection,
         executed,
@@ -2563,13 +2623,18 @@ fn build_replacement_file_report(
         );
     }
     Ok(serde_json::json!({
+        "schema_version": REPLACEMENT_EXECUTION_REPORT_SCHEMA_VERSION,
+        "compiler_version": crate::version::INCAN_VERSION,
+        "status": "success",
+        "mode": "executable",
+        "entrypoint": entrypoint,
         "backend": backend_receipt,
         "replacement_execution": {
             "result": execution.value.observable_text(),
             "output_identity": execution.output_identity,
             "body_snapshot": execution.body_snapshot,
-            "ownership_read_count": execution.ownership_reads.len(),
-            "runtime_requirements": format!("{:?}", execution.runtime_requirements),
+            "ownership_reads": execution.ownership_evidence(),
+            "runtime_requirements": execution.runtime_requirement_evidence(),
         },
         "timings_ms": { "total": elapsed_ms(start) },
     }))
@@ -13800,7 +13865,10 @@ mod tests {
             fallback_policy: FallbackPolicy::Refuse,
         };
         assert!(!replacement_refusal.allows_completed_output_reuse());
-        assert!(ensure_backend_request_available(&replacement_refusal).is_err());
+        assert!(
+            ensure_backend_request_available(&replacement_refusal).is_ok(),
+            "the capability preflight recognizes the partial executor; source-profile support is resolved later through the source-bound selection"
+        );
 
         let declared_fallback = BackendSelectionOptions {
             requested: BackendKind::Replacement,

--- a/src/cli/commands/build.rs
+++ b/src/cli/commands/build.rs
@@ -19,6 +19,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::backend::project::generator::GENERATED_CARGO_TARGET_DIR_ENV;
 use crate::backend::project::runner::resolved_cargo_executable;
+use crate::backend::replacement::execute_free_function;
 use crate::backend::selection::{
     BackendExecutionReceipt, BackendKind, BackendSelection, FallbackOutcome, FallbackPolicy, ShadowComparisonState,
     digest_output, finalize_receipt, resolve_execution, select_backend,
@@ -33,6 +34,7 @@ use crate::frontend::api_metadata::{
     materialize_checked_api_public_namespaces, validate_checked_api_docstrings,
 };
 use crate::frontend::ast::{Declaration, Decorator, Expr, ImportKind, Literal, Span, Spanned, Statement, Visibility};
+use crate::frontend::body_ir::build_body_ir_module_v0;
 use crate::frontend::contract_metadata::{ContractMetadataPackage, read_project_model_bundles};
 use crate::frontend::library_exports::{CheckedExportKind, CheckedNamedExport, collect_checked_public_exports};
 use crate::frontend::library_manifest_index::{
@@ -48,7 +50,7 @@ use crate::frontend::registry_metadata::{
     collect_checked_registry_metadata, materialize_registry_reexport_projections,
 };
 use crate::frontend::typechecker::stdlib_loader::StdlibAstCache;
-use crate::frontend::{diagnostics, typechecker};
+use crate::frontend::{diagnostics, lexer, parser, typechecker};
 use crate::generated_cache::resolve_generated_cargo_target;
 #[cfg(feature = "rust_inspect")]
 use crate::library_manifest::LibraryRustAbi;
@@ -2450,6 +2452,127 @@ fn write_backend_receipt(receipt: &crate::backend::selection::BackendExecutionRe
             path.display()
         ))
     })
+}
+
+/// Execute the first #988 replacement-backend profile directly from typed Body IR.
+///
+/// This intentionally has no `ProjectGenerator`, Oven, or generated-Rust path. It accepts only one source module
+/// containing free functions and executes its zero-argument `main` body through the replacement executor. A
+/// requested replacement build therefore either records a replacement receipt over a real Body-IR result or fails
+/// visibly at the original Incan span; it can never reach `IrCodegen` as an implicit compatibility fallback.
+fn build_replacement_file_report(
+    file_path: &str,
+    options: BuildCommandOptions,
+    report_options: &BuildReportOptions,
+) -> CliResult<serde_json::Value> {
+    reject_normal_cargo_controls(&options.cargo_policy, options.generated_cargo_target_dir.as_ref())?;
+    let start = Instant::now();
+    let entrypoint = if Path::new(file_path).is_absolute() {
+        PathBuf::from(file_path)
+    } else {
+        env::current_dir()
+            .map_err(|error| CliError::failure(format!("failed to determine current directory: {error}")))?
+            .join(file_path)
+    };
+    let source = fs::read_to_string(&entrypoint).map_err(|error| {
+        CliError::failure(format!(
+            "failed to read replacement entrypoint {}: {error}",
+            entrypoint.display()
+        ))
+    })?;
+    let tokens = lexer::lex(&source).map_err(|errors| {
+        CliError::failure(format!(
+            "replacement backend could not lex {}: {errors:?}",
+            entrypoint.display()
+        ))
+    })?;
+    let program = parser::parse(&tokens).map_err(|errors| {
+        CliError::failure(format!(
+            "replacement backend could not parse {}: {errors:?}",
+            entrypoint.display()
+        ))
+    })?;
+    if program.rust_module_path.is_some()
+        || program
+            .declarations
+            .iter()
+            .any(|declaration| !matches!(declaration.node, Declaration::Function(_) | Declaration::Docstring(_)))
+    {
+        return Err(CliError::failure(
+            "replacement backend #988 supports one source-only free-function module; imports, packages, Rust interop, models, and top-level values are refused",
+        ));
+    }
+    let module_path = vec![
+        entrypoint
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .unwrap_or("main")
+            .to_string(),
+    ];
+    let mut checker = typechecker::TypeChecker::new();
+    checker.set_current_module_path(Some(module_path.clone()));
+    checker.check_program(&program).map_err(|errors| {
+        CliError::failure(format!(
+            "replacement backend could not typecheck {}: {errors:?}",
+            entrypoint.display()
+        ))
+    })?;
+    let body_ir = build_body_ir_module_v0(&program, &module_path, checker.type_info());
+    let selection = select_backend(
+        options.backend.requested,
+        options.backend.explicit,
+        options.backend.shadow,
+        digest_output(&[source.as_str()]),
+        options.backend.fallback_policy,
+    );
+    let executed = resolve_execution(&selection, BackendKind::Replacement.is_implemented())
+        .map_err(|error| CliError::failure(error.to_string()))?;
+    if executed != BackendKind::Replacement {
+        return Err(CliError::failure(
+            "replacement backend #988 refuses declared fallback execution; run `--backend legacy` explicitly for the legacy backend",
+        ));
+    }
+    let execution =
+        execute_free_function(&body_ir, "main", &[]).map_err(|error| CliError::failure(error.to_string()))?;
+    let shadow_comparison = if selection.shadow_requested {
+        ShadowComparisonState::Unavailable {
+            reason: "#988's source-only free-function build profile has no source-observable legacy entrypoint; shadow comparison is unavailable rather than inferred from generated Rust".to_string(),
+        }
+    } else {
+        ShadowComparisonState::NotRequested
+    };
+    let backend_receipt = finalize_receipt(
+        &selection,
+        executed,
+        execution.output_identity.clone(),
+        shadow_comparison,
+        diagnostics::DIAGNOSTIC_SCHEMA_VERSION,
+    )
+    .map_err(|error| CliError::failure(error.to_string()))?;
+    let project_root = resolve_project_root(&entrypoint);
+    write_backend_receipt(&backend_receipt, &default_backend_receipt_path(&project_root))?;
+    print_build_progress(report_options, "✓ replacement backend executed typed Body IR directly");
+    print_build_progress(
+        report_options,
+        format!("Replacement result: {}", execution.value.observable_text()),
+    );
+    if !report_options.enabled() {
+        println!(
+            "✓ replacement backend executed `main`: {}",
+            execution.value.observable_text()
+        );
+    }
+    Ok(serde_json::json!({
+        "backend": backend_receipt,
+        "replacement_execution": {
+            "result": execution.value.observable_text(),
+            "output_identity": execution.output_identity,
+            "body_snapshot": execution.body_snapshot,
+            "ownership_read_count": execution.ownership_reads.len(),
+            "runtime_requirements": format!("{:?}", execution.runtime_requirements),
+        },
+        "timings_ms": { "total": elapsed_ms(start) },
+    }))
 }
 
 /// Build the project identity block used by build and generated Rust inspection reports.
@@ -9217,6 +9340,11 @@ pub fn build_file(
 ) -> CliResult<ExitCode> {
     reject_normal_cargo_controls(&options.cargo_policy, options.generated_cargo_target_dir.as_ref())?;
     ensure_backend_request_available(&options.backend)?;
+    if options.backend.requested == BackendKind::Replacement {
+        let report = build_replacement_file_report(file_path, options, &report_options)?;
+        emit_workspace_build_report(&report, &report_options)?;
+        return Ok(ExitCode::SUCCESS);
+    }
     if !report_options.enabled()
         && let Some((project_root, selected, backend_receipt)) =
             select_default_executable_project_output(file_path, output_dir, &options)?
@@ -9242,6 +9370,9 @@ pub(crate) fn build_file_report(
 ) -> CliResult<serde_json::Value> {
     reject_normal_cargo_controls(&options.cargo_policy, options.generated_cargo_target_dir.as_ref())?;
     ensure_backend_request_available(&options.backend)?;
+    if options.backend.requested == BackendKind::Replacement {
+        return build_replacement_file_report(file_path, options, report_options);
+    }
     let total_start = Instant::now();
     if let Some((project_root, selected, backend_receipt)) =
         select_default_executable_project_output(file_path, output_dir, &options)?
@@ -12708,6 +12839,11 @@ pub fn build_library(
     report_options: BuildReportOptions,
 ) -> CliResult<ExitCode> {
     ensure_backend_request_available(&options.backend)?;
+    if options.backend.requested == BackendKind::Replacement {
+        return Err(CliError::failure(
+            "replacement backend #988 supports source-only executable free functions, not libraries or package artifacts",
+        ));
+    }
     let artifact_only = env::var_os(INTERNAL_LIBRARY_ARTIFACT_ONLY_ENV).is_some();
     if !artifact_only {
         reject_normal_cargo_controls(&options.cargo_policy, options.generated_cargo_target_dir.as_ref())?;
@@ -13237,6 +13373,11 @@ pub(crate) fn build_library_report(
     report_options: &BuildReportOptions,
 ) -> CliResult<crate::cli::commands::build_report::BuildReport> {
     ensure_backend_request_available(&options.backend)?;
+    if options.backend.requested == BackendKind::Replacement {
+        return Err(CliError::failure(
+            "replacement backend #988 supports source-only executable free functions, not libraries or package artifacts",
+        ));
+    }
     let total_start = Instant::now();
     let artifact_only = env::var_os(INTERNAL_LIBRARY_ARTIFACT_ONLY_ENV).is_some();
     if !artifact_only {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -203,30 +203,21 @@ impl From<BackendCliKind> for crate::backend::selection::BackendKind {
 
 /// CLI-facing fallback policy for `incan build --backend-fallback`.
 ///
-/// `refuse` is explicit syntax for the safe default: unsupported replacement input must stop visibly rather than
-/// entering the legacy backend. The backend spellings retain #986's separately declared fallback capability for
-/// later profiles, but #988's source-only replacement profile never selects it implicitly.
+/// The #988 source-only profile exposes only `refuse`: it has no receipt-bound legacy execution path for an
+/// unsupported source profile, so accepting a target backend spelling here would promise a fallback the CLI cannot
+/// truthfully perform. #986 retains `FallbackPolicy::AllowTo` for a future profile that implements both dispatch
+/// and its paired execution receipt.
 #[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
 #[value(rename_all = "lower")]
 pub enum BackendFallbackCliKind {
     /// Refuse an unavailable backend selection instead of substituting another backend.
     Refuse,
-    /// Permit an explicitly recorded fallback to the legacy backend.
-    Legacy,
-    /// Permit an explicitly recorded fallback to the replacement backend.
-    Replacement,
 }
 
 impl From<BackendFallbackCliKind> for crate::backend::selection::FallbackPolicy {
     fn from(kind: BackendFallbackCliKind) -> Self {
         match kind {
             BackendFallbackCliKind::Refuse => crate::backend::selection::FallbackPolicy::Refuse,
-            BackendFallbackCliKind::Legacy => {
-                crate::backend::selection::FallbackPolicy::AllowTo(crate::backend::selection::BackendKind::Legacy)
-            }
-            BackendFallbackCliKind::Replacement => {
-                crate::backend::selection::FallbackPolicy::AllowTo(crate::backend::selection::BackendKind::Replacement)
-            }
         }
     }
 }
@@ -378,12 +369,13 @@ pub enum Command {
         /// executes supported free functions from Body IR and refuses unsupported input visibly.
         #[arg(long = "backend", value_enum)]
         backend: Option<BackendCliKind>,
-        /// Request a shadow comparison against the replacement backend alongside normal execution. Recorded
-        /// explicitly as unavailable until the replacement backend exists.
+        /// Request a source-observable shadow comparison against the replacement backend. Recorded explicitly as
+        /// unavailable when the selected profile has no such legacy/replacement comparator; generated Rust is not
+        /// used as semantic proof.
         #[arg(long = "shadow")]
         shadow: bool,
-        /// Allow the build to fall back to this backend if `--backend` cannot execute, recording the substitution
-        /// explicitly in the build report instead of refusing.
+        /// Declare the explicit refusal policy for an unavailable backend. The #988 source-only profile accepts
+        /// only `refuse` until a receipt-bound legacy fallback execution path exists.
         #[arg(long = "backend-fallback", value_enum)]
         backend_fallback: Option<BackendFallbackCliKind>,
         /// Emit a machine-readable build report

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -182,13 +182,13 @@ pub enum ColorMode {
     Never,
 }
 
-/// CLI-facing selector for [`crate::backend::selection::BackendKind`] (`--backend`, `--backend-fallback`).
+/// CLI-facing selector for [`crate::backend::selection::BackendKind`] (`--backend`).
 #[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
 #[value(rename_all = "lower")]
 pub enum BackendCliKind {
     /// The current Rust-source-emission pipeline.
     Legacy,
-    /// The Body IR replacement backend tracked by #653. Not implemented yet.
+    /// The intentionally partial Body-IR replacement backend.
     Replacement,
 }
 
@@ -197,6 +197,36 @@ impl From<BackendCliKind> for crate::backend::selection::BackendKind {
         match kind {
             BackendCliKind::Legacy => crate::backend::selection::BackendKind::Legacy,
             BackendCliKind::Replacement => crate::backend::selection::BackendKind::Replacement,
+        }
+    }
+}
+
+/// CLI-facing fallback policy for `incan build --backend-fallback`.
+///
+/// `refuse` is explicit syntax for the safe default: unsupported replacement input must stop visibly rather than
+/// entering the legacy backend. The backend spellings retain #986's separately declared fallback capability for
+/// later profiles, but #988's source-only replacement profile never selects it implicitly.
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+#[value(rename_all = "lower")]
+pub enum BackendFallbackCliKind {
+    /// Refuse an unavailable backend selection instead of substituting another backend.
+    Refuse,
+    /// Permit an explicitly recorded fallback to the legacy backend.
+    Legacy,
+    /// Permit an explicitly recorded fallback to the replacement backend.
+    Replacement,
+}
+
+impl From<BackendFallbackCliKind> for crate::backend::selection::FallbackPolicy {
+    fn from(kind: BackendFallbackCliKind) -> Self {
+        match kind {
+            BackendFallbackCliKind::Refuse => crate::backend::selection::FallbackPolicy::Refuse,
+            BackendFallbackCliKind::Legacy => {
+                crate::backend::selection::FallbackPolicy::AllowTo(crate::backend::selection::BackendKind::Legacy)
+            }
+            BackendFallbackCliKind::Replacement => {
+                crate::backend::selection::FallbackPolicy::AllowTo(crate::backend::selection::BackendKind::Replacement)
+            }
         }
     }
 }
@@ -344,8 +374,8 @@ pub enum Command {
         #[arg(long)]
         release: bool,
         /// Select the compiler backend for this build. Defaults to the legacy Rust-emission backend, declared
-        /// explicitly even when this flag is omitted. `replacement` is not implemented yet (#653); requesting it
-        /// fails visibly unless `--backend-fallback` is also given.
+        /// explicitly even when this flag is omitted. The `replacement` profile is source-only and partial: it
+        /// executes supported free functions from Body IR and refuses unsupported input visibly.
         #[arg(long = "backend", value_enum)]
         backend: Option<BackendCliKind>,
         /// Request a shadow comparison against the replacement backend alongside normal execution. Recorded
@@ -355,7 +385,7 @@ pub enum Command {
         /// Allow the build to fall back to this backend if `--backend` cannot execute, recording the substitution
         /// explicitly in the build report instead of refusing.
         #[arg(long = "backend-fallback", value_enum)]
-        backend_fallback: Option<BackendCliKind>,
+        backend_fallback: Option<BackendFallbackCliKind>,
         /// Emit a machine-readable build report
         #[arg(long = "report", value_enum)]
         report: Option<BuildReportFormat>,
@@ -1501,7 +1531,7 @@ fn execute(cli: Cli, use_color: bool) -> CliResult<ExitCode> {
                         explicit: backend.is_some(),
                         shadow,
                         fallback_policy: backend_fallback
-                            .map(|kind| crate::backend::selection::FallbackPolicy::AllowTo(kind.into()))
+                            .map(Into::into)
                             .unwrap_or(crate::backend::selection::FallbackPolicy::Refuse),
                     },
                 },

--- a/tests/parity_corpus_tests.rs
+++ b/tests/parity_corpus_tests.rs
@@ -452,12 +452,11 @@ fn seed_corpus_every_case_confirms_its_documented_current_behavior() {
 }
 
 #[test]
-fn no_case_reaches_green_while_the_replacement_backend_is_unimplemented() {
-    // This is the corpus's core promise: an unavailable comparison must never be counted as parity. #986 has
-    // landed, so every case now consults a real receipt (`receipt_schema_available` is `true`) — but the
-    // replacement backend itself is not implemented yet (#653), so every case's shadow comparison against it is
-    // genuinely unavailable. Every case — even a behaviorally-confirmed one — must land in
-    // `NonGreenShadowUnavailable`, never `Green`.
+fn existing_seed_cases_remain_non_green_until_each_has_a_real_replacement_execution() {
+    // This is the corpus's core promise: an unavailable comparison must never be counted as parity. #988 now
+    // executes its separately selected free-function profile, but none of these older #987 seed rows has yet been
+    // bound to a matching replacement execution receipt. Every row therefore remains explicitly shadow-unavailable
+    // rather than becoming green merely because some other source corpus is executable.
     let summary = parity_corpus::summarize(&seed_corpus());
     assert!(
         summary.receipt_schema_available,
@@ -470,12 +469,12 @@ fn no_case_reaches_green_while_the_replacement_backend_is_unimplemented() {
         .collect();
     assert!(
         falsely_green.is_empty(),
-        "no case should reach OverallState::Green before #653 lands the replacement backend: {falsely_green:#?}"
+        "no existing seed case should reach OverallState::Green without its own replacement execution: {falsely_green:#?}"
     );
     assert_eq!(summary.green, 0);
     assert_eq!(
         summary.non_green_shadow_unavailable, summary.total_cases,
-        "every behaviorally-confirmed seed case must report shadow-unavailable, not green, today"
+        "every existing seed case must report shadow-unavailable, not green, until it has its own execution evidence"
     );
     assert_eq!(summary.non_green_behavior, 0);
 }

--- a/tests/parity_corpus_tests.rs
+++ b/tests/parity_corpus_tests.rs
@@ -8,7 +8,7 @@
 //!
 //! Run with: `cargo test --test parity_corpus_tests`
 //!
-//! ## Why these six cases
+//! ## Why these eleven cases
 //!
 //! Per #987's own plan step 3 ("add a narrow source-only seed corpus before public package or Rust-interop
 //! rows"), every seed case here uses a direct-parser/typechecker, generated-project-run, or codegen-snapshot
@@ -20,6 +20,7 @@
 //! so a behavior change shows up as [`parity_corpus::ComparisonOutcome::Mismatch`] the next time this test runs.
 
 use incan::backend::IrCodegen;
+use incan::backend::replacement::ReplacementValue;
 use incan::frontend::{lexer, parser, typechecker};
 use std::path::PathBuf;
 
@@ -27,7 +28,8 @@ use std::path::PathBuf;
 mod parity_corpus;
 
 use parity_corpus::{
-    BehaviorCategory, ComparisonOutcome, Disposition, EvidenceLane, OverallState, ParityCase, validate_corpus,
+    BehaviorCategory, ComparisonOutcome, Disposition, EvidenceLane, OverallState, ParityCase, ReceiptRef,
+    validate_corpus,
 };
 
 // ============================================================================
@@ -233,6 +235,82 @@ fn case_bug_compatible_dead_code_after_return() -> ComparisonOutcome {
 }
 
 // ============================================================================
+// #988 replacement execution corpus — stable receipt-bound source cases
+// ============================================================================
+
+const REPLACEMENT_BODY_V0_001_SRC: &str = r#"
+def add(x: int, y: int) -> int:
+    return x + y
+"#;
+
+const REPLACEMENT_BODY_V0_002_SRC: &str = r#"
+def greet(name: str) -> str:
+    return "hello, " + name
+"#;
+
+const REPLACEMENT_BODY_V0_003_SRC: &str = r#"
+def return_owned() -> str:
+    value = "owned"
+    return value
+"#;
+
+const REPLACEMENT_BODY_V0_004_SRC: &str = r#"
+def control_flow() -> int:
+    for value in range(1, 5):
+        if value % 2 == 0:
+            continue
+    while false:
+        return 0
+    return 10
+"#;
+
+const REPLACEMENT_BODY_V0_005_SRC: &str = r#"
+def guarded_floor_div(a: int, b: int) -> int:
+    assert b != 0
+    return a // b
+"#;
+
+fn replacement_body_v0_001_arguments() -> Vec<ReplacementValue> {
+    vec![ReplacementValue::Int(40), ReplacementValue::Int(2)]
+}
+
+fn replacement_body_v0_001_expected() -> ReplacementValue {
+    ReplacementValue::Int(42)
+}
+
+fn replacement_body_v0_002_arguments() -> Vec<ReplacementValue> {
+    vec![ReplacementValue::Str("Ada".to_string())]
+}
+
+fn replacement_body_v0_002_expected() -> ReplacementValue {
+    ReplacementValue::Str("hello, Ada".to_string())
+}
+
+fn replacement_body_v0_003_arguments() -> Vec<ReplacementValue> {
+    vec![]
+}
+
+fn replacement_body_v0_003_expected() -> ReplacementValue {
+    ReplacementValue::Str("owned".to_string())
+}
+
+fn replacement_body_v0_004_arguments() -> Vec<ReplacementValue> {
+    vec![]
+}
+
+fn replacement_body_v0_004_expected() -> ReplacementValue {
+    ReplacementValue::Int(10)
+}
+
+fn replacement_body_v0_005_arguments() -> Vec<ReplacementValue> {
+    vec![ReplacementValue::Int(84), ReplacementValue::Int(2)]
+}
+
+fn replacement_body_v0_005_expected() -> ReplacementValue {
+    ReplacementValue::Int(42)
+}
+
+// ============================================================================
 // Seed corpus
 // ============================================================================
 
@@ -249,7 +327,8 @@ fn seed_corpus() -> Vec<ParityCase> {
             evidence: "tests/parity_corpus_tests.rs::case_supported_match_exhaustiveness",
             disposition: Disposition::Preserved,
             source: CASE_1_SRC,
-            evaluate: case_supported_match_exhaustiveness,
+            evaluate: Some(case_supported_match_exhaustiveness),
+            replacement_execution: None,
         },
         ParityCase {
             id: "parity-987-0002",
@@ -259,7 +338,8 @@ fn seed_corpus() -> Vec<ParityCase> {
             evidence: "tests/parity_corpus_tests.rs::case_diagnostic_chained_comparison_rejected",
             disposition: Disposition::Preserved,
             source: CASE_2_SRC,
-            evaluate: case_diagnostic_chained_comparison_rejected,
+            evaluate: Some(case_diagnostic_chained_comparison_rejected),
+            replacement_execution: None,
         },
         ParityCase {
             id: "parity-987-0003",
@@ -269,7 +349,8 @@ fn seed_corpus() -> Vec<ParityCase> {
             evidence: "tests/parity_corpus_tests.rs::case_stdlib_runtime_string_membership",
             disposition: Disposition::Preserved,
             source: CASE_3_SRC,
-            evaluate: case_stdlib_runtime_string_membership,
+            evaluate: Some(case_stdlib_runtime_string_membership),
+            replacement_execution: None,
         },
         ParityCase {
             id: "parity-987-0004",
@@ -279,7 +360,8 @@ fn seed_corpus() -> Vec<ParityCase> {
             evidence: "tests/parity_corpus_tests.rs::case_generated_artifact_valid_rust_shape",
             disposition: Disposition::Preserved,
             source: CASE_4_SRC,
-            evaluate: case_generated_artifact_valid_rust_shape,
+            evaluate: Some(case_generated_artifact_valid_rust_shape),
+            replacement_execution: None,
         },
         ParityCase {
             id: "parity-987-0005",
@@ -289,7 +371,8 @@ fn seed_corpus() -> Vec<ParityCase> {
             evidence: "tests/parity_corpus_tests.rs::case_supported_builtin_len_shadowing",
             disposition: Disposition::Preserved,
             source: CASE_5_SRC,
-            evaluate: case_supported_builtin_len_shadowing,
+            evaluate: Some(case_supported_builtin_len_shadowing),
+            replacement_execution: None,
         },
         ParityCase {
             id: "parity-987-0006",
@@ -306,7 +389,83 @@ fn seed_corpus() -> Vec<ParityCase> {
                                   backend.",
             },
             source: CASE_6_SRC,
-            evaluate: case_bug_compatible_dead_code_after_return,
+            evaluate: Some(case_bug_compatible_dead_code_after_return),
+            replacement_execution: None,
+        },
+        ParityCase {
+            id: "replacement-body-v0-001",
+            title: "Parameterized integer addition executes through Body IR",
+            category: BehaviorCategory::SupportedLanguageContract,
+            lane: EvidenceLane::DirectReplacementBodyIr,
+            evidence: "#988 replacement-body-v0-001; tests/parity_corpus_tests.rs::seed_corpus",
+            disposition: Disposition::Preserved,
+            source: REPLACEMENT_BODY_V0_001_SRC,
+            evaluate: None,
+            replacement_execution: Some(parity_corpus::ReplacementExecutionPlan {
+                function: "add",
+                arguments: replacement_body_v0_001_arguments,
+                expected: replacement_body_v0_001_expected,
+            }),
+        },
+        ParityCase {
+            id: "replacement-body-v0-002",
+            title: "Parameterized string concatenation executes through Body IR",
+            category: BehaviorCategory::SupportedLanguageContract,
+            lane: EvidenceLane::DirectReplacementBodyIr,
+            evidence: "#988 replacement-body-v0-002; tests/parity_corpus_tests.rs::seed_corpus",
+            disposition: Disposition::Preserved,
+            source: REPLACEMENT_BODY_V0_002_SRC,
+            evaluate: None,
+            replacement_execution: Some(parity_corpus::ReplacementExecutionPlan {
+                function: "greet",
+                arguments: replacement_body_v0_002_arguments,
+                expected: replacement_body_v0_002_expected,
+            }),
+        },
+        ParityCase {
+            id: "replacement-body-v0-003",
+            title: "Owned local return preserves move evidence through Body IR",
+            category: BehaviorCategory::SupportedLanguageContract,
+            lane: EvidenceLane::DirectReplacementBodyIr,
+            evidence: "#988 replacement-body-v0-003; tests/parity_corpus_tests.rs::seed_corpus",
+            disposition: Disposition::Preserved,
+            source: REPLACEMENT_BODY_V0_003_SRC,
+            evaluate: None,
+            replacement_execution: Some(parity_corpus::ReplacementExecutionPlan {
+                function: "return_owned",
+                arguments: replacement_body_v0_003_arguments,
+                expected: replacement_body_v0_003_expected,
+            }),
+        },
+        ParityCase {
+            id: "replacement-body-v0-004",
+            title: "Normalized range, branch, and while control flow execute through Body IR",
+            category: BehaviorCategory::SupportedLanguageContract,
+            lane: EvidenceLane::DirectReplacementBodyIr,
+            evidence: "#988 replacement-body-v0-004; tests/parity_corpus_tests.rs::seed_corpus",
+            disposition: Disposition::Preserved,
+            source: REPLACEMENT_BODY_V0_004_SRC,
+            evaluate: None,
+            replacement_execution: Some(parity_corpus::ReplacementExecutionPlan {
+                function: "control_flow",
+                arguments: replacement_body_v0_004_arguments,
+                expected: replacement_body_v0_004_expected,
+            }),
+        },
+        ParityCase {
+            id: "replacement-body-v0-005",
+            title: "Assertion and floor division execute through Body IR",
+            category: BehaviorCategory::SupportedLanguageContract,
+            lane: EvidenceLane::DirectReplacementBodyIr,
+            evidence: "#988 replacement-body-v0-005; tests/parity_corpus_tests.rs::seed_corpus",
+            disposition: Disposition::Preserved,
+            source: REPLACEMENT_BODY_V0_005_SRC,
+            evaluate: None,
+            replacement_execution: Some(parity_corpus::ReplacementExecutionPlan {
+                function: "guarded_floor_div",
+                arguments: replacement_body_v0_005_arguments,
+                expected: replacement_body_v0_005_expected,
+            }),
         },
     ]
 }
@@ -326,10 +485,11 @@ fn malformed_cases_for_red_state_proof() -> Vec<ParityCase> {
             lane: EvidenceLane::DirectParserTypechecker,
             evidence: "tests/parity_corpus_tests.rs (red-state fixture)",
             disposition: Disposition::Preserved,
-            // Never reaches `evaluate_case`/`compute_receipt` — `red_state_validate_corpus_...` calls
+            // Never reaches `evaluate_case` — `red_state_validate_corpus_...` calls
             // `validate_corpus` directly, so this placeholder source is never hashed into a real receipt.
             source: "",
-            evaluate: || ComparisonOutcome::Match,
+            evaluate: Some(|| ComparisonOutcome::Match),
+            replacement_execution: None,
         },
         ParityCase {
             id: "parity-987-dup",
@@ -338,10 +498,11 @@ fn malformed_cases_for_red_state_proof() -> Vec<ParityCase> {
             lane: EvidenceLane::DirectParserTypechecker,
             evidence: "tests/parity_corpus_tests.rs (red-state fixture)",
             disposition: Disposition::Preserved,
-            // Never reaches `evaluate_case`/`compute_receipt` — `red_state_validate_corpus_...` calls
+            // Never reaches `evaluate_case` — `red_state_validate_corpus_...` calls
             // `validate_corpus` directly, so this placeholder source is never hashed into a real receipt.
             source: "",
-            evaluate: || ComparisonOutcome::Match,
+            evaluate: Some(|| ComparisonOutcome::Match),
+            replacement_execution: None,
         },
         ParityCase {
             id: "parity-987-empty-title",
@@ -350,10 +511,11 @@ fn malformed_cases_for_red_state_proof() -> Vec<ParityCase> {
             lane: EvidenceLane::DirectParserTypechecker,
             evidence: "tests/parity_corpus_tests.rs (red-state fixture)",
             disposition: Disposition::Preserved,
-            // Never reaches `evaluate_case`/`compute_receipt` — `red_state_validate_corpus_...` calls
+            // Never reaches `evaluate_case` — `red_state_validate_corpus_...` calls
             // `validate_corpus` directly, so this placeholder source is never hashed into a real receipt.
             source: "",
-            evaluate: || ComparisonOutcome::Match,
+            evaluate: Some(|| ComparisonOutcome::Match),
+            replacement_execution: None,
         },
         ParityCase {
             id: "parity-987-unsupported-no-issue",
@@ -365,10 +527,11 @@ fn malformed_cases_for_red_state_proof() -> Vec<ParityCase> {
                 owning_issue: 0,
                 migration_note: "",
             },
-            // Never reaches `evaluate_case`/`compute_receipt` — `red_state_validate_corpus_...` calls
+            // Never reaches `evaluate_case` — `red_state_validate_corpus_...` calls
             // `validate_corpus` directly, so this placeholder source is never hashed into a real receipt.
             source: "",
-            evaluate: || ComparisonOutcome::Match,
+            evaluate: Some(|| ComparisonOutcome::Match),
+            replacement_execution: None,
         },
     ]
 }
@@ -429,8 +592,8 @@ fn seed_corpus_ids_are_stable_and_globally_unique() {
     assert_eq!(sorted.len(), ids.len(), "seed corpus case ids must be globally unique");
     for id in &ids {
         assert!(
-            id.starts_with("parity-987-"),
-            "case id {id} should carry the parity-987- namespace prefix for stability across future slices"
+            id.starts_with("parity-987-") || id.starts_with("replacement-body-v0-"),
+            "case id {id} must carry a stable #987 or #988 replacement-body namespace prefix"
         );
     }
 }
@@ -452,11 +615,10 @@ fn seed_corpus_every_case_confirms_its_documented_current_behavior() {
 }
 
 #[test]
-fn existing_seed_cases_remain_non_green_until_each_has_a_real_replacement_execution() {
-    // This is the corpus's core promise: an unavailable comparison must never be counted as parity. #988 now
-    // executes its separately selected free-function profile, but none of these older #987 seed rows has yet been
-    // bound to a matching replacement execution receipt. Every row therefore remains explicitly shadow-unavailable
-    // rather than becoming green merely because some other source corpus is executable.
+fn seed_cases_and_direct_replacement_cases_remain_non_green_without_a_legacy_runtime_comparator() {
+    // This is the corpus's core promise: direct replacement execution does not become green parity merely because
+    // it has a receipt. The older seed rows and the new #988 rows both stay explicitly shadow-unavailable until a
+    // source-observable legacy comparison is available for the same source profile.
     let summary = parity_corpus::summarize(&seed_corpus());
     assert!(
         summary.receipt_schema_available,
@@ -474,9 +636,75 @@ fn existing_seed_cases_remain_non_green_until_each_has_a_real_replacement_execut
     assert_eq!(summary.green, 0);
     assert_eq!(
         summary.non_green_shadow_unavailable, summary.total_cases,
-        "every existing seed case must report shadow-unavailable, not green, until it has its own execution evidence"
+        "every corpus row must report shadow-unavailable, not green, until it has a source-observable legacy comparison"
     );
     assert_eq!(summary.non_green_behavior, 0);
+}
+
+/// Bind each selected #988 source case to its own replacement receipt and complete Body-IR proof evidence.
+#[test]
+fn replacement_body_v0_cases_have_receipt_bound_non_green_execution_evidence() -> Result<(), Box<dyn std::error::Error>>
+{
+    let summary = parity_corpus::summarize(&seed_corpus());
+    let replacement_rows: Vec<&parity_corpus::CaseReport> = summary
+        .cases
+        .iter()
+        .filter(|case| case.id.starts_with("replacement-body-v0-"))
+        .collect();
+    assert_eq!(
+        replacement_rows.len(),
+        5,
+        "the five agreed #988 cases must stay stable in #987"
+    );
+
+    for row in replacement_rows {
+        assert_eq!(row.lane, EvidenceLane::DirectReplacementBodyIr);
+        assert_eq!(row.overall_state, OverallState::NonGreenShadowUnavailable);
+        match &row.receipt {
+            ReceiptRef::ReplacementExecuted {
+                selection_identity,
+                receipt_identity,
+                output_identity,
+                body_snapshot,
+                ownership_reads,
+                runtime_requirements,
+                comparison_reason,
+            } => {
+                assert!(selection_identity.starts_with("sha256:"));
+                assert!(receipt_identity.starts_with("sha256:"));
+                assert!(output_identity.starts_with("sha256:"));
+                assert!(body_snapshot.contains("body "));
+                assert!(
+                    ownership_reads
+                        .iter()
+                        .all(|read| read.span_end >= read.span_start && !read.fact.is_empty()),
+                    "{} lost canonical ownership evidence: {ownership_reads:?}",
+                    row.id
+                );
+                assert!(
+                    runtime_requirements
+                        .iter()
+                        .all(|requirement| !requirement.requirement.is_empty()),
+                    "{} emitted an invalid runtime-requirement projection: {runtime_requirements:?}",
+                    row.id
+                );
+                assert_eq!(
+                    comparison_reason,
+                    incan::backend::selection::SHADOW_COMPARISON_UNAVAILABLE_REASON,
+                    "{} must report the actual missing legacy comparator rather than generated-Rust evidence",
+                    row.id
+                );
+            }
+            receipt => {
+                return Err(format!(
+                    "{} needs its own replacement execution receipt, got {receipt:?}",
+                    row.id
+                )
+                .into());
+            }
+        }
+    }
+    Ok(())
 }
 
 // ============================================================================

--- a/tests/replacement_backend_execution_tests.rs
+++ b/tests/replacement_backend_execution_tests.rs
@@ -1,0 +1,304 @@
+//! End-to-end proof for the bounded #988 Body-IR replacement executor.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+use incan::backend::replacement::{ReplacementValue, execute_free_function};
+use incan::backend::selection::{
+    BackendKind, FallbackOutcome, FallbackPolicy, ShadowComparisonState, digest_output, finalize_receipt,
+    select_backend,
+};
+use incan::frontend::body_ir::build_body_ir_module_v0;
+use incan::frontend::typechecker::TypeChecker;
+use incan::frontend::{lexer, parser};
+use incan_semantics_core::body_ir::{BodyIrModule, OwnershipFact};
+
+/// Lower one self-contained, typechecked source module into the Body IR the replacement backend consumes.
+fn lower_typed_body_ir(source: &str) -> Result<BodyIrModule, Box<dyn std::error::Error>> {
+    let tokens = lexer::lex(source).map_err(|errors| std::io::Error::other(format!("{errors:?}")))?;
+    let program = parser::parse(&tokens).map_err(|errors| std::io::Error::other(format!("{errors:?}")))?;
+    let module_path = vec!["replacement_execution".to_string()];
+    let mut checker = TypeChecker::new();
+    checker.set_current_module_path(Some(module_path.clone()));
+    checker
+        .check_program(&program)
+        .map_err(|errors| std::io::Error::other(format!("{errors:?}")))?;
+    Ok(build_body_ir_module_v0(&program, &module_path, checker.type_info()))
+}
+
+/// Locate the compiler binary built for this integration-test invocation.
+fn incan_binary() -> PathBuf {
+    std::env::var_os("CARGO_BIN_EXE_incan")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("target/debug/incan"))
+}
+
+/// Execute typed source through Body IR and bind the observed result to an explicit replacement receipt.
+#[test]
+fn replacement_executes_core_body_and_binds_a_real_receipt() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+def main() -> int:
+  left = 40
+  right = 2
+  if left > right:
+    return left + right
+  return right
+"#;
+    let module = lower_typed_body_ir(source)?;
+    let execution = execute_free_function(&module, "main", &[])?;
+
+    assert_eq!(execution.value, ReplacementValue::Int(42));
+    assert!(execution.body_snapshot.contains("body main"));
+    assert!(execution.body_snapshot.contains("span="));
+    assert!(
+        execution
+            .ownership_reads
+            .iter()
+            .all(|read| !matches!(read.fact, OwnershipFact::Unknown)),
+        "the selected core corpus must not erase ownership facts: {:?}",
+        execution.ownership_reads
+    );
+
+    let selection = select_backend(
+        BackendKind::Replacement,
+        true,
+        false,
+        digest_output(&[source]),
+        FallbackPolicy::Refuse,
+    );
+    let receipt = finalize_receipt(
+        &selection,
+        BackendKind::Replacement,
+        execution.output_identity.clone(),
+        ShadowComparisonState::NotRequested,
+        incan::frontend::diagnostics::DIAGNOSTIC_SCHEMA_VERSION,
+    )?;
+    receipt.verify_identity()?;
+    assert_eq!(receipt.executed_backend, BackendKind::Replacement);
+    assert_eq!(receipt.fallback_outcome, FallbackOutcome::NotNeeded);
+    assert_eq!(receipt.selection.source_identity, digest_output(&[source]));
+    Ok(())
+}
+
+/// Reject a Body-IR projection outside the first replacement profile without a legacy fallback.
+#[test]
+fn replacement_refuses_unsupported_body_ir_with_the_original_source_span() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+def main() -> int:
+  values = [1, 2]
+  return values[0]
+"#;
+    let module = lower_typed_body_ir(source)?;
+    let error = match execute_free_function(&module, "main", &[]) {
+        Ok(execution) => {
+            return Err(format!(
+                "index projections are outside #988's core profile but executed as {:?}",
+                execution.value
+            )
+            .into());
+        }
+        Err(error) => error,
+    };
+
+    assert!(
+        error.primary_span().is_some(),
+        "unsupported execution must retain an Incan source span: {error}"
+    );
+    assert!(
+        error.to_string().contains("projection"),
+        "unsupported operation must be named visibly: {error}"
+    );
+    Ok(())
+}
+
+/// Execute the remaining source-only cases selected for the first #988 proof corpus.
+#[test]
+fn replacement_executes_the_selected_string_ownership_control_flow_and_assertion_cases()
+-> Result<(), Box<dyn std::error::Error>> {
+    let cases = [
+        (
+            "string concatenation",
+            r#"def main() -> str:
+  name = "Ada"
+  return "hi " + name
+"#,
+            ReplacementValue::Str("hi Ada".to_string()),
+            "helper:str_concat",
+        ),
+        (
+            "non-copy return",
+            r#"def main() -> str:
+  value = "owned"
+  return value
+"#,
+            ReplacementValue::Str("owned".to_string()),
+            "move(_",
+        ),
+        (
+            "normalized range and while control flow",
+            r#"def main() -> int:
+  total = 0
+  for value in range(1, 5):
+    if value % 2 == 0:
+      total = total + value
+  while total < 10:
+    total = total + 1
+  return total
+"#,
+            ReplacementValue::Int(10),
+            "loop:",
+        ),
+        (
+            "assertion and floor division",
+            r#"def main() -> int:
+  a = 84
+  b = 2
+  assert b != 0
+  return a // b
+"#,
+            ReplacementValue::Int(42),
+            "assert",
+        ),
+    ];
+    for (name, source, expected, snapshot_evidence) in cases {
+        let module = lower_typed_body_ir(source)?;
+        let execution = execute_free_function(&module, "main", &[]).map_err(|error| {
+            format!(
+                "replacement execution failed for {name}: {error}\n{}",
+                module.render_snapshot()
+            )
+        })?;
+        assert_eq!(execution.value, expected, "replacement result diverged for {name}");
+        assert!(
+            execution.body_snapshot.contains(snapshot_evidence),
+            "Body IR proof for {name} omitted `{snapshot_evidence}`:\n{}",
+            execution.body_snapshot
+        );
+    }
+
+    let failing_assertion = lower_typed_body_ir(
+        r#"def main() -> int:
+  a = 84
+  b = 0
+  assert b != 0
+  return a // b
+"#,
+    )?;
+    let error = match execute_free_function(&failing_assertion, "main", &[]) {
+        Ok(execution) => return Err(format!("failing assertion executed as {:?}", execution.value).into()),
+        Err(error) => error,
+    };
+    assert!(
+        error.to_string().contains("assertion failed"),
+        "unexpected assertion outcome: {error}"
+    );
+    assert!(
+        error.primary_span().is_some(),
+        "assertion failure lost its source span: {error}"
+    );
+    Ok(())
+}
+
+/// Run the explicit replacement CLI path without allowing a legacy fallback.
+#[test]
+fn replacement_cli_executes_typed_body_ir_and_persists_a_replacement_receipt() -> Result<(), Box<dyn std::error::Error>>
+{
+    let temporary = tempfile::tempdir()?;
+    let entrypoint = temporary.path().join("main.incn");
+    fs::write(
+        &entrypoint,
+        r#"def main() -> int:
+  left = 40
+  right = 2
+  if left > right:
+    return left + right
+  return right
+"#,
+    )?;
+
+    let output = Command::new(incan_binary())
+        .args([
+            "build",
+            entrypoint.to_string_lossy().as_ref(),
+            "--backend",
+            "replacement",
+            "--backend-fallback",
+            "refuse",
+        ])
+        .output()?;
+    assert!(
+        output.status.success(),
+        "replacement build must execute directly. stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout)?;
+    assert!(
+        stdout.contains("replacement backend executed `main`: 42"),
+        "unexpected replacement output: {stdout}"
+    );
+    assert!(
+        !stdout.contains("Generated Rust project"),
+        "replacement path must not enter Rust generation: {stdout}"
+    );
+
+    let receipt_path = temporary.path().join(".incan/backend/receipt.json");
+    let receipt: serde_json::Value = serde_json::from_str(&fs::read_to_string(receipt_path)?)?;
+    assert_eq!(receipt["executed_backend"], "replacement");
+    assert_eq!(receipt["selection"]["selected_backend"], "replacement");
+    assert_eq!(receipt["fallback_outcome"], serde_json::json!("not_needed"));
+    assert!(
+        receipt["identity"]
+            .as_str()
+            .is_some_and(|identity| identity.starts_with("sha256:"))
+    );
+    Ok(())
+}
+
+/// Ensure an unsupported source shape fails before any legacy output can be generated.
+#[test]
+fn replacement_cli_refuses_unsupported_source_without_legacy_generation() -> Result<(), Box<dyn std::error::Error>> {
+    let temporary = tempfile::tempdir()?;
+    let entrypoint = temporary.path().join("main.incn");
+    fs::write(
+        &entrypoint,
+        r#"def main() -> int:
+  values = [1, 2]
+  return values[0]
+"#,
+    )?;
+
+    let output = Command::new(incan_binary())
+        .args([
+            "build",
+            entrypoint.to_string_lossy().as_ref(),
+            "--backend",
+            "replacement",
+            "--backend-fallback",
+            "refuse",
+        ])
+        .output()?;
+    assert!(
+        !output.status.success(),
+        "unsupported source must refuse instead of falling back"
+    );
+    let combined = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("place projection"),
+        "unsupported construct must be visible: {combined}"
+    );
+    assert!(
+        combined.contains("original Incan source span"),
+        "refusal must retain source authority: {combined}"
+    );
+    assert!(
+        !combined.contains("Generated Rust project"),
+        "refusal must not enter legacy generation: {combined}"
+    );
+    Ok(())
+}

--- a/tests/replacement_backend_execution_tests.rs
+++ b/tests/replacement_backend_execution_tests.rs
@@ -78,10 +78,30 @@ def main() -> int:
     assert_eq!(receipt.executed_backend, BackendKind::Replacement);
     assert_eq!(receipt.fallback_outcome, FallbackOutcome::NotNeeded);
     assert_eq!(receipt.selection.source_identity, digest_output(&[source]));
+    let ownership_evidence = execution.ownership_evidence();
+    let runtime_evidence = execution.runtime_requirement_evidence();
+    assert!(
+        ownership_evidence
+            .iter()
+            .all(|read| !read.fact.is_empty() && read.span_end >= read.span_start),
+        "canonical ownership evidence must retain stable facts and spans: {ownership_evidence:?}"
+    );
+    assert_eq!(
+        serde_json::to_string(&runtime_evidence)?,
+        serde_json::to_string(&execution.runtime_requirement_evidence())?,
+        "runtime-requirement evidence must be deterministic across repeated projections"
+    );
+    let repeated = execute_free_function(&module, "main", &[])?;
+    assert_eq!(execution.output_identity, repeated.output_identity);
+    assert_eq!(execution.ownership_evidence(), repeated.ownership_evidence());
+    assert_eq!(
+        execution.runtime_requirement_evidence(),
+        repeated.runtime_requirement_evidence()
+    );
     Ok(())
 }
 
-/// Reject a Body-IR projection outside the first replacement profile without a legacy fallback.
+/// Reject a list aggregate before the first replacement profile can execute a compound local value.
 #[test]
 fn replacement_refuses_unsupported_body_ir_with_the_original_source_span() -> Result<(), Box<dyn std::error::Error>> {
     let source = r#"
@@ -93,7 +113,7 @@ def main() -> int:
     let error = match execute_free_function(&module, "main", &[]) {
         Ok(execution) => {
             return Err(format!(
-                "index projections are outside #988's core profile but executed as {:?}",
+                "list aggregates are outside #988's core profile but executed as {:?}",
                 execution.value
             )
             .into());
@@ -105,9 +125,137 @@ def main() -> int:
         error.primary_span().is_some(),
         "unsupported execution must retain an Incan source span: {error}"
     );
+    let expected_start = source
+        .find("[1, 2]")
+        .ok_or("aggregate fixture must contain its list assignment")?;
+    let expected_end = expected_start + "[1, 2]".len();
+    let span = error
+        .primary_span()
+        .ok_or("projection refusal must retain its original source span")?;
+    assert_eq!(span.start, expected_start);
+    assert_eq!(span.end, expected_end);
     assert!(
-        error.to_string().contains("projection"),
+        error.to_string().contains("list aggregate"),
         "unsupported operation must be named visibly: {error}"
+    );
+    Ok(())
+}
+
+/// Refuse a list aggregate even when it appears directly in the return expression.
+#[test]
+fn replacement_refuses_list_aggregate_return_values() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+def main() -> list[int]:
+  return [1]
+"#;
+    let module = lower_typed_body_ir(source)?;
+    let error = match execute_free_function(&module, "main", &[]) {
+        Ok(execution) => {
+            return Err(format!(
+                "a list aggregate is outside #988's scalar profile but executed as {:?}",
+                execution.value
+            )
+            .into());
+        }
+        Err(error) => error,
+    };
+
+    assert!(
+        error.primary_span().is_some(),
+        "list aggregate refusal must retain an Incan source span: {error}"
+    );
+    assert!(
+        error.to_string().contains("list aggregate"),
+        "list aggregate must be named visibly: {error}"
+    );
+    Ok(())
+}
+
+/// Refuse a lexical shadowing shape until Body IR carries a binding-equivalence fact the direct executor can honor.
+#[test]
+fn replacement_refuses_lexically_shadowed_bindings() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+def main() -> int:
+  x = 1
+  if true:
+    let x = 2
+  return x
+"#;
+    let module = lower_typed_body_ir(source)?;
+    let error = match execute_free_function(&module, "main", &[]) {
+        Ok(execution) => {
+            return Err(format!(
+                "lexically shadowed source must refuse instead of executing as {:?}",
+                execution.value
+            )
+            .into());
+        }
+        Err(error) => error,
+    };
+    let expected_start = source
+        .find("let x = 2")
+        .ok_or("shadowing fixture must contain the inner binding")?;
+    let span = error
+        .primary_span()
+        .ok_or("shadowing refusal must retain the inner binding span")?;
+    assert_eq!(span.start, expected_start);
+    assert!(error.to_string().contains("lexical shadowing"));
+    Ok(())
+}
+
+/// Refuse same-scope reassignment until Body IR carries a binding-equivalence fact the executor can honor.
+#[test]
+fn replacement_refuses_reassignment_with_a_repeated_user_binding_name() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+def main() -> int:
+  mut x = 1
+  x = 2
+  return x
+"#;
+    let module = lower_typed_body_ir(source)?;
+    let error = match execute_free_function(&module, "main", &[]) {
+        Ok(execution) => {
+            return Err(format!(
+                "reassignment must refuse until binding equivalence is available, but executed as {:?}",
+                execution.value
+            )
+            .into());
+        }
+        Err(error) => error,
+    };
+    let expected_start = source
+        .rfind("x = 2")
+        .ok_or("reassignment fixture must contain the second binding")?;
+    let span = error
+        .primary_span()
+        .ok_or("reassignment refusal must retain the second binding span")?;
+    assert_eq!(span.start, expected_start);
+    assert!(error.to_string().contains("repeated user binding"));
+    assert!(error.to_string().contains("reassignment"));
+    Ok(())
+}
+
+/// Match Incan's Python-style signed integer division and modulo contract through the replacement executor.
+#[test]
+fn replacement_uses_python_signed_floor_division_and_modulo() -> Result<(), Box<dyn std::error::Error>> {
+    let division = lower_typed_body_ir(
+        r#"def main() -> int:
+  return 7 // -3
+"#,
+    )?;
+    let modulo = lower_typed_body_ir(
+        r#"def main() -> int:
+  return 7 % -3
+"#,
+    )?;
+
+    assert_eq!(
+        execute_free_function(&division, "main", &[])?.value,
+        ReplacementValue::Int(-3)
+    );
+    assert_eq!(
+        execute_free_function(&modulo, "main", &[])?.value,
+        ReplacementValue::Int(-2)
     );
     Ok(())
 }
@@ -138,13 +286,12 @@ fn replacement_executes_the_selected_string_ownership_control_flow_and_assertion
         (
             "normalized range and while control flow",
             r#"def main() -> int:
-  total = 0
   for value in range(1, 5):
     if value % 2 == 0:
-      total = total + value
-  while total < 10:
-    total = total + 1
-  return total
+      continue
+  while false:
+    return 0
+  return 10
 "#,
             ReplacementValue::Int(10),
             "loop:",
@@ -242,6 +389,10 @@ fn replacement_cli_executes_typed_body_ir_and_persists_a_replacement_receipt() -
         !stdout.contains("Generated Rust project"),
         "replacement path must not enter Rust generation: {stdout}"
     );
+    assert!(
+        !temporary.path().join("target/incan").exists(),
+        "direct replacement execution must not create a legacy generated-project directory"
+    );
 
     let receipt_path = temporary.path().join(".incan/backend/receipt.json");
     let receipt: serde_json::Value = serde_json::from_str(&fs::read_to_string(receipt_path)?)?;
@@ -249,9 +400,100 @@ fn replacement_cli_executes_typed_body_ir_and_persists_a_replacement_receipt() -
     assert_eq!(receipt["selection"]["selected_backend"], "replacement");
     assert_eq!(receipt["fallback_outcome"], serde_json::json!("not_needed"));
     assert!(
+        receipt["replacement_execution"].is_null(),
+        "persisted #986 receipts must remain receipt-only; execution evidence belongs to the report payload"
+    );
+    assert!(
         receipt["identity"]
             .as_str()
             .is_some_and(|identity| identity.starts_with("sha256:"))
+    );
+    Ok(())
+}
+
+/// Emit stable direct-execution evidence in the distinct, non-Oven replacement JSON report.
+#[test]
+fn replacement_cli_json_report_projects_canonical_execution_evidence() -> Result<(), Box<dyn std::error::Error>> {
+    let temporary = tempfile::tempdir()?;
+    let entrypoint = temporary.path().join("main.incn");
+    fs::write(&entrypoint, "def main() -> int:\n  return 42\n")?;
+
+    let output = Command::new(incan_binary())
+        .args([
+            "build",
+            entrypoint.to_string_lossy().as_ref(),
+            "--backend",
+            "replacement",
+            "--backend-fallback",
+            "refuse",
+            "--report",
+            "json",
+        ])
+        .output()?;
+    assert!(
+        output.status.success(),
+        "replacement JSON report must succeed. stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout)?;
+    assert_eq!(report["schema_version"], "incan.replacement_execution.v0");
+    assert_eq!(report["status"], "success");
+    assert_eq!(report["mode"], "executable");
+    assert_eq!(report["backend"]["executed_backend"], "replacement");
+    assert_eq!(report["replacement_execution"]["result"], "42");
+    assert!(
+        report["replacement_execution"]["output_identity"]
+            .as_str()
+            .is_some_and(|identity| identity.starts_with("sha256:")),
+        "direct report must project the receipt-bound output identity: {report}"
+    );
+    assert!(
+        report["replacement_execution"]["ownership_reads"].is_array()
+            && report["replacement_execution"]["runtime_requirements"].is_array(),
+        "direct report must project canonical ownership and runtime evidence: {report}"
+    );
+    assert!(
+        report.get("generated").is_none() && report.get("oven").is_none(),
+        "direct replacement report must not invent generated-Rust or Oven evidence: {report}"
+    );
+    Ok(())
+}
+
+/// Reject the unimplemented legacy fallback spelling before it can create an artifact or receipt.
+#[test]
+fn replacement_cli_rejects_legacy_fallback_without_artifacts_or_receipts() -> Result<(), Box<dyn std::error::Error>> {
+    let temporary = tempfile::tempdir()?;
+    let entrypoint = temporary.path().join("main.incn");
+    fs::write(&entrypoint, "def main() -> int:\n  return 42\n")?;
+
+    let output = Command::new(incan_binary())
+        .args([
+            "build",
+            entrypoint.to_string_lossy().as_ref(),
+            "--backend",
+            "replacement",
+            "--backend-fallback",
+            "legacy",
+        ])
+        .output()?;
+    assert!(
+        !output.status.success(),
+        "the unavailable legacy fallback spelling must be rejected"
+    );
+    let combined = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("possible values: refuse"),
+        "CLI must make the only supported fallback policy visible: {combined}"
+    );
+    assert!(
+        !temporary.path().join("target/incan").exists()
+            && !temporary.path().join(".incan/backend/receipt.json").exists(),
+        "an invalid fallback policy must not produce legacy output or a replacement receipt"
     );
     Ok(())
 }
@@ -289,16 +531,177 @@ fn replacement_cli_refuses_unsupported_source_without_legacy_generation() -> Res
         String::from_utf8_lossy(&output.stderr)
     );
     assert!(
-        combined.contains("place projection"),
+        combined.contains("list aggregate"),
         "unsupported construct must be visible: {combined}"
     );
     assert!(
         combined.contains("original Incan source span"),
         "refusal must retain source authority: {combined}"
     );
+    let expected_start = r#"def main() -> int:
+  values = [1, 2]
+  return values[0]
+"#
+    .find("[1, 2]")
+    .ok_or("aggregate fixture must contain its list literal")?;
+    let expected_end = expected_start + "[1, 2]".len();
+    assert!(
+        combined.contains(&format!(
+            "primary Incan source location: {}:{expected_start}..{expected_end}",
+            entrypoint.display()
+        )),
+        "CLI refusal must identify the aggregate-bearing source expression exactly: {combined}"
+    );
     assert!(
         !combined.contains("Generated Rust project"),
         "refusal must not enter legacy generation: {combined}"
+    );
+    assert!(
+        !temporary.path().join("target/incan").exists(),
+        "unsupported replacement input must not create a legacy generated-project directory"
+    );
+    Ok(())
+}
+
+/// Persist a requested shadow comparison as explicitly unavailable when no legacy runtime comparator exists.
+#[test]
+fn replacement_cli_shadow_receipt_is_explicitly_non_green() -> Result<(), Box<dyn std::error::Error>> {
+    let temporary = tempfile::tempdir()?;
+    let entrypoint = temporary.path().join("main.incn");
+    fs::write(&entrypoint, "def main() -> int:\n  return 42\n")?;
+
+    let output = Command::new(incan_binary())
+        .args([
+            "build",
+            entrypoint.to_string_lossy().as_ref(),
+            "--backend",
+            "replacement",
+            "--backend-fallback",
+            "refuse",
+            "--shadow",
+        ])
+        .output()?;
+    assert!(
+        output.status.success(),
+        "shadowed replacement build must execute directly. stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let receipt_path = temporary.path().join(".incan/backend/receipt.json");
+    let receipt: serde_json::Value = serde_json::from_str(&fs::read_to_string(receipt_path)?)?;
+    assert_eq!(receipt["selection"]["shadow_requested"], true);
+    let reason = receipt["shadow_comparison"]["unavailable"]["reason"]
+        .as_str()
+        .ok_or("requested shadow comparison must persist an unavailable reason")?;
+    assert_eq!(reason, incan::backend::selection::SHADOW_COMPARISON_UNAVAILABLE_REASON);
+    assert!(
+        !temporary.path().join("target/incan").exists(),
+        "shadow comparison must not generate a legacy project as semantic evidence"
+    );
+    Ok(())
+}
+
+/// Refuse imports and Rust-module directives with typed, file-addressable source diagnostics.
+#[test]
+fn replacement_cli_refuses_module_boundaries_with_primary_spans() -> Result<(), Box<dyn std::error::Error>> {
+    let cases = [
+        (
+            "import",
+            "import std.io\n\ndef main() -> int:\n  return 42\n",
+            "import declaration",
+        ),
+        (
+            "rust-module",
+            "rust.module(\"incan_stdlib::testing\")\n\ndef main() -> int:\n  return 42\n",
+            "Rust interop `rust.module` directive",
+        ),
+    ];
+    for (name, source, expected_boundary) in cases {
+        let temporary = tempfile::tempdir()?;
+        let entrypoint = temporary.path().join(format!("{name}.incn"));
+        fs::write(&entrypoint, source)?;
+        let output = Command::new(incan_binary())
+            .args([
+                "build",
+                entrypoint.to_string_lossy().as_ref(),
+                "--backend",
+                "replacement",
+                "--backend-fallback",
+                "refuse",
+            ])
+            .output()?;
+        assert!(
+            !output.status.success(),
+            "{name} must be refused by the source-only profile"
+        );
+        let combined = format!(
+            "{}\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            combined.contains("INCAN-R988-UNSUPPORTED"),
+            "missing typed diagnostic: {combined}"
+        );
+        assert!(
+            combined.contains(expected_boundary),
+            "missing refusal boundary: {combined}"
+        );
+        assert!(
+            combined.contains(&format!("primary Incan source location: {}:0..", entrypoint.display())),
+            "refusal must retain the first unsupported source span: {combined}"
+        );
+        assert!(
+            !temporary.path().join("target/incan").exists(),
+            "{name} refusal must not create a legacy generated-project directory"
+        );
+    }
+    Ok(())
+}
+
+/// Refuse an unsupported sibling function before a source-wide replacement receipt can be published.
+#[test]
+fn replacement_cli_refuses_additional_free_functions_before_writing_a_receipt() -> Result<(), Box<dyn std::error::Error>>
+{
+    let temporary = tempfile::tempdir()?;
+    let entrypoint = temporary.path().join("main.incn");
+    fs::write(
+        &entrypoint,
+        r#"def main() -> int:
+  return 42
+
+def unused() -> list[int]:
+  return [1]
+"#,
+    )?;
+
+    let output = Command::new(incan_binary())
+        .args([
+            "build",
+            entrypoint.to_string_lossy().as_ref(),
+            "--backend",
+            "replacement",
+            "--backend-fallback",
+            "refuse",
+        ])
+        .output()?;
+    assert!(
+        !output.status.success(),
+        "a source-wide replacement receipt must not ignore an unsupported sibling function"
+    );
+    let combined = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("additional free function `unused`"),
+        "the rejected sibling function must be visible: {combined}"
+    );
+    assert!(
+        !temporary.path().join("target/incan").exists()
+            && !temporary.path().join(".incan/backend/receipt.json").exists(),
+        "a source-wide profile refusal must not produce legacy output or a replacement receipt"
     );
     Ok(())
 }

--- a/tests/support/parity_corpus.rs
+++ b/tests/support/parity_corpus.rs
@@ -19,19 +19,28 @@
 //! ## Receipt-awareness (#986, landed via PR #1120)
 //!
 //! #987's own scope calls for "receipt-aware reference/replacement or shadow comparisons where both paths are
-//! available." #986 landed [`incan::backend::selection`], so [`compute_receipt`] declares a real
+//! available." #986 landed [`incan::backend::selection`], so [`evaluate_case`] declares a real
 //! [`BackendSelection`], resolves it, and finalizes a real [`BackendExecutionReceipt`] for every case's source —
-//! the same three-call sequence `src/cli/commands/build.rs` uses for an actual build. The replacement backend
-//! itself is not implemented yet (#653), so every case's shadow comparison against it is genuinely
-//! [`ShadowComparisonState::Unavailable`], not a guessed placeholder: [`ReceiptRef::ShadowUnavailable`] carries the
-//! real receipt's content identity, and the summary's `receipt_schema_available` field is `true` because the
-//! comparison the corpus attempted was real, even though its result is not yet green.
+//! the same three-call sequence `src/cli/commands/build.rs` uses for an actual build. The first #988 Body-IR cases
+//! additionally execute the replacement backend and carry their own selection/execution receipt, Body-IR snapshot,
+//! ownership evidence, and runtime requirements. Their requested shadow comparison remains genuinely
+//! [`ShadowComparisonState::Unavailable`] because no source-observable legacy comparator exists; generated Rust is
+//! never substituted as semantic proof.
 
+use incan::backend::replacement::{
+    OwnershipReadProjection, ReplacementValue, RuntimeRequirementProjection, execute_prevalidated_free_function,
+    prepare_free_function_execution,
+};
 use incan::backend::selection::{
     BackendExecutionReceipt, BackendKind, BackendSelection, BackendSelectionError, FallbackPolicy,
     ShadowComparisonState, digest_output, finalize_receipt, resolve_execution, select_backend,
+    unavailable_shadow_comparison,
 };
+use incan::frontend::body_ir::build_body_ir_module_v0;
 use incan::frontend::diagnostics::DIAGNOSTIC_SCHEMA_VERSION;
+use incan::frontend::typechecker::TypeChecker;
+use incan::frontend::{lexer, parser};
+use incan_semantics_core::body_ir::BodyIrModule;
 use std::collections::BTreeSet;
 
 // ============================================================================
@@ -79,6 +88,8 @@ pub(crate) enum EvidenceLane {
     CodegenSnapshot,
     /// Integration tests, stdlib runtime tests, smoke tests — compiled/runtime behavior.
     GeneratedProjectRun,
+    /// Typed source lowered to Body IR and executed directly by the bounded replacement profile.
+    DirectReplacementBodyIr,
     /// Package consumer fixtures, facade/reexport tests, checked API metadata tests.
     ///
     /// No seed case uses this lane yet — deferred to plan step 4 alongside `RustInteropBehavior`.
@@ -143,17 +154,38 @@ impl Disposition {
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(tag = "state", rename_all = "snake_case")]
 pub(crate) enum ReceiptRef {
-    /// A real receipt was produced, but its shadow comparison against the replacement backend is unavailable
-    /// because the replacement backend itself is not implemented yet (#653). This is the only reachable variant
-    /// today: every seed case lands here, honestly, until #653 gives the replacement backend something to compare
-    /// against. See [`OverallState::NonGreenShadowUnavailable`].
+    /// A real legacy receipt was produced, but its requested source-observable comparison is unavailable. This is
+    /// the honest state for pre-#988 seed rows that do not yet own a direct replacement execution. See
+    /// [`OverallState::NonGreenShadowUnavailable`].
     ShadowUnavailable { receipt_identity: String, reason: String },
-    /// A real receipt's shadow comparison against the replacement backend matched. Not reachable until #653 lands
-    /// the replacement backend; kept so the schema does not need another shape change when it does.
+    /// A #988 replacement execution with its own #986 selection/execution receipt and Body-IR evidence.
+    ///
+    /// The comparison remains non-green because the requested source-observable legacy comparator is unavailable;
+    /// this variant proves replacement execution without promoting it to parity.
+    ReplacementExecuted {
+        /// Identity of the pre-execution replacement selection.
+        selection_identity: String,
+        /// Identity of the finalized replacement execution receipt.
+        receipt_identity: String,
+        /// Identity of the direct Body-IR output bound into that receipt.
+        output_identity: String,
+        /// Deterministic snapshot of the Body IR the replacement executor consumed.
+        body_snapshot: String,
+        /// Canonical ownership facts observed during direct execution.
+        ownership_reads: Vec<OwnershipReadProjection>,
+        /// Canonical Body-IR runtime requirements observed by direct execution.
+        runtime_requirements: Vec<RuntimeRequirementProjection>,
+        /// Concrete reason the intentionally requested semantic comparison is non-green.
+        comparison_reason: String,
+    },
+    /// A real receipt's source-observable shadow comparison against the replacement backend matched. Not reachable
+    /// until a paired legacy runtime comparator is implemented; kept so the schema does not need another shape
+    /// change when it does.
     #[allow(dead_code)]
     ShadowMatched { receipt_identity: String },
     /// A real receipt's shadow comparison against the replacement backend diverged — a genuine regression signal
-    /// on the backend-selection axis itself, not a schema gap. Not reachable until #653 lands.
+    /// on the backend-selection axis itself, not a schema gap. Not reachable until a paired legacy runtime
+    /// comparator exists.
     #[allow(dead_code)]
     ShadowDiverged { receipt_identity: String, detail: String },
     /// The backend-selection API itself returned an error while declaring or resolving a selection for this
@@ -163,15 +195,8 @@ pub(crate) enum ReceiptRef {
     SelectionError { detail: String },
 }
 
-/// Declare, resolve, and finalize a real #986 backend-selection receipt for `source`, and fold the outcome into a
-/// [`ReceiptRef`].
-///
-/// Mirrors the exact `select_backend` -> `resolve_execution` -> `finalize_receipt` sequence
-/// `src/cli/commands/build.rs`'s `select_and_resolve_backend`/`finalize_backend_receipt` helpers use for a real
-/// build, including requesting a shadow comparison and using the same "replacement backend not implemented yet
-/// (#653)" reason `build.rs` records — so this corpus exercises the real #986 contract rather than a parallel,
-/// possibly-drifting reimplementation of it.
-pub(crate) fn compute_receipt(source: &str) -> ReceiptRef {
+/// Declare, resolve, and finalize the legacy-side #986 receipt retained by the pre-#988 seed rows.
+fn compute_legacy_receipt(source: &str) -> ReceiptRef {
     let source_identity = digest_output(&[source]);
     let selection = select_backend(
         BackendKind::Legacy,
@@ -199,17 +224,151 @@ pub(crate) fn compute_receipt(source: &str) -> ReceiptRef {
     }
 }
 
+/// The behavior result and #986 receipt produced by one direct replacement execution.
+///
+/// The two values are inseparable evidence: the value comes from the same selected, validated Body-IR execution
+/// whose output identity is finalized into `receipt`.
+struct ReplacementPlanEvidence {
+    behavior_outcome: ComparisonOutcome,
+    receipt: ReceiptRef,
+}
+
+/// Execute one #988 plan once, through #986 selection, and bind the observed Body-IR result to its receipt.
+fn execute_replacement_plan(source: &str, plan: ReplacementExecutionPlan) -> ReplacementPlanEvidence {
+    let arguments = (plan.arguments)();
+    let expected = (plan.expected)();
+    let selection = select_backend(
+        BackendKind::Replacement,
+        true,
+        true,
+        digest_output(&[source]),
+        FallbackPolicy::Refuse,
+    );
+    let body_ir = match lower_replacement_case(source) {
+        Ok(body_ir) => body_ir,
+        Err(detail) => return replacement_profile_refusal(&selection, detail),
+    };
+    let execution_plan = match prepare_free_function_execution(&body_ir, plan.function, &arguments) {
+        Ok(execution_plan) => execution_plan,
+        Err(error) => return replacement_profile_refusal(&selection, error.to_string()),
+    };
+    let executed = match resolve_execution(&selection, true) {
+        Ok(backend) => backend,
+        Err(error) => {
+            return ReplacementPlanEvidence {
+                behavior_outcome: ComparisonOutcome::Incompatible {
+                    reason: format!("replacement corpus selection failure: {error}"),
+                },
+                receipt: receipt_ref_from_error(&error),
+            };
+        }
+    };
+    let execution = match execute_prevalidated_free_function(execution_plan) {
+        Ok(execution) => execution,
+        Err(error) => {
+            return ReplacementPlanEvidence {
+                behavior_outcome: ComparisonOutcome::Mismatch {
+                    detail: format!("replacement corpus execution failure: {error}"),
+                },
+                receipt: ReceiptRef::SelectionError {
+                    detail: format!("replacement corpus execution failure: {error}"),
+                },
+            };
+        }
+    };
+    let behavior_outcome = if execution.value == expected {
+        ComparisonOutcome::Match
+    } else {
+        ComparisonOutcome::Mismatch {
+            detail: format!(
+                "replacement `{}` returned {:?}, expected {:?}",
+                plan.function, execution.value, expected
+            ),
+        }
+    };
+    let shadow_comparison = unavailable_shadow_comparison(selection.shadow_requested);
+    let comparison_reason = match &shadow_comparison {
+        ShadowComparisonState::Unavailable { reason } => reason.clone(),
+        state => {
+            return ReplacementPlanEvidence {
+                behavior_outcome,
+                receipt: ReceiptRef::SelectionError {
+                    detail: format!("replacement corpus expected unavailable shadow comparison, got {state:?}"),
+                },
+            };
+        }
+    };
+    let receipt = match finalize_receipt(
+        &selection,
+        executed,
+        execution.output_identity.clone(),
+        shadow_comparison,
+        DIAGNOSTIC_SCHEMA_VERSION,
+    ) {
+        Ok(receipt) => receipt,
+        Err(error) => {
+            return ReplacementPlanEvidence {
+                behavior_outcome,
+                receipt: receipt_ref_from_error(&error),
+            };
+        }
+    };
+    if let Err(error) = receipt.verify_identity() {
+        return ReplacementPlanEvidence {
+            behavior_outcome,
+            receipt: receipt_ref_from_error(&error),
+        };
+    }
+    let output_identity = execution.output_identity.clone();
+    let body_snapshot = execution.body_snapshot.clone();
+    let ownership_reads = execution.ownership_evidence();
+    let runtime_requirements = execution.runtime_requirement_evidence();
+    ReplacementPlanEvidence {
+        behavior_outcome,
+        receipt: ReceiptRef::ReplacementExecuted {
+            selection_identity: receipt.selection.identity,
+            receipt_identity: receipt.identity,
+            output_identity,
+            body_snapshot,
+            ownership_reads,
+            runtime_requirements,
+            comparison_reason,
+        },
+    }
+}
+
+/// Refuse a replacement corpus profile through the canonical #986 selection boundary.
+///
+/// A Body-IR lowering or profile error must not execute directly, and must not silently turn into legacy behavior.
+/// Resolving the declared selection with availability set to `false` preserves that refusal as receipt evidence.
+fn replacement_profile_refusal(selection: &BackendSelection, detail: String) -> ReplacementPlanEvidence {
+    match resolve_execution(selection, false) {
+        Ok(executed) => ReplacementPlanEvidence {
+            behavior_outcome: ComparisonOutcome::Incompatible {
+                reason: format!("replacement corpus profile refusal: {detail}"),
+            },
+            receipt: ReceiptRef::SelectionError {
+                detail: format!(
+                    "replacement corpus profile refusal was incorrectly resolved to `{executed:?}`: {detail}"
+                ),
+            },
+        },
+        Err(error) => ReplacementPlanEvidence {
+            behavior_outcome: ComparisonOutcome::Incompatible {
+                reason: format!("replacement corpus profile refusal: {detail}"),
+            },
+            receipt: ReceiptRef::SelectionError {
+                detail: format!("replacement corpus profile refusal: {detail}; selection refusal: {error}"),
+            },
+        },
+    }
+}
+
 /// Decide the shadow-comparison state for a selection, matching `build.rs`'s own `backend_shadow_comparison`
 /// helper exactly (same condition, same reason string) so the two do not drift into disagreeing explanations for
 /// the same unavailability.
 fn shadow_comparison_for(selection: &BackendSelection) -> ShadowComparisonState {
-    if selection.shadow_requested {
-        ShadowComparisonState::Unavailable {
-            reason: "replacement backend not implemented yet (#653)".to_string(),
-        }
-    } else {
-        ShadowComparisonState::NotRequested
-    }
+    unavailable_shadow_comparison(selection.shadow_requested)
 }
 
 /// Fold a finalized receipt's shadow-comparison outcome into the [`ReceiptRef`] a [`CaseReport`] carries.
@@ -255,9 +414,9 @@ pub(crate) enum ComparisonOutcome {
     Mismatch { detail: String },
     /// The comparison was not run for a stated reason (for example, the required backend path does not exist yet).
     ///
-    /// No seed case produces this yet — every seed `evaluate` function can run today. Reserved for cases that
-    /// depend on a boundary that does not exist yet (for example Body IR execution, #653), so a future case can
-    /// report "not run" honestly instead of being omitted from the corpus entirely.
+    /// No seed case produces this yet — every seed `evaluate` function can run today. Reserved for a future source
+    /// profile whose required execution boundary is unavailable, so that case can report "not run" honestly instead
+    /// of being omitted from the corpus entirely.
     #[allow(dead_code)]
     Skipped { reason: String },
     /// The two sides of the comparison are not comparable (for example, mismatched build profiles).
@@ -291,13 +450,42 @@ pub(crate) struct ParityCase {
     /// Repo-relative pointer to the primary evidence for this case (fixture path, test name, or doc anchor).
     pub(crate) evidence: &'static str,
     pub(crate) disposition: Disposition,
-    /// The case's own Incan source, used to derive a real #986 backend-selection receipt via [`compute_receipt`].
+    /// The case's own Incan source, used to derive a real #986 backend-selection receipt via [`evaluate_case`].
     /// Red-state fixtures that never reach [`evaluate_case`] may use a trivial placeholder since it is unused.
     pub(crate) source: &'static str,
-    /// Executes the actual comparison and returns its outcome. Must not panic on an expected-non-green result —
-    /// return [`ComparisonOutcome::Mismatch`]/`Skipped`/`Incompatible` instead so the corpus test can assert on
-    /// the report rather than on a panicking case function.
-    pub(crate) evaluate: fn() -> ComparisonOutcome,
+    /// Executes the legacy/non-replacement comparison for this case. Direct replacement plans instead derive their
+    /// outcome from the single selected execution that also produces their receipt. Must not panic on an expected
+    /// non-green result — return [`ComparisonOutcome::Mismatch`]/`Skipped`/`Incompatible` instead.
+    pub(crate) evaluate: Option<fn() -> ComparisonOutcome>,
+    /// Optional direct replacement execution that owns this case's #988 proof bundle.
+    pub(crate) replacement_execution: Option<ReplacementExecutionPlan>,
+}
+
+/// A parameterized direct replacement execution bound to one stable #987 corpus case.
+///
+/// This intentionally names a function plus concrete values rather than a generated-Rust entrypoint. The source is
+/// typechecked and lowered to Body IR in-process, then the replacement executor consumes that Body IR directly.
+#[derive(Clone, Copy)]
+pub(crate) struct ReplacementExecutionPlan {
+    /// Source-level free function executed by the replacement profile.
+    pub(crate) function: &'static str,
+    /// Concrete typed values passed to `function` in source parameter order.
+    pub(crate) arguments: fn() -> Vec<ReplacementValue>,
+    /// The source-observable value the direct execution must produce.
+    pub(crate) expected: fn() -> ReplacementValue,
+}
+
+/// Typecheck and lower source into the Body IR that replacement selection validates before execution.
+fn lower_replacement_case(source: &str) -> Result<BodyIrModule, String> {
+    let tokens = lexer::lex(source).map_err(|errors| format!("replacement corpus lex failure: {errors:?}"))?;
+    let program = parser::parse(&tokens).map_err(|errors| format!("replacement corpus parse failure: {errors:?}"))?;
+    let module_path = vec!["parity_987_replacement".to_string()];
+    let mut checker = TypeChecker::new();
+    checker.set_current_module_path(Some(module_path.clone()));
+    checker
+        .check_program(&program)
+        .map_err(|errors| format!("replacement corpus typecheck failure: {errors:?}"))?;
+    Ok(build_body_ir_module_v0(&program, &module_path, checker.type_info()))
 }
 
 // ============================================================================
@@ -404,20 +592,17 @@ pub(crate) struct CaseReport {
 /// The final, honest per-case state a CI consumer or #655 should read.
 ///
 /// There is deliberately no plain `Green` reachable today: reaching it requires both a [`ComparisonOutcome::Match`]
-/// behavior outcome *and* a matched shadow comparison against the replacement backend, and the replacement backend
-/// itself is not implemented yet (#653). This keeps the summary from ever silently claiming full backend-cutover
-/// parity before that dependency exists — even though #986's receipt contract has landed and every case now
-/// consults a real receipt.
+/// behavior outcome *and* a matched source-observable shadow comparison against the replacement backend. #988's
+/// direct executions remain non-green until the same source profile has a paired legacy runtime comparator, even
+/// though every case already consults a real receipt.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum OverallState {
-    /// Behavior matched and a real shadow comparison against the replacement backend also matched. Not reachable
-    /// until #653 lands the replacement backend — kept as a variant so the summary schema does not need to change
-    /// when it does.
+    /// Behavior matched and a real source-observable shadow comparison against the replacement backend also
+    /// matched. Not reachable until a paired legacy runtime comparator exists.
     Green,
     /// Behavior matched and a real receipt was produced, but its shadow comparison against the replacement
-    /// backend is unavailable (today: always this, for a `Match` case) because the replacement backend is not
-    /// implemented yet (#653).
+    /// backend is unavailable because the active source profile has no paired legacy runtime comparator.
     NonGreenShadowUnavailable,
     /// The case's own behavior evaluation did not match (mismatch, skip, or incompatible) — a real signal.
     NonGreenBehavior,
@@ -426,8 +611,25 @@ pub(crate) enum OverallState {
 /// Evaluate one case: run its behavior probe, consult a real #986 receipt for its source, and fold both into a
 /// [`CaseReport`].
 pub(crate) fn evaluate_case(case: &ParityCase) -> CaseReport {
-    let behavior_outcome = (case.evaluate)();
-    let receipt = compute_receipt(case.source);
+    let (behavior_outcome, receipt) = match case.replacement_execution {
+        Some(plan) => {
+            let evidence = execute_replacement_plan(case.source, plan);
+            (evidence.behavior_outcome, evidence.receipt)
+        }
+        None => match case.evaluate {
+            Some(evaluate) => (evaluate(), compute_legacy_receipt(case.source)),
+            None => (
+                ComparisonOutcome::Incompatible {
+                    reason: "corpus case has neither a legacy behavior probe nor a replacement execution plan"
+                        .to_string(),
+                },
+                ReceiptRef::SelectionError {
+                    detail: "corpus case has neither a legacy behavior probe nor a replacement execution plan"
+                        .to_string(),
+                },
+            ),
+        },
+    };
     // `shadow_matched` is its own match (rather than folded into one match on `(outcome, receipt)`) so that adding
     // a future reachable `ReceiptRef` variant only requires updating this one arm.
     let shadow_matched = matches!(receipt, ReceiptRef::ShadowMatched { .. });
@@ -466,12 +668,11 @@ pub(crate) struct CorpusSummary {
     pub(crate) cases: Vec<CaseReport>,
 }
 
-/// The current CI-summary schema version. Bumped to `2`: `#986` landed, so every case now consults a real receipt
-/// instead of a placeholder, `non_green_pending_receipt` was renamed to `non_green_shadow_unavailable` to describe
-/// what is actually unavailable (the replacement backend, not the receipt schema), and `receipt_schema_available`
-/// now reflects reality (`true`) instead of always being `false`. Bump again whenever `CorpusSummary`'s or
+/// The current CI-summary schema version. Version `3` adds `ReceiptRef::ReplacementExecuted`, which binds the five
+/// #988 Body-IR cases to their own selection/execution identities and canonical body, ownership, and runtime
+/// evidence while retaining an explicit non-green unavailable comparison. Bump again whenever `CorpusSummary`'s or
 /// `CaseReport`'s field shape changes in a way a consumer (including #655) would need to notice.
-pub(crate) const SCHEMA_VERSION: u32 = 2;
+pub(crate) const SCHEMA_VERSION: u32 = 3;
 
 /// Evaluate every case in the corpus and assemble the CI-readable summary.
 ///

--- a/workspaces/docs-site/docs/tooling/explanation/backend_selection_receipts.md
+++ b/workspaces/docs-site/docs/tooling/explanation/backend_selection_receipts.md
@@ -1,8 +1,8 @@
 # Backend selection & execution receipts
 
-The v0.6 replacement-backend cutover ([#652](https://github.com/encero-systems/incan/issues/652)) introduces a second compiler backend: the Body IR replacement backend tracked by [#653](https://github.com/encero-systems/incan/issues/653), alongside the current Rust-source-emission backend (`IrCodegen`, `src/backend/ir/`) that this document calls the legacy backend. Until the replacement backend lands, a build must still be able to declare which backend it intends to use, record which backend it actually ran, and refuse visibly rather than quietly falling back to legacy when the requested backend cannot execute. `src/backend/selection.rs` (#986) is the compiler-owned boundary that makes that possible.
+The v0.6 replacement-backend cutover ([#652](https://github.com/encero-systems/incan/issues/652)) introduces a second compiler backend: the Body IR replacement backend tracked by [#653](https://github.com/encero-systems/incan/issues/653), alongside the current Rust-source-emission backend (`IrCodegen`, `src/backend/ir/`) that this document calls the legacy backend. #988 provides the first deliberately partial direct-execution profile. Every request still declares the intended backend, records the backend that actually ran, and refuses unsupported source visibly rather than quietly falling back to legacy. `src/backend/selection.rs` (#986) is the compiler-owned boundary that makes that possible.
 
-This is a different axis from Oven's own receipt, described in [Oven Alpha](oven_alpha.md): Oven's receipt selects how an already-generated artifact is compiled (its legacy-Cargo-vs-direct-`rustc` build boundary), and never influences which compiler backend produced that artifact in the first place. The two receipts are complementary and travel together: a build first declares and executes a backend selection, then hands the resulting generated source to Oven for compilation.
+This is a different axis from Oven's own receipt, described in [Oven Alpha](oven_alpha.md): Oven's receipt selects how an already-generated artifact is compiled (its legacy-Cargo-vs-direct-`rustc` build boundary), and never influences which compiler backend produced that artifact in the first place. Legacy builds hand generated source to Oven; the #988 direct replacement profile does not create generated source or an Oven plan.
 
 ## The two records
 
@@ -18,23 +18,23 @@ Every successful `incan build` exposes a selection and a receipt, including the 
 
 The first #988 replacement profile produces a visible outcome, never a silent legacy execution:
 
-- `incan build --backend replacement --backend-fallback refuse` typechecks one source-only free-function module, lowers it to Body IR, and directly executes its zero-argument `main` body. Its receipt records `executed_backend: "replacement"`, `fallback_outcome: "not_needed"`, and an output identity over the actual Body-IR execution result; this path does not construct generated Rust or an Oven plan.
-- The supported profile is deliberately partial: scalar arithmetic, local bindings, returns, compiler-owned string concatenation, normalized range/while branches and loops, and assertions. Packages, imports, Rust interop, callable values, generators, destructuring, projections, and shadowing are refused visibly with the original Incan source span. A refusal writes no success receipt and cannot be mistaken for a replacement pass.
-- `--backend-fallback legacy` remains a separately declared #986 capability, but it is not used as an implicit compatibility path for the #988 profile. Choose `--backend legacy` explicitly when the source is outside the profile.
+- `incan build --backend replacement --backend-fallback refuse` typechecks one source-only module containing exactly the selected zero-argument `main` free function, lowers it to Body IR, and executes that body directly. Its receipt records `executed_backend: "replacement"`, `fallback_outcome: "not_needed"`, and an output identity over the actual Body-IR execution result; this path does not construct generated Rust or an Oven plan.
+- The supported profile is deliberately partial: scalar arithmetic, scalar local bindings with no repeated user-binding name, returns, compiler-owned string concatenation, normalized range/while branches and loops, and assertions. Packages, imports, Rust interop, additional free functions, callable values, generators, destructuring, all aggregates, projections, and any repeated user-binding spelling (lexical shadowing or reassignment) are refused visibly with the original Incan source span. A refusal emits no new receipt; it does not remove a receipt written by an earlier successful build.
+- The #988 CLI surface accepts only `--backend-fallback refuse`. It has no receipt-bound legacy execution path for an unavailable source profile, so users must choose `--backend legacy` explicitly when the source is outside the profile.
 
 A `--shadow` request without a source-observable legacy entrypoint remains `{"unavailable": {"reason": "..."}}`, never `"matched"`. It is deliberately non-green: generated-Rust token shape is not a semantic comparison.
 
-Any explicit backend request, fallback policy, or shadow request bypasses completed-output reuse and takes the normal source-aware preparation path. This prevents a cached default result from being presented as the outcome of a different declared selection.
+Any explicit backend request, fallback policy, or shadow request bypasses completed-output reuse and takes the source-based path appropriate to the declared backend. This prevents a cached default result from being presented as the outcome of a different declared selection.
 
 ## CLI surface
 
 `incan build` accepts three flags:
 
 - `--backend <legacy|replacement>` — declare the backend for this build. Defaults to `legacy`.
-- `--backend-fallback <refuse|legacy|replacement>` — declare what to do if `--backend` cannot execute. Omitting this flag means refuse.
+- `--backend-fallback <refuse>` — declare that an unavailable backend must stop visibly. Omitting this flag means refuse.
 - `--shadow` — request a comparison against the replacement backend alongside normal execution.
 
-A successful build publishes its receipt to `.incan/backend/receipt.json` in the project root (parallel to Oven's own `.incan/oven/receipt.json`), and embeds it as the `backend` field of `incan build --report json` output. An eligible completed-output reuse republishes its verified sealed receipt at the same path. Inspect a persisted receipt directly with:
+A successful build publishes its receipt to `.incan/backend/receipt.json` in the project root (parallel to Oven's own `.incan/oven/receipt.json`), and embeds it as the `backend` field of `incan build --report json` output. The #988 direct path has the explicit `incan.replacement_execution.v0` report schema: alongside `status`, `mode`, and `entrypoint`, its `replacement_execution` payload projects the Body-IR result, receipt-bound output identity, snapshot, canonical ownership reads, and runtime requirements. It intentionally has no generated-artifact or Oven fields. An eligible completed-output reuse republishes its verified sealed receipt at the same path. Inspect a persisted receipt directly with:
 
 ```bash
 incan inspect backend-selection --receipt .incan/backend/receipt.json

--- a/workspaces/docs-site/docs/tooling/explanation/backend_selection_receipts.md
+++ b/workspaces/docs-site/docs/tooling/explanation/backend_selection_receipts.md
@@ -16,12 +16,13 @@ Both types are plain, I/O-free data — building and executing them does not tou
 
 Every successful `incan build` exposes a selection and a receipt, including the default path: selecting the legacy backend with no flags produces an explicit `selection_reason: "default"` record rather than an implicit, unrecorded choice. A source-current completed-output reuse is eligible only when its immutable Loaf already carries and verifies that same implicit-default receipt; it republishes the verified receipt after materialization rather than inventing a new execution record.
 
-Requesting the replacement backend today always produces a visible outcome, never a silent legacy execution:
+The first #988 replacement profile produces a visible outcome, never a silent legacy execution:
 
-- With the default fallback policy (`refuse`), the build stops immediately — before any codegen or Oven work — with a typed refusal naming the unavailable backend. No receipt is written for a refused build: there is no code path in `src/backend/selection.rs` that can turn a refusal into a receipt, so a refused build cannot be mistaken for a green replacement-backend result.
-- With an explicit fallback policy (`--backend-fallback legacy`), the build proceeds through the fallback backend, prints `⚠ backend fallback: ...` to stderr, and records `fallback_outcome: {"declared": {"from": "replacement", "to": "legacy"}}` in the receipt. The substitution is always visible in both the terminal and the machine-readable record.
+- `incan build --backend replacement --backend-fallback refuse` typechecks one source-only free-function module, lowers it to Body IR, and directly executes its zero-argument `main` body. Its receipt records `executed_backend: "replacement"`, `fallback_outcome: "not_needed"`, and an output identity over the actual Body-IR execution result; this path does not construct generated Rust or an Oven plan.
+- The supported profile is deliberately partial: scalar arithmetic, local bindings, returns, compiler-owned string concatenation, normalized range/while branches and loops, and assertions. Packages, imports, Rust interop, callable values, generators, destructuring, projections, and shadowing are refused visibly with the original Incan source span. A refusal writes no success receipt and cannot be mistaken for a replacement pass.
+- `--backend-fallback legacy` remains a separately declared #986 capability, but it is not used as an implicit compatibility path for the #988 profile. Choose `--backend legacy` explicitly when the source is outside the profile.
 
-A `--shadow` comparison request is recorded the same way: since the replacement backend is not implemented yet, the receipt's `shadow_comparison` is `{"unavailable": {"reason": "..."}}` rather than silently reporting `"not_requested"`.
+A `--shadow` request without a source-observable legacy entrypoint remains `{"unavailable": {"reason": "..."}}`, never `"matched"`. It is deliberately non-green: generated-Rust token shape is not a semantic comparison.
 
 Any explicit backend request, fallback policy, or shadow request bypasses completed-output reuse and takes the normal source-aware preparation path. This prevents a cached default result from being presented as the outcome of a different declared selection.
 
@@ -30,7 +31,7 @@ Any explicit backend request, fallback policy, or shadow request bypasses comple
 `incan build` accepts three flags:
 
 - `--backend <legacy|replacement>` — declare the backend for this build. Defaults to `legacy`.
-- `--backend-fallback <legacy|replacement>` — declare what to do if `--backend` cannot execute. Omitting this flag means refuse.
+- `--backend-fallback <refuse|legacy|replacement>` — declare what to do if `--backend` cannot execute. Omitting this flag means refuse.
 - `--shadow` — request a comparison against the replacement backend alongside normal execution.
 
 A successful build publishes its receipt to `.incan/backend/receipt.json` in the project root (parallel to Oven's own `.incan/oven/receipt.json`), and embeds it as the `backend` field of `incan build --report json` output. An eligible completed-output reuse republishes its verified sealed receipt at the same path. Inspect a persisted receipt directly with:

--- a/workspaces/docs-site/docs/tooling/reference/cli_reference.md
+++ b/workspaces/docs-site/docs/tooling/reference/cli_reference.md
@@ -173,17 +173,17 @@ Dependency flags:
 - `--features`, `--no-default-features`, `--all-features`: Select public Incan package features for this build.
 - `--sdk-profile <PROFILE>`: Select a non-persistent SDK profile for this build.
 - `--release`: Explicitly request the release profile. This is the default for `incan build`.
-- `--backend <legacy|replacement>`: Declare the compiler backend for this build (#986). Defaults to `legacy`, declared explicitly even when the flag is omitted. `replacement` is the Body IR backend tracked by [#653](https://github.com/encero-systems/incan/issues/653) and is not implemented yet; requesting it fails visibly unless `--backend-fallback` is also given. See [Backend selection & execution receipts](../explanation/backend_selection_receipts.md).
-- `--backend-fallback <legacy|replacement>`: Allow the build to fall back to this backend if `--backend` cannot execute, recording the substitution explicitly instead of refusing.
-- `--shadow`: Request a shadow comparison against the replacement backend alongside normal execution. Recorded explicitly as unavailable until the replacement backend exists.
-- `--report json`: Emit a versioned machine-readable build report.
+- `--backend <legacy|replacement>`: Declare the compiler backend for this build (#986). Defaults to `legacy`, declared explicitly even when the flag is omitted. `replacement` directly executes only a module containing the selected zero-argument `main` Body-IR free function; it visibly refuses sibling functions, aggregates, repeated user-binding names (shadowing or reassignment), and other source outside that bounded #988 profile. It does not create generated Rust or an Oven plan. See [Backend selection & execution receipts](../explanation/backend_selection_receipts.md).
+- `--backend-fallback <refuse>`: Declare the visible refusal policy for an unavailable backend. The #988 source-only profile exposes no legacy fallback target until it has a receipt-bound legacy execution path.
+- `--shadow`: Request a source-observable shadow comparison against the replacement backend alongside normal execution. It is recorded explicitly as unavailable when the active profile has no legacy/replacement comparator; generated Rust is not semantic proof.
+- `--report json`: Emit a versioned machine-readable build report. The source-only replacement path emits its own `incan.replacement_execution.v0` report because it has no generated Rust, native artifact, or Oven plan.
 - `--report-output <PATH>`: Write the build report to a file instead of stdout.
 - `--workspace`: Build every selected workspace member.
 - `--member <NAME_OR_PATH>`: Build one or more selected workspace members.
 
 Normal build, run, and test first select a compatible immutable full-stdlib Loaf from the active toolchain. A project outside that envelope selects its receipt-bound extension from `$INCAN_HOME/oven/store/v2`, or `~/.incan/oven/store/v2` when `INCAN_HOME` is unset, together with the exact base Loaf recorded by the extension. The plan selection key includes target, toolchain, profile, Incan runtime, dependency, feature, and provider inputs. The receipt remains source-strict, so a source change regenerates caller-owned source and receipt while a compatible project can reuse the same immutable base plus extension. `incan inspect oven --receipt PATH --format json` reports the receipt/build-unit identities, selection hit or miss with reason, and physical/logical/reclaimable/lease-protected storage.
 
-Build reports use `schema_version: 1` and describe the successful Oven build rather than restating terminal prose. They include source and generated paths, emitted artifacts, dependency and provider summaries, `oven.receipt_identity`, `oven.build_unit_identity`, `oven.plan_identity`, prepare/build/total elapsed time, a note that no normal Cargo consumer ran, and a `backend` field carrying the build's backend-selection execution receipt (#986). A completed-output reuse is allowed only for the implicit legacy default and retains the verified receipt sealed by its explicit bake; explicit backend, fallback, and shadow requests take the normal preparation path instead.
+Legacy and Oven builds use `schema_version: 1` and describe the successful Oven build rather than restating terminal prose. They include source and generated paths, emitted artifacts, dependency and provider summaries, `oven.receipt_identity`, `oven.build_unit_identity`, `oven.plan_identity`, prepare/build/total elapsed time, a note that no normal Cargo consumer ran, and a `backend` field carrying the build's backend-selection execution receipt (#986). The #988 direct replacement profile instead uses `schema_version: "incan.replacement_execution.v0"` with `status`, `mode`, `entrypoint`, `backend`, direct `replacement_execution` evidence (`result`, `output_identity`, Body-IR snapshot, canonical ownership reads, and runtime requirements), and total elapsed time. It intentionally omits `generated`, artifacts, and `oven`: those facts do not exist for direct Body-IR execution. A completed-output reuse is allowed only for the implicit legacy default and retains the verified receipt sealed by its explicit bake; explicit backend, fallback, and shadow requests take the normal preparation path instead.
 
 A successful build also publishes that same receipt to `.incan/backend/receipt.json` in the project root, independent of `--report`. Inspect it with `incan inspect backend-selection --receipt .incan/backend/receipt.json`. See [Backend selection & execution receipts](../explanation/backend_selection_receipts.md).
 
@@ -200,7 +200,7 @@ incan build src/main.incn --report json
 incan build src/main.incn --features json,http --sdk-profile minimal
 incan build --release
 incan build src/main.incn --report json --report-output target/build-report.json
-incan build src/main.incn --backend replacement --backend-fallback legacy
+incan build src/main.incn --backend replacement --backend-fallback refuse
 ```
 
 ### `incan cache`


### PR DESCRIPTION
## Summary

This PR delivers #988’s first narrow executable replacement-backend vertical: typed source is lowered to Body IR, selected through the #986 boundary, executed directly, and finalized into a real replacement receipt. Unsupported input fails visibly with original source spans; it does not silently reach legacy codegen, Oven, or a generated-Rust semantic comparison.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [x] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [x] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: `incan build --backend replacement --backend-fallback refuse` can execute the bounded, source-only free-function profile and persist a replacement receipt. Unsupported source, lexical shadowing/reassignment, aggregates, and unsupported module boundaries refuse visibly; `legacy` is not accepted as a fallback spelling.
- **Internals**: The direct path uses a validated Body-IR execution capability after #986 selection, binds output/ownership/runtime projections to matching receipt identities, and adds five receipt-bound #987 corpus rows. Python signed `//` and `%` semantics share the core implementation; the unrepresentable signed quotient fails closed.
- **Risks**: This is intentionally not a complete replacement backend. The CLI accepts one zero-argument `main`; packages, Rust interop, callable values, destructuring, generators, and source-observable legacy comparison remain unsupported. Requested shadow comparison is explicitly unavailable/non-green.

## Testing / verification

- [x] Focused `cargo test` coverage (below); the maintainer deferred the broad slice suite.
- [ ] `make examples` (not applicable to this source-only backend vertical)
- [x] `incan fmt --check .` equivalent: `cargo fmt --all -- --check`
- [x] Manual verification described below

Manual verification notes:

- After rebasing onto `origin/0.6-dev` (including #1131), resolved the sole corpus conflict by preserving #1116’s `SupportedLanguageContract` / `Preserved` row and retaining #988’s executable, non-green replacement rows.
- `cargo test --test replacement_backend_execution_tests` — 14 passed.
- `cargo test --test parity_corpus_tests` — 7 passed.
- `git diff --check origin/0.6-dev...HEAD` — passed.
- Earlier focused verification also passed Clippy with `-D warnings`, the changed-rustdoc gate, strict MkDocs, selection tests, signed core/stdlib tests, and layer/registry guards.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): backend-selection receipt explanation and CLI reference distinguish the direct `incan.replacement_execution.v0` report from legacy/Oven reports and describe explicit non-green shadow unavailability.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #988