### PR TITLE
feature - support local callable partial defaults (#1124)

### DIFF
--- a/crates/incan_semantics_core/src/body_ir.rs
+++ b/crates/incan_semantics_core/src/body_ir.rs
@@ -18,8 +18,10 @@
 //! `Generator[T]` behavior. Expression-position `yield` remains a stub in the existing Rust-emission backend too.
 //!
 //! #1101 adds dict/set aggregates, slices, assignment variants, expression-position `if`/`loop`/`try`, f-strings,
-//! general iteration, list/dict comprehensions, closures/partial construction, statement `yield`, and `match`.
-//! Captures are explicit [`Operand`] reads on [`Rvalue::Closure`], not an implicit target-backend decision.
+//! general iteration, list/dict comprehensions, closures/partial construction and local invocation, statement
+//! `yield`, and `match`. Captures are explicit [`Operand`] reads on [`Rvalue::Closure`], and a stored callable is
+//! invoked through [`CallableTarget::Local`] rather than being approximated as a named function, so neither fact is
+//! an implicit target-backend decision.
 //!
 //! "Method body" includes `class`/`model`/`trait` methods (#1102). A `self`/`mut self` receiver is an ordinary
 //! [`LocalOrigin::Receiver`] local and is always reference-shaped at the emission boundary, so a bare receiver
@@ -598,16 +600,34 @@ impl Rvalue {
 }
 
 /// One parameter of a [`Rvalue::Closure`] (or a partial callable's synthesized forwarding closure).
+///
+/// `has_default` preserves whether an argument may be omitted for this callable value. A partial's preset parameter
+/// remains present as an overrideable default: [`Self::preset_capture`] identifies the value captured when the
+/// partial was constructed. A source-declared default has `has_default` set but no capture; its computation remains
+/// owned by the declaration/closure definition that introduced it.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ClosureParam {
     pub name: String,
     pub ty: IncanType,
+    pub has_default: bool,
+    /// The closure-body local holding this partial parameter's construction-time preset, if any.
+    ///
+    /// This is set only when `has_default` is true. It distinguishes the callable value's materialized preset from
+    /// an ordinary source default and ensures an executor can use the captured value exactly when the caller omits
+    /// this named parameter, while still accepting a caller-provided override.
+    pub preset_capture: Option<LocalId>,
 }
 
 impl ClosureParam {
     /// Render a deterministic maintainer-facing spelling for this parameter.
     fn render_snapshot(&self) -> String {
-        format!("{}: {}", self.name, self.ty)
+        let default = match (self.has_default, self.preset_capture) {
+            (true, Some(capture)) => format!(" = captured(_{})", capture.0),
+            (true, None) => " = default".to_string(),
+            (false, None) => String::new(),
+            (false, Some(capture)) => format!(" = invalid-capture(_{})", capture.0),
+        };
+        format!("{}: {}{default}", self.name, self.ty)
     }
 }
 
@@ -1005,12 +1025,12 @@ impl AggregateKind {
 /// Call target for a [`StatementKind::Call`].
 #[derive(Debug, Clone, PartialEq)]
 pub enum Callee {
-    /// A direct call to a named Incan function, by its source-level spelling.
+    /// A direct named function or a locally held callable value.
     ///
     /// Full call-target resolution (which physical declaration binds through imports/traits/overloads) mirrors the
     /// typechecker/backend resolution passes and is deferred past v0; Body IR records the source-level callee
     /// spelling plus argument ownership facts, which is enough to prove the model end-to-end.
-    Function(String),
+    Function(CallableTarget),
     /// A method call `receiver.method(args)`. `args[0]` in the surrounding [`StatementKind::Call`] is the receiver.
     ///
     /// Also used for compiler-synthesized collection-growth calls a comprehension desugar introduces (`push`/
@@ -1026,9 +1046,83 @@ impl Callee {
     /// Render a deterministic maintainer-facing spelling for this callee.
     fn render_snapshot(&self) -> String {
         match self {
-            Self::Function(name) => format!("fn:{name}"),
+            Self::Function(target) => target.render_snapshot(),
             Self::Method(name) => format!("method:{name}"),
             Self::Helper(op) => format!("helper:{}", op.as_str()),
+        }
+    }
+}
+
+/// The source-authoritative target carried by [`Callee::Function`].
+///
+/// The outer `Callee::Function` spelling is retained as the established call statement category: both alternatives
+/// ultimately invoke a callable. The alternatives themselves are intentionally distinct. In particular, a stored
+/// closure/partial is never represented as [`Self::Named`] with a fabricated source name; it is a
+/// [`Self::Local`] operand, carrying the lexical-environment ownership decision the caller made.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CallableTarget {
+    /// A direct call to a named Incan function, by its source-level spelling.
+    ///
+    /// Full call-target resolution (which physical declaration binds through imports/traits/overloads) mirrors the
+    /// typechecker/backend resolution passes and is deferred past v0; Body IR records the source-level callee
+    /// spelling plus argument ownership facts, which is enough to prove the model end-to-end.
+    Named(String),
+    /// Invoke a callable value held in one local place.
+    ///
+    /// The [`PlaceOperand`] records the read's Duckborrower ownership fact and last-use marker exactly once, at the
+    /// call target. Frontend lowering emits only an unprojected local place here: field/index call targets remain
+    /// unsupported until Body IR has an equally explicit representation for their receiver/projection evaluation.
+    /// Consumers must preserve this operand's ownership decision when invoking the value, because it can own a
+    /// closure's lexical environment.
+    Local(LocalCallableTarget),
+}
+
+/// A locally stored callable target and the declaration slots occupied by its call arguments.
+///
+/// `parameter_slots[i]` is the declared callable-parameter index supplied by the surrounding
+/// [`StatementKind::Call::args`]'s `i`-th operand. It makes a local partial's two source-level call conventions
+/// explicit: positional arguments skip preset-default slots, while named arguments may override them. Callers that
+/// lower an ordinary local closure use the identity mapping.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LocalCallableTarget {
+    /// The local read that owns the callable value and its lexical environment.
+    pub operand: PlaceOperand,
+    /// Declared parameter slot for each surrounding call argument, in the same order as `args`.
+    pub parameter_slots: Vec<usize>,
+}
+
+impl CallableTarget {
+    /// Render this callable target without collapsing local values into named functions.
+    fn render_snapshot(&self) -> String {
+        match self {
+            Self::Named(name) => format!("fn:{name}"),
+            Self::Local(target) => format!(
+                "local:{} slots={:?}",
+                Operand::Place(target.operand.clone()).render_snapshot(),
+                target.parameter_slots
+            ),
+        }
+    }
+}
+
+impl PartialEq<str> for CallableTarget {
+    /// A local callable can never compare equal to a direct function name. This compatibility implementation keeps
+    /// existing bounded consumers' direct-function checks conservative while they visibly reject `Local`.
+    fn eq(&self, other: &str) -> bool {
+        matches!(self, Self::Named(name) if name == other)
+    }
+}
+
+impl std::fmt::Display for CallableTarget {
+    /// Render a concise diagnostics label without exposing a local callable as a function name.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Named(name) => f.write_str(name),
+            Self::Local(target) => write!(
+                f,
+                "<local:{}>",
+                Operand::Place(target.operand.clone()).render_snapshot()
+            ),
         }
     }
 }
@@ -1245,7 +1339,7 @@ pub struct Statement {
 pub enum StatementKind {
     /// Assign an rvalue into a place.
     Assign { place: Place, rvalue: Rvalue },
-    /// Call a function, method, or runtime helper, optionally storing its result.
+    /// Call a function, method, locally stored callable value, or runtime helper, optionally storing its result.
     Call {
         destination: Option<Place>,
         callee: Callee,
@@ -1495,6 +1589,46 @@ mod tests {
     }
 
     #[test]
+    fn local_callable_target_and_defaulted_closure_parameter_render() {
+        let mut body = sample_body();
+        body.block.stmts.insert(
+            0,
+            Statement {
+                kind: StatementKind::Call {
+                    destination: Some(Place::from_local(LocalId(2))),
+                    callee: Callee::Function(CallableTarget::Local(LocalCallableTarget {
+                        operand: PlaceOperand {
+                            place: Place::from_local(LocalId(0)),
+                            fact: OwnershipFact::Copy,
+                            last_use: false,
+                        },
+                        parameter_slots: vec![0],
+                    })),
+                    args: vec![Operand::Constant(Constant::Int(1))],
+                    may_panic: false,
+                },
+                span: HirSourceSpan::new(0, 1),
+            },
+        );
+
+        let snapshot = body.render_snapshot();
+        assert!(
+            snapshot.contains("call local:copy(_0) slots=[0](const(1))"),
+            "a local call target must retain its operand ownership fact: {snapshot}"
+        );
+        assert_eq!(
+            ClosureParam {
+                name: "suffix".to_string(),
+                ty: IncanType::Primitive(IncanPrimitiveType::Str),
+                has_default: true,
+                preset_capture: None,
+            }
+            .render_snapshot(),
+            "suffix: str = default"
+        );
+    }
+
+    #[test]
     fn dict_aggregate_renders_as_key_value_pairs() {
         let mut body = sample_body();
         body.block.stmts.insert(
@@ -1697,6 +1831,8 @@ mod tests {
                         params: vec![ClosureParam {
                             name: "z".to_string(),
                             ty: IncanType::Primitive(IncanPrimitiveType::Int),
+                            has_default: false,
+                            preset_capture: None,
                         }],
                         captured_operands: vec![Operand::place(
                             Place::from_local(LocalId(0)),

--- a/crates/incan_semantics_core/src/types.rs
+++ b/crates/incan_semantics_core/src/types.rs
@@ -216,6 +216,11 @@ pub struct IncanCallableParam {
     pub ty: IncanType,
     pub kind: IncanCallableParamKind,
     pub has_default: bool,
+    /// Whether this local partial parameter is defaulted from its closure's construction-time capture.
+    ///
+    /// A caller may override this parameter by name. Positional invocation instead skips it and fills the remaining
+    /// residual parameters in declaration order. Ordinary callable parameters always set this to `false`.
+    pub is_partial_preset: bool,
 }
 
 impl fmt::Display for IncanCallableParam {
@@ -329,12 +334,14 @@ mod tests {
                     },
                     kind: IncanCallableParamKind::Normal,
                     has_default: false,
+                    is_partial_preset: false,
                 },
                 IncanCallableParam {
                     name: Some("rest".to_string()),
                     ty: IncanType::Primitive(IncanPrimitiveType::Str),
                     kind: IncanCallableParamKind::RestPositional,
                     has_default: false,
+                    is_partial_preset: false,
                 },
             ],
             return_type: Box::new(IncanType::Tuple(vec![

--- a/src/backend/ir/codegen.rs
+++ b/src/backend/ir/codegen.rs
@@ -2032,7 +2032,7 @@ pub def use() -> str:
     }
 
     #[test]
-    fn local_partial_codegen_fills_omitted_preset_argument() {
+    fn local_partial_codegen_captures_a_defaulted_overrideable_preset() {
         let code = generate(
             r#"
 def route(method: str, path: str) -> str:
@@ -2043,11 +2043,29 @@ pub def use() -> str:
   return get(path="/health")
 "#,
         );
-        assert!(code.contains("|method, path|"), "{code}");
+        assert!(code.contains("move |method: Option<String>, path: String|"), "{code}");
+        assert!(code.contains("unwrap_or_else"), "{code}");
+        assert!(code.contains("get(None"), "{code}");
+    }
+
+    #[test]
+    fn local_partial_codegen_materializes_a_trailing_residual_default() {
+        let code = generate(
+            r#"
+def route(method: str, path: str, content_type: str = "text") -> str:
+  return method + path + content_type
+
+pub def use() -> str:
+  get = partial route(method="GET")
+  return get("/health")
+"#,
+        );
         assert!(
-            code.contains("get(\"GET\".to_string(), \"/health\".to_string())"),
+            code.contains("let get = {\n        let __incan_partial_preset_0_method"),
             "{code}"
         );
+        assert!(code.contains("\"GET\".to_string()"), "{code}");
+        assert!(code.contains("return get(None"), "{code}");
     }
 
     #[test]

--- a/src/backend/ir/decl.rs
+++ b/src/backend/ir/decl.rs
@@ -279,8 +279,29 @@ pub struct FunctionParam {
     pub is_self: bool,
     /// Surface call-binding kind preserved for RFC 038 rest parameters.
     pub kind: crate::frontend::ast::ParamKind,
-    /// Optional default argument expression (used for call-site default filling).
-    pub default: Option<super::IrExpr>,
+    /// Optional default plan used for call-site argument filling.
+    pub default: Option<FunctionParamDefault>,
+}
+
+/// The source of an optional [`FunctionParam`] argument value.
+///
+/// Source defaults remain an IR expression that the caller materializes. A captured partial preset deliberately has
+/// no source expression: its synthesized local closure owns the construction-time value, and omitted calls must
+/// pass `None` to its `Option<T>` slot so that closure selects that captured value. This distinction prevents legacy
+/// Rust lowering from re-evaluating a runtime-local preset at every invocation.
+#[derive(Debug, Clone)]
+pub enum FunctionParamDefault {
+    /// A default expression declared by the callable's source definition.
+    Source(Box<super::IrExpr>),
+    /// A local partial's construction-time captured, name-overrideable preset.
+    CapturedPartialPreset,
+}
+
+impl FunctionParamDefault {
+    /// Construct a source-owned default plan without inflating every parameter's in-memory representation.
+    pub fn source(expr: super::IrExpr) -> Self {
+        Self::Source(Box::new(expr))
+    }
 }
 
 /// IR struct definition

--- a/src/backend/ir/emit/expressions/calls.rs
+++ b/src/backend/ir/emit/expressions/calls.rs
@@ -8,7 +8,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 
 use super::super::super::conversions::{BinOpEmitKind, determine_binop_plan};
-use super::super::super::decl::FunctionParam;
+use super::super::super::decl::{FunctionParam, FunctionParamDefault};
 use super::super::super::expr::{BinOp, IrCallArg, IrCallArgKind, IrExprKind, TypedExpr, VarRefKind};
 use super::super::super::ownership::{ArgumentPassingPlan, ValueUseSite};
 use super::super::super::types::IrType;
@@ -781,10 +781,48 @@ impl<'a> IrEmitter<'a> {
             return Ok(quote! { #f #turbofish (#(#arg_tokens),*) });
         }
 
-        // Order arguments only when keyword args are present (positional-only calls preserve previous behavior,
-        // which is important for snapshots + for default-arg lowering work that happens elsewhere).
+        // A local partial with captured presets has an explicit slot for each overrideable default. Its positional
+        // arguments skip those slots, while named arguments may fill them; omitted preset slots become typed `None`
+        // values for the synthesized `Option<T>` closure parameters. Other calls preserve the established ordering.
+        let captured_partial_signature = function_sig.filter(|sig| {
+            sig.params.iter().any(|param| {
+                matches!(
+                    param.default.as_ref(),
+                    Some(FunctionParamDefault::CapturedPartialPreset)
+                )
+            })
+        });
         let has_named_args = args.iter().any(|a| a.name.is_some());
-        let ordered_args: Vec<(TypedExpr, bool)> = if has_named_args {
+        let ordered_args: Vec<(TypedExpr, bool)> = if let Some(sig) = captured_partial_signature {
+            let mut positional: Vec<TypedExpr> = Vec::new();
+            let mut named: std::collections::HashMap<&str, TypedExpr> = std::collections::HashMap::new();
+            for arg in args {
+                if let Some(name) = arg.name.as_deref() {
+                    named.insert(name, arg.expr.clone());
+                } else {
+                    positional.push(arg.expr.clone());
+                }
+            }
+
+            let mut pos_idx = 0usize;
+            let mut out = Vec::with_capacity(sig.params.len());
+            for param in &sig.params {
+                if let Some(value) = named.get(param.name.as_str()) {
+                    out.push((value.clone(), false));
+                } else if matches!(
+                    param.default.as_ref(),
+                    Some(FunctionParamDefault::CapturedPartialPreset)
+                ) {
+                    out.push((TypedExpr::new(IrExprKind::None, param.ty.clone()), true));
+                } else if pos_idx < positional.len() {
+                    out.push((positional[pos_idx].clone(), false));
+                    pos_idx += 1;
+                } else if let Some(FunctionParamDefault::Source(default_arg)) = &param.default {
+                    out.push((default_arg.as_ref().clone(), true));
+                }
+            }
+            out
+        } else if has_named_args {
             if let Some(sig) = function_sig {
                 let mut positional: Vec<TypedExpr> = Vec::new();
                 let mut named: std::collections::HashMap<&str, TypedExpr> = std::collections::HashMap::new();
@@ -804,8 +842,8 @@ impl<'a> IrEmitter<'a> {
                     } else if pos_idx < positional.len() {
                         out.push((positional[pos_idx].clone(), false));
                         pos_idx += 1;
-                    } else if let Some(default_arg) = &p.default {
-                        out.push((default_arg.clone(), true));
+                    } else if let Some(FunctionParamDefault::Source(default_arg)) = &p.default {
+                        out.push((default_arg.as_ref().clone(), true));
                     }
                 }
                 out
@@ -816,8 +854,8 @@ impl<'a> IrEmitter<'a> {
             let mut out: Vec<(TypedExpr, bool)> = args.iter().map(|a| (a.expr.clone(), false)).collect();
             if let Some(sig) = function_sig {
                 for p in sig.params.iter().skip(out.len()) {
-                    if let Some(default_arg) = &p.default {
-                        out.push((default_arg.clone(), true));
+                    if let Some(FunctionParamDefault::Source(default_arg)) = &p.default {
+                        out.push((default_arg.as_ref().clone(), true));
                     } else {
                         break;
                     }
@@ -1068,7 +1106,7 @@ impl<'a> IrEmitter<'a> {
                 ParamKind::Normal => {
                     if let Some(arg) = normal_bindings.get(normal_binding_index).and_then(|binding| *binding) {
                         out.push(self.emit_regular_call_arg(func, &arg.expr, param_idx, param)?);
-                    } else if let Some(default_arg) = &param.default {
+                    } else if let Some(FunctionParamDefault::Source(default_arg)) = &param.default {
                         out.push(self.emit_regular_call_arg(func, default_arg, param_idx, param)?);
                     }
                     normal_binding_index += 1;
@@ -1750,7 +1788,7 @@ mod tests {
                     mutability: Mutability::Immutable,
                     is_self: false,
                     kind: ParamKind::Normal,
-                    default: Some(default_expr),
+                    default: Some(FunctionParamDefault::source(default_expr)),
                 },
             ],
             IrType::Int,

--- a/src/backend/ir/emit/expressions/methods.rs
+++ b/src/backend/ir/emit/expressions/methods.rs
@@ -7,7 +7,7 @@ use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
 use super::super::super::FunctionSignature;
-use super::super::super::decl::FunctionParam;
+use super::super::super::decl::{FunctionParam, FunctionParamDefault};
 use super::super::super::expr::{
     CollectionMethodKind, InternalMethodKind, IrCallArg, IrCallArgKind, IrExprKind, IrMethodDispatch,
     MethodCallArgPolicy, MethodKind, TypedExpr, VarAccess, VarRefKind,
@@ -413,16 +413,16 @@ impl<'a> IrEmitter<'a> {
                     } else if pos_idx < positional.len() {
                         out.push((positional[pos_idx].clone(), false));
                         pos_idx += 1;
-                    } else if let Some(default_arg) = &param.default {
-                        out.push((default_arg.clone(), true));
+                    } else if let Some(FunctionParamDefault::Source(default_arg)) = &param.default {
+                        out.push((default_arg.as_ref().clone(), true));
                     }
                 }
                 out
             } else {
                 let mut out: Vec<(TypedExpr, bool)> = args.iter().map(|arg| (arg.expr.clone(), false)).collect();
                 for param in sig.params.iter().skip(out.len()) {
-                    if let Some(default_arg) = &param.default {
-                        out.push((default_arg.clone(), true));
+                    if let Some(FunctionParamDefault::Source(default_arg)) = &param.default {
+                        out.push((default_arg.as_ref().clone(), true));
                     } else {
                         break;
                     }

--- a/src/backend/ir/emit/expressions/mod.rs
+++ b/src/backend/ir/emit/expressions/mod.rs
@@ -1346,7 +1346,7 @@ impl<'a> IrEmitter<'a> {
             IrExprKind::Closure {
                 params,
                 body,
-                captures: _,
+                captures,
                 annotate_param_types,
             } => {
                 let param_tokens: Vec<TokenStream> = params
@@ -1369,7 +1369,8 @@ impl<'a> IrEmitter<'a> {
                     }
                     _ => self.emit_expr(body)?,
                 };
-                Ok(quote! { |#(#param_tokens),*| #b })
+                let capture_mode = (!captures.is_empty()).then(|| quote! { move });
+                Ok(quote! { #capture_mode |#(#param_tokens),*| #b })
             }
 
             IrExprKind::Block { stmts, value } => {

--- a/src/backend/ir/emit/mod.rs
+++ b/src/backend/ir/emit/mod.rs
@@ -2434,7 +2434,8 @@ impl<'a> IrEmitter<'a> {
                         mutability: Mutability::Immutable,
                         is_self: false,
                         kind,
-                        default: Self::manifest_param_default_to_ir_expr(library, param),
+                        default: Self::manifest_param_default_to_ir_expr(library, param)
+                            .map(crate::backend::ir::decl::FunctionParamDefault::source),
                     }
                 })
                 .collect(),

--- a/src/backend/ir/emit/program.rs
+++ b/src/backend/ir/emit/program.rs
@@ -33,8 +33,8 @@ use incan_core::lang::types::numerics::{self, NumericFamily};
 use incan_core::lang::{conventions, keywords, magic_methods, stdlib as core_stdlib, trait_capabilities};
 
 use super::super::decl::{
-    IrDeclKind, IrEnum, IrEnumValue, IrEnumValueType, IrFunction, IrImportOrigin, IrImportQualifier, IrRustTraitImport,
-    IrTraitBound, IrTypeParam, Visibility,
+    FunctionParamDefault, IrDeclKind, IrEnum, IrEnumValue, IrEnumValueType, IrFunction, IrImportOrigin,
+    IrImportQualifier, IrRustTraitImport, IrTraitBound, IrTypeParam, Visibility,
 };
 use super::super::expr::{
     IrCallArg, IrDictEntry, IrExprKind, IrGeneratorClause, IrListEntry, IrMethodDispatch, MethodKind, Pattern,
@@ -461,7 +461,7 @@ impl<'program> GeneratedUseAnalyzer<'program> {
             if !param.is_self {
                 self.variable_types.insert(param.name.clone(), param.ty.clone());
             }
-            if let Some(default) = &param.default {
+            if let Some(FunctionParamDefault::Source(default)) = &param.default {
                 self.scan_expr(default);
             }
         }
@@ -2928,7 +2928,7 @@ impl<'a> IrEmitter<'a> {
     /// Collect union shapes from callable defaults that may be emitted as missing call arguments.
     fn collect_union_types_from_signature_defaults(signature: &FunctionSignature, out: &mut HashMap<String, IrType>) {
         for param in &signature.params {
-            if let Some(default) = &param.default {
+            if let Some(FunctionParamDefault::Source(default)) = &param.default {
                 Self::collect_union_types_from_expr_for_target(default, Some(&param.ty), out);
             }
         }
@@ -3302,7 +3302,7 @@ impl<'a> IrEmitter<'a> {
             IrDeclKind::Function(func) => {
                 for param in &func.params {
                     Self::collect_union_types_from_type(&param.ty, out);
-                    if let Some(default) = &param.default {
+                    if let Some(FunctionParamDefault::Source(default)) = &param.default {
                         Self::collect_union_types_from_expr(default, out);
                     }
                 }

--- a/src/backend/ir/lower/decl/functions.rs
+++ b/src/backend/ir/lower/decl/functions.rs
@@ -1,7 +1,7 @@
 //! Function declaration lowering.
 
 use super::super::super::Mutability;
-use super::super::super::decl::{FunctionParam, IrFunction, IrTraitBound, IrTraitBoundOrigin};
+use super::super::super::decl::{FunctionParam, FunctionParamDefault, IrFunction, IrTraitBound, IrTraitBoundOrigin};
 use super::super::super::expr::{IrDictEntry, IrExprKind, IrGeneratorClause, IrListEntry};
 use super::super::super::stmt::{AssignTarget, IrStmt, IrStmtKind};
 use super::super::super::types::IrType;
@@ -407,7 +407,9 @@ impl AstLowering {
                     },
                     is_self: false,
                     kind: p.node.kind,
-                    default: self.lower_param_default_expr(p.node.default.as_ref())?,
+                    default: self
+                        .lower_param_default_expr(p.node.default.as_ref())?
+                        .map(FunctionParamDefault::source),
                 })
             })
             .collect::<Result<_, LoweringError>>()?;

--- a/src/backend/ir/lower/decl/methods.rs
+++ b/src/backend/ir/lower/decl/methods.rs
@@ -2,7 +2,9 @@
 
 use std::collections::{HashMap, HashSet};
 
-use super::super::super::decl::{FunctionParam, IrAssociatedType, IrDecl, IrDeclKind, IrFunction, IrImpl, Visibility};
+use super::super::super::decl::{
+    FunctionParam, FunctionParamDefault, IrAssociatedType, IrDecl, IrDeclKind, IrFunction, IrImpl, Visibility,
+};
 use super::super::super::expr::{IrCallArg, IrCallArgKind, IrExprKind, VarAccess, VarRefKind};
 use super::super::super::stmt::{IrStmt, IrStmtKind};
 use super::super::super::types::IrType;
@@ -531,7 +533,7 @@ impl AstLowering {
                 mutability: Mutability::Immutable,
                 is_self: false,
                 kind: param.kind,
-                default: defaults.get(idx).cloned().flatten(),
+                default: defaults.get(idx).cloned().flatten().map(FunctionParamDefault::source),
             }
         }));
         let return_type = self.lower_resolved_type(&ret);
@@ -1360,7 +1362,9 @@ impl AstLowering {
                     },
                     is_self: false,
                     kind: p.node.kind,
-                    default: self.lower_param_default_expr(p.node.default.as_ref())?,
+                    default: self
+                        .lower_param_default_expr(p.node.default.as_ref())?
+                        .map(FunctionParamDefault::source),
                 })
             })
             .collect::<Result<_, LoweringError>>()?;
@@ -1619,7 +1623,9 @@ impl AstLowering {
                     },
                     is_self: p.node.name == keywords::as_str(KeywordId::SelfKw),
                     kind: p.node.kind,
-                    default: self.lower_param_default_expr(p.node.default.as_ref())?,
+                    default: self
+                        .lower_param_default_expr(p.node.default.as_ref())?
+                        .map(FunctionParamDefault::source),
                 })
             })
             .collect::<Result<_, LoweringError>>()?;

--- a/src/backend/ir/lower/decl/traits.rs
+++ b/src/backend/ir/lower/decl/traits.rs
@@ -9,7 +9,7 @@ use incan_core::lang::traits::TraitId;
 use incan_core::lang::{callables, stdlib, trait_bounds};
 
 use super::super::super::Mutability;
-use super::super::super::decl::{FunctionParam, IrFunction, IrTrait, Visibility};
+use super::super::super::decl::{FunctionParam, FunctionParamDefault, IrFunction, IrTrait, Visibility};
 use super::super::super::types::IrType;
 use super::super::AstLowering;
 use super::super::errors::LoweringError;
@@ -144,7 +144,9 @@ impl AstLowering {
                             },
                             is_self: false,
                             kind: p.node.kind,
-                            default: self.lower_param_default_expr(p.node.default.as_ref())?,
+                            default: self
+                                .lower_param_default_expr(p.node.default.as_ref())?
+                                .map(FunctionParamDefault::source),
                         })
                     })
                     .collect::<Result<_, LoweringError>>()?;

--- a/src/backend/ir/lower/expr/calls.rs
+++ b/src/backend/ir/lower/expr/calls.rs
@@ -3,7 +3,7 @@
 
 use std::collections::HashMap;
 
-use super::super::super::decl::FunctionParam;
+use super::super::super::decl::{FunctionParam, FunctionParamDefault};
 use super::super::super::expr::{
     BuiltinFn, IrCallArg, IrCallArgKind, IrDictEntry, IrExprKind, IrInteropCoercionKind, IrListEntry,
     Literal as IrLiteral, MatchArm, MethodCallArgPolicy, Pattern, VarAccess, VarRefKind,
@@ -266,7 +266,9 @@ impl AstLowering {
                         },
                         is_self: false,
                         kind: param.node.kind,
-                        default: self.lower_param_default_expr(param.node.default.as_ref())?,
+                        default: self
+                            .lower_param_default_expr(param.node.default.as_ref())?
+                            .map(FunctionParamDefault::source),
                     })
                 })
                 .collect::<Result<_, LoweringError>>()?,
@@ -297,7 +299,9 @@ impl AstLowering {
                         },
                         is_self: false,
                         kind: param.node.kind,
-                        default: self.lower_param_default_expr(param.node.default.as_ref())?,
+                        default: self
+                            .lower_param_default_expr(param.node.default.as_ref())?
+                            .map(FunctionParamDefault::source),
                     })
                 })
                 .collect::<Result<_, LoweringError>>()?,
@@ -536,7 +540,9 @@ impl AstLowering {
                         mutability: Mutability::Immutable,
                         is_self: false,
                         kind,
-                        default: self.lower_pub_param_default(library, param),
+                        default: self
+                            .lower_pub_param_default(library, param)
+                            .map(FunctionParamDefault::source),
                     }
                 })
                 .collect(),
@@ -709,7 +715,9 @@ impl AstLowering {
                         mutability: Mutability::Immutable,
                         is_self: false,
                         kind,
-                        default: self.lower_pub_param_default(library, param),
+                        default: self
+                            .lower_pub_param_default(library, param)
+                            .map(FunctionParamDefault::source),
                     }
                 })
                 .collect(),
@@ -1114,7 +1122,9 @@ impl AstLowering {
                         mutability: Mutability::Immutable,
                         is_self: false,
                         kind,
-                        default: self.lower_pub_param_default(library, param),
+                        default: self
+                            .lower_pub_param_default(library, param)
+                            .map(FunctionParamDefault::source),
                     }
                 })
                 .collect(),
@@ -1145,7 +1155,9 @@ impl AstLowering {
                         mutability: Mutability::Immutable,
                         is_self: false,
                         kind,
-                        default: self.lower_compiled_provider_param_default(provider_crate, param),
+                        default: self
+                            .lower_compiled_provider_param_default(provider_crate, param)
+                            .map(FunctionParamDefault::source),
                     }
                 })
                 .collect(),
@@ -1178,7 +1190,9 @@ impl AstLowering {
                         mutability: Mutability::Immutable,
                         is_self: false,
                         kind,
-                        default: self.lower_compiled_provider_param_default(provider_crate, param),
+                        default: self
+                            .lower_compiled_provider_param_default(provider_crate, param)
+                            .map(FunctionParamDefault::source),
                     }
                 })
                 .collect(),
@@ -1312,7 +1326,9 @@ impl AstLowering {
                             mutability: Mutability::Immutable,
                             is_self: false,
                             kind,
-                            default: self.lower_compiled_provider_param_default(provider_crate, param),
+                            default: self
+                                .lower_compiled_provider_param_default(provider_crate, param)
+                                .map(FunctionParamDefault::source),
                         }
                     })
                     .collect(),

--- a/src/backend/ir/lower/expr/mod.rs
+++ b/src/backend/ir/lower/expr/mod.rs
@@ -13,13 +13,14 @@ mod patterns;
 
 use std::collections::HashMap;
 
+use super::super::decl::FunctionParamDefault;
 use super::super::expr::{
     BuiltinFn, CollectionMethodKind, IrCallArg, IrCallArgKind, IrDictEntry, IrExpr, IrExprKind, IrListEntry,
     IrMethodDispatch, Literal as IrLiteral, MethodCallArgPolicy, MethodKind, NumericResizePolicy, RaceArm, UnaryOp,
     VarAccess, VarRefKind,
 };
 use super::super::types::IrType;
-use super::super::{IrCheckedCFunction, IrCheckedCType, TypedExpr};
+use super::super::{IrCheckedCFunction, IrCheckedCType, IrStmt, IrStmtKind, Mutability, TypedExpr};
 use super::AstLowering;
 use super::errors::LoweringError;
 use crate::frontend::ast::{self, Spanned};
@@ -2268,57 +2269,177 @@ impl AstLowering {
             // ---- Yield (placeholder) ----
             ast::Expr::Yield(_) => (IrExprKind::Unit, IrType::Unknown),
             ast::Expr::Partial(partial) => {
-                let Some(crate::frontend::symbols::ResolvedType::Function(params, ret)) = self
+                let Some(crate::frontend::symbols::ResolvedType::Function(target_params, _)) = self
                     .type_info
                     .as_ref()
-                    .and_then(|info| info.expr_type(expr_span).cloned())
+                    .and_then(|info| info.expr_type(partial.target.span).cloned())
                 else {
                     return Err(LoweringError {
+                        message: "Partial callable target is missing typechecker signature metadata".to_string(),
+                        span: partial.target.span.into(),
+                    });
+                };
+                let signature = self
+                    .partial_expr_callable_signature(partial, expr_span)?
+                    .ok_or_else(|| LoweringError {
                         message: "Partial callable preset expression is missing typechecker projection metadata"
                             .to_string(),
                         span: expr_span.into(),
-                    });
-                };
-                let closure_params: Vec<(String, IrType)> = params
+                    })?;
+                let target = self.lower_expr_spanned(&partial.target)?;
+
+                // Evaluate every preset exactly once before the closure is constructed. The generated closure is
+                // `move`, so a later mutation of the source local cannot change an omitted preset argument.
+                let mut capture_stmts = Vec::with_capacity(partial.args.len());
+                let mut captures = HashMap::with_capacity(partial.args.len());
+                let mut capture_names = Vec::with_capacity(partial.args.len());
+                for (index, preset) in partial.args.iter().enumerate() {
+                    let value = self.lower_expr_spanned(&preset.value)?;
+                    let ty = value.ty.clone();
+                    let capture_name = format!("__incan_partial_preset_{index}_{}", preset.name);
+                    capture_stmts.push(IrStmt::new(IrStmtKind::Let {
+                        name: capture_name.clone(),
+                        ty: ty.clone(),
+                        type_annotation: None,
+                        mutability: Mutability::Immutable,
+                        value,
+                    }));
+                    captures.insert(preset.name.clone(), (capture_name.clone(), ty));
+                    capture_names.push(capture_name);
+                }
+
+                let closure_params: Vec<(String, IrType)> = signature
+                    .params
                     .iter()
-                    .enumerate()
-                    .map(|(idx, param)| {
-                        (
-                            param.name.clone().unwrap_or_else(|| format!("__incan_arg_{idx}")),
-                            Self::lower_param_container_type(param.kind, self.lower_resolved_type(&param.ty)),
-                        )
-                    })
+                    .map(|param| (param.name.clone(), param.ty.clone()))
                     .collect();
-                let _signature = self.partial_expr_callable_signature(partial, expr_span)?;
-                self.push_scope();
-                for (name, ty) in &closure_params {
-                    self.define_local_binding(name.clone(), ty.clone(), false);
+                let mut forward_args = Vec::with_capacity(target_params.len());
+                for (idx, target_param) in target_params.iter().enumerate() {
+                    let Some(name) = target_param.name.as_ref() else {
+                        return Err(LoweringError {
+                            message: format!(
+                                "Partial callable target has unsupported anonymous parameter at index {idx}"
+                            ),
+                            span: partial.target.span.into(),
+                        });
+                    };
+                    let target_ty =
+                        Self::lower_param_container_type(target_param.kind, self.lower_resolved_type(&target_param.ty));
+                    let parameter = signature.params.get(idx).ok_or_else(|| LoweringError {
+                        message: format!(
+                            "Partial callable target parameter '{name}' is absent from its callable signature"
+                        ),
+                        span: partial.target.span.into(),
+                    })?;
+                    let value = if matches!(
+                        parameter.default.as_ref(),
+                        Some(FunctionParamDefault::CapturedPartialPreset)
+                    ) {
+                        let (capture_name, capture_ty) = captures.get(name).ok_or_else(|| LoweringError {
+                            message: format!("Partial callable preset '{name}' has no construction-time capture"),
+                            span: expr_span.into(),
+                        })?;
+                        let fallback = TypedExpr::new(
+                            IrExprKind::Closure {
+                                params: Vec::new(),
+                                body: Box::new(TypedExpr::new(
+                                    IrExprKind::MethodCall {
+                                        receiver: Box::new(TypedExpr::new(
+                                            IrExprKind::Var {
+                                                name: capture_name.clone(),
+                                                access: VarAccess::Read,
+                                                ref_kind: VarRefKind::Value,
+                                            },
+                                            capture_ty.clone(),
+                                        )),
+                                        method: "clone".to_string(),
+                                        dispatch: None,
+                                        type_args: Vec::new(),
+                                        args: Vec::new(),
+                                        callable_signature: None,
+                                        arg_policy: MethodCallArgPolicy::Default,
+                                    },
+                                    capture_ty.clone(),
+                                )),
+                                captures: Vec::new(),
+                                annotate_param_types: false,
+                            },
+                            IrType::Function {
+                                params: Vec::new(),
+                                ret: Box::new(capture_ty.clone()),
+                            },
+                        );
+                        TypedExpr::new(
+                            IrExprKind::MethodCall {
+                                receiver: Box::new(TypedExpr::new(
+                                    IrExprKind::Var {
+                                        name: name.clone(),
+                                        access: VarAccess::Read,
+                                        ref_kind: VarRefKind::Value,
+                                    },
+                                    parameter.ty.clone(),
+                                )),
+                                method: "unwrap_or_else".to_string(),
+                                dispatch: None,
+                                type_args: Vec::new(),
+                                args: vec![IrCallArg {
+                                    name: None,
+                                    kind: IrCallArgKind::Positional,
+                                    expr: fallback,
+                                }],
+                                callable_signature: None,
+                                arg_policy: MethodCallArgPolicy::Default,
+                            },
+                            target_ty,
+                        )
+                    } else {
+                        TypedExpr::new(
+                            IrExprKind::Var {
+                                name: name.clone(),
+                                access: VarAccess::Read,
+                                ref_kind: VarRefKind::Value,
+                            },
+                            target_ty,
+                        )
+                    };
+                    forward_args.push(IrCallArg {
+                        name: Some(name.clone()),
+                        kind: IrCallArgKind::Named,
+                        expr: value,
+                    });
                 }
-                let mut forward_args = Vec::new();
-                for (name, _) in &closure_params {
-                    forward_args.push(ast::CallArg::Named(
-                        name.clone(),
-                        ast::Spanned::new(ast::Expr::Ident(name.clone()), expr_span),
-                    ));
-                }
-                let call = ast::Spanned::new(
-                    ast::Expr::Call(partial.target.clone(), partial.type_args.clone(), forward_args),
-                    expr_span,
+                let body = TypedExpr::new(
+                    IrExprKind::Call {
+                        func: Box::new(target),
+                        type_args: self.lower_call_site_type_args(expr_span, &partial.type_args),
+                        args: forward_args,
+                        callable_signature: None,
+                        canonical_path: None,
+                    },
+                    signature.return_type.clone(),
                 );
-                let body_result = self.lower_expr_spanned(&call);
-                self.pop_scope();
-                let body = body_result?;
-                let ret_ty = self.lower_resolved_type(ret.as_ref());
-                (
+                let closure = TypedExpr::new(
                     IrExprKind::Closure {
                         params: closure_params.clone(),
                         body: Box::new(body),
-                        captures: vec![],
-                        annotate_param_types: false,
+                        captures: capture_names,
+                        // A local partial has no surrounding Rust callable type to infer its parameters. Emit their
+                        // source-checked IR types, including `Option<T>` for overrideable preset slots.
+                        annotate_param_types: true,
                     },
                     IrType::Function {
                         params: closure_params.into_iter().map(|(_, ty)| ty).collect(),
-                        ret: Box::new(ret_ty),
+                        ret: Box::new(signature.return_type.clone()),
+                    },
+                );
+                (
+                    IrExprKind::Block {
+                        stmts: capture_stmts,
+                        value: Some(Box::new(closure)),
+                    },
+                    IrType::Function {
+                        params: signature.params.into_iter().map(|param| param.ty).collect(),
+                        ret: Box::new(signature.return_type),
                     },
                 )
             }

--- a/src/backend/ir/lower/mod.rs
+++ b/src/backend/ir/lower/mod.rs
@@ -36,7 +36,9 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use super::TypedExpr;
-use super::decl::{FunctionParam, IrDecl, IrDeclKind, IrImportOrigin, IrImportQualifier, IrTypeParam};
+use super::decl::{
+    FunctionParam, FunctionParamDefault, IrDecl, IrDeclKind, IrImportOrigin, IrImportQualifier, IrTypeParam,
+};
 use super::expr::{IrCallArg, IrCallArgKind, IrExprKind, MethodCallArgPolicy, VarAccess, VarRefKind};
 use super::stmt::{IrStmt, IrStmtKind};
 use super::types::IrType;
@@ -505,7 +507,7 @@ impl AstLowering {
                     mutability: Mutability::Immutable,
                     is_self: false,
                     kind: param.kind,
-                    default: defaults.get(idx).cloned().flatten(),
+                    default: defaults.get(idx).cloned().flatten().map(FunctionParamDefault::source),
                 }
             })
             .collect()
@@ -608,7 +610,7 @@ impl AstLowering {
                     },
                     is_self: false,
                     kind: param.kind,
-                    default,
+                    default: default.map(FunctionParamDefault::source),
                 })
             })
             .collect()
@@ -1291,8 +1293,13 @@ impl AstLowering {
         self.partial_expr_signatures.get(&(span.start, span.end)).cloned()
     }
 
-    /// Rehydrate a local partial expression into an IR callable signature so default values survive calls through
-    /// function-typed locals.
+    /// Record the callable signature of a local partial expression for calls through its bound closure value.
+    ///
+    /// A preset remains a name-overrideable default parameter. Its Rust closure slot is `Option<T>` and its
+    /// [`FunctionParamDefault::CapturedPartialPreset`] marker tells call emission to send `None` when the caller
+    /// omits it; the closure then selects the value captured at partial construction. Ordinary source defaults retain
+    /// their materializable source expression. Keeping these cases distinct prevents a mutable local preset from
+    /// being re-evaluated at each invocation.
     pub(super) fn partial_expr_callable_signature(
         &mut self,
         partial: &ast::PartialExpr,
@@ -1304,28 +1311,54 @@ impl AstLowering {
             return Ok(None);
         };
 
-        let mut defaults = HashMap::new();
-        for arg in &partial.args {
-            defaults.insert(arg.name.clone(), self.lower_expr_spanned(&arg.value)?);
-        }
-
-        let signature = FunctionSignature {
-            params: params
-                .iter()
-                .enumerate()
-                .map(|(idx, param)| {
-                    let base_ty = self.lower_resolved_type(&param.ty);
-                    let ty = Self::lower_param_container_type(param.kind, base_ty);
-                    FunctionParam {
-                        name: param.name.clone().unwrap_or_else(|| format!("__incan_arg_{idx}")),
-                        ty,
-                        mutability: Mutability::Immutable,
-                        is_self: false,
-                        kind: param.kind,
-                        default: param.name.as_ref().and_then(|name| defaults.get(name).cloned()),
+        let default_source = match &partial.target.node {
+            ast::Expr::Ident(name) => self.lookup_local_callable_signature(name),
+            _ => None,
+        };
+        let signature_params = params
+            .iter()
+            .enumerate()
+            .map(|(idx, param)| {
+                let base_ty = self.lower_resolved_type(&param.ty);
+                let ty = if param.is_partial_preset {
+                    IrType::Option(Box::new(Self::lower_param_container_type(param.kind, base_ty)))
+                } else {
+                    Self::lower_param_container_type(param.kind, base_ty)
+                };
+                let default = if param.is_partial_preset {
+                    Some(FunctionParamDefault::CapturedPartialPreset)
+                } else if param.has_default {
+                    let name = param.name.as_deref().unwrap_or("<anonymous>");
+                    let source_default = default_source
+                        .as_ref()
+                        .and_then(|signature| signature.params.iter().find(|source| source.name == name))
+                        .and_then(|source| source.default.clone());
+                    match source_default {
+                        Some(FunctionParamDefault::Source(default)) => Some(FunctionParamDefault::Source(default)),
+                        Some(FunctionParamDefault::CapturedPartialPreset) | None => {
+                            return Err(LoweringError {
+                                message: format!(
+                                    "Local partial default for '{name}' cannot be materialized from its callable target"
+                                ),
+                                span: span.into(),
+                            });
+                        }
                     }
+                } else {
+                    None
+                };
+                Ok(FunctionParam {
+                    name: param.name.clone().unwrap_or_else(|| format!("__incan_arg_{idx}")),
+                    ty,
+                    mutability: Mutability::Immutable,
+                    is_self: false,
+                    kind: param.kind,
+                    default,
                 })
-                .collect(),
+            })
+            .collect::<Result<Vec<_>, LoweringError>>()?;
+        let signature = FunctionSignature {
+            params: signature_params,
             return_type: self.lower_resolved_type(ret.as_ref()),
         };
         self.partial_expr_signatures
@@ -1372,6 +1405,15 @@ impl AstLowering {
                     params: params.iter().map(|param| param.ty.clone()).collect(),
                     ret: Box::new(return_type.clone()),
                 },
+            );
+        }
+        if let Some(scope) = self.local_callable_signature_scopes.first_mut() {
+            scope.insert(
+                name.to_string(),
+                Some(FunctionSignature {
+                    params: params.to_vec(),
+                    return_type: return_type.clone(),
+                }),
             );
         }
     }
@@ -1795,7 +1837,9 @@ impl AstLowering {
                                     },
                                     is_self: false,
                                     kind: p.node.kind,
-                                    default: self.lower_param_default_expr(p.node.default.as_ref())?,
+                                    default: self
+                                        .lower_param_default_expr(p.node.default.as_ref())?
+                                        .map(FunctionParamDefault::source),
                                 })
                             })
                             .collect()
@@ -1890,7 +1934,9 @@ impl AstLowering {
                                     },
                                     is_self: false,
                                     kind: p.node.kind,
-                                    default: self.lower_param_default_expr(p.node.default.as_ref())?,
+                                    default: self
+                                        .lower_param_default_expr(p.node.default.as_ref())?
+                                        .map(FunctionParamDefault::source),
                                 })
                             })
                             .collect()

--- a/src/backend/ir/lower/stmt.rs
+++ b/src/backend/ir/lower/stmt.rs
@@ -982,7 +982,13 @@ impl AstLowering {
             ast::Statement::Assignment(a) => {
                 let rhs_direct_static = self.is_direct_static_ident(&a.value);
                 let lowered_value = self.lower_expr_spanned(&a.value)?;
-                let local_callable_signature = self.partial_expr_signature_for_span(a.value.span);
+                let local_callable_signature = self.partial_expr_signature_for_span(a.value.span).or_else(|| {
+                    if let ast::Expr::Ident(source_name) = &a.value.node {
+                        self.lookup_local_callable_signature(source_name)
+                    } else {
+                        None
+                    }
+                });
                 let type_annotation = a.ty.as_ref().map(|t| self.lower_type(&t.node));
                 let ty = type_annotation.clone().unwrap_or_else(|| lowered_value.ty.clone());
 

--- a/src/backend/ir/lower/types.rs
+++ b/src/backend/ir/lower/types.rs
@@ -354,6 +354,7 @@ impl AstLowering {
                         ty: self.expand_pub_manifest_type_aliases(library, param.ty, expanding),
                         kind: param.kind,
                         has_default: param.has_default,
+                        is_partial_preset: param.is_partial_preset,
                     })
                     .collect(),
                 Box::new(self.expand_pub_manifest_type_aliases(library, *ret, expanding)),

--- a/src/frontend/body_ir.rs
+++ b/src/frontend/body_ir.rs
@@ -793,7 +793,13 @@ impl<'a> BodyBuilder<'a> {
         span: HirSourceSpan,
         out: &mut Vec<bir::Statement>,
     ) {
-        let ty = self.resolve_ty(assignment.value.span);
+        // A closure value already carries the typechecker's callable shape. A partial retains that full callable
+        // type, with captured presets represented as named-overrideable defaults. Positional calls skip those preset
+        // slots, and `LocalCallableTarget::parameter_slots` records the resulting declaration mapping. Keeping this
+        // type on the binding makes the local call contract agree with the `Rvalue::Closure` that creates the value.
+        let ty = self
+            .callable_value_ty(&assignment.value)
+            .unwrap_or_else(|| self.resolve_ty(assignment.value.span));
         let value = self.lower_expr_to_operand(&assignment.value, scope, out);
         let local = match assignment.binding {
             ast::BindingKind::Reassign => self
@@ -2281,10 +2287,18 @@ impl<'a> BodyBuilder<'a> {
         Some(operands)
     }
 
-    /// Lower a direct call `name(args)` to a [`bir::Callee::Function`] call. An indirect callee (anything other than
-    /// a bare identifier), explicit type arguments, or non-positional arguments each lower to an explicit
-    /// unsupported placeholder instead — v0 defers full call-target resolution (see [`bir::Callee::Function`]'s own
-    /// docs) and does not model generic call-site type arguments.
+    /// Lower a call to either a locally held callable value or a direct named function.
+    ///
+    /// A bare identifier that resolves to one of this body's locals is deliberately a
+    /// [`bir::CallableTarget::Local`] call: it carries the local read's ownership fact, so a closure's lexical
+    /// environment is not lost by pretending the identifier were a declaration. Its callable signature also
+    /// enforces the stored value's fixed callable contract before any call arguments are lowered. A bare identifier
+    /// with no local binding remains a direct [`bir::Callee::Function`] call. Local fixed-parameter callables
+    /// additionally normalize supplied arguments into declaration order before the IR call. A partial's preset slot
+    /// stays present for named overrides but is skipped by positional binding, and the local target records the
+    /// resulting declaration-slot map. Non-identifier callees, type arguments, unpack arguments, local
+    /// rest-parameter callables, and named calls that would need a non-trailing non-preset default hole remain
+    /// explicit unsupported forms; v0 has no general dynamic-call-target or sparse-argument-map node for them yet.
     fn lower_call(
         &mut self,
         callee: &ast::Spanned<ast::Expr>,
@@ -2307,6 +2321,64 @@ impl<'a> BodyBuilder<'a> {
             );
         }
         let name = name.clone();
+
+        if let Some(&local) = self.bindings.get(&name) {
+            let local_ty = self.locals[local.index()].ty.clone();
+            let IncanType::Function { params, return_type: _ } = local_ty else {
+                return self.unsupported_operand(
+                    format!("call to non-callable local `{name}`"),
+                    scope,
+                    hir_span_value,
+                    out,
+                );
+            };
+            let planned_args = match plan_local_callable_args(&name, &params, args) {
+                Ok(planned_args) => planned_args,
+                Err(description) => {
+                    return self.unsupported_operand(description, scope, hir_span_value, out);
+                }
+            };
+
+            // Source evaluation observes the callable value before its arguments. The target read also performs the
+            // one ownership/last-use decision for that lexical environment, which `CallableTarget::Local` preserves
+            // for a later executor instead of re-deriving it from the local's source spelling.
+            let place = bir::Place::from_local(local);
+            let (fact, last_use) = self.ownership_fact_for_place(&place, &self.locals[local.index()].ty.clone());
+            // The plan keeps expressions in source evaluation order, then fills their normalized declaration slots.
+            // A caller can therefore use a captured preset by omission or override it by name without turning the
+            // flat call-argument vector into an ambiguous sparse representation.
+            let mut normalized_args: Vec<Option<bir::Operand>> = vec![None; params.len()];
+            for (index, expr) in planned_args {
+                normalized_args[index] = Some(self.lower_expr_to_operand(expr, scope, out));
+            }
+            let highest_supplied = normalized_args.iter().rposition(Option::is_some);
+            let mut operands = Vec::with_capacity(highest_supplied.map_or(0, |highest| highest + 1));
+            let mut parameter_slots = Vec::with_capacity(operands.capacity());
+            if let Some(highest) = highest_supplied {
+                for (index, operand) in normalized_args.into_iter().take(highest + 1).enumerate() {
+                    let Some(operand) = operand else {
+                        if params[index].is_partial_preset {
+                            continue;
+                        }
+                        return self.unsupported_operand(
+                            format!("local callable `{name}` has an omitted argument at position {index}"),
+                            scope,
+                            hir_span_value,
+                            out,
+                        );
+                    };
+                    operands.push(operand);
+                    parameter_slots.push(index);
+                }
+            }
+            let callee = bir::Callee::Function(bir::CallableTarget::Local(bir::LocalCallableTarget {
+                operand: bir::PlaceOperand { place, fact, last_use },
+                parameter_slots,
+            }));
+            let ty = self.resolve_ty(span);
+            return self.push_call_temp(callee, operands, ty, scope, hir_span_value, false, out);
+        }
+
         let Some(operands) = self.lower_positional_args(args, scope, out) else {
             return self.unsupported_operand(
                 "call with named or unpack arguments".to_string(),
@@ -2317,7 +2389,7 @@ impl<'a> BodyBuilder<'a> {
         };
         let ty = self.resolve_ty(span);
         self.push_call_temp(
-            bir::Callee::Function(name),
+            bir::Callee::Function(bir::CallableTarget::Named(name)),
             operands,
             ty,
             scope,
@@ -2325,6 +2397,17 @@ impl<'a> BodyBuilder<'a> {
             false,
             out,
         )
+    }
+
+    /// Return the typechecker's callable type for a closure or local partial value that Body IR constructs itself.
+    ///
+    /// Local partials use the typechecker's canonical full signature with overrideable preset-default slots, so the
+    /// binding, its [`bir::Rvalue::Closure`], and a later [`Self::lower_call`] share one arity/default contract.
+    fn callable_value_ty(&self, expr: &ast::Spanned<ast::Expr>) -> Option<IncanType> {
+        match &expr.node {
+            ast::Expr::Closure(_, _) | ast::Expr::Partial(_) => Some(self.resolve_ty(expr.span)),
+            _ => None,
+        }
     }
 
     /// Lower a method call `recv.name(args)` to a [`bir::Callee::Method`] call, with the receiver prepended to
@@ -2643,6 +2726,8 @@ impl<'a> BodyBuilder<'a> {
             closure_params.push(bir::ClosureParam {
                 name: param.node.name.clone(),
                 ty,
+                has_default: param.node.default.is_some(),
+                preset_capture: None,
             });
             param_locals.push(local);
             saved_bindings.push((param.node.name.clone(), previous));
@@ -2707,38 +2792,24 @@ impl<'a> BodyBuilder<'a> {
     /// [`bir::Rvalue::Closure`] shape a closure literal produces, mirroring how the existing Rust-emission backend
     /// already desugars a partial application into a synthesized closure that forwards the still-missing arguments
     /// into a call (`src/backend/ir/lower/expr/mod.rs`'s `ast::Expr::Partial` arm) -- see #1101's B4 pre-intake.
-    /// Body IR's own call shape ([`bir::Callee`]) only models bare-identifier direct calls with positional
-    /// arguments (see [`Self::lower_call`]), so this only supports a bare function-name `target` whose full
-    /// parameter list the typechecker resolved as a top-level function binding; anything else (a method-shaped
-    /// partial target from `partial recv.method(...)`, explicit type arguments, or a target with an unnamed
-    /// parameter) lowers to an explicit unsupported placeholder instead.
+    /// Partial construction currently supports only a bare top-level function-name `target` whose full parameter list
+    /// the typechecker resolved. General Body IR calls still distinguish named functions from local callable values
+    /// and record local supplied-parameter slots (see [`Self::lower_call`]). A method-shaped partial target from
+    /// `partial recv.method(...)`, explicit type arguments, or a target with an unnamed parameter lowers to an
+    /// explicit unsupported placeholder instead.
     ///
     /// Preset values (`partial.args`) are lowered once each, at the partial-creation site -- exactly like an
     /// ordinary call argument, not deduplicated per free-variable name the way [`Self::lower_closure`]'s captures
-    /// are -- and folded into the synthesized closure's own `captured_operands` so its body can read them as
-    /// pre-bound locals. Every declared parameter the target function has that is *not* covered by a preset becomes
-    /// one of the synthesized closure's own parameters, in the target's declaration order. The synthesized body is
-    /// a single call forwarding every target parameter, positionally, from whichever of the two sources supplied
-    /// it. A compound-assignment-style mutation of a captured preset from inside a nested closure is out of scope
-    /// here in the same way [`Self::lower_closure`]'s own docs note for ordinary closures.
+    /// are -- and folded into the synthesized closure's own `captured_operands`. Every declared target parameter
+    /// remains a closure parameter in declaration order. A preset parameter has `has_default` plus an explicit
+    /// `preset_capture`, so callers may omit it to use the construction-time value or override it by name. Positional
+    /// local calls skip those preset-default parameters; [`Self::lower_call`] records the supplied declaration slots
+    /// rather than pretending the complete callable surface is a residual function type.
     ///
-    /// This deliberately does **not** reuse [`Self::resolve_ty`] for the resulting closure's own [`IncanType`]:
-    /// the typechecker's own resolved type for a `partial` expression (`check_partial_expr` in
-    /// `src/frontend/typechecker/check_expr/mod.rs`, via `project_partial_params` in
-    /// `src/frontend/typechecker/collect.rs`) keeps *every* one of the target's original parameters, merely marking
-    /// the preset ones `has_default: true` internally -- it does not shrink the parameter list the way this
-    /// lowering's own `params` does. The existing Rust-emission backend's own `ast::Expr::Partial` arm mirrors that
-    /// full-arity shape exactly (building one Rust closure parameter per *original* target parameter) and relies on
-    /// a separate `partial_expr_signatures` side table, consulted elsewhere during call-argument lowering, to fill
-    /// a preset's value in at each call site that omits it -- machinery Body IR v0 has no equivalent of anywhere
-    /// else in this file. Reusing the typechecker's full-arity type here would leave the rendered
-    /// [`bir::Rvalue::Closure`] internally inconsistent (an `IncanType::Function` claiming N parameters next to a
-    /// `params` list with fewer entries), so this instead builds its own [`IncanType::Function`] directly from the
-    /// residual `closure_params`/target return type -- semantically equivalent (calling the residual closure with
-    /// the missing arguments behaves like calling the target with the preset values already applied),
-    /// self-contained, and consistent with the rest of this model, at the cost of not literally mirroring the
-    /// existing backend's own default-argument side-channel bit for bit. See `plan.md`'s "B4 implementation notes"
-    /// for the full pre-intake-vs-reality discrepancy this resolves.
+    /// `Expr::Partial` uses this same full callable surface through `local_partial_params`; module-level partial
+    /// declarations intentionally keep their existing full-signature-plus-preset-metadata projection for backend
+    /// and export consumers. A compound-assignment-style mutation of a captured preset from inside a nested closure
+    /// is out of scope here in the same way [`Self::lower_closure`]'s own docs note for ordinary closures.
     fn lower_partial(
         &mut self,
         partial: &ast::PartialExpr,
@@ -2771,9 +2842,13 @@ impl<'a> BodyBuilder<'a> {
                 out,
             );
         };
-        if binding.params.iter().any(|param| param.name.is_none()) {
+        if binding
+            .params
+            .iter()
+            .any(|param| param.name.is_none() || param.kind != ast::ParamKind::Normal)
+        {
             return self.unsupported_operand(
-                "partial callable target with an unnamed parameter".to_string(),
+                "partial callable target with an unnamed or rest parameter".to_string(),
                 scope,
                 hir_span_value,
                 out,
@@ -2786,21 +2861,22 @@ impl<'a> BodyBuilder<'a> {
         let mut captured_operands = Vec::with_capacity(partial.args.len());
         let mut capture_locals = Vec::with_capacity(partial.args.len());
         let mut preset_lookup: HashMap<String, bir::LocalId> = HashMap::with_capacity(partial.args.len());
-        let mut saved_bindings = Vec::with_capacity(binding.params.len());
+        let mut saved_bindings = Vec::with_capacity(binding.params.len() + partial.args.len());
         for arg in &partial.args {
             let value_ty = self.resolve_ty(arg.value.span);
             let operand = self.lower_expr_to_operand(&arg.value, scope, out);
             captured_operands.push(operand);
-            let previous = self.bindings.get(&arg.name).copied();
+            let capture_name = format!("__partial_preset_{}", arg.name);
+            let previous = self.bindings.get(&capture_name).copied();
             let capture_local =
-                self.declare_new_local_with_reads(arg.name.clone(), value_ty, closure_scope, hir_span_value, 1);
+                self.declare_new_local_with_reads(capture_name.clone(), value_ty, closure_scope, hir_span_value, 1);
             self.locals[capture_local.index()].origin = bir::LocalOrigin::Captured;
             capture_locals.push(capture_local);
             preset_lookup.insert(arg.name.clone(), capture_local);
-            saved_bindings.push((arg.name.clone(), previous));
+            saved_bindings.push((capture_name, previous));
         }
 
-        // ---- Every target parameter not covered by a preset becomes one of the closure's own parameters ----
+        // ---- Every target parameter stays on the closure surface; presets become overrideable defaults ----
         let mut closure_params = Vec::new();
         let mut param_locals = Vec::new();
         let mut call_arg_locals = Vec::with_capacity(binding.params.len());
@@ -2813,10 +2889,6 @@ impl<'a> BodyBuilder<'a> {
                     out,
                 );
             };
-            if let Some(&capture_local) = preset_lookup.get(param_name) {
-                call_arg_locals.push(capture_local);
-                continue;
-            }
             let ty = semantic_type_from_resolved(&param.ty);
             let previous = self.bindings.get(param_name).copied();
             let local =
@@ -2825,6 +2897,8 @@ impl<'a> BodyBuilder<'a> {
             closure_params.push(bir::ClosureParam {
                 name: param_name.clone(),
                 ty,
+                has_default: param.has_default || preset_lookup.contains_key(param_name),
+                preset_capture: preset_lookup.get(param_name).copied(),
             });
             param_locals.push(local);
             call_arg_locals.push(local);
@@ -2845,9 +2919,9 @@ impl<'a> BodyBuilder<'a> {
             .collect();
         let ret_ty = semantic_type_from_resolved(&binding.return_type);
         let result = self.push_call_temp(
-            bir::Callee::Function(target_name),
+            bir::Callee::Function(bir::CallableTarget::Named(target_name)),
             call_args,
-            ret_ty.clone(),
+            ret_ty,
             closure_scope,
             hir_span_value,
             false,
@@ -2873,20 +2947,7 @@ impl<'a> BodyBuilder<'a> {
             }
         }
 
-        // Built directly from `closure_params`/`ret_ty` rather than `Self::resolve_ty(expr_span)` -- see this
-        // method's own docs for why the typechecker's resolved type for a `partial` expression is not usable here.
-        let ty = IncanType::Function {
-            params: closure_params
-                .iter()
-                .map(|param| IncanCallableParam {
-                    name: Some(param.name.clone()),
-                    ty: param.ty.clone(),
-                    kind: IncanCallableParamKind::Normal,
-                    has_default: false,
-                })
-                .collect(),
-            return_type: Box::new(ret_ty),
-        };
+        let ty = self.resolve_ty(expr_span);
         self.push_assign_temp(
             bir::Rvalue::Closure {
                 params: closure_params,
@@ -3235,6 +3296,92 @@ fn count_reads_in_comprehension_clauses(name: &str, clauses: &[ast::Comprehensio
 // ============================================================================
 // Free helper functions
 // ============================================================================
+
+/// Plan a local callable's supplied arguments into declaration parameter slots before lowering any expression.
+///
+/// This validates the whole call before a callee or argument ownership read is emitted, then leaves the returned
+/// expressions in source evaluation order. The caller can therefore lower values left-to-right while the final
+/// [`bir::StatementKind::Call`] argument vector follows parameter order. Preset-default slots are intentionally
+/// omitted from positional binding and may be skipped in the vector because the local target records each supplied
+/// operand's declaration slot. An interior ordinary default hole still needs a future sparse argument-map node and
+/// is refused explicitly instead of being compacted into the wrong position.
+fn plan_local_callable_args<'a>(
+    name: &str,
+    params: &[IncanCallableParam],
+    args: &'a [ast::CallArg],
+) -> Result<Vec<(usize, &'a ast::Spanned<ast::Expr>)>, String> {
+    if params.iter().any(|param| param.kind != IncanCallableParamKind::Normal) {
+        return Err(format!("local callable `{name}` has a rest parameter"));
+    }
+    let positional_slots: Vec<usize> = params
+        .iter()
+        .enumerate()
+        .filter_map(|(index, param)| (!param.is_partial_preset).then_some(index))
+        .collect();
+    let mut slots: Vec<Option<&ast::Spanned<ast::Expr>>> = vec![None; params.len()];
+    let mut positional_index = 0usize;
+    let mut planned = Vec::with_capacity(args.len());
+    for arg in args {
+        let (index, expr) = match arg {
+            ast::CallArg::Positional(expr) => {
+                if positional_index >= positional_slots.len() {
+                    return Err(format!(
+                        "local callable `{name}` expects at most {} positional arguments, got {}",
+                        positional_slots.len(),
+                        args.len()
+                    ));
+                }
+                let index = positional_slots[positional_index];
+                positional_index += 1;
+                (index, expr)
+            }
+            ast::CallArg::Named(arg_name, expr) => {
+                let Some(index) = params
+                    .iter()
+                    .position(|param| param.name.as_deref() == Some(arg_name.as_str()))
+                else {
+                    return Err(format!("local callable `{name}` has no parameter `{arg_name}`"));
+                };
+                (index, expr)
+            }
+            ast::CallArg::PositionalUnpack(_) | ast::CallArg::KeywordUnpack(_) => {
+                return Err("call with unpack arguments".to_string());
+            }
+        };
+        if slots[index].is_some() {
+            let parameter = params[index].name.as_deref().unwrap_or("<unnamed>");
+            return Err(format!("local callable `{name}` receives `{parameter}` more than once"));
+        }
+        slots[index] = Some(expr);
+        planned.push((index, expr));
+    }
+
+    let required = params.iter().filter(|param| !param.has_default).count();
+    if let Some((_index, parameter)) = params
+        .iter()
+        .enumerate()
+        .find(|(index, parameter)| slots[*index].is_none() && !parameter.has_default)
+    {
+        return Err(format!(
+            "local callable `{name}` expects at least {required} required arguments, got {}; missing required parameter `{}`",
+            args.len(),
+            parameter.name.as_deref().unwrap_or("<unnamed>")
+        ));
+    }
+    if let Some(highest_supplied) = slots.iter().rposition(Option::is_some)
+        && let Some((index, _)) = slots
+            .iter()
+            .enumerate()
+            .take(highest_supplied + 1)
+            .find(|(index, value)| value.is_none() && !params[*index].is_partial_preset)
+    {
+        let parameter = params[index].name.as_deref().unwrap_or("<unnamed>");
+        return Err(format!(
+            "local callable `{name}` omits non-trailing default parameter `{parameter}`"
+        ));
+    }
+    Ok(planned)
+}
 
 /// Whether a type is string-like enough to route binary operators through the compiler-owned string helpers
 /// (mirrors `is_string_like_type` in `src/backend/ir/conversions.rs`, restated here so Body IR does not depend on
@@ -4096,6 +4243,33 @@ mod tests {
         Ok(build_body_ir_module_v0(&program, &module_path, checker.type_info()))
     }
 
+    /// Lower an intentionally-invalid source program after recording its typecheck diagnostics.
+    ///
+    /// Positive local-partial coverage must go through [`build`], which requires ordinary typechecking. This helper
+    /// is only for Body IR's fail-closed assertions: after the source checker correctly rejects an invalid residual
+    /// call, lowering must still make its unsupported representation explicit rather than approximating it.
+    fn build_after_expected_typecheck_errors(
+        source: &str,
+        module_path: &[&str],
+    ) -> Result<(bir::BodyIrModule, Vec<String>), Box<dyn std::error::Error>> {
+        let tokens = lexer::lex(source).map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+        let program = parser::parse(&tokens).map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+        let module_path: Vec<String> = module_path.iter().map(|s| s.to_string()).collect();
+        let mut checker = TypeChecker::new();
+        checker.set_current_module_path(Some(module_path.clone()));
+        let diagnostics = checker
+            .check_program(&program)
+            .err()
+            .ok_or("expected the intentional residual-call diagnostic")?
+            .into_iter()
+            .map(|diagnostic| diagnostic.message)
+            .collect();
+        Ok((
+            build_body_ir_module_v0(&program, &module_path, checker.type_info()),
+            diagnostics,
+        ))
+    }
+
     /// Build a Body IR module from `source` after rewriting its first `for a, b in ...:` header into the nested
     /// `for a, (b, c) in ...:` shape the parser has no spelling for (see
     /// `nested_tuple_for_patterns_have_no_source_spelling_yet`). The rewrite happens *before* typechecking, so the
@@ -4927,6 +5101,31 @@ mod tests {
     }
 
     #[test]
+    fn invokes_a_stored_closure_through_its_local_operand_and_preserves_its_capture_ownership()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // The local `decorate` is a value with a lexical environment, not a declaration named `decorate`.
+        // Its call target must therefore retain the closure-local read (including its ownership fact) rather than
+        // being approximated as a direct function call and losing the relationship to the captured `prefix`.
+        let source = "def greet(prefix: str) -> str:\n  decorate: (str) -> str = (suffix) => prefix + suffix\n  return decorate(\"!\")\n";
+        let module = build(source, &["m", "stored_closure_call"])?;
+        let snapshot = module.render_snapshot();
+
+        assert!(
+            snapshot.contains("captures=[move(_0, last_use)]"),
+            "the closure must own its last-use capture explicitly: {snapshot}"
+        );
+        assert!(
+            snapshot.contains("call local:move(_"),
+            "the stored closure must be invoked through its local operand: {snapshot}"
+        );
+        assert!(
+            !snapshot.contains("call fn:decorate("),
+            "a stored closure must never be misrepresented as a named function: {snapshot}"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn closure_body_can_still_read_its_capture_after_lowering_restores_outer_bindings()
     -> Result<(), Box<dyn std::error::Error>> {
         // The closure's own capture-binding local must resolve inside the closure body (via `result:`), and the
@@ -4954,18 +5153,9 @@ mod tests {
 
     #[test]
     fn lowers_a_partial_callable_into_a_forwarding_closure() -> Result<(), Box<dyn std::error::Error>> {
-        // `partial add3(a=1)` should synthesize a closure with two residual parameters (`b`, `c`, in `add3`'s own
-        // declaration order) plus one captured preset (`a`), whose body forwards all three, positionally, into a
-        // call to `add3`.
-        // No explicit type annotation on `add_with_one`: the typechecker's own resolved type for a `partial` expr
-        // keeps *all* of the target's original parameters (marking the preset one `has_default` internally, not
-        // shrinking the list -- see `Self::lower_partial`'s docs on why Body IR deliberately does not mirror that),
-        // so annotating this binding with a residual 2-param type would be a real type mismatch against what the
-        // typechecker itself reports for the expression, not a Body IR concern.
-        // The call below passes all three arguments positionally: the typechecker's own resolved type for
-        // `add_with_one` keeps all of `add3`'s original parameters (see the comment above), so that is what the
-        // *source* must satisfy to typecheck, independent of how Body IR itself represents the synthesized closure.
-        let source = "def add3(a: int, b: int, c: int) -> int:\n  return a + b + c\n\ndef make() -> int:\n  add_with_one = partial add3(a=1)\n  return add_with_one(9, 2, 3)\n";
+        // A local partial retains every target parameter in its callable surface. The captured `method` is a
+        // defaulted, overrideable slot, while `path` remains required and `content_type` keeps the target default.
+        let source = "def route(method: str, path: str, content_type: str = \"text\") -> str:\n  return method + path + content_type\n\ndef make() -> str:\n  get = partial route(method=\"GET\")\n  return get(path=\"/health\")\n";
         let module = build(source, &["m", "partial_callable"])?;
         let snapshot = module.render_snapshot();
 
@@ -4974,12 +5164,107 @@ mod tests {
             "a bare-function-name partial callable should lower fully: {snapshot}"
         );
         assert!(
-            snapshot.contains("closure(params=[b: int, c: int], captures=["),
-            "residual params should be b/c, in add3's declaration order, with one captured preset: {snapshot}"
+            snapshot.contains("method: str = captured("),
+            "the preset must remain an overrideable closure parameter backed by a captured default: {snapshot}"
         );
         assert!(
-            snapshot.contains("call fn:add3("),
+            snapshot.contains("call local:move(_"),
+            "a stored partial must be invoked through its local operand: {snapshot}"
+        );
+        assert!(
+            !snapshot.contains("call fn:get("),
+            "a stored partial must never be misrepresented as a named function: {snapshot}"
+        );
+        assert!(
+            snapshot.contains("call fn:route("),
             "the synthesized closure body should forward into a call to the target function: {snapshot}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn stored_partial_refuses_too_few_or_too_many_residual_arguments() -> Result<(), Box<dyn std::error::Error>> {
+        let too_few = "def add3(a: int, b: int, c: int) -> int:\n  return a + b + c\n\ndef make() -> int:\n  add_with_one = partial add3(a=1)\n  return add_with_one(9)\n";
+        let (too_few_module, diagnostics) = build_after_expected_typecheck_errors(too_few, &["m", "partial_too_few"])?;
+        let too_few_snapshot = too_few_module.render_snapshot();
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.contains("Missing required argument 'c'")),
+            "the source checker must diagnose the missing residual parameter: {diagnostics:?}"
+        );
+        assert!(
+            too_few_snapshot
+            .contains("unsupported(local callable `add_with_one` expects at least 2 required arguments, got 1; missing required parameter `c`)"),
+            "a partial invocation may not omit a required residual argument: {too_few_snapshot}"
+        );
+
+        let too_many = "def add3(a: int, b: int, c: int) -> int:\n  return a + b + c\n\ndef make() -> int:\n  add_with_one = partial add3(a=1)\n  return add_with_one(9, 2, 3)\n";
+        let (too_many_module, diagnostics) =
+            build_after_expected_typecheck_errors(too_many, &["m", "partial_too_many"])?;
+        let too_many_snapshot = too_many_module.render_snapshot();
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.contains("expects 2 argument(s), got 3")),
+            "the source checker must use the residual arity: {diagnostics:?}"
+        );
+        assert!(
+            too_many_snapshot
+                .contains("unsupported(local callable `add_with_one` expects at most 2 positional arguments, got 3)"),
+            "a partial invocation may not provide more residual positional arguments than its target accepts: {too_many_snapshot}"
+        );
+        assert!(
+            !too_many_snapshot.contains("call fn:add_with_one("),
+            "invalid residual arity must not be approximated as a named-function call: {too_many_snapshot}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn stored_partial_passes_positional_residual_arguments_in_target_declaration_order()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // Positional calls skip the defaulted preset `a`, while Body IR records their target slots explicitly.
+        let source = "def add3(a: int, b: int, c: int) -> int:\n  return a + b + c\n\ndef make() -> int:\n  add_with_one = partial add3(a=1)\n  return add_with_one(9, 2)\n";
+        let module = build(source, &["m", "partial_order"])?;
+        let snapshot = module.render_snapshot();
+        let local_call = snapshot
+            .lines()
+            .find(|line| line.contains("call local:"))
+            .ok_or("stored partial call missing from Body IR snapshot")?;
+        assert!(
+            local_call.contains("const(9), const(2)"),
+            "residual positional arguments must remain b/c ordered while the preset default stays captured: {local_call}"
+        );
+        assert!(
+            local_call.contains("slots=[1, 2]"),
+            "positional residual arguments must map to their target declaration slots: {local_call}"
+        );
+        assert!(
+            !snapshot.contains("unsupported("),
+            "the residual Body IR call itself should be executable once admitted by the typechecker: {snapshot}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn stored_partial_allows_a_named_preset_override() -> Result<(), Box<dyn std::error::Error>> {
+        // The construction-time capture remains the default, but a named argument replaces it for this invocation.
+        let source = "def add3(a: int, b: int, c: int) -> int:\n  return a + b + c\n\ndef make() -> int:\n  add_with_one = partial add3(a=1)\n  return add_with_one(a=7, b=9, c=2)\n";
+        let module = build(source, &["m", "partial_named_override"])?;
+        let snapshot = module.render_snapshot();
+
+        assert!(
+            !snapshot.contains("unsupported("),
+            "a named preset override must lower as an ordinary local callable invocation: {snapshot}"
+        );
+        assert!(
+            snapshot.contains("const(7), const(9), const(2)"),
+            "the local invocation must retain the explicit target slots for the override and residual values: {snapshot}"
+        );
+        assert!(
+            snapshot.contains("slots=[0, 1, 2]"),
+            "a named override must explicitly occupy the captured preset's declaration slot: {snapshot}"
         );
         Ok(())
     }

--- a/src/frontend/resolved_type_subst.rs
+++ b/src/frontend/resolved_type_subst.rs
@@ -53,6 +53,7 @@ pub(crate) fn substitute_resolved_type(ty: &ResolvedType, map: &HashMap<String, 
                     ty: substitute_resolved_type(&p.ty, map),
                     kind: p.kind,
                     has_default: p.has_default,
+                    is_partial_preset: p.is_partial_preset,
                 })
                 .collect(),
             Box::new(substitute_resolved_type(ret, map)),
@@ -121,6 +122,7 @@ pub(crate) fn substitute_method_info(info: &MethodInfo, map: &HashMap<String, Re
                 ty: substitute_resolved_type(&p.ty, map),
                 kind: p.kind,
                 has_default: p.has_default,
+                is_partial_preset: p.is_partial_preset,
             })
             .collect(),
         return_type: substitute_resolved_type(&info.return_type, map),

--- a/src/frontend/symbols.rs
+++ b/src/frontend/symbols.rs
@@ -560,6 +560,12 @@ pub struct CallableParam {
     pub ty: ResolvedType,
     pub kind: ParamKind,
     pub has_default: bool,
+    /// This parameter receives a construction-time-captured partial preset when its caller omits it.
+    ///
+    /// It remains callable by name, but positional calls bind only non-preset parameters so the residual positional
+    /// surface stays stable. This flag is meaningful only for a local `partial` expression; module partial
+    /// declarations retain their established full-signature metadata without it.
+    pub is_partial_preset: bool,
 }
 
 impl CallableParam {
@@ -570,6 +576,7 @@ impl CallableParam {
             ty,
             kind,
             has_default: false,
+            is_partial_preset: false,
         }
     }
 
@@ -580,6 +587,7 @@ impl CallableParam {
             ty,
             kind,
             has_default,
+            is_partial_preset: false,
         }
     }
 
@@ -590,6 +598,7 @@ impl CallableParam {
             ty,
             kind: ParamKind::Normal,
             has_default: false,
+            is_partial_preset: false,
         }
     }
 

--- a/src/frontend/typechecker/check_decl.rs
+++ b/src/frontend/typechecker/check_decl.rs
@@ -395,6 +395,7 @@ impl TypeChecker {
                         ty: Self::concretize_self_type_in_annotation(&param.ty, self_ty),
                         kind: param.kind,
                         has_default: param.has_default,
+                        is_partial_preset: param.is_partial_preset,
                     })
                     .collect(),
                 Box::new(Self::concretize_self_type_in_annotation(ret, self_ty)),
@@ -456,6 +457,7 @@ impl TypeChecker {
                 ty: Self::concretize_self_type_in_annotation(&param.ty, self_ty),
                 kind: param.kind,
                 has_default: param.has_default,
+                is_partial_preset: param.is_partial_preset,
             })
             .collect();
         concrete.return_type = Self::concretize_self_type_in_annotation(&method.return_type, self_ty);

--- a/src/frontend/typechecker/check_expr/access.rs
+++ b/src/frontend/typechecker/check_expr/access.rs
@@ -2623,6 +2623,7 @@ impl TypeChecker {
                 ty: self.substitute_self_in_resolved_type(param.ty.clone(), receiver_ty),
                 kind: param.kind,
                 has_default: param.has_default,
+                is_partial_preset: param.is_partial_preset,
             })
             .collect();
         let return_type = self.substitute_self_in_resolved_type(method_info.return_type.clone(), receiver_ty);

--- a/src/frontend/typechecker/check_expr/calls/args.rs
+++ b/src/frontend/typechecker/check_expr/calls/args.rs
@@ -132,6 +132,11 @@ impl TypeChecker {
     ) -> Vec<ResolvedType> {
         let normal_params: Vec<&CallableParam> =
             params.iter().filter(|param| param.kind == ParamKind::Normal).collect();
+        let positional_params: Vec<&CallableParam> = normal_params
+            .iter()
+            .copied()
+            .filter(|param| !param.is_partial_preset)
+            .collect();
         let rest_positional = params.iter().find(|param| param.kind == ParamKind::RestPositional);
         let rest_keyword = params.iter().find(|param| param.kind == ParamKind::RestKeyword);
         let mut positional_index = 0usize;
@@ -140,7 +145,7 @@ impl TypeChecker {
         for arg in args {
             match arg {
                 CallArg::Positional(expr) => {
-                    let expected = normal_params
+                    let expected = positional_params
                         .get(positional_index)
                         .map(|param| param.ty.clone())
                         .or_else(|| rest_positional.map(|param| param.ty.clone()));
@@ -163,11 +168,11 @@ impl TypeChecker {
                     if let Some(items) = Self::shaped_positional_unpack_items(expr) {
                         let mut item_types = Vec::with_capacity(items.len());
                         for item in items {
-                            let expected = normal_params
+                            let expected = positional_params
                                 .get(positional_index)
                                 .map(|param| param.ty.clone())
                                 .or_else(|| rest_positional.map(|param| param.ty.clone()));
-                            if positional_index < normal_params.len() {
+                            if positional_index < positional_params.len() {
                                 positional_index += 1;
                             }
                             self.call_argument_depth += 1;
@@ -298,6 +303,11 @@ impl TypeChecker {
             .enumerate()
             .filter(|(_, param)| param.kind == ParamKind::Normal)
             .collect();
+        let positional_param_indices: Vec<usize> = normal_params
+            .iter()
+            .enumerate()
+            .filter_map(|(normal_idx, (_, param))| (!param.is_partial_preset).then_some(normal_idx))
+            .collect();
         let rest_positional = params.iter().find(|param| param.kind == ParamKind::RestPositional);
         let rest_keyword = params.iter().find(|param| param.kind == ParamKind::RestKeyword);
 
@@ -310,8 +320,9 @@ impl TypeChecker {
             let arg_span = Self::call_arg_expr(arg).span;
             match arg {
                 CallArg::Positional(_) => {
-                    if let Some((_, param)) = normal_params.get(positional_index) {
-                        normal_bound_spans[positional_index] = Some(arg_span);
+                    if let Some(&normal_idx) = positional_param_indices.get(positional_index) {
+                        let (_, param) = normal_params[normal_idx];
+                        normal_bound_spans[normal_idx] = Some(arg_span);
                         self.infer_type_param_bindings(&param.ty, arg_ty, type_bindings);
                         self.emit_arg_type_mismatch_if_needed(
                             callee,
@@ -350,8 +361,9 @@ impl TypeChecker {
                         self.record_fixed_unpack_plan(arg_span, FixedUnpackPlan::Positional(item_types.to_vec()));
                         for (item, item_ty) in items.iter().zip(item_types.iter()) {
                             let item_span = item.span;
-                            if let Some((_, param)) = normal_params.get(positional_index) {
-                                normal_bound_spans[positional_index] = Some(item_span);
+                            if let Some(&normal_idx) = positional_param_indices.get(positional_index) {
+                                let (_, param) = normal_params[normal_idx];
+                                normal_bound_spans[normal_idx] = Some(item_span);
                                 self.infer_type_param_bindings(&param.ty, item_ty, type_bindings);
                                 self.emit_arg_type_mismatch_if_needed(
                                     callee,
@@ -379,8 +391,9 @@ impl TypeChecker {
                     } else if let Some(item_types) = Self::shaped_positional_unpack_types(arg_ty) {
                         self.record_fixed_unpack_plan(arg_span, FixedUnpackPlan::Positional(item_types.to_vec()));
                         for item_ty in item_types {
-                            if let Some((_, param)) = normal_params.get(positional_index) {
-                                normal_bound_spans[positional_index] = Some(arg_span);
+                            if let Some(&normal_idx) = positional_param_indices.get(positional_index) {
+                                let (_, param) = normal_params[normal_idx];
+                                normal_bound_spans[normal_idx] = Some(arg_span);
                                 self.infer_type_param_bindings(&param.ty, item_ty, type_bindings);
                                 self.emit_arg_type_mismatch_if_needed(
                                     callee,
@@ -562,8 +575,8 @@ impl TypeChecker {
         if unexpected_positional > 0 {
             self.errors.push(errors::builtin_arity(
                 callee,
-                normal_params.len(),
-                normal_params.len() + unexpected_positional,
+                positional_param_indices.len(),
+                positional_param_indices.len() + unexpected_positional,
                 call_span,
             ));
         }

--- a/src/frontend/typechecker/check_expr/calls/generic_bounds.rs
+++ b/src/frontend/typechecker/check_expr/calls/generic_bounds.rs
@@ -166,6 +166,7 @@ impl TypeChecker {
                 ty: substitute_resolved_type(&param.ty, bindings),
                 kind: param.kind,
                 has_default: param.has_default,
+                is_partial_preset: param.is_partial_preset,
             })
             .collect()
     }
@@ -322,6 +323,7 @@ impl TypeChecker {
                     ty,
                     kind: param.kind,
                     has_default: param.has_default,
+                    is_partial_preset: param.is_partial_preset,
                 }
             })
             .collect()

--- a/src/frontend/typechecker/check_expr/calls/rust_boundary.rs
+++ b/src/frontend/typechecker/check_expr/calls/rust_boundary.rs
@@ -678,6 +678,7 @@ impl TypeChecker {
                     ty,
                     kind: ParamKind::Normal,
                     has_default: false,
+                    is_partial_preset: false,
                 }
             })
             .collect();
@@ -704,6 +705,7 @@ impl TypeChecker {
                     ty,
                     kind: ParamKind::Normal,
                     has_default: false,
+                    is_partial_preset: false,
                 }
             })
             .collect();

--- a/src/frontend/typechecker/check_expr/mod.rs
+++ b/src/frontend/typechecker/check_expr/mod.rs
@@ -45,6 +45,25 @@ impl TypeChecker {
             return ResolvedType::Unknown;
         };
 
+        // Calling a stored callable is supported, but constructing another partial from one is not yet representable:
+        // the existing callable signature does not retain enough provenance to distinguish a preset captured by the
+        // target from one captured by this new partial. Reject this at the source boundary instead of accepting a
+        // program that legacy lowering or Body IR must later refuse.
+        if let Expr::Ident(name) = &partial.target.node
+            && self
+                .lookup_symbol(name)
+                .is_some_and(|symbol| matches!(&symbol.kind, SymbolKind::Variable(_)))
+        {
+            self.errors.push(CompileError::type_error(
+                "Partial application of a locally stored callable is not supported".to_string(),
+                partial.target.span,
+            ));
+            for arg in &partial.args {
+                self.check_expr(&arg.value);
+            }
+            return ResolvedType::Unknown;
+        }
+
         let Some(projected) = self.project_partial_params("<local partial>", "<callable>", params, &partial.args, span)
         else {
             for arg in &partial.args {
@@ -70,7 +89,9 @@ impl TypeChecker {
             }
         }
 
-        ResolvedType::Function(projected, ret)
+        // A local partial retains its complete callable signature. Presets become defaulted, name-overrideable
+        // slots; `is_partial_preset` preserves the separate positional rule that starts at the residual arguments.
+        ResolvedType::Function(Self::local_partial_params(projected, &partial.args), ret)
     }
 
     /// Resolve a field by canonical name or alias, returning the canonical name and FieldInfo.

--- a/src/frontend/typechecker/collect.rs
+++ b/src/frontend/typechecker/collect.rs
@@ -483,6 +483,20 @@ impl TypeChecker {
         ok.then_some(params)
     }
 
+    /// Preserve a local partial's full callable surface while marking construction-time presets.
+    ///
+    /// [`Self::project_partial_params`] marks every preset defaulted for module partial declarations. A local
+    /// [`Expr::Partial`] has the same name-overrideable default surface, plus `is_partial_preset` to preserve its
+    /// residual positional rule: positional calls bind only non-preset parameters, while a named argument may replace
+    /// the captured value for one invocation.
+    pub(crate) fn local_partial_params(mut params: Vec<CallableParam>, args: &[PartialArg]) -> Vec<CallableParam> {
+        let preset_names: HashSet<&str> = args.iter().map(|arg| arg.name.as_str()).collect();
+        for param in &mut params {
+            param.is_partial_preset = param.name().is_some_and(|name| preset_names.contains(name));
+        }
+        params
+    }
+
     /// Register a module-level const binding (first pass).
     ///
     /// Note: the initializer is validated in the second pass.

--- a/src/frontend/typechecker/collect/decl_helpers.rs
+++ b/src/frontend/typechecker/collect/decl_helpers.rs
@@ -56,6 +56,7 @@ fn resolve_owner_self_reference(
                     ty: resolve_owner_self_reference(param.ty, Some(owner_name), Some(owner_self_ty)),
                     kind: param.kind,
                     has_default: param.has_default,
+                    is_partial_preset: param.is_partial_preset,
                 })
                 .collect(),
             Box::new(resolve_owner_self_reference(
@@ -138,6 +139,7 @@ fn shadow_declared_type_params(ty: ResolvedType, type_param_names: &HashSet<Stri
                     ty: shadow_declared_type_params(param.ty, type_param_names),
                     kind: param.kind,
                     has_default: param.has_default,
+                    is_partial_preset: param.is_partial_preset,
                 })
                 .collect(),
             Box::new(shadow_declared_type_params(*ret, type_param_names)),

--- a/src/frontend/typechecker/mod.rs
+++ b/src/frontend/typechecker/mod.rs
@@ -3817,6 +3817,7 @@ impl TypeChecker {
                         ty: self.expand_type_aliases_inner(param.ty, expanding),
                         kind: param.kind,
                         has_default: param.has_default,
+                        is_partial_preset: param.is_partial_preset,
                     })
                     .collect(),
                 Box::new(self.expand_type_aliases_inner(*ret, expanding)),

--- a/src/frontend/typechecker/tests.rs
+++ b/src/frontend/typechecker/tests.rs
@@ -502,6 +502,91 @@ def use() -> str:
 }
 
 #[test]
+fn test_local_partial_expression_preserves_overrideable_preset_defaults() -> Result<(), String> {
+    let source = r#"
+def add3(a: int, b: int, c: int = 3) -> int:
+  return a + b + c
+
+def use() -> int:
+  p = partial add3(a=1)
+  positional = p(9, 2)
+  named = p(b=9, c=2)
+  override = p(a=7, b=9, c=2)
+  defaulted = p(9)
+  return positional + named + override + defaulted
+"#;
+
+    check_str(source).map_err(|errors| format!("local partial preset defaults should typecheck: {errors:?}"))
+}
+
+#[test]
+fn test_local_partial_expression_rejects_invalid_residual_arity() {
+    let too_few = check_str_err(
+        r#"
+def add3(a: int, b: int, c: int) -> int:
+  return a + b + c
+
+def use() -> int:
+  p = partial add3(a=1)
+  return p(9)
+"#,
+        "a local partial call missing residual c must be rejected",
+    );
+    assert!(
+        too_few
+            .iter()
+            .any(|error| error.message.contains("Missing required argument 'c'")),
+        "missing residual c should be diagnosed: {too_few:?}"
+    );
+    assert!(
+        !too_few
+            .iter()
+            .any(|error| error.message.contains("Missing required argument 'b'")),
+        "the preset a must not leave a phantom positional slot: {too_few:?}"
+    );
+
+    let too_many = check_str_err(
+        r#"
+def add3(a: int, b: int, c: int) -> int:
+  return a + b + c
+
+def use() -> int:
+  p = partial add3(a=1)
+  return p(9, 2, 3)
+"#,
+        "a local partial call with a third residual argument must be rejected",
+    );
+    assert!(
+        too_many
+            .iter()
+            .any(|error| error.message.contains("expects 2 argument(s), got 3")),
+        "residual arity should be two after presetting a: {too_many:?}"
+    );
+}
+
+#[test]
+fn test_local_partial_expression_refuses_partial_of_stored_callable() {
+    let errors = check_str_err(
+        r#"
+def add3(a: int, b: int, c: int) -> int:
+  return a + b + c
+
+def use() -> int:
+  p = partial add3(a=1)
+  q = partial p(b=2)
+  return q(c=3)
+"#,
+        "partial application of a stored callable must fail before lowering",
+    );
+    assert!(
+        errors.iter().any(|error| error
+            .message
+            .contains("Partial application of a locally stored callable is not supported")),
+        "unsupported local partial composition should have an intentional source diagnostic: {errors:?}"
+    );
+}
+
+#[test]
 fn test_public_partial_exports_projected_defaults() {
     let source = r#"
 pub def route(method: str, path: str, content_type: str = "text") -> str:
@@ -11100,6 +11185,7 @@ def f(encoded: bytes) -> None:
             ty: ResolvedType::TypeVar("implBuf".to_string()),
             kind: ParamKind::Normal,
             has_default: false,
+            is_partial_preset: false,
         }],
         "expected exact call-span decode parameter shape"
     );
@@ -11210,6 +11296,7 @@ def f(encoded: bytes) -> None:
             ty: ResolvedType::TypeVar("implBuf".to_string()),
             kind: ParamKind::Normal,
             has_default: false,
+            is_partial_preset: false,
         }],
         "expected exact call-span decode parameter shape when receiver metadata lacks the trait edge"
     );

--- a/src/frontend/typechecker/type_info.rs
+++ b/src/frontend/typechecker/type_info.rs
@@ -1947,5 +1947,6 @@ fn semantic_callable_param_from_resolved(param: &CallableParam) -> IncanCallable
             ParamKind::RestKeyword => IncanCallableParamKind::RestKeyword,
         },
         has_default: param.has_default,
+        is_partial_preset: param.is_partial_preset,
     }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -3203,7 +3203,9 @@ def main() -> None:
 
 /// End-to-end codegen tests
 mod codegen_tests {
-    use super::{compiled_sdk_provider_artifact_root, incan_command, strip_ansi_escapes};
+    use super::{
+        compiled_sdk_provider_artifact_root, incan_command, strip_ansi_escapes, support, unique_test_project_name,
+    };
     use incan::backend::IrCodegen;
     use incan::frontend::{lexer, parser, typechecker};
     use std::fs;
@@ -3538,6 +3540,121 @@ def main() -> None:
         let stdout = strip_ansi_escapes(&String::from_utf8_lossy(&output.stdout));
         let lines: Vec<&str> = stdout.lines().map(str::trim).filter(|line| !line.is_empty()).collect();
         assert_eq!(lines, vec!["25"], "unexpected variadic rest output:\n{stdout}");
+        Ok(())
+    }
+
+    /// Compile and run one standalone local-partial program through the normal Oven-backed generated-Rust path.
+    fn compile_and_run_local_partial_project(
+        source: &str,
+        project_stem: &str,
+    ) -> Result<String, Box<dyn std::error::Error>> {
+        let tmp = tempfile::tempdir()?;
+        let project_name = unique_test_project_name(project_stem);
+        let src_dir = tmp.path().join("src");
+        fs::create_dir_all(&src_dir)?;
+        fs::write(
+            tmp.path().join("incan.toml"),
+            format!("[project]\nname = \"{project_name}\"\nversion = \"0.1.0\"\n"),
+        )?;
+        let main_path = src_dir.join("main.incn");
+        fs::write(&main_path, source)?;
+
+        let oven_home = tmp.path().join("incan-home");
+        let mut bake_command = incan_command();
+        bake_command
+            .args(["oven", "bake", "--project", "."])
+            .current_dir(tmp.path())
+            .env("CARGO_NET_OFFLINE", "true")
+            .env("INCAN_HOME", &oven_home);
+        support::configure_explicit_oven_bake_command(&mut bake_command)?;
+        let bake_output = bake_command.output()?;
+        assert!(
+            bake_output.status.success(),
+            "expected explicit Oven bake to prepare local-partial regression.\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&bake_output.stdout),
+            String::from_utf8_lossy(&bake_output.stderr)
+        );
+
+        let out_dir = tmp.path().join("out");
+        let build_output = incan_command()
+            .args([
+                "build",
+                main_path.to_string_lossy().as_ref(),
+                out_dir.to_string_lossy().as_ref(),
+            ])
+            .current_dir(tmp.path())
+            .env("CARGO_NET_OFFLINE", "true")
+            .env("INCAN_HOME", &oven_home)
+            .output()?;
+        assert!(
+            build_output.status.success(),
+            "local partial generated-Rust build regression failed: status={:?}\nstdout:\n{}\nstderr:\n{}",
+            build_output.status,
+            String::from_utf8_lossy(&build_output.stdout),
+            String::from_utf8_lossy(&build_output.stderr)
+        );
+
+        let binary = out_dir.join("oven/release").join(&project_name);
+        assert!(
+            binary.is_file(),
+            "expected generated Rust executable at {}",
+            binary.display()
+        );
+        let run_output = Command::new(&binary).output()?;
+        assert!(
+            run_output.status.success(),
+            "local partial generated Rust executable failed.\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&run_output.stdout),
+            String::from_utf8_lossy(&run_output.stderr)
+        );
+        Ok(strip_ansi_escapes(&String::from_utf8_lossy(&run_output.stdout)))
+    }
+
+    #[test]
+    fn local_partial_default_and_override_compile_and_run_issue1124() -> Result<(), Box<dyn std::error::Error>> {
+        let stdout = compile_and_run_local_partial_project(
+            r#"
+def route(method: str, path: str, content_type: str = "text") -> str:
+  return method + path + content_type
+
+def main() -> None:
+  get = partial route(method="GET")
+  alias = get
+  println(alias("/health") + "|" + alias(method="HEAD", path="/head"))
+"#,
+            "local_partial_default_contract",
+        )?;
+        let lines: Vec<&str> = stdout.lines().map(str::trim).filter(|line| !line.is_empty()).collect();
+        assert_eq!(
+            lines,
+            vec!["GET/healthtext|HEAD/headtext"],
+            "unexpected local partial output:\n{stdout}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn local_partial_runtime_preset_captures_at_construction_issue1124() -> Result<(), Box<dyn std::error::Error>> {
+        let stdout = compile_and_run_local_partial_project(
+            r#"
+def route(method: int, path: int, content_type: int = 3) -> int:
+  return method + path + content_type
+
+def main() -> None:
+  mut method = 1
+  get = partial route(method=method)
+  method = 2
+  println(get(4))
+  println(get(method=7, path=4))
+"#,
+            "local_partial_capture_contract",
+        )?;
+        let lines: Vec<&str> = stdout.lines().map(str::trim).filter(|line| !line.is_empty()).collect();
+        assert_eq!(
+            lines,
+            vec!["8", "14"],
+            "the omitted preset must retain its construction-time value while a named call overrides it:\n{stdout}"
+        );
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Closes #1124.

Makes locally stored closures and direct local partials callable through Body IR, while preserving the language contract for partial presets: named callers can override a preset and positional callers bind residual slots.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [x] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [x] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: `p = partial route(method="GET")` supports `p("/health")` and `p(method="HEAD", path="/head")`; omitted trailing defaults still materialize.
- **Internals**: Body IR represents local call targets as operands with explicit declaration-slot mapping. Legacy lowering captures presets at construction, uses an optional override slot, and retains callable metadata through direct aliases.
- **Risks**: Local partial composition is intentionally rejected at typecheck time because capture provenance is not compositional yet. The replacement executor remains unchanged and refuses local callable targets.

## Testing / verification

- [x] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- Focused semantic-core Body IR and frontend Body IR tests.
- Source-level checks for residual arity, named preset override, defaults, and unsupported local-partial composition.
- Generated-Rust compile/run regressions for default use, named override, direct alias calls, and construction-time capture after mutable-local reassignment.
- `cargo clippy --workspace --all-targets -- -D warnings` and `make pre-commit`.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

The existing callable-presets reference already specifies that presets remain defaulted and name-overrideable; this implementation now matches it.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions