### PR TITLE
bugfix - reject statement tuple unpack of a non-tuple value (#1132)

### DIFF
--- a/crates/incan_semantics_core/src/lib.rs
+++ b/crates/incan_semantics_core/src/lib.rs
@@ -35,7 +35,7 @@ pub use facts::{
 pub use hir::{HirDeclaration, HirDeclarationKind, HirModule, HirSourceSpan, SemanticModuleSnapshot};
 pub use types::{
     AbiV0Ownership, AbiV0Representation, AbiV0ReservedFacts, AbiV0RuntimeRequirement, AbiV0TypeFacts,
-    AbiV0TypeIdentity, IncanCallableParam, IncanCallableParamKind, IncanPrimitiveType, IncanType,
+    AbiV0TypeIdentity, IncanCallableParam, IncanCallableParamKind, IncanPrimitiveType, IncanType, rust_tuple_arity,
 };
 
 /// Stable feature key used by parser handoff and semantics dispatch.

--- a/crates/incan_semantics_core/src/types.rs
+++ b/crates/incan_semantics_core/src/types.rs
@@ -5,6 +5,57 @@
 
 use std::fmt;
 
+/// Read the arity of a Rust tuple type spelling, or `None` when the shape cannot be established.
+///
+/// This is the single place the compiler decides whether an interop value is destructurable, shared by the
+/// typechecker's statement/loop destructuring and by Body IR lowering so the two can never disagree about what
+/// counts as tuple-shaped. `None` means "not proven to be a tuple" — including opaque named paths like
+/// `rust::String` — and callers must refuse rather than assume, because a wrong `yes` re-emits the `.0`/`.1`
+/// field projection into a fieldless value that #1132 exists to prevent.
+///
+/// Parentheses alone do not make a tuple. Rust spells a one-element tuple `(String,)`; plain `(String)` is just a
+/// parenthesised `String` and has no `.0` field at all. The distinguishing fact is a comma at depth zero, so a
+/// spelling with none is reported as unverifiable rather than as a one-element tuple. Commas nested inside a
+/// generic (`(String, HashMap<K, V>)`) are not counted, and a trailing comma does not add an element.
+///
+/// Parsing a type *string* is a deliberate stopgap. The durable fix is structured Rust type-shape metadata, so
+/// that interop shape is a fact the compiler is given rather than one it re-derives from spelling.
+pub fn rust_tuple_arity(path: &str) -> Option<usize> {
+    let path = path.trim();
+    let path = path.strip_prefix("rust::").unwrap_or(path);
+    let inner = path.strip_prefix('(')?.strip_suffix(')')?;
+    if inner.trim().is_empty() {
+        // `()` is the unit type: a genuine zero-element tuple.
+        return Some(0);
+    }
+
+    let mut depth = 0usize;
+    let mut separators = 0usize;
+    let mut trailing_separator = false;
+    for character in inner.chars() {
+        match character {
+            '<' | '(' | '[' => depth += 1,
+            '>' | ')' | ']' => depth = depth.saturating_sub(1),
+            ',' if depth == 0 => {
+                separators += 1;
+                trailing_separator = true;
+                continue;
+            }
+            _ => {}
+        }
+        if !character.is_whitespace() {
+            trailing_separator = false;
+        }
+    }
+
+    if separators == 0 {
+        // `(String)` — a parenthesised type, not a one-element tuple.
+        return None;
+    }
+    // A trailing comma closes the final element rather than opening another: `(String,)` is one element.
+    Some(if trailing_separator { separators } else { separators + 1 })
+}
+
 /// Backend-neutral Incan type universe used by v0.5 middle-end facts.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum IncanType {
@@ -314,5 +365,45 @@ mod tests {
         assert_eq!(interop.identity.canonical, "rust::rubato::Fft");
         assert_eq!(interop.representation, AbiV0Representation::RustInterop);
         assert_eq!(interop.reserved, AbiV0ReservedFacts::default());
+    }
+}
+
+#[cfg(test)]
+mod rust_tuple_arity_tests {
+    use super::rust_tuple_arity;
+
+    /// Parentheses alone do not make a tuple (#1132).
+    ///
+    /// Reading `(String)` as a one-element tuple would let a one-name destructure lower to `.0` on a `String`,
+    /// recreating the raw-Rust failure through a narrower spelling than the `int` case the issue started from.
+    #[test]
+    fn a_parenthesised_type_is_not_a_one_element_tuple() {
+        assert_eq!(rust_tuple_arity("(String)"), None);
+        assert_eq!(rust_tuple_arity("(std::vec::Vec<u8>)"), None);
+        assert_eq!(rust_tuple_arity("( String )"), None);
+    }
+
+    #[test]
+    fn a_trailing_comma_marks_a_genuine_one_element_tuple() {
+        assert_eq!(rust_tuple_arity("(String,)"), Some(1));
+        assert_eq!(rust_tuple_arity("(String, )"), Some(1));
+    }
+
+    #[test]
+    fn multi_element_and_nested_generic_spellings_keep_their_arity() {
+        assert_eq!(rust_tuple_arity("(A, B)"), Some(2));
+        assert_eq!(rust_tuple_arity("(A, B,)"), Some(2));
+        assert_eq!(rust_tuple_arity("(String,incan_stdlib::json::JsonValue)"), Some(2));
+        // A generic's own commas sit at depth one and must not inflate the count.
+        assert_eq!(rust_tuple_arity("(String, HashMap<K, V>)"), Some(2));
+        assert_eq!(rust_tuple_arity("(HashMap<K, V>, Vec<(A, B)>)"), Some(2));
+    }
+
+    #[test]
+    fn unit_is_a_zero_element_tuple_and_opaque_paths_stay_unverifiable() {
+        assert_eq!(rust_tuple_arity("()"), Some(0));
+        assert_eq!(rust_tuple_arity("String"), None);
+        assert_eq!(rust_tuple_arity("std::collections::HashMap<K, V>"), None);
+        assert_eq!(rust_tuple_arity("rust::(A, B)"), Some(2));
     }
 }

--- a/crates/incan_syntax/src/diagnostics/catalog/errors/types.rs
+++ b/crates/incan_syntax/src/diagnostics/catalog/errors/types.rs
@@ -1973,6 +1973,47 @@ pub fn for_pattern_expects_tuple_item(names: usize, item_ty: &str, span: Span) -
     .with_hint("Iterate a sequence of tuples, or bind each item to a single name")
 }
 
+/// Build the error emitted when a statement destructures a value whose type is not a tuple at all.
+///
+/// The statement-level sibling of [`for_pattern_expects_tuple_item`]: same question, asked where `a, b = value`
+/// binds names rather than where a loop binds an item. Naming the resolved type is the point of the diagnostic —
+/// without it the failure only surfaced as a `rustc` field-projection error against a compiler-internal binding.
+pub fn tuple_unpack_expects_tuple_value(names: usize, value_ty: &str, span: Span) -> CompileError {
+    CompileError::type_error(
+        format!("Cannot destructure {names} values from value of type '{value_ty}'"),
+        span,
+    )
+    .with_hint("Assign a tuple of matching length, or bind the value to a single name")
+}
+
+/// Build the error emitted when a loop pattern destructures a Rust interop item whose shape is unverifiable.
+///
+/// The loop-shaped sibling of [`tuple_unpack_rust_shape_unverified`], paired the same way
+/// [`for_pattern_expects_tuple_item`] pairs with [`tuple_unpack_expects_tuple_value`]. Separate because the
+/// remedy differs: a loop's reader changes what the sequence yields, not what a single assignment produces.
+pub fn for_pattern_rust_shape_unverified(names: usize, item_ty: &str, span: Span) -> CompileError {
+    CompileError::type_error(
+        format!(
+            "Cannot verify Rust iteration item of type '{item_ty}' is tuple-shaped for destructuring {names} values"
+        ),
+        span,
+    )
+    .with_hint("Iterate a sequence of tuples the compiler can read, or bind each item to a single name")
+}
+
+/// Build the error emitted when destructuring a Rust interop value whose shape the compiler cannot establish.
+///
+/// Distinct from [`tuple_unpack_expects_tuple_value`], which reports a type known *not* to be a tuple. Here the
+/// compiler simply cannot tell, and "not proven tuple-shaped" must refuse for the same reason a bare type variable
+/// does: assuming otherwise re-emits a tuple-field projection into a value that may have no such fields.
+pub fn tuple_unpack_rust_shape_unverified(names: usize, value_ty: &str, span: Span) -> CompileError {
+    CompileError::type_error(
+        format!("Cannot verify Rust value of type '{value_ty}' is tuple-shaped for destructuring {names} values"),
+        span,
+    )
+    .with_hint("Bind the value to a single name, or return it from Rust as a tuple the compiler can read")
+}
+
 pub fn tuple_unpack_count_mismatch(expected: usize, found: usize, span: Span) -> CompileError {
     CompileError::type_error(
         format!("Cannot unpack {} values from tuple with {} elements", expected, found),

--- a/src/frontend/body_ir.rs
+++ b/src/frontend/body_ir.rs
@@ -32,7 +32,7 @@ use std::collections::{HashMap, HashSet};
 use incan_semantics_core::body_ir as bir;
 use incan_semantics_core::{
     AbiV0RuntimeRequirement, CompilerNodeId, HirSourceSpan, IncanCallableParam, IncanCallableParamKind,
-    IncanPrimitiveType, IncanType,
+    IncanPrimitiveType, IncanType, rust_tuple_arity,
 };
 
 use incan_core::lang::types::collections::{self, CollectionTypeId};
@@ -961,6 +961,10 @@ impl<'a> BodyBuilder<'a> {
         out: &mut Vec<bir::Statement>,
     ) {
         let value_ty = self.resolve_ty(tuple_unpack.value.span);
+        if let Some(reason) = unsupported_tuple_destructure(&value_ty, tuple_unpack.names.len()) {
+            self.push_unsupported_stmt(reason, span, out);
+            return;
+        }
         let value_operand = self.lower_expr_to_operand(&tuple_unpack.value, scope, out);
         let value_place = self.materialize_operand_to_place(value_operand, value_ty.clone(), scope, span, out);
         let element_types = tuple_element_types(&value_ty, tuple_unpack.names.len());
@@ -998,6 +1002,10 @@ impl<'a> BodyBuilder<'a> {
         out: &mut Vec<bir::Statement>,
     ) {
         let value_ty = self.resolve_ty(tuple_assign.value.span);
+        if let Some(reason) = unsupported_tuple_destructure(&value_ty, tuple_assign.targets.len()) {
+            self.push_unsupported_stmt(reason, span, out);
+            return;
+        }
         let value_operand = self.lower_expr_to_operand(&tuple_assign.value, scope, out);
         let value_place = self.materialize_operand_to_place(value_operand, value_ty.clone(), scope, span, out);
         let element_types = tuple_element_types(&value_ty, tuple_assign.targets.len());
@@ -3335,6 +3343,44 @@ fn unsupported_expr_label(expr: &ast::Expr) -> String {
 /// element read `Borrow` rather than its real Copy/non-Copy fact. The generic base is classified through
 /// [`collections::from_str`] rather than compared against a literal name, so the registry stays the single source
 /// of truth for that vocabulary.
+/// Why a statement-level destructure of `value_ty` into `arity` names cannot be lowered, or `None` when it can.
+///
+/// The statement sibling of [`unsupported_for_pattern`], and it exempts the same two types for the same reason:
+/// `Unknown` and `Never` mean the typechecker either already reported a failure or is looking at unreachable code,
+/// so lowering has nothing to refuse. Everything else — including Rust interop, which is checked against the same
+/// [`rust_tuple_arity`] rule the typechecker uses rather than waved through — must be a tuple of exactly matching
+/// arity before lowering may emit a `.0`/`.1` field projection. Without this, a non-tuple value produced
+/// `__incan_tuple_unpack_*.0` against a fieldless value and surfaced as a raw `rustc` E0610 (#1132).
+fn unsupported_tuple_destructure(value_ty: &IncanType, arity: usize) -> Option<String> {
+    if matches!(value_ty, IncanType::Unknown | IncanType::Never) {
+        return None;
+    }
+    // Interop values go through the same accepted-shape rule the typechecker uses, not an exemption: a readable
+    // tuple spelling lowers, and anything opaque refuses. Waving every `RustInteropPath` through would have let a
+    // genuine non-tuple Rust value reach a `.0`/`.1` projection, which is the leakage #1132 closes.
+    if let IncanType::RustInteropPath(path) = value_ty {
+        return match rust_tuple_arity(path) {
+            Some(rust_arity) if rust_arity == arity => None,
+            Some(rust_arity) => Some(format!(
+                "tuple destructure binds {arity} names but Rust value type `{path}` has {rust_arity} elements"
+            )),
+            None => Some(format!(
+                "tuple destructure of Rust value type `{path}` whose tuple shape cannot be verified"
+            )),
+        };
+    }
+    let Some(element_types) = tuple_type_elements(value_ty) else {
+        return Some(format!("tuple destructure of non-tuple value type `{value_ty}`"));
+    };
+    if element_types.len() != arity {
+        return Some(format!(
+            "tuple destructure binds {arity} names but value type `{value_ty}` has {} elements",
+            element_types.len()
+        ));
+    }
+    None
+}
+
 fn tuple_element_types(ty: &IncanType, count: usize) -> Vec<IncanType> {
     match tuple_type_elements(ty) {
         Some(items) if items.len() == count => items.to_vec(),
@@ -5599,5 +5645,54 @@ mod tests {
             "lowering must not emit tuple-field projections into a type variable: {snapshot}"
         );
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tuple_destructure_interop_tests {
+    use super::{IncanType, unsupported_tuple_destructure};
+
+    /// Lowering must apply the same accepted-shape rule as the typechecker to interop values (#1132).
+    ///
+    /// A blanket `RustInteropPath` exemption here would leave the original defect reachable through interop: an
+    /// opaque Rust value would lower to a `.0`/`.1` projection and fail as raw `rustc` output.
+    #[test]
+    fn opaque_rust_interop_values_refuse_to_lower_a_tuple_destructure() {
+        assert!(
+            unsupported_tuple_destructure(&IncanType::RustInteropPath("String".to_string()), 2).is_some(),
+            "an opaque Rust value must not lower to a tuple field projection"
+        );
+        assert!(
+            unsupported_tuple_destructure(&IncanType::RustInteropPath("std::vec::Vec<u8>".to_string()), 2).is_some(),
+            "a Rust generic that is not a tuple must not lower to a tuple field projection"
+        );
+        // `(String)` is a parenthesised `String`, not a one-element tuple, so a single-name destructure must not
+        // lower to `.0` against it.
+        assert!(
+            unsupported_tuple_destructure(&IncanType::RustInteropPath("(String)".to_string()), 1).is_some(),
+            "a parenthesised Rust type has no `.0` field and must refuse to lower"
+        );
+        // The genuine one-element spelling still lowers.
+        assert!(
+            unsupported_tuple_destructure(&IncanType::RustInteropPath("(String,)".to_string()), 1).is_none(),
+            "`(String,)` is a real one-element tuple and must keep lowering"
+        );
+    }
+
+    /// The readable tuple spelling the stdlib relies on must still lower, so the refusal stays narrow.
+    #[test]
+    fn readable_rust_tuple_values_still_lower_a_tuple_destructure() {
+        assert!(
+            unsupported_tuple_destructure(
+                &IncanType::RustInteropPath("(String,incan_stdlib::json::JsonValue)".to_string()),
+                2
+            )
+            .is_none(),
+            "`std.json` destructures a `rust::HashMap` item and must keep lowering"
+        );
+        assert!(
+            unsupported_tuple_destructure(&IncanType::RustInteropPath("(String,JsonValue)".to_string()), 3).is_some(),
+            "a Rust tuple of the wrong arity must still be refused"
+        );
     }
 }

--- a/src/frontend/typechecker/check_stmt.rs
+++ b/src/frontend/typechecker/check_stmt.rs
@@ -13,6 +13,7 @@ use incan_core::lang::surface::constructors::{self, ConstructorId};
 use incan_core::lang::types::collections::CollectionTypeId;
 use incan_core::{NumericTy, result_numeric_type};
 use incan_semantics_core::SurfaceStmtTypeCheck;
+use incan_semantics_core::rust_tuple_arity;
 
 use super::{CAbiSpanLocal, CBindingType, COutputMode, LoopContextKind, TypeChecker};
 use crate::frontend::typechecker::helpers::{collection_type_id, ensure_bool_condition, option_ty};
@@ -45,6 +46,70 @@ struct BranchRefinement {
     ty: ResolvedType,
     is_mutable: bool,
     span: Span,
+}
+
+/// What a value's type says about whether it can be destructured into a fixed number of names.
+///
+/// Reading this once, in one place, is what keeps the three destructuring sites honest. Each used to answer the
+/// question inline and fall back to `vec![Unknown; n]` for anything it did not recognise, which sized the element
+/// list to the name list and so made the arity guard below it unreachable for a non-tuple (#1125, #1132).
+#[derive(Debug)]
+pub(in crate::frontend::typechecker) enum TupleShape {
+    /// A tuple in either Incan spelling, carrying its element types so arity can be checked against them.
+    Tuple(Vec<ResolvedType>),
+    /// A Rust-interop tuple whose arity the compiler can actually read, such as the `(String, JsonValue)` a
+    /// `rust::HashMap::items()` yields.
+    ///
+    /// Element types are not modelled, so it carries only the count and binds `Unknown` per name. Arity is still
+    /// checked, so interop is not simply exempted from the guard.
+    RustTuple(usize),
+    /// A Rust-interop value whose shape the compiler cannot establish.
+    ///
+    /// Deliberately *not* [`TupleShape::Recovery`]. "The frontend has no structural model of this type" is not the
+    /// same claim as "checking already failed", and treating it as recovery would let a genuine non-tuple Rust
+    /// value reach a generated field projection — the exact leakage class #1132 exists to close, arriving through
+    /// interop instead of through `int`. This is the same rule applied to a bare type variable: not proven
+    /// tuple-shaped must refuse.
+    OpaqueRust,
+    /// `Unknown` or `Never`: bind `Unknown` per name and stay silent.
+    ///
+    /// `Unknown` is recovery-only — checking already failed upstream, so a second diagnostic here is noise on top
+    /// of the real one. `Never` is the bottom type, and [`TypeChecker::types_compatible`] already answers
+    /// `(Never, _) => true` for every type including a tuple; accepting it is that established policy rather than
+    /// a carve-out, and the code is unreachable either way.
+    Recovery,
+    /// Anything else, including a bare type variable, which must be reported.
+    NotTuple,
+}
+
+/// Classify a value type for destructuring.
+///
+/// A tuple arrives in two spellings: a tuple *literal* infers [`ResolvedType::Tuple`], while a written
+/// `tuple[A, B]` annotation resolves through the collection-type registry as a [`ResolvedType::Generic`] named
+/// `Tuple`. Both are destructurable and both must be recognised here.
+///
+/// A bare type variable is deliberately [`TupleShape::NotTuple`]. It is not "not yet known" — it is known to be
+/// underdetermined, and `T` can be instantiated as `int`. Incan's bounds are trait-based, so no caller can promise
+/// a tuple shape. This does not affect `tuple[K, V]`, whose *elements* are type variables but whose shape is
+/// known; that takes the [`TupleShape::Tuple`] arm above.
+pub(in crate::frontend::typechecker) fn classify_tuple_shape(ty: &ResolvedType) -> TupleShape {
+    match ty {
+        ResolvedType::Tuple(types) => TupleShape::Tuple(types.clone()),
+        ResolvedType::Generic(name, args)
+            if matches!(collection_type_id(name.as_str()), Some(CollectionTypeId::Tuple)) =>
+        {
+            TupleShape::Tuple(args.clone())
+        }
+        ResolvedType::Unknown | ResolvedType::Never => TupleShape::Recovery,
+        // A Rust type is destructurable only when its shape can actually be read. The parenthesised tuple
+        // spelling gives a reliable arity — `std.json`'s `key, value = item` over a `rust::HashMap` item is
+        // exactly that shape — and everything else is refused rather than assumed.
+        ResolvedType::RustPath(path) => match rust_tuple_arity(path) {
+            Some(arity) => TupleShape::RustTuple(arity),
+            None => TupleShape::OpaqueRust,
+        },
+        _ => TupleShape::NotTuple,
+    }
 }
 
 /// Return the fallback binary dunder used when compound assignment cannot resolve an explicit in-place hook.
@@ -316,23 +381,7 @@ impl TypeChecker {
                 // Check the value expression and get its type
                 let value_ty = self.check_expr(&unpack.value);
 
-                // Extract element types if it's a tuple
-                let element_types: Vec<ResolvedType> = match &value_ty {
-                    ResolvedType::Tuple(types) => types.clone(),
-                    _ => {
-                        // Not a tuple, create Unknown types for each name
-                        vec![ResolvedType::Unknown; unpack.names.len()]
-                    }
-                };
-
-                // Check that tuple has enough elements
-                if element_types.len() < unpack.names.len() {
-                    self.errors.push(errors::tuple_unpack_count_mismatch(
-                        unpack.names.len(),
-                        element_types.len(),
-                        stmt.span,
-                    ));
-                }
+                let element_types = self.destructured_element_types(&value_ty, unpack.names.len(), stmt.span);
 
                 // Define each variable with its corresponding type
                 let is_mutable = matches!(unpack.binding, BindingKind::Mutable);
@@ -357,23 +406,7 @@ impl TypeChecker {
                 // Check the value expression (should be a tuple)
                 let value_ty = self.check_expr(&assign.value);
 
-                // Extract element types if it's a tuple
-                let element_types: Vec<ResolvedType> = match &value_ty {
-                    ResolvedType::Tuple(types) => types.clone(),
-                    _ => {
-                        // Not a tuple, create Unknown types for each target
-                        vec![ResolvedType::Unknown; assign.targets.len()]
-                    }
-                };
-
-                // Check that tuple has enough elements
-                if element_types.len() < assign.targets.len() {
-                    self.errors.push(errors::tuple_unpack_count_mismatch(
-                        assign.targets.len(),
-                        element_types.len(),
-                        stmt.span,
-                    ));
-                }
+                let element_types = self.destructured_element_types(&value_ty, assign.targets.len(), stmt.span);
 
                 // Check each target expression - must be a valid lvalue
                 for (i, target) in assign.targets.iter().enumerate() {
@@ -1247,6 +1280,49 @@ impl TypeChecker {
         self.symbols.exit_scope();
     }
 
+    /// Resolve the element types a statement destructure should bind, reporting the right diagnostic when the
+    /// value cannot supply them.
+    ///
+    /// Returns exactly `arity` types so callers can bind positionally without re-checking length. The `Unknown`
+    /// padding it returns on the error paths is recovery state for the *rest* of the check, not a claim that the
+    /// value had that shape — the diagnostic has already been recorded by then.
+    fn destructured_element_types(&mut self, value_ty: &ResolvedType, arity: usize, span: Span) -> Vec<ResolvedType> {
+        match classify_tuple_shape(value_ty) {
+            TupleShape::Tuple(types) => {
+                if types.len() != arity {
+                    self.errors
+                        .push(errors::tuple_unpack_count_mismatch(arity, types.len(), span));
+                    return vec![ResolvedType::Unknown; arity];
+                }
+                types
+            }
+            TupleShape::RustTuple(rust_arity) => {
+                if rust_arity != arity {
+                    self.errors
+                        .push(errors::tuple_unpack_count_mismatch(arity, rust_arity, span));
+                }
+                vec![ResolvedType::Unknown; arity]
+            }
+            TupleShape::OpaqueRust => {
+                self.errors.push(errors::tuple_unpack_rust_shape_unverified(
+                    arity,
+                    &value_ty.to_string(),
+                    span,
+                ));
+                vec![ResolvedType::Unknown; arity]
+            }
+            TupleShape::NotTuple => {
+                self.errors.push(errors::tuple_unpack_expects_tuple_value(
+                    arity,
+                    &value_ty.to_string(),
+                    span,
+                ));
+                vec![ResolvedType::Unknown; arity]
+            }
+            TupleShape::Recovery => vec![ResolvedType::Unknown; arity],
+        }
+    }
+
     /// Validate a `break` statement against the innermost active loop context.
     ///
     /// For expression-form `loop:` bodies this records the break value type so the loop result can be resolved after
@@ -1322,59 +1398,52 @@ impl TypeChecker {
             }
             Pattern::Wildcard => {}
             Pattern::Tuple(items) => {
-                // A tuple element type reaches here in two spellings: a tuple *literal* infers
-                // `ResolvedType::Tuple`, while a written `tuple[A, B]` annotation resolves through the
-                // collection-type registry and arrives as a `ResolvedType::Generic` named `Tuple`. Reading only the
-                // first spelling left every binding of an annotated tuple iteration typed `Unknown` for the whole
-                // loop body, and suppressed the arity-mismatch diagnostic there too (#1125).
-                let declared = match ty {
-                    ResolvedType::Tuple(types) => Some(types.clone()),
-                    ResolvedType::Generic(name, args)
-                        if matches!(collection_type_id(name.as_str()), Some(CollectionTypeId::Tuple)) =>
-                    {
-                        Some(args.clone())
-                    }
-                    _ => None,
-                };
-                let element_types = match declared {
-                    Some(types) => {
+                // The shape question is answered by `classify_tuple_shape`, shared with the statement-level
+                // destructuring arms (#1132). Only the diagnostic differs: a loop names the *iteration item* type,
+                // because that is what the reader has to change.
+                let element_types = match classify_tuple_shape(ty) {
+                    TupleShape::Tuple(types) => {
                         if types.len() != items.len() {
                             self.errors.push(errors::tuple_unpack_count_mismatch(
                                 items.len(),
                                 types.len(),
                                 pattern.span,
                             ));
+                            vec![ResolvedType::Unknown; items.len()]
+                        } else {
+                            types
                         }
-                        types
                     }
-                    None => {
-                        // A tuple pattern can only destructure a tuple. Binding `Unknown` per name and staying
-                        // silent used to hide `for a, b in items` over a `list[int]` completely, and Body IR would
-                        // then project `.0`/`.1` out of an `int` (#1125).
-                        //
-                        // Exactly two item types are exempt, and a bare type variable is not one of them:
-                        //
-                        // - `Unknown` is recovery-only. It means checking already failed somewhere upstream, so a
-                        //   second diagnostic here would just be noise on top of the real one.
-                        // - `Never` is the bottom type, and `Self::types_compatible` already answers `(Never, _) =>
-                        //   true` for every type including a tuple. Accepting it here is that same established policy,
-                        //   not a carve-out; the loop body is unreachable either way.
-                        //
-                        // An unconstrained type variable is *not* "not yet known" -- it is known to be
-                        // underdetermined, and `T` can be instantiated as `int`. Incan has no tuple-shaped bound a
-                        // caller could write to promise otherwise (bounds are trait-based), so `for a, b in
-                        // list[T]` can never be proven safe and is rejected. Note this does not affect the common
-                        // `list[Tuple[K, V]]` shape, whose item type is a tuple whose *elements* are type
-                        // variables -- that takes the `Some(types)` branch above.
-                        if !matches!(ty, ResolvedType::Unknown | ResolvedType::Never) {
-                            self.errors.push(errors::for_pattern_expects_tuple_item(
+                    TupleShape::RustTuple(rust_arity) => {
+                        if rust_arity != items.len() {
+                            self.errors.push(errors::tuple_unpack_count_mismatch(
                                 items.len(),
-                                &ty.to_string(),
+                                rust_arity,
                                 pattern.span,
                             ));
                         }
                         vec![ResolvedType::Unknown; items.len()]
                     }
+                    TupleShape::OpaqueRust => {
+                        self.errors.push(errors::for_pattern_rust_shape_unverified(
+                            items.len(),
+                            &ty.to_string(),
+                            pattern.span,
+                        ));
+                        vec![ResolvedType::Unknown; items.len()]
+                    }
+                    TupleShape::NotTuple => {
+                        // A tuple pattern can only destructure a tuple. Binding `Unknown` per name and staying
+                        // silent used to hide `for a, b in items` over a `list[int]` completely, and Body IR would
+                        // then project `.0`/`.1` out of an `int` (#1125).
+                        self.errors.push(errors::for_pattern_expects_tuple_item(
+                            items.len(),
+                            &ty.to_string(),
+                            pattern.span,
+                        ));
+                        vec![ResolvedType::Unknown; items.len()]
+                    }
+                    TupleShape::Recovery => vec![ResolvedType::Unknown; items.len()],
                 };
 
                 for (i, item) in items.iter().enumerate() {

--- a/src/frontend/typechecker/tests.rs
+++ b/src/frontend/typechecker/tests.rs
@@ -21830,3 +21830,243 @@ def main() -> None:
     // A default method body is one block of source, so it must warn once — not once per implementing type.
     let _ = single_unreachable_warning(source, "a trait default method body with dead code");
 }
+
+// ========================================================================
+// Issue #1132: statement-level tuple unpacking is a typechecking decision
+// ========================================================================
+
+#[test]
+fn test_statement_tuple_unpack_of_non_tuple_value_is_rejected() {
+    let source = r#"
+def main() -> None:
+    a, b = 5
+    println(f"{a} {b}")
+"#;
+    let errors = check_str_err(source, "unpacking two names from an `int` must be rejected");
+    assert!(
+        errors.iter().any(|error| error
+            .message
+            .contains("Cannot destructure 2 values from value of type 'int'")),
+        "the diagnostic must name the resolved value type: {:?}",
+        errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_tuple_assign_spelling_of_non_tuple_value_is_rejected() {
+    // The `TupleAssign` spelling reaches a different statement arm than `TupleUnpack`; both carried the same
+    // `vec![Unknown; n]` fallback, so both need the diagnostic.
+    let source = r#"
+def main() -> None:
+    mut xs = [1, 2]
+    xs[0], xs[1] = 5
+"#;
+    let errors = check_str_err(source, "tuple-assigning two lvalues from an `int` must be rejected");
+    assert!(
+        errors.iter().any(|error| error
+            .message
+            .contains("Cannot destructure 2 values from value of type 'int'")),
+        "the diagnostic must name the resolved value type: {:?}",
+        errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_statement_tuple_unpack_accepts_inferred_and_annotated_tuples() {
+    let inferred = r#"
+def main() -> None:
+    pair = (1, "two")
+    a, b = pair
+    println(f"{a} {b}")
+"#;
+    assert!(
+        check_str(inferred).is_ok(),
+        "an inferred tuple literal must still destructure: {:?}",
+        check_str(inferred)
+    );
+
+    // A written `tuple[A, B]` annotation resolves through the collection-type registry as
+    // `ResolvedType::Generic("Tuple", args)`, not `ResolvedType::Tuple`. Reading only the latter left every
+    // binding typed `Unknown` and suppressed the arity guard.
+    let annotated = r#"
+def main() -> None:
+    pair: tuple[int, str] = (1, "two")
+    a, b = pair
+    println(f"{a} {b}")
+"#;
+    assert!(
+        check_str(annotated).is_ok(),
+        "an annotated `tuple[int, str]` must destructure: {:?}",
+        check_str(annotated)
+    );
+}
+
+#[test]
+fn test_statement_tuple_unpack_arity_mismatch_is_rejected_in_both_directions() {
+    let too_many_names = r#"
+def main() -> None:
+    a, b, c = (1, 2)
+    println(f"{a} {b} {c}")
+"#;
+    let errors = check_str_err(too_many_names, "unpacking three names from a 2-tuple must be rejected");
+    assert!(
+        errors.iter().any(|error| error
+            .message
+            .contains("Cannot unpack 3 values from tuple with 2 elements")),
+        "expected the existing arity diagnostic: {:?}",
+        errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+
+    // The guard used to be `element_types.len() < names.len()`, so a tuple with *more* elements than names was
+    // silently accepted. #1125 settled on an exact-arity comparison for loop patterns; statements match it.
+    let too_few_names = r#"
+def main() -> None:
+    a, b = (1, 2, 3)
+    println(f"{a} {b}")
+"#;
+    let errors = check_str_err(too_few_names, "unpacking two names from a 3-tuple must be rejected");
+    assert!(
+        errors.iter().any(|error| error
+            .message
+            .contains("Cannot unpack 2 values from tuple with 3 elements")),
+        "a tuple longer than the name list must not be silently truncated: {:?}",
+        errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_statement_tuple_unpack_of_a_bare_type_variable_is_rejected() {
+    // An unconstrained type variable is not "not yet known" — it is known to be underdetermined, and `T` can be
+    // instantiated as `int`. Incan's bounds are trait-based, so no caller can promise a tuple shape.
+    let source = r#"
+def split[T](value: T) -> None:
+    a, b = value
+    println(f"{a} {b}")
+"#;
+    let errors = check_str_err(source, "destructuring a bare type variable must be rejected");
+    assert!(
+        errors
+            .iter()
+            .any(|error| error.message.contains("Cannot destructure 2 values from value of type")),
+        "a bare type variable must not be treated as destructurable: {:?}",
+        errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_statement_tuple_unpack_accepts_a_tuple_of_type_variables() {
+    // `tuple[K, V]` is a tuple whose *elements* are type variables. The shape is known even though the element
+    // types are not, so it destructures — this is the common `dict` item shape and must not regress.
+    let source = r#"
+def split[K, V](pair: tuple[K, V]) -> None:
+    a, b = pair
+    println(f"{a} {b}")
+"#;
+    assert!(
+        check_str(source).is_ok(),
+        "a tuple of type variables must destructure: {:?}",
+        check_str(source)
+    );
+}
+
+#[test]
+fn test_tuple_shape_classifier_covers_both_spellings_and_recovery_types() {
+    use super::check_stmt::{TupleShape, classify_tuple_shape};
+
+    // `Unknown` and `Never` are exercised directly: `Unknown` means checking already failed upstream, and `Never`
+    // reaches a value position only through Rust interop's diverging `!`, which is not cheaply source-expressible.
+    // Both must classify as recovery so no second diagnostic piles onto the real one.
+    assert!(matches!(
+        classify_tuple_shape(&ResolvedType::Unknown),
+        TupleShape::Recovery
+    ));
+    assert!(matches!(
+        classify_tuple_shape(&ResolvedType::Never),
+        TupleShape::Recovery
+    ));
+    assert!(matches!(classify_tuple_shape(&ResolvedType::Int), TupleShape::NotTuple));
+    assert!(matches!(
+        classify_tuple_shape(&ResolvedType::TypeVar("T".to_string())),
+        TupleShape::NotTuple
+    ));
+
+    // Regression for a false positive this change originally introduced: `std.json` destructures a
+    // `rust::HashMap` item, whose type is a Rust tuple path rather than either Incan spelling. Rejecting it broke
+    // the stdlib's own SDK component build.
+    match classify_tuple_shape(&ResolvedType::RustPath(
+        "(String,incan_stdlib::json::JsonValue)".to_string(),
+    )) {
+        TupleShape::RustTuple(2) => {}
+        other => panic!("a Rust tuple path must be destructurable with arity 2, got {other:?}"),
+    }
+    // Commas inside a nested generic must not inflate the arity.
+    match classify_tuple_shape(&ResolvedType::RustPath("(String,HashMap<K, V>)".to_string())) {
+        TupleShape::RustTuple(2) => {}
+        other => panic!("nested generic commas must not be counted, got {other:?}"),
+    }
+    // An opaque Rust path refuses rather than going silent. "No structural model of this type" is not the same
+    // claim as "checking already failed": treating it as recovery would let a real non-tuple Rust value reach a
+    // generated field projection, which is the same leakage this issue closes, arriving via interop.
+    assert!(matches!(
+        classify_tuple_shape(&ResolvedType::RustPath("String".to_string())),
+        TupleShape::OpaqueRust
+    ));
+    assert!(matches!(
+        classify_tuple_shape(&ResolvedType::RustPath("std::vec::Vec<u8>".to_string())),
+        TupleShape::OpaqueRust
+    ));
+    // A one-element Rust tuple is one element, not two with an empty slot.
+    match classify_tuple_shape(&ResolvedType::RustPath("(String,)".to_string())) {
+        TupleShape::RustTuple(1) => {}
+        other => panic!("`(String,)` is a one-element tuple, got {other:?}"),
+    }
+    // But `(String)` is a parenthesised type with no `.0` field, not a one-element tuple. Reading it as one would
+    // let a single-name destructure lower to `.0` on a `String` — the same raw-Rust failure through a narrower
+    // spelling than `int`.
+    assert!(
+        matches!(
+            classify_tuple_shape(&ResolvedType::RustPath("(String)".to_string())),
+            TupleShape::OpaqueRust
+        ),
+        "a parenthesised Rust type must not be classified as a one-element tuple"
+    );
+
+    let literal = ResolvedType::Tuple(vec![ResolvedType::Int, ResolvedType::Str]);
+    let annotated = ResolvedType::Generic("Tuple".to_string(), vec![ResolvedType::Int, ResolvedType::Str]);
+    for (label, ty) in [("inferred", &literal), ("annotated", &annotated)] {
+        match classify_tuple_shape(ty) {
+            TupleShape::Tuple(elements) => assert_eq!(
+                elements,
+                vec![ResolvedType::Int, ResolvedType::Str],
+                "{label} tuple spelling must yield its element types"
+            ),
+            other => panic!("{label} tuple spelling must classify as a tuple, got {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn test_statement_tuple_unpack_of_an_opaque_rust_value_is_refused() {
+    // The `RustPath` path must apply the same rule as a bare type variable: not proven tuple-shaped refuses.
+    // Accepting it silently would re-open the leak through interop — a `rust::String` reaching a `.0` projection
+    // is the same defect as an `int` reaching one.
+    use super::check_stmt::{TupleShape, classify_tuple_shape};
+
+    assert!(matches!(
+        classify_tuple_shape(&ResolvedType::RustPath("String".to_string())),
+        TupleShape::OpaqueRust
+    ));
+    // `(String)` is the same type as `String`, only parenthesised, and must be refused identically.
+    assert!(matches!(
+        classify_tuple_shape(&ResolvedType::RustPath("(String)".to_string())),
+        TupleShape::OpaqueRust
+    ));
+
+    // And the readable tuple spelling the stdlib depends on must keep working, so the refusal is narrow.
+    match classify_tuple_shape(&ResolvedType::RustPath(
+        "(String,incan_stdlib::json::JsonValue)".to_string(),
+    )) {
+        TupleShape::RustTuple(2) => {}
+        other => panic!("a readable Rust tuple must still destructure, got {other:?}"),
+    }
+}

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -11863,3 +11863,63 @@ def main() -> None:
 
     Ok(())
 }
+
+/// Statement tuple-unpack of a non-tuple must fail at the source language, not in generated Rust (#1132).
+///
+/// The regression is specifically about *where* the failure surfaces. Before this, `incan check` passed and the
+/// program only failed while compiling emitted Rust, with `error[E0610]` pointing at a `__incan_tuple_unpack_*`
+/// binding the user never wrote. Asserting the absence of both strings is the point: a diagnostic that merely
+/// exists is not enough if the raw Rust error can still reach the user.
+#[test]
+fn check_rejects_statement_tuple_unpack_of_non_tuple_without_leaking_generated_rust()
+-> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let path = tmp.path().join("unpack.incn");
+    fs::write(
+        &path,
+        r#"def main() -> None:
+    a, b = 5
+    println(f"{a} {b}")
+"#,
+    )?;
+
+    let arg = path.to_str().ok_or("path was not valid UTF-8")?;
+    let output = run_incan(tmp.path(), &["check", arg, "--format", "json"])?;
+    assert_failure(&output, "destructuring an `int` must fail `incan check`");
+    let report = parse_json_stdout(&output)?;
+
+    assert_eq!(report["ok"], serde_json::json!(false));
+    let diagnostics = report["diagnostics"]
+        .as_array()
+        .ok_or("check report had no diagnostics array")?;
+    let first = diagnostics.first().ok_or("expected at least one diagnostic")?;
+    assert_eq!(first["severity"], serde_json::json!("error"));
+    assert_eq!(first["phase"], serde_json::json!("typecheck"));
+    assert!(
+        first["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("Cannot destructure 2 values from value of type 'int'")),
+        "the diagnostic must name the resolved value type: {first}"
+    );
+    assert_eq!(
+        first["primary_span"]["start"]["line"],
+        serde_json::json!(2),
+        "the span must point at the offending statement, not the file: {first}"
+    );
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !combined.contains("E0610"),
+        "a raw rustc field-projection error must never reach the user:\n{combined}"
+    );
+    assert!(
+        !combined.contains("__incan_tuple_unpack"),
+        "a compiler-internal binding name must never reach the user:\n{combined}"
+    );
+
+    Ok(())
+}

--- a/tests/parity_corpus_tests.rs
+++ b/tests/parity_corpus_tests.rs
@@ -365,6 +365,31 @@ fn replacement_body_v0_006_expected() -> ReplacementValue {
 }
 
 // ============================================================================
+// Case 7 — Diagnostic behavior: statement tuple unpack of a non-tuple (migrated from a silent accept)
+// ============================================================================
+
+// Entered the corpus as a silent accept: `a, b = 5` typechecked clean, bound both names `Unknown`, and only
+// failed while compiling the emitted Rust with an `E0610` naming a `__incan_tuple_unpack_*` binding the user never
+// wrote. #1132 migrated it to a source-language decision. Asserted through the message rather than a stable code
+// because this family reports under the broad `INCAN-T0001` typecheck code.
+const CASE_7_SRC: &str = r#"
+def main() -> None:
+    a, b = 5
+    println(f"{a} {b}")
+"#;
+
+fn case_diagnostic_statement_tuple_unpack_of_non_tuple() -> ComparisonOutcome {
+    outcome_from_typecheck(
+        CASE_7_SRC,
+        |errs| {
+            errs.iter()
+                .any(|error| error.contains("Cannot destructure 2 values from value of type 'int'"))
+        },
+        "a typechecker diagnostic naming the non-tuple value type",
+    )
+}
+
+// ============================================================================
 // Seed corpus
 // ============================================================================
 
@@ -447,6 +472,30 @@ fn seed_corpus() -> Vec<ParityCase> {
             },
             source: CASE_6_SRC,
             evaluate: Some(case_diagnostic_unreachable_code_after_return),
+            replacement_execution: None,
+        },
+        ParityCase {
+            id: "parity-987-0007",
+            title: "Statement tuple unpack of a non-tuple value is a typechecker error",
+            category: BehaviorCategory::DiagnosticBehavior,
+            lane: EvidenceLane::DirectParserTypechecker,
+            evidence: "tests/parity_corpus_tests.rs::case_diagnostic_statement_tuple_unpack_of_non_tuple",
+            disposition: Disposition::IntentionalMigration {
+                owning_issue: 1132,
+                migration_note: "Migrated by #1132 before 0.6 cutover: `a, b = <non-tuple>` and the `TupleAssign` \
+                                  spelling now raise a source-span typechecker error naming the resolved value \
+                                  type, instead of binding every name `Unknown` and failing later in generated \
+                                  Rust. Migration guidance for the replacement backend: the contract is the \
+                                  frontend diagnostic, so a replacement backend must not be relied on to \
+                                  reproduce it, and must never emit a tuple-field projection into a value with no \
+                                  such fields. A value is destructurable only when its shape is actually known: \
+                                  inferred tuples, annotated `tuple[A, B]`, and Rust-interop paths whose tuple \
+                                  spelling the compiler can read. `Unknown` and `Never` stay silent as recovery \
+                                  states; a bare type variable and an opaque Rust path are both refused, because \
+                                  \"not proven tuple-shaped\" must not be treated as destructurable.",
+            },
+            source: CASE_7_SRC,
+            evaluate: Some(case_diagnostic_statement_tuple_unpack_of_non_tuple),
             replacement_execution: None,
         },
         ParityCase {


### PR DESCRIPTION
## Summary

`a, b = 5` typechecked clean, bound both names `Unknown`, and only failed while compiling the emitted Rust with an `error[E0610]` naming a `__incan_tuple_unpack_*` binding the user never wrote. This makes statement-level destructurability a source-language decision, reported with the value's resolved type on the offending statement — the statement-level sibling of the loop-level hole #1125 closed.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [x] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [x] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

### User-facing behavior

A value is destructurable only when its shape is actually known:

| Value shape | Behavior |
| --- | --- |
| inferred tuple literal | destructures; arity checked |
| annotated `tuple[A, B]` | destructures; arity checked |
| Rust-interop tuple whose spelling can be read, e.g. `(String, JsonValue)` | destructures; arity checked from the spelling, elements bind `Unknown` |
| `Unknown`, `Never` | silent recovery |
| bare type variable | refused |
| opaque Rust path, e.g. `rust::String` | refused — *"Cannot verify Rust value of type 'X' is tuple-shaped"* |
| anything else | refused — *"Cannot destructure N values from value of type 'T'"* |

Two behavior changes beyond the reported symptom:

- **Exact arity.** The guard compared `element_types.len() < names.len()`, so `a, b = (1, 2, 3)` silently truncated. It now compares exact arity, matching the rule #1125 settled for loop patterns. This rejects programs that compile today.
- **`(String)` is not a one-element tuple.** Rust spells that `(String,)`; plain `(String)` is a parenthesised `String` with no `.0` field. A spelling with no depth-zero comma is reported unverifiable rather than as arity one.

### Internals

The original defect was that the non-tuple fallback was built at exactly `names.len()`, which sized the element list to the name list and so made the arity guard below it unreachable for a non-tuple. Both statement spellings carried the same fallback.

The shape question is now answered once — `classify_tuple_shape` for Incan types, `incan_semantics_core::rust_tuple_arity` for interop spellings — and consumed by statement unpacking, tuple assignment, `for` patterns, and Body IR lowering. Lowering applies the same rule rather than trusting the typechecker, so it cannot invent a `.0`/`.1` projection into a value with no such fields even from a hand-built AST.

`rust_tuple_arity` lives in `incan_semantics_core` because it is a shared compiler fact, not frontend or backend policy; putting it anywhere else would let the typechecker and Body IR drift about what counts as tuple-shaped. Parsing a type *string* is a deliberate stopgap — structured Rust type-shape metadata is the durable fix, and the helper's rustdoc says so.

### Risks

- Programs relying on silent truncation of an over-long tuple now fail to compile. Intentional; the corpus records it.
- The interop rule reads Rust type spelling rather than structured metadata, so an unusual spelling could be refused. Every misclassification found during review errs toward refusal rather than acceptance, which is the safe direction — a wrong "yes" re-emits the field projection this PR exists to prevent.
- `std.json` destructures a `rust::HashMap` item, so stdlib compatibility was the real risk here and is covered below.

## Testing / verification

- [x] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

| Suite | Result |
| --- | --- |
| `cargo test -p incan_semantics_core` | 36 passed |
| `cargo test --lib frontend::typechecker` | 911 passed |
| `cargo test --lib body_ir` | 78 passed |
| `cargo test --test parity_corpus_tests` | 7 passed |
| `cargo test --test construction_diagnostics_tests` | 2 passed |
| `cargo test --test cli_integration` (targeted) | passed |
| `make fmt-check`, changed-rustdoc gate, `clippy --all-targets --all-features -D warnings` | clean |

Manual verification notes:

- Direct probe: `INCAN-T0001`, severity `error`, phase `typecheck`, origin `typechecker`, span on line 2, *"Cannot destructure 2 values from value of type 'int'"*.
- End-to-end regression asserts the failure lands at typecheck **and** that neither `E0610` nor `__incan_tuple_unpack` appears anywhere in output — a diagnostic that merely exists is not enough if the raw Rust error can still reach the user.
- Rebuilt the compiler and confirmed all ten SDK components prepare cleanly, so `std.json`'s `key, value = item` still compiles under the stricter rule. This is the check that caught two defects during development that no unit test saw.
- `rust_tuple_arity` audited in the dangerous direction against `fn(A, B)`, `(A, B) -> C`, `impl Fn(A, B)`, `&(A, B)`, `Vec<(A, B)>`, `(Fn(A) -> B, C)`, `(A, [B, C])`, `(HashMap<K, V>)`, `((A, B))`.

**Not run:** the full Oven-orchestrated suite, which was withheld because sibling slices are active on the same machine and it contends for shared Oven state. CI is therefore the first full-suite signal for this branch.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

No authored user-facing page documents statement destructuring behavior today, and the new diagnostics are self-describing. `0_6.md` states it curates user-visible fixes only once merged, so a release-note entry belongs after merge rather than here.

Closes #1132
