### PR TITLE
feature - preserve generator-expression laziness in Body IR (#1123)

### DIFF
--- a/crates/incan_semantics_core/src/body_ir.rs
+++ b/crates/incan_semantics_core/src/body_ir.rs
@@ -14,14 +14,16 @@
 //!
 //! Unsupported source constructs lower to an explicit [`StatementKind::Unsupported`] node rather than panicking or
 //! being silently dropped, so the model stays total over real programs while being honest about v0's coverage.
-//! Generator expressions remain explicitly unsupported pending #1123: an eager list cannot stand in for their lazy
-//! `Generator[T]` behavior. Expression-position `yield` remains a stub in the existing Rust-emission backend too.
+//! Generator expressions lower to [`Rvalue::Generator`], preserving their established iterator-adapter timing: the
+//! outer source expression is evaluated at construction, while polling, later clause sources, filters, and elements
+//! remain inside the owned [`GeneratorBody`]. Expression-position `yield` remains a stub in the existing
+//! Rust-emission backend too.
 //!
 //! #1101 adds dict/set aggregates, slices, assignment variants, expression-position `if`/`loop`/`try`, f-strings,
 //! general iteration, list/dict comprehensions, closures/partial construction and local invocation, statement
-//! `yield`, and `match`. Captures are explicit [`Operand`] reads on [`Rvalue::Closure`], and a stored callable is
-//! invoked through [`CallableTarget::Local`] rather than being approximated as a named function, so neither fact is
-//! an implicit target-backend decision.
+//! `yield`, generator expressions, and `match`. Captures are explicit [`Operand`] reads on
+//! [`Rvalue::Closure`]/[`Rvalue::Generator`], and a stored callable is invoked through [`CallableTarget::Local`]
+//! rather than being approximated as a named function, so neither fact is an implicit target-backend decision.
 //!
 //! "Method body" includes `class`/`model`/`trait` methods (#1102). A `self`/`mut self` receiver is an ordinary
 //! [`LocalOrigin::Receiver`] local and is always reference-shaped at the emission boundary, so a bare receiver
@@ -120,10 +122,10 @@ impl Body {
     /// enforces this), so this alone is already a reliable generator signal for a `Body` in isolation.
     ///
     /// The walk recurses into nested [`StatementKind::If`]/[`StatementKind::Loop`] blocks (the only statement kinds
-    /// that themselves carry a nested [`Block`]) but does not recurse into a [`Rvalue::Closure`]'s own
-    /// [`ClosureBody`] -- a `yield` nested inside a closure literal does not make the *enclosing* function body a
-    /// generator, matching how the existing backend's own `body_contains_yield` walker also never descends into
-    /// nested closure/function literals.
+    /// that themselves carry a nested [`Block`]) but does not recurse into a [`Rvalue::Closure`]'s
+    /// [`ClosureBody`] or a [`Rvalue::Generator`]'s [`GeneratorBody`]. A yield nested in either value does not make
+    /// the *enclosing* function body a generator, matching how the existing backend's own `body_contains_yield`
+    /// walker never descends into nested closure/function literals.
     pub fn is_generator(&self) -> bool {
         block_contains_yield(&self.block)
     }
@@ -261,12 +263,12 @@ pub enum LocalOrigin {
         /// Whether the receiver was declared `mut self` (`true`) rather than plain `self` (`false`).
         mutable: bool,
     },
-    /// Bound to a free variable a [`Rvalue::Closure`] captured from its enclosing scope, or to a preset value a
-    /// partial callable's synthesized closure captured from its own preset expression. The initial value comes from
-    /// a single [`Operand`] read recorded on [`Rvalue::Closure::captured_operands`] at the point the closure was
-    /// constructed, not from a caller-supplied argument the way [`Self::Parameter`] locals are -- kept as its own
-    /// origin rather than folded into [`Self::Parameter`] so a later consumer can tell "the caller supplied this"
-    /// apart from "the closure's environment supplied this."
+    /// Bound to a free variable a [`Rvalue::Closure`] or [`Rvalue::Generator`] captured from its enclosing scope,
+    /// to a generator expression's construction-time first-clause source, or to a preset value a partial callable's
+    /// synthesized closure captured from its own preset expression. The initial value comes from one explicit
+    /// [`Operand`] read recorded on the owning rvalue at construction, not from a caller-supplied argument the way
+    /// [`Self::Parameter`] locals are -- kept as its own origin rather than folded into [`Self::Parameter`] so a
+    /// later consumer can tell "the caller supplied this" apart from "the value's environment supplied this."
     Captured,
 }
 
@@ -510,6 +512,26 @@ pub enum Rvalue {
         /// The closure's own body.
         body: Box<ClosureBody>,
     },
+    /// A lazy generator expression (`(element for ... if ...)`).
+    ///
+    /// `source` is the first `for` clause's source value, evaluated exactly once before this rvalue is constructed.
+    /// Every later clause source, filter, and element evaluation belongs to `body` and runs only when a consumer
+    /// polls the generator. `captured_operands` snapshots the remaining free variables needed by that deferred body
+    /// at construction time, in the same first-occurrence order as [`GeneratorBody::capture_locals`]; a consumer
+    /// must bind each captured value to that local before executing `body`. The initial `source` binds separately to
+    /// [`GeneratorBody::source_local`] because it is an eagerly evaluated source value rather than a lexical name.
+    ///
+    /// This is deliberately neither an eager [`AggregateKind::List`] nor a named function call. It makes the
+    /// construction-versus-poll boundary, source-order clause evaluation, and capture ownership visible to every
+    /// backend instead of asking a target language's closure inference to reconstruct them.
+    Generator {
+        /// The first `for` clause's source, evaluated once at generator construction.
+        source: Operand,
+        /// Values captured for deferred clauses, filters, and the element expression.
+        captured_operands: Vec<Operand>,
+        /// The suspendable body that consumes `source` and yields accepted elements.
+        body: Box<GeneratorBody>,
+    },
     /// A `match` expression, evaluated by testing the scrutinee against each arm's [`Pattern`] in order and running
     /// the first arm whose pattern matches (and whose optional [`MatchArm::guard`], if present, evaluates truthy).
     ///
@@ -587,6 +609,19 @@ impl Rvalue {
                 format!(
                     "closure(params=[{}], captures=[{}]) {{ {} }}",
                     params_str.join(", "),
+                    captures_str.join(", "),
+                    body.render_snapshot()
+                )
+            }
+            Self::Generator {
+                source,
+                captured_operands,
+                body,
+            } => {
+                let captures_str: Vec<String> = captured_operands.iter().map(Operand::render_snapshot).collect();
+                format!(
+                    "generator(source={}, captures=[{}]) {{ {} }}",
+                    source.render_snapshot(),
                     captures_str.join(", "),
                     body.render_snapshot()
                 )
@@ -675,10 +710,39 @@ impl ClosureBody {
     }
 }
 
+/// The deferred, suspendable body of one [`Rvalue::Generator`].
+///
+/// Like [`ClosureBody`], this reuses its owning [`Body`]'s flat local-id namespace. `source_local` receives the
+/// rvalue's construction-time [`Rvalue::Generator::source`] value. `capture_locals[i]` receives the matching
+/// `captured_operands[i]` value, so no statement in `stmts` reaches back into the enclosing body's places when the
+/// generator is later polled. Clause bindings and iterator temporaries are ordinary locals in `stmts`; they become
+/// live only while the corresponding deferred loops execute.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GeneratorBody {
+    /// Local holding the eagerly evaluated first-clause source value.
+    pub source_local: LocalId,
+    /// Locals holding the rvalue's construction-time lexical captures, in operand order.
+    pub capture_locals: Vec<LocalId>,
+    /// Deferred iteration, filtering, and [`StatementKind::Yield`] operations.
+    pub stmts: Vec<Statement>,
+}
+
+impl GeneratorBody {
+    /// Render a deterministic maintainer-facing spelling of the deferred body for nested rvalue snapshots.
+    fn render_snapshot(&self) -> String {
+        let flattened = render_flattened_stmts(&self.stmts);
+        if flattened.is_empty() {
+            "deferred: <empty>".to_string()
+        } else {
+            format!("deferred: {}", flattened.join("; "))
+        }
+    }
+}
+
 /// Render `stmts` at zero indentation and split into trimmed, non-empty lines, for embedding a (possibly
 /// multi-statement) nested block into a single-line snapshot alongside a trailing `result: ...`/`if ...` segment.
-/// Shared by [`ClosureBody::render_snapshot`] and [`MatchArm::render_snapshot`], which both need to flatten a
-/// nested [`Block`]-shaped computation the same way.
+/// Shared by [`ClosureBody::render_snapshot`], [`GeneratorBody::render_snapshot`], and
+/// [`MatchArm::render_snapshot`], which all need to flatten a nested [`Block`]-shaped computation the same way.
 fn render_flattened_stmts(stmts: &[Statement]) -> Vec<String> {
     let mut body = String::new();
     for stmt in stmts {
@@ -1372,10 +1436,12 @@ pub enum StatementKind {
     /// protocol, e.g. `x = yield val`) are out of scope for v0: both are stubs even in the existing Rust-emission
     /// backend today (`ast::Expr::Yield(_) => (IrExprKind::Unit, IrType::Unknown)` in
     /// `src/backend/ir/lower/expr/mod.rs`), so there is no real, delivered behavior for this variant to preserve.
-    /// A generator function's body needs no distinct suspendable-state-machine representation of its own: it
-    /// lowers through the exact same statement vocabulary as any other body, and the actual state-machine
-    /// transformation is left entirely to the target backend (the existing Rust-emission backend defers to Rust's
-    /// own native generator/coroutine support rather than the compiler modeling suspension points itself).
+    /// A generator function's body needs no separate top-level state-machine node: it lowers through this same
+    /// statement vocabulary, while the target runtime owns the concrete suspension mechanism. The existing
+    /// generated-Rust path uses `incan_stdlib::iter::Generator`'s channel-backed spawn bridge for `yield`-based
+    /// functions; generator expressions instead carry their own deferred [`Rvalue::Generator`] body and use the
+    /// iterator-adapter runtime path. Neither representation asks a consumer to infer a suspension point from a
+    /// target-language closure shape.
     Yield { value: Operand },
     /// `assert cond[, message]`.
     Assert {
@@ -1553,6 +1619,51 @@ mod tests {
         assert!(snapshot.contains("local 2 <tmp> : int [temp]"));
         assert!(snapshot.contains("_2 = copy(_0) + copy(_1, last_use)"));
         assert!(snapshot.contains("return move(_2, last_use)"));
+    }
+
+    #[test]
+    fn generator_rvalue_keeps_construction_inputs_separate_from_its_deferred_body() {
+        let source_local = LocalId(2);
+        let capture_local = LocalId(1);
+        let generator = Rvalue::Generator {
+            source: Operand::Constant(Constant::Int(1)),
+            captured_operands: vec![Operand::place(
+                Place::from_local(capture_local),
+                OwnershipFact::Copy,
+                false,
+            )],
+            body: Box::new(GeneratorBody {
+                source_local,
+                capture_locals: vec![capture_local],
+                stmts: vec![Statement {
+                    kind: StatementKind::Yield {
+                        value: Operand::Constant(Constant::Int(2)),
+                    },
+                    span: HirSourceSpan::new(10, 15),
+                }],
+            }),
+        };
+        let snapshot = generator.render_snapshot();
+        assert_eq!(
+            snapshot,
+            "generator(source=const(1), captures=[copy(_1)]) { deferred: yield const(2) }"
+        );
+
+        let mut body = sample_body();
+        body.block.stmts.insert(
+            0,
+            Statement {
+                kind: StatementKind::Assign {
+                    place: Place::from_local(source_local),
+                    rvalue: generator,
+                },
+                span: HirSourceSpan::new(0, 15),
+            },
+        );
+        assert!(
+            !body.is_generator(),
+            "a yielded generator expression is a value; it must not turn its enclosing function into a generator"
+        );
     }
 
     #[test]

--- a/src/backend/replacement/mod.rs
+++ b/src/backend/replacement/mod.rs
@@ -6,8 +6,10 @@
 //! scalar local values, scalar tuple collections, arithmetic, compiler-owned string concatenation, branches,
 //! normalized loops, returns, and assertions. It admits only the one-level `.0`/`.1` tuple projections Body IR
 //! emits for `for a, b in pairs`, where `pairs` is `list[tuple[scalar, scalar]]`; packages, Rust interop, callable
-//! values, generators, general destructuring, and other projections remain visible refusals for later #988
-//! extensions.
+//! values, generator functions, generator adapters, general destructuring, and other projections remain visible
+//! refusals for later #988 extensions. A generator expression with the selected `range` source profile may be
+//! materialized by its `.collect()` consumer: construction records its source/captures without running the deferred
+//! body, and collection executes that body in this interpreter rather than falling back to generated Rust.
 
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -17,8 +19,8 @@ use incan_core::{
     python_floor_div_i64, python_mod_i64,
 };
 use incan_semantics_core::body_ir::{
-    AggregateKind, BinOp, Body, BodyIrModule, Callee, Constant, HelperOp, IterProtocol, LocalId, LocalOrigin, Operand,
-    OwnershipFact, Place, PlaceElem, Rvalue, Statement, StatementKind, UnOp,
+    AggregateKind, BinOp, Body, BodyIrModule, Callee, Constant, GeneratorBody, HelperOp, IterProtocol, LocalId,
+    LocalOrigin, Operand, OwnershipFact, Place, PlaceElem, Rvalue, Statement, StatementKind, UnOp,
 };
 use incan_semantics_core::{AbiV0RuntimeRequirement, HirSourceSpan, IncanPrimitiveType, IncanType};
 
@@ -31,8 +33,8 @@ use crate::backend::selection::digest_output;
 /// test or CLI invocation to hang without a receipt.
 const MAX_EXECUTION_STEPS: usize = 100_000;
 
-/// One scalar value supported by the first replacement-execution profile.
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// One runtime value supported by the bounded replacement-execution profile.
+#[derive(Debug, Clone, PartialEq)]
 pub enum ReplacementValue {
     /// An Incan `int` value.
     Int(i64),
@@ -53,6 +55,30 @@ pub enum ReplacementValue {
     },
     /// A two-element scalar tuple, retained only as one element of an admitted replacement list value.
     Tuple(Vec<ReplacementValue>),
+    /// A generator expression whose source and lexical captures were evaluated at construction time, while its body
+    /// remains deferred until an admitted consumer asks for its values.
+    Generator(Box<ReplacementGenerator>),
+    /// Values materialized by the bounded generator-expression `.collect()` profile.
+    ///
+    /// This is deliberately distinct from [`Self::List`]: the latter remains the existing scalar-pair collection
+    /// profile, while this variant makes the narrow generator consumer explicit and lets its scalar results be
+    /// indexed without admitting general list execution.
+    CollectedGenerator {
+        elements: Vec<ReplacementValue>,
+        next: usize,
+    },
+}
+
+/// Deferred state for a bounded replacement generator expression.
+///
+/// `source` and `captures` hold the values observed when the surrounding body constructed the generator. `body`
+/// contains only compiler-owned Body-IR statements and is interpreted when `.collect()` consumes this value. The
+/// fields are private so callers cannot construct a replacement generator without the executor's ownership reads.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ReplacementGenerator {
+    source: ReplacementValue,
+    captures: Vec<(LocalId, ReplacementValue)>,
+    body: GeneratorBody,
 }
 
 impl ReplacementValue {
@@ -75,6 +101,15 @@ impl ReplacementValue {
             ),
             Self::Tuple(elements) => format!(
                 "({})",
+                elements
+                    .iter()
+                    .map(Self::observable_text)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+            Self::Generator(_) => "<generator>".to_string(),
+            Self::CollectedGenerator { elements, .. } => format!(
+                "[{}]",
                 elements
                     .iter()
                     .map(Self::observable_text)
@@ -122,7 +157,7 @@ pub struct RuntimeRequirementProjection {
 }
 
 /// Successful replacement execution evidence for one free function.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ReplacementExecution {
     /// The function's source-level return value.
     pub value: ReplacementValue,
@@ -835,7 +870,8 @@ fn validate_call_profile(
         // Body IR v0 has only this source spelling. The one-function, import-free CLI profile makes it unambiguous
         // for #988; canonical call-target identity belongs to #1042.
         Callee::Function(name) => name == "range",
-        Callee::Helper(_) | Callee::Method(_) => false,
+        Callee::Method(name) => name == "collect",
+        Callee::Helper(_) => false,
     };
     if !supported {
         return Err(unsupported(format!("call to {}", callee_label(callee)), span));
@@ -872,8 +908,75 @@ fn validate_rvalue_profile(
         ),
         Rvalue::Format(_) => Err(unsupported("f-string", span)),
         Rvalue::Closure { .. } => Err(unsupported("callable value", span)),
+        Rvalue::Generator {
+            source,
+            captured_operands,
+            body,
+        } => {
+            validate_operand_profile(source, span, tuple_iteration_locals)?;
+            for operand in captured_operands {
+                validate_operand_profile(operand, span, tuple_iteration_locals)?;
+            }
+            validate_generator_body_profile(body, tuple_iteration_locals, scalar_tuple_collection_locals)
+        }
         Rvalue::Match { .. } => Err(unsupported("match expression", span)),
     }
+}
+
+/// Validate the deferred body carried by an admitted generator-expression rvalue.
+///
+/// A normal function body still refuses [`StatementKind::Yield`]. Within this explicitly stored generator body,
+/// however, `yield` is exactly the deferred result boundary and is interpreted only by `.collect()` below.
+fn validate_generator_body_profile(
+    body: &GeneratorBody,
+    tuple_iteration_locals: &BTreeSet<LocalId>,
+    scalar_tuple_collection_locals: &BTreeSet<LocalId>,
+) -> Result<(), ReplacementExecutionError> {
+    validate_generator_statements_profile(&body.stmts, tuple_iteration_locals, scalar_tuple_collection_locals)
+}
+
+/// Recurse through the generator's normalized control flow while admitting only its terminal yields.
+fn validate_generator_statements_profile(
+    statements: &[Statement],
+    tuple_iteration_locals: &BTreeSet<LocalId>,
+    scalar_tuple_collection_locals: &BTreeSet<LocalId>,
+) -> Result<(), ReplacementExecutionError> {
+    for statement in statements {
+        match &statement.kind {
+            StatementKind::Yield { value } => {
+                validate_operand_profile(value, statement.span, tuple_iteration_locals)?;
+            }
+            StatementKind::If {
+                cond,
+                then_block,
+                else_block,
+            } => {
+                validate_operand_profile(cond, statement.span, tuple_iteration_locals)?;
+                validate_generator_statements_profile(
+                    &then_block.stmts,
+                    tuple_iteration_locals,
+                    scalar_tuple_collection_locals,
+                )?;
+                if let Some(else_block) = else_block {
+                    validate_generator_statements_profile(
+                        &else_block.stmts,
+                        tuple_iteration_locals,
+                        scalar_tuple_collection_locals,
+                    )?;
+                }
+            }
+            StatementKind::Loop { body } => validate_generator_statements_profile(
+                &body.stmts,
+                tuple_iteration_locals,
+                scalar_tuple_collection_locals,
+            )?,
+            StatementKind::Return { .. } => {
+                return Err(unsupported("return from a generator expression", statement.span));
+            }
+            _ => validate_statement_profile(statement, tuple_iteration_locals, scalar_tuple_collection_locals)?,
+        }
+    }
+    Ok(())
 }
 
 /// Validate the narrow aggregate vocabulary needed to materialize scalar tuple collections.
@@ -965,10 +1068,9 @@ fn validate_read_place(
             "non-numeric tuple field projection outside the scalar tuple collection profile",
             span,
         )),
-        [PlaceElem::Index(_)] => Err(unsupported(
-            "index projection outside the scalar tuple collection profile",
-            span,
-        )),
+        // The only admitted index target is a list created by the generator-expression `.collect()` consumer. The
+        // runtime check keeps ordinary list indexing outside the original scalar-pair collection profile.
+        [PlaceElem::Index(index)] => validate_operand_profile(index, span, tuple_iteration_locals),
         [PlaceElem::Slice { .. }] => Err(unsupported(
             "slice projection outside the scalar tuple collection profile",
             span,
@@ -1082,14 +1184,18 @@ impl BodyExecutor {
                 iterator,
                 protocol: IterProtocol::Builtin,
             } => self.execute_builtin_next(destination, iterator, statement.span),
-            StatementKind::Yield { .. } => Err(unsupported("generator yield", statement.span)),
+            StatementKind::Yield { .. } => Err(unsupported(
+                "generator yield outside a generator expression",
+                statement.span,
+            )),
             StatementKind::TryPropagate { .. } => Err(unsupported("try propagation", statement.span)),
             StatementKind::IterNext { .. } => Err(unsupported("non-range iteration", statement.span)),
             StatementKind::Unsupported { description } => Err(unsupported(description, statement.span)),
         }
     }
 
-    /// Evaluate a supported helper or the profile's admitted `range` source-spelling call.
+    /// Evaluate a supported helper, the profile's admitted `range` source-spelling call, or a lazy generator
+    /// materialization. Generator construction itself is an rvalue; this call is the first supported consumer.
     fn execute_call(
         &mut self,
         destination: Option<&Place>,
@@ -1109,6 +1215,13 @@ impl BodyExecutor {
                 ReplacementValue::Str(format!("{left}{right}"))
             }
             Callee::Function(name) if name == "range" => self.evaluate_range(args, span)?,
+            Callee::Method(name) if name == "collect" => {
+                let [receiver] = args else {
+                    return Err(unsupported("generator collect call arity", span));
+                };
+                let generator = self.take_generator_receiver(receiver, span)?;
+                self.collect_generator(generator, span)?
+            }
             _ => return Err(unsupported(format!("call to {}", callee_label(callee)), span)),
         };
         self.assign_local(local, value);
@@ -1229,7 +1342,171 @@ impl BodyExecutor {
             Rvalue::Aggregate(kind, operands) => self.evaluate_aggregate(kind, operands, span),
             Rvalue::Format(_) => Err(unsupported("f-string", span)),
             Rvalue::Closure { .. } => Err(unsupported("callable value", span)),
+            Rvalue::Generator {
+                source,
+                captured_operands,
+                body,
+            } => self.construct_generator(source, captured_operands, body, span),
             Rvalue::Match { .. } => Err(unsupported("match expression", span)),
+        }
+    }
+
+    /// Capture a generator expression's construction-time source and free values without executing its body.
+    fn construct_generator(
+        &mut self,
+        source: &Operand,
+        captured_operands: &[Operand],
+        body: &GeneratorBody,
+        span: HirSourceSpan,
+    ) -> Result<ReplacementValue, ReplacementExecutionError> {
+        if captured_operands.len() != body.capture_locals.len() {
+            return Err(unsupported("generator capture metadata mismatch", span));
+        }
+        let source = self.evaluate_operand(source, span)?;
+        let captures = captured_operands
+            .iter()
+            .zip(&body.capture_locals)
+            .map(|(operand, local)| self.evaluate_operand(operand, span).map(|value| (*local, value)))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(ReplacementValue::Generator(Box::new(ReplacementGenerator {
+            source,
+            captures,
+            body: body.clone(),
+        })))
+    }
+
+    /// Consume an admitted generator expression by running only its deferred Body-IR body.
+    ///
+    /// The child executor receives the source and captures already observed at construction time. It intentionally
+    /// does not inherit any other outer locals, preventing deferred evaluation from reaching mutable construction
+    /// scope state by name. Its ownership evidence and bounded step count are merged back into the caller only after
+    /// the consumer has actually asked for collection.
+    fn collect_generator(
+        &mut self,
+        generator: ReplacementGenerator,
+        span: HirSourceSpan,
+    ) -> Result<ReplacementValue, ReplacementExecutionError> {
+        let mut locals = BTreeMap::new();
+        locals.insert(generator.body.source_local, generator.source);
+        for (local, value) in generator.captures {
+            if locals.insert(local, value).is_some() {
+                return Err(unsupported("generator capture aliases its source local", span));
+            }
+        }
+        let mut deferred = Self {
+            locals,
+            ownership_reads: Vec::new(),
+            steps: self.steps,
+        };
+        let mut elements = Vec::new();
+        match deferred.collect_generator_statements(&generator.body.stmts, &mut elements)? {
+            Flow::Next => {}
+            Flow::Break | Flow::Continue => {
+                return Err(unsupported("generator loop control outside a normalized loop", span));
+            }
+            Flow::Return(_) => return Err(unsupported("return from a generator expression", span)),
+        }
+        self.steps = deferred.steps;
+        self.ownership_reads.extend(deferred.ownership_reads);
+        Ok(ReplacementValue::CollectedGenerator { elements, next: 0 })
+    }
+
+    /// Take the generator receiver consumed by `.collect()` while retaining Body IR's recorded receiver read.
+    ///
+    /// Body-IR's generic method-lowering convention records receivers as borrows, but `Generator.collect` consumes
+    /// its iterator in the runtime contract. The bounded executor therefore removes precisely this bare local after
+    /// recording that compiler-owned read, so a second collection cannot manufacture a fresh deferred iterator.
+    fn take_generator_receiver(
+        &mut self,
+        receiver: &Operand,
+        span: HirSourceSpan,
+    ) -> Result<ReplacementGenerator, ReplacementExecutionError> {
+        let Operand::Place(place_operand) = receiver else {
+            return Err(unsupported("non-place generator collect receiver", span));
+        };
+        let local = bare_local(&place_operand.place, span)?;
+        self.ownership_reads.push(OwnershipRead {
+            span,
+            fact: place_operand.fact,
+            last_use: place_operand.last_use,
+        });
+        let value = self
+            .locals
+            .remove(&local)
+            .ok_or_else(|| runtime_failure("read of an unavailable generator receiver".to_string(), span))?;
+        let ReplacementValue::Generator(generator) = value else {
+            return Err(unsupported(
+                format!(
+                    "collecting {} outside the generator-expression profile",
+                    value_kind(&value)
+                ),
+                span,
+            ));
+        };
+        Ok(*generator)
+    }
+
+    /// Execute deferred generator statements, appending each explicit Body-IR `yield` and continuing its loop.
+    fn collect_generator_statements(
+        &mut self,
+        statements: &[Statement],
+        elements: &mut Vec<ReplacementValue>,
+    ) -> Result<Flow, ReplacementExecutionError> {
+        for statement in statements {
+            self.record_step(statement.span)?;
+            let flow = match &statement.kind {
+                StatementKind::Yield { value } => {
+                    elements.push(self.evaluate_operand(value, statement.span)?);
+                    Flow::Next
+                }
+                StatementKind::If {
+                    cond,
+                    then_block,
+                    else_block,
+                } => {
+                    if self.evaluate_operand(cond, statement.span)?.into_bool(statement.span)? {
+                        self.collect_generator_statements(&then_block.stmts, elements)?
+                    } else if let Some(else_block) = else_block {
+                        self.collect_generator_statements(&else_block.stmts, elements)?
+                    } else {
+                        Flow::Next
+                    }
+                }
+                StatementKind::Loop { body } => self.collect_generator_loop(&body.stmts, elements, statement.span)?,
+                StatementKind::Return { .. } => {
+                    return Err(unsupported("return from a generator expression", statement.span));
+                }
+                _ => self.execute_statement(statement)?,
+            };
+            match flow {
+                Flow::Next => {}
+                flow => return Ok(flow),
+            }
+        }
+        Ok(Flow::Next)
+    }
+
+    /// Execute one normalized loop nested in a deferred generator body.
+    fn collect_generator_loop(
+        &mut self,
+        statements: &[Statement],
+        elements: &mut Vec<ReplacementValue>,
+        span: HirSourceSpan,
+    ) -> Result<Flow, ReplacementExecutionError> {
+        loop {
+            match self.collect_generator_statements(statements, elements)? {
+                Flow::Next | Flow::Continue => {}
+                Flow::Break => return Ok(Flow::Next),
+                Flow::Return(value) => return Ok(Flow::Return(value)),
+            }
+            if self.steps >= MAX_EXECUTION_STEPS {
+                return Err(runtime_failure(
+                    format!(
+                        "normalized generator loop exceeded the {MAX_EXECUTION_STEPS}-step replacement profile limit"
+                    ),
+                    span,
+                ));
+            }
         }
     }
 
@@ -1381,7 +1658,7 @@ impl BodyExecutor {
                         .ok_or_else(|| runtime_failure("read of an unavailable local".to_string(), span))?,
                     OwnershipFact::Unknown => return Err(unsupported("unknown ownership fact", span)),
                 };
-                let value = project_tuple_field(value, &place_operand.place, span)?;
+                let value = self.project_place(value, &place_operand.place, span)?;
                 if matches!(place_operand.fact, OwnershipFact::Copy) && !value.is_copy_shaped() {
                     return Err(unsupported("copy of a non-copy or unavailable local", span));
                 }
@@ -1405,6 +1682,43 @@ impl BodyExecutor {
         self.locals
             .remove(&place.local)
             .ok_or_else(|| runtime_failure("read of a moved or dropped local".to_string(), span))
+    }
+
+    /// Apply the one scalar-tuple field projection or collected-generator list index admitted by this profile.
+    fn project_place(
+        &mut self,
+        value: ReplacementValue,
+        place: &Place,
+        span: HirSourceSpan,
+    ) -> Result<ReplacementValue, ReplacementExecutionError> {
+        match place.projection.as_slice() {
+            [] | [PlaceElem::Field(_)] => project_tuple_field(value, place, span),
+            [PlaceElem::Index(index)] => {
+                let index = self.evaluate_operand(index, span)?;
+                let ReplacementValue::Int(index) = index else {
+                    return Err(unsupported("collected generator index using a non-int value", span));
+                };
+                let index = usize::try_from(index)
+                    .map_err(|_| runtime_failure("collected generator index is negative".to_string(), span))?;
+                match value {
+                    ReplacementValue::CollectedGenerator { elements, .. } => elements
+                        .get(index)
+                        .cloned()
+                        .ok_or_else(|| runtime_failure("collected generator index is out of range".to_string(), span)),
+                    value => Err(unsupported(
+                        format!(
+                            "indexing {} outside the generator-expression collect profile",
+                            value_kind(&value)
+                        ),
+                        span,
+                    )),
+                }
+            }
+            _ => Err(unsupported(
+                "place projection outside the scalar tuple collection profile",
+                span,
+            )),
+        }
     }
 
     /// Record one executed statement and enforce the bounded-profile step limit.
@@ -1715,6 +2029,8 @@ const fn value_kind(value: &ReplacementValue) -> &'static str {
         ReplacementValue::Range { .. } => "range",
         ReplacementValue::List { .. } => "list",
         ReplacementValue::Tuple(_) => "tuple",
+        ReplacementValue::Generator(_) => "generator",
+        ReplacementValue::CollectedGenerator { .. } => "collected generator list",
     }
 }
 

--- a/src/frontend/body_ir.rs
+++ b/src/frontend/body_ir.rs
@@ -18,11 +18,11 @@
 //! expression), `continue`. Expressions fully lowered: identifiers, literals (int/float/decimal/bool/string),
 //! binary/unary operators, calls, method calls, field access, indexing, slicing, parenthesization, tuples,
 //! list/dict/set literals (no spreads), constructors, expression-position `if`/`loop`, `try` (`?`), f-strings,
-//! list/dict comprehensions, closure literals, partial callables (see
+//! list/dict comprehensions, lazy generator expressions, closure literals, partial callables (see
 //! [`BodyBuilder::lower_closure`]/[`BodyBuilder::lower_partial`] for how captures
 //! are computed and represented explicitly rather than left implicit), and `match` (see [`BodyBuilder::lower_match`]
-//! for how patterns are lowered and their bindings scoped). Everything else -- generator expressions, a bare
-//! `yield` with no value, and expression-position `yield` (the two-way send/receive protocol) -- lowers to an explicit
+//! for how patterns are lowered and their bindings scoped). Everything else -- a bare `yield` with no value, and
+//! expression-position `yield` (the two-way send/receive protocol) -- lowers to an explicit
 //! `Statement::Unsupported` / `Operand::Unknown` node rather than panicking, so the model stays total over real
 //! programs. Expression-position `yield` is a stub even in the existing Rust-emission backend today, not real
 //! behavior this bucket needs to preserve.
@@ -1814,12 +1814,16 @@ impl<'a> BodyBuilder<'a> {
         self.temp_operand(dict_local, &ty)
     }
 
-    /// Record the current generator-expression boundary without misrepresenting its lazy semantics.
+    /// Lower a generator expression into a distinct, deferred [`bir::Rvalue::Generator`].
     ///
-    /// The established language behavior is a lazy iterator-adapter chain. Materializing its clauses into a `List`
-    /// while reporting `Generator[T]` changes source-visible evaluation order and cannot serve as replacement-backend
-    /// evidence. #1123 owns a suspension-aware representation; until then the Body IR must retain an explicit
-    /// unsupported marker for this expression.
+    /// The first `for` source is evaluated exactly once at construction, matching the established legacy
+    /// iterator-adapter emitter. Its value and every other needed outer lexical value are then captured into fresh
+    /// generator-local bindings. Clause polling, later `for` sources, filters, and element evaluation lower only
+    /// into the generator body, so the enclosing body neither materializes the sequence nor runs a deferred effect.
+    ///
+    /// Body IR currently accepts only plain binding patterns for generator clauses. It rejects a whole generator
+    /// expression before evaluating its source when another pattern shape would require a partially represented
+    /// deferred binding protocol; that keeps unsupported forms visible rather than approximating them as a list.
     fn lower_generator_expr(
         &mut self,
         generator: &ast::GeneratorExpr,
@@ -1827,11 +1831,196 @@ impl<'a> BodyBuilder<'a> {
         scope: bir::ScopeId,
         out: &mut Vec<bir::Statement>,
     ) -> bir::Operand {
-        let _ = generator;
-        self.unsupported_operand(
-            "generator expression requires lazy suspension semantics (#1123)".to_string(),
+        let hir_span_value = hir_span(span);
+        let Some((first_clause, remaining_clauses)) = generator.clauses.split_first() else {
+            return self.unsupported_operand(
+                "generator expression without a for clause".to_string(),
+                scope,
+                hir_span_value,
+                out,
+            );
+        };
+        let ast::ComprehensionClause::For {
+            pattern: first_pattern,
+            iter: first_iter,
+        } = first_clause
+        else {
+            return self.unsupported_operand(
+                "generator expression whose first clause is not a for clause".to_string(),
+                scope,
+                hir_span_value,
+                out,
+            );
+        };
+        let ast::Pattern::Binding(first_name) = &first_pattern.node else {
+            return self.unsupported_operand(
+                "generator for-clause pattern is not a simple binding".to_string(),
+                scope,
+                hir_span_value,
+                out,
+            );
+        };
+        if generator.clauses.iter().any(|clause| {
+            matches!(clause, ast::ComprehensionClause::For { pattern, .. }
+                if !matches!(pattern.node, ast::Pattern::Binding(_)))
+        }) {
+            return self.unsupported_operand(
+                "generator for-clause pattern is not a simple binding".to_string(),
+                scope,
+                hir_span_value,
+                out,
+            );
+        }
+
+        // The first source is the legacy adapter chain's eager boundary. Lowering it before creating the rvalue
+        // preserves source-visible construction timing; all remaining expression lowering below writes only into
+        // `generator_stmts` and therefore happens at poll time.
+        let first_protocol = self.type_info.protocol_iteration(first_iter.span).cloned();
+        let first_is_fallible = first_protocol
+            .as_ref()
+            .is_some_and(|protocol| protocol.fallible_error_type.is_some());
+        let effective_first_iter: &ast::Spanned<ast::Expr> = match (&first_iter.node, first_is_fallible) {
+            (ast::Expr::Try(inner), true) => inner,
+            _ => first_iter,
+        };
+        let source = self.lower_expr_to_operand(effective_first_iter, scope, out);
+
+        let generator_scope = self.new_scope(Some(scope), hir_span_value);
+        let source_local = self.new_temp(
+            self.resolve_ty(effective_first_iter.span),
+            generator_scope,
+            hir_span_value,
+        );
+        self.locals[source_local.index()].origin = bir::LocalOrigin::Captured;
+
+        // Capture every lexical value used after the first source once, at construction. The body cannot read the
+        // enclosing place directly after this point, and restoring the full binding map below prevents generator
+        // clause/capture names from leaking into the following enclosing statement.
+        let enclosing_bindings = self.bindings.clone();
+        let free_names = free_vars_in_generator_deferred_body(generator);
+        let mut captured_operands = Vec::with_capacity(free_names.len());
+        let mut capture_locals = Vec::with_capacity(free_names.len());
+        for name in &free_names {
+            let Some(&outer_local) = self.bindings.get(name) else {
+                // Module/external names remain explicit `External` references when the deferred body is lowered;
+                // there is no local value available to capture and rebind here.
+                continue;
+            };
+            let outer_ty = self.locals[outer_local.index()].ty.clone();
+            let outer_place = bir::Place::from_local(outer_local);
+            let (fact, last_use) = self.ownership_fact_for_place(&outer_place, &outer_ty);
+            captured_operands.push(bir::Operand::place(outer_place, fact, last_use));
+
+            let total_reads = count_reads_in_generator_deferred_body(name, generator);
+            let capture_local =
+                self.declare_new_local_with_reads(name.clone(), outer_ty, generator_scope, hir_span_value, total_reads);
+            self.locals[capture_local.index()].origin = bir::LocalOrigin::Captured;
+            capture_locals.push(capture_local);
+        }
+
+        let first_loop_scope = self.new_scope(Some(generator_scope), hir_span_value);
+        let first_total_reads = count_reads_in_expr(first_name, &generator.expr.node)
+            + count_reads_in_comprehension_clauses(first_name, remaining_clauses);
+        let first_local = self.declare_new_local_with_reads(
+            first_name.clone(),
+            self.resolve_ty(first_pattern.span),
+            first_loop_scope,
+            hir_span(first_pattern.span),
+            first_total_reads,
+        );
+
+        let mut generator_stmts = Vec::new();
+        let iterator_ty = match &first_protocol {
+            Some(protocol) => semantic_type_from_resolved(&protocol.iterator_type),
+            None => self.resolve_ty(effective_first_iter.span),
+        };
+        let iterator_local = self.new_temp(iterator_ty, generator_scope, hir_span_value);
+        match &first_protocol {
+            Some(protocol) => generator_stmts.push(bir::Statement {
+                kind: bir::StatementKind::Call {
+                    destination: Some(bir::Place::from_local(iterator_local)),
+                    callee: bir::Callee::Method(protocol.iter_method.clone()),
+                    args: vec![bir::Operand::place(
+                        bir::Place::from_local(source_local),
+                        bir::OwnershipFact::Borrow,
+                        false,
+                    )],
+                    may_panic: false,
+                },
+                span: hir_span_value,
+            }),
+            None => generator_stmts.push(bir::Statement {
+                kind: bir::StatementKind::Assign {
+                    place: bir::Place::from_local(iterator_local),
+                    rvalue: bir::Rvalue::Use(bir::Operand::place(
+                        bir::Place::from_local(source_local),
+                        bir::OwnershipFact::Borrow,
+                        false,
+                    )),
+                },
+                span: hir_span_value,
+            }),
+        }
+
+        self.loop_break_targets.push(None);
+        let mut first_loop_stmts = vec![bir::Statement {
+            kind: bir::StatementKind::IterNext {
+                destination: bir::Place::from_local(first_local),
+                iterator: bir::Operand::place(
+                    bir::Place::from_local(iterator_local),
+                    bir::OwnershipFact::MutBorrow,
+                    false,
+                ),
+                protocol: match &first_protocol {
+                    Some(protocol) => bir::IterProtocol::UserDefined {
+                        next_method: protocol.next_method.clone(),
+                        fallible: first_is_fallible,
+                    },
+                    None => bir::IterProtocol::Builtin,
+                },
+            },
+            span: hir_span_value,
+        }];
+        let terminal = ComprehensionTerminal::GeneratorYield {
+            element: &generator.expr,
+        };
+        self.lower_comprehension_clauses(
+            remaining_clauses,
+            &terminal,
+            first_loop_scope,
+            hir_span_value,
+            &mut first_loop_stmts,
+        );
+        self.insert_scope_drops(&mut first_loop_stmts, first_loop_scope);
+        self.loop_break_targets.pop();
+        generator_stmts.push(bir::Statement {
+            kind: bir::StatementKind::Loop {
+                body: bir::Block {
+                    scope: first_loop_scope,
+                    stmts: first_loop_stmts,
+                },
+            },
+            span: hir_span_value,
+        });
+        self.bindings = enclosing_bindings;
+
+        // `Generator::new` owns a boxed iterator in the legacy runtime, even when every captured source value is
+        // Copy-shaped. Record that allocation fact directly rather than relying on incidental temporary locals.
+        self.record_runtime_requirement(AbiV0RuntimeRequirement::Allocator);
+        let ty = self.resolve_ty(span);
+        self.push_assign_temp(
+            bir::Rvalue::Generator {
+                source,
+                captured_operands,
+                body: Box::new(bir::GeneratorBody {
+                    source_local,
+                    capture_locals,
+                    stmts: generator_stmts,
+                }),
+            },
+            ty,
             scope,
-            hir_span(span),
+            hir_span_value,
             out,
         )
     }
@@ -1973,6 +2162,13 @@ impl<'a> BodyBuilder<'a> {
                         may_panic: false,
                     },
                     span,
+                });
+            }
+            ComprehensionTerminal::GeneratorYield { element } => {
+                let value = self.lower_expr_to_operand(element, scope, out);
+                out.push(bir::Statement {
+                    kind: bir::StatementKind::Yield { value },
+                    span: hir_span(element.span),
                 });
             }
         }
@@ -3244,6 +3440,8 @@ enum ComprehensionTerminal<'a> {
         key: &'a ast::Spanned<ast::Expr>,
         value: &'a ast::Spanned<ast::Expr>,
     },
+    /// Suspend the surrounding generator body with `element` for one accepted binding combination.
+    GeneratorYield { element: &'a ast::Spanned<ast::Expr> },
 }
 
 impl ComprehensionTerminal<'_> {
@@ -3256,6 +3454,7 @@ impl ComprehensionTerminal<'_> {
             Self::DictInsert { key, value, .. } => {
                 count_reads_in_expr(name, &key.node) + count_reads_in_expr(name, &value.node)
             }
+            Self::GeneratorYield { element } => count_reads_in_expr(name, &element.node),
         }
     }
 }
@@ -3862,6 +4061,44 @@ fn unsupported_for_pattern(pattern: &ast::Pattern, item_ty: &IncanType) -> Optio
     }
 }
 
+/// Determine every lexical free variable used after a generator expression's first source, in first-occurrence
+/// order. The initial source is evaluated before constructing [`bir::Rvalue::Generator`] and therefore is not a
+/// deferred capture. Each `for` pattern becomes bound only after its own source expression has been visited, so a
+/// later source/filter/element sees every preceding clause binding but not a name it introduces itself.
+fn free_vars_in_generator_deferred_body(generator: &ast::GeneratorExpr) -> Vec<String> {
+    let Some((first, remaining)) = generator.clauses.split_first() else {
+        return Vec::new();
+    };
+    let mut bound = HashSet::new();
+    if let ast::ComprehensionClause::For { pattern, .. } = first {
+        bind_pattern_names(&pattern.node, &mut bound);
+    }
+    let mut free = Vec::new();
+    for clause in remaining {
+        match clause {
+            ast::ComprehensionClause::For { pattern, iter } => {
+                collect_free_vars_in_expr(&iter.node, &mut bound, &mut free);
+                bind_pattern_names(&pattern.node, &mut bound);
+            }
+            ast::ComprehensionClause::If(condition) => {
+                collect_free_vars_in_expr(&condition.node, &mut bound, &mut free);
+            }
+        }
+    }
+    collect_free_vars_in_expr(&generator.expr.node, &mut bound, &mut free);
+    free
+}
+
+/// Count a generator capture's deferred reads after the first source. This intentionally remains a conservative
+/// source-order over-approximation, like [`count_reads_in_expr`]: a later pattern can shadow the same spelling and
+/// leave this count high, which selects a clone rather than an unsound move in the generator-local body.
+fn count_reads_in_generator_deferred_body(name: &str, generator: &ast::GeneratorExpr) -> usize {
+    let Some((_, remaining)) = generator.clauses.split_first() else {
+        return 0;
+    };
+    count_reads_in_comprehension_clauses(name, remaining) + count_reads_in_expr(name, &generator.expr.node)
+}
+
 /// Determine every free variable a closure literal's body reads from its enclosing scope, in first-occurrence
 /// source order, given the closure's own declared parameters as the initial bound set. A "free variable" is any
 /// `Ident` read the closure body itself does not bind -- exactly the set [`BodyBuilder::lower_closure`] must
@@ -4458,15 +4695,15 @@ mod tests {
     #[test]
     fn unsupported_constructs_lower_to_an_explicit_placeholder_instead_of_panicking()
     -> Result<(), Box<dyn std::error::Error>> {
-        // v0 does not lower generator expressions (see this module's docs); a generator expression is valid Incan
-        // but hits the explicit `Unsupported` placeholder rather than being silently dropped or panicking. This
-        // used to use a destructuring `for` pattern as its example, which #1125 made a lowered construct.
-        let source = "def pick(x: int) -> int:\n  gen = (v for v in [1, 2])\n  return x\n";
+        // #1123 supports lazy generator expressions with simple binding clauses. A destructuring clause still needs
+        // a generator-specific binding/poll representation, so it must refuse the complete expression rather than
+        // partly lowering it as an eager list or silently dropping the pattern.
+        let source = "def pick(x: int) -> int:\n  gen = (left + right for left, right in [(1, 2)])\n  return x\n";
         let module = build(source, &["m", "unsupported"])?;
         let snapshot = module.render_snapshot();
 
         assert!(
-            snapshot.contains("unsupported("),
+            snapshot.contains("unsupported(generator for-clause pattern is not a simple binding)"),
             "should record an explicit placeholder rather than panicking: {snapshot}"
         );
         Ok(())
@@ -4639,21 +4876,154 @@ mod tests {
     }
 
     #[test]
-    fn generator_expression_is_explicitly_unsupported_pending_1123() -> Result<(), Box<dyn std::error::Error>> {
+    fn generator_expression_keeps_its_multi_clause_body_lazy_and_captures_its_environment()
+    -> Result<(), Box<dyn std::error::Error>> {
         // Mirrors the multi-clause fixture from `test_rfc006_generator_expression_infers_element_type` in
-        // `src/frontend/typechecker/tests.rs`, which is real, delivered RFC 006 behavior: two `for` clauses and two
-        // `if` filters chained in source order.
-        let source = "def positives(xs: list[int], ys: list[int]) -> Generator[int]:\n  return (x * y for x in xs if x > 0 for y in ys if y > x)\n";
+        // `src/frontend/typechecker/tests.rs`, but also reads `offset` from both the filter and element. The Body IR
+        // value must capture that enclosing local once at construction; it must not materialize the chain or run
+        // either filter/element in the enclosing body.
+        let source = "def positives(offset: int, xs: list[int], ys: list[int]) -> Generator[int]:\n  return (x * offset for x in xs if x > offset for y in ys if y > x)\n";
         let module = build(source, &["m", "generator_expr"])?;
         let snapshot = module.render_snapshot();
 
         assert!(
-            snapshot.contains("unsupported(generator expression requires lazy suspension semantics (#1123))"),
-            "generator expressions must stay explicit until Body IR models lazy suspension: {snapshot}"
+            snapshot.contains("generator(source="),
+            "generator construction must be represented as a distinct lazy rvalue: {snapshot}"
+        );
+        assert!(
+            snapshot.contains("captures=["),
+            "the deferred body must receive explicit construction-time captures: {snapshot}"
         );
         assert!(
             !snapshot.contains("list[]"),
             "a generator expression must not materialize an eager list while claiming Generator[T]: {snapshot}"
+        );
+        assert!(
+            snapshot.contains("yield "),
+            "the element must be suspended in the generator body: {snapshot}"
+        );
+        assert!(
+            snapshot.contains("iter_next("),
+            "for clauses must remain deferred iteration operations: {snapshot}"
+        );
+        assert!(
+            snapshot.contains("if "),
+            "filters must remain deferred guard operations: {snapshot}"
+        );
+        assert!(
+            !snapshot.contains("unsupported("),
+            "a valid generator expression must not leave an unsupported placeholder: {snapshot}"
+        );
+        let body = module
+            .bodies
+            .iter()
+            .find(|body| body.name == "positives")
+            .ok_or("generator fixture must lower its function body")?;
+        assert!(
+            body.block.stmts.iter().all(|statement| !matches!(
+                statement.kind,
+                bir::StatementKind::IterNext { .. } | bir::StatementKind::Yield { .. }
+            )),
+            "polling and yield must stay inside the generator rvalue, not the enclosing body: {snapshot}"
+        );
+        let (source, captured_operands, generator_body) = body
+            .block
+            .stmts
+            .iter()
+            .find_map(|statement| match &statement.kind {
+                bir::StatementKind::Assign {
+                    rvalue:
+                        bir::Rvalue::Generator {
+                            source,
+                            captured_operands,
+                            body,
+                        },
+                    ..
+                } => Some((source, captured_operands, body)),
+                _ => None,
+            })
+            .ok_or("generator fixture must assign a Generator rvalue")?;
+        assert!(
+            matches!(source, bir::Operand::Place(_)),
+            "the first for source must be captured as a construction-time operand: {source:?}"
+        );
+        assert_eq!(
+            captured_operands.len(),
+            2,
+            "offset and ys are the deferred free captures"
+        );
+        let capture_names: Vec<_> = generator_body
+            .capture_locals
+            .iter()
+            .map(|local| body.locals[local.index()].name.as_deref())
+            .collect();
+        assert_eq!(capture_names, vec![Some("offset"), Some("ys")]);
+        assert!(
+            matches!(
+                body.locals[generator_body.source_local.index()].origin,
+                bir::LocalOrigin::Captured
+            ),
+            "the construction-time source needs a generator-owned local"
+        );
+        assert!(
+            generator_body
+                .capture_locals
+                .iter()
+                .all(|local| matches!(body.locals[local.index()].origin, bir::LocalOrigin::Captured)),
+            "each deferred free value must bind through an explicit captured local"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn generator_expression_evaluates_only_its_outer_source_before_construction()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let source = concat!(
+            "def source() -> list[int]:\n",
+            "  return [1, 2]\n\n",
+            "def lazy() -> Generator[int]:\n",
+            "  return (item for item in source())\n"
+        );
+        let module = build(source, &["m", "generator_source_timing"])?;
+        let snapshot = module.render_snapshot();
+        let source_call = snapshot
+            .find("call fn:source()")
+            .ok_or("outer generator source call must lower at construction")?;
+        let generator = snapshot
+            .find("generator(source=")
+            .ok_or("generator construction must have a distinct rvalue")?;
+        assert!(
+            source_call < generator,
+            "the first for source must be evaluated before generator construction: {snapshot}"
+        );
+        assert!(
+            !snapshot.contains("unsupported("),
+            "a supported outer source must not leave an unsupported marker: {snapshot}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn generator_expression_captures_an_outer_value_without_leaking_its_clause_binding()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let source = concat!(
+            "def preserve(prefix: str, values: list[str]) -> str:\n",
+            "  generated = (prefix + value for value in values)\n",
+            "  return prefix\n"
+        );
+        let module = build(source, &["m", "generator_capture_scope"])?;
+        let snapshot = module.render_snapshot();
+        assert!(
+            snapshot.contains("captures=[clone(_0)"),
+            "the generator must own a construction-time clone while the enclosing binding remains live: {snapshot}"
+        );
+        assert!(
+            snapshot.contains("return move(_0, last_use)"),
+            "the trailing source read must resolve the outer prefix, not a generator-local capture: {snapshot}"
+        );
+        assert!(
+            !snapshot.contains("unsupported("),
+            "captured generator values must lower without an unsupported placeholder: {snapshot}"
         );
         Ok(())
     }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -6240,6 +6240,63 @@ def main() -> None:
         Ok(())
     }
 
+    /// #1123 regression: generator-expression construction evaluates the outer source once, but every filter and
+    /// element evaluation remains deferred until a consumer polls the generator. This is a generated-Rust
+    /// compile-and-run oracle for the established source contract; it does not claim replacement-executor support.
+    #[test]
+    fn test_generator_expression_defers_filter_and_element_evaluation() -> Result<(), Box<dyn std::error::Error>> {
+        let source = r#"
+def source() -> list[int]:
+    println("outer source")
+    return [1, 2, 3]
+
+
+def keep(value: int) -> bool:
+    println("filter")
+    return value > 1
+
+
+def project(value: int) -> int:
+    println("element")
+    return value * 10
+
+
+def main() -> None:
+    values = (project(value) for value in source() if keep(value))
+    println("after construction")
+    collected = values.collect()
+    println(collected[0])
+    println(collected[1])
+"#;
+        let output = run_incan_source(source);
+        assert!(
+            output.status.success(),
+            "generator-expression laziness regression failed: status={:?}\nstdout:\n{}\nstderr:\n{}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let stdout = strip_ansi_escapes(&String::from_utf8_lossy(&output.stdout));
+        let lines: Vec<&str> = stdout.lines().map(str::trim).filter(|line| !line.is_empty()).collect();
+        assert_eq!(
+            lines,
+            vec![
+                "outer source",
+                "after construction",
+                "filter",
+                "filter",
+                "element",
+                "filter",
+                "element",
+                "20",
+                "30",
+            ],
+            "generator-expression filters/elements must not run before construction completes:\n{stdout}"
+        );
+        Ok(())
+    }
+
     #[test]
     fn test_clone_self_struct_field_reads_do_not_move_out_of_borrowed_self() -> Result<(), Box<dyn std::error::Error>> {
         let output = incan_command()

--- a/tests/parity_corpus_tests.rs
+++ b/tests/parity_corpus_tests.rs
@@ -316,6 +316,12 @@ def select_second_pair() -> int:
     return 0
 "#;
 
+const REPLACEMENT_BODY_V0_007_SRC: &str = r#"
+def collect_lazy_values() -> int:
+    values = (value * 10 for value in range(1, 5) if value > 2).collect()
+    return values[0] + values[1]
+"#;
+
 fn replacement_body_v0_001_arguments() -> Vec<ReplacementValue> {
     vec![ReplacementValue::Int(40), ReplacementValue::Int(2)]
 }
@@ -362,6 +368,14 @@ fn replacement_body_v0_006_arguments() -> Vec<ReplacementValue> {
 
 fn replacement_body_v0_006_expected() -> ReplacementValue {
     ReplacementValue::Int(45)
+}
+
+fn replacement_body_v0_007_arguments() -> Vec<ReplacementValue> {
+    vec![]
+}
+
+fn replacement_body_v0_007_expected() -> ReplacementValue {
+    ReplacementValue::Int(70)
 }
 
 // ============================================================================
@@ -588,6 +602,21 @@ fn seed_corpus() -> Vec<ParityCase> {
                 expected: replacement_body_v0_006_expected,
             }),
         },
+        ParityCase {
+            id: "replacement-body-v0-007",
+            title: "Lazy generator expressions materialize through Body IR only when collected",
+            category: BehaviorCategory::SupportedLanguageContract,
+            lane: EvidenceLane::DirectReplacementBodyIr,
+            evidence: "#1123; tests/replacement_backend_execution_tests.rs::replacement_executes_a_lazy_generator_expression_only_when_collect_consumes_it",
+            disposition: Disposition::Preserved,
+            source: REPLACEMENT_BODY_V0_007_SRC,
+            evaluate: None,
+            replacement_execution: Some(parity_corpus::ReplacementExecutionPlan {
+                function: "collect_lazy_values",
+                arguments: replacement_body_v0_007_arguments,
+                expected: replacement_body_v0_007_expected,
+            }),
+        },
     ]
 }
 
@@ -762,7 +791,7 @@ fn seed_cases_and_direct_replacement_cases_remain_non_green_without_a_legacy_run
     assert_eq!(summary.non_green_behavior, 0);
 }
 
-/// Bind each selected #988 source case to its own replacement receipt and complete Body-IR proof evidence.
+/// Bind each selected direct-replacement source case to its own receipt and complete Body-IR proof evidence.
 #[test]
 fn replacement_body_v0_cases_have_receipt_bound_non_green_execution_evidence() -> Result<(), Box<dyn std::error::Error>>
 {
@@ -774,8 +803,8 @@ fn replacement_body_v0_cases_have_receipt_bound_non_green_execution_evidence() -
         .collect();
     assert_eq!(
         replacement_rows.len(),
-        6,
-        "the six agreed #988 cases must stay stable in #987"
+        7,
+        "the six #988 cases plus #1123's lazy-generator case must stay stable in #987"
     );
 
     for row in replacement_rows {

--- a/tests/replacement_backend_execution_tests.rs
+++ b/tests/replacement_backend_execution_tests.rs
@@ -171,6 +171,51 @@ def main() -> list[int]:
     Ok(())
 }
 
+/// Materialize a lazy generator expression in the replacement executor without evaluating its filter or element
+/// while constructing the Body-IR value. The selected profile admits only the explicit `.collect()` consumer and
+/// indexes its scalar result; it must not treat the generator rvalue itself as an eager list or use generated Rust.
+#[test]
+fn replacement_executes_a_lazy_generator_expression_only_when_collect_consumes_it()
+-> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+def main() -> int:
+  values = (value * 10 for value in range(1, 5) if value > 2).collect()
+  return values[0] + values[1]
+"#;
+    let module = lower_typed_body_ir(source)?;
+    let execution = execute_free_function(&module, "main", &[])?;
+    assert_eq!(execution.value, ReplacementValue::Int(70));
+    assert!(
+        execution.body_snapshot.contains("generator(source="),
+        "replacement execution must consume the explicit deferred generator rvalue"
+    );
+    assert!(
+        execution.body_snapshot.contains("yield"),
+        "the Body-IR proof must retain a yield rather than materializing an eager list"
+    );
+    Ok(())
+}
+
+/// Constructing a generator must not evaluate its deferred element body. The division would fail if the replacement
+/// executor accidentally treated the rvalue as an eager collection; dropping the unconsumed value must still return
+/// the surrounding scalar result.
+#[test]
+fn replacement_keeps_an_unconsumed_generator_expression_deferred() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+def main() -> int:
+  unused = (value // 0 for value in range(1, 2))
+  return 7
+"#;
+    let module = lower_typed_body_ir(source)?;
+    let execution = execute_free_function(&module, "main", &[])?;
+    assert_eq!(execution.value, ReplacementValue::Int(7));
+    assert!(
+        execution.body_snapshot.contains("yield ") && execution.body_snapshot.contains("const(0)"),
+        "the deferred body must remain represented even though it was never consumed"
+    );
+    Ok(())
+}
+
 /// Execute the selected plain builtin-collection loop over scalar tuple values.
 #[test]
 fn replacement_executes_plain_scalar_tuple_collection_loop() -> Result<(), Box<dyn std::error::Error>> {

--- a/tests/support/parity_corpus.rs
+++ b/tests/support/parity_corpus.rs
@@ -670,10 +670,11 @@ pub(crate) struct CorpusSummary {
     pub(crate) cases: Vec<CaseReport>,
 }
 
-/// The current CI-summary schema version. Version `3` adds `ReceiptRef::ReplacementExecuted`, which binds the five
-/// #988 Body-IR cases to their own selection/execution identities and canonical body, ownership, and runtime
-/// evidence while retaining an explicit non-green unavailable comparison. Bump again whenever `CorpusSummary`'s or
-/// `CaseReport`'s field shape changes in a way a consumer (including #655) would need to notice.
+/// The current CI-summary schema version. Version `3` adds `ReceiptRef::ReplacementExecuted`, which binds direct
+/// Body-IR cases (initially #988's profile and subsequently #1123's lazy-generator case) to their own
+/// selection/execution identities and canonical body, ownership, and runtime evidence while retaining an explicit
+/// non-green unavailable comparison. Bump again whenever `CorpusSummary`'s or `CaseReport`'s field shape changes
+/// in a way a consumer (including #655) would need to notice.
 pub(crate) const SCHEMA_VERSION: u32 = 3;
 
 /// Evaluate every case in the corpus and assemble the CI-readable summary.


### PR DESCRIPTION
## Summary

This PR gives Body IR a real lazy generator-expression value instead of an eager list or an unsupported placeholder. It preserves construction-time source/capture ownership, keeps later clauses, filters, and elements deferred, and adds the bounded replacement execution path needed to materialize selected generator expressions through `.collect()` without falling back to generated Rust.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [x] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [x] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: Generator expressions retain lazy timing: their outer source evaluates at construction, while filters and element expressions run only when consumed. Generated Rust regression coverage proves the observable ordering.
- **Internals**: `Rvalue::Generator` owns its first source and lexical captures explicitly, with a deferred `GeneratorBody`. The replacement profile can construct that value without evaluation and consume the selected `range`/scalar `.collect()` profile, producing receipt-bound #987 evidence.
- **Risks**: The replacement profile remains deliberately narrow: generator functions, adapters, arbitrary collection operations, and local callable targets continue to refuse visibly. The #987 row remains non-green until a paired legacy runtime comparator exists.

## Testing / verification

- [x] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- Semantic-core Body-IR tests: 22 passed.
- Frontend Body-IR tests: 82 passed.
- Replacement executor regressions: 22 passed.
- Generated-Rust lazy timing regression and receipt-bound #987 corpus regression passed.
- Full Oven compiler suite: 4,030 passed, 0 failed, 5 ignored across 40 roots.
- Workspace Clippy with `-D warnings` and elevated `cargo-deny-ci` passed.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

Updated public semantic rustdoc for the generator rvalue/body invariants and corpus-schema documentation for the direct execution evidence.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #1123