### PR TITLE
feature - preserve resolved method parameter types for Body IR (#1121)

### DIFF
--- a/src/frontend/body_ir.rs
+++ b/src/frontend/body_ir.rs
@@ -200,19 +200,22 @@ fn lower_function_body(
 /// Lower one method declaration's body into Body IR v0, or `None` for an abstract method (`body: None` — a trait
 /// requirement with no implementation, which has no body to lower).
 ///
-/// Unlike [`lower_function_body`], there is no [`TypeCheckInfo::declarations`] binding table for method parameter
-/// types (`function_bindings`/`function_bindings_by_span` are populated only for top-level `ast::FunctionDecl`
-/// items, never for `ast::MethodDecl`), so non-receiver method parameters declare with an explicit
-/// [`IncanType::Unknown`] rather than a resolved type — the same "no info available" fallback
-/// [`lower_function_body`] already falls back to when its own binding lookup misses. This does not affect the
-/// accuracy of ownership facts computed for actual *reads* of those parameters inside the body: those go through
-/// [`BodyBuilder::resolve_ty`] at each read's own span, which is populated uniformly for every checked expression
-/// regardless of whether it sits in a function or a method body.
+/// Ordinary (non-receiver) method parameters declare with the resolved type the typechecker recorded in
+/// [`DeclarationArtifacts::method_bindings_by_span`](
+/// crate::frontend::typechecker::type_info::DeclarationArtifacts::method_bindings_by_span), keyed by this method's
+/// own declaration span (#1121) — mirroring exactly how [`lower_function_body`] consumes `function_bindings` for
+/// top-level `def` parameters. This lookup can only miss (falling back to [`IncanType::Unknown`], matching
+/// `lower_function_body`'s own fallback) when the typechecker genuinely produced no fact for this declaration, such
+/// as a method belonging to a declaration kind excluded from `TypeChecker::check_method_with_self_ty`'s call sites;
+/// it is not the normal path for an ordinarily checked method. This does not change the accuracy of ownership facts
+/// computed for actual *reads* of those parameters inside the body: those go through [`BodyBuilder::resolve_ty`] at
+/// each read's own span, which is populated uniformly for every checked expression regardless of whether it sits in
+/// a function or a method body.
 ///
 /// The `self`/`mut self` receiver, when present, is declared as the body's first local (before ordinary
 /// parameters) via [`BodyBuilder::declare_receiver_local`], typed with the typechecker-equivalent `receiver_ty`.
 /// A method with `receiver: None` (a static/associated method) lowers with no receiver local at all, identically
-/// in shape to a free function's body.
+/// in shape to a free function's body; its ordinary parameters still resolve through the same binding lookup.
 fn lower_method_body(
     method: &ast::MethodDecl,
     decl_span: ast::Span,
@@ -227,6 +230,10 @@ fn lower_method_body(
     // declare a method named `new`), so the method's CompilerNodeId is scoped under its owning declaration's name
     // rather than reusing `CompilerNodeId::declaration(module_identity, &method.name)` directly.
     let decl_id = CompilerNodeId::declaration(module_identity, &format!("{owner_name}::{}", method.name));
+    let binding = type_info
+        .declarations
+        .method_bindings_by_span
+        .get(&(decl_span.start, decl_span.end));
 
     let mut builder = BodyBuilder::new(type_info);
     let root_scope = builder.new_scope(None, hir_span(decl_span));
@@ -238,10 +245,14 @@ fn lower_method_body(
         param_locals.push(self_local);
     }
 
-    for param in &method.params {
+    for (index, param) in method.params.iter().enumerate() {
+        let ty = binding
+            .and_then(|b| b.params.get(index))
+            .map(|p| semantic_type_from_resolved(&p.ty))
+            .unwrap_or(IncanType::Unknown);
         let local = builder.declare_new_local(
             param.node.name.clone(),
-            IncanType::Unknown,
+            ty,
             root_scope,
             hir_span(param.span),
             body_stmts,
@@ -5177,6 +5188,137 @@ mod tests {
         assert!(
             !snapshot.contains("[receiver"),
             "a static/associated method (receiver: None) must not declare a receiver local: {snapshot}"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn method_parameter_type_is_recorded_from_the_checked_callable_signature() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let source =
+            "model Counter:\n  value: int\n\n  def add(self, amount: int) -> int:\n    return self.value + amount\n";
+        let module = build(source, &["m", "method_param"])?;
+        let snapshot = module.render_snapshot();
+
+        assert!(snapshot.contains("body add decl:m::method_param::Counter::add"));
+        assert!(
+            snapshot.contains("local 1 amount : int [param]"),
+            "an ordinary method parameter must declare with its checked resolved type, not Unknown: {snapshot}"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn aliased_method_parameter_type_retains_the_checked_callable_type() -> Result<(), Box<dyn std::error::Error>> {
+        // `UserId` is a type alias for `int` (RFC-style `type X = Y`). A naive re-parse of the raw `id: UserId`
+        // annotation inside Body IR (with no alias table of its own) could only produce `Named("UserId")`; the
+        // checked callable type resolves the alias all the way through, so the local must show `int`.
+        let source = "type UserId = int\n\nmodel Account:\n  balance: int\n\n  def credit(self, id: UserId, amount: int) -> int:\n    return self.balance + amount\n";
+        let module = build(source, &["m", "aliased_param"])?;
+        let snapshot = module.render_snapshot();
+
+        assert!(
+            snapshot.contains("local 1 id : int [param]"),
+            "an aliased parameter type must resolve through the alias like any other checked expression, not stay \
+             the raw `UserId` annotation spelling: {snapshot}"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn generic_method_parameter_type_retains_the_owner_type_variable() -> Result<(), Box<dyn std::error::Error>> {
+        let source = "class Box[T]:\n  value: T\n\n  def replace(mut self, other: T) -> None:\n    self.value = other\n\n  def wrap(mut self, items: list[T]) -> None:\n    pass\n";
+        let module = build(source, &["m", "generic_param"])?;
+        let snapshot = module.render_snapshot();
+
+        assert!(
+            snapshot.contains("local 1 other : T [param]"),
+            "a bare owner type-variable parameter must retain the checked type variable: {snapshot}"
+        );
+        assert!(
+            snapshot.contains("local 1 items : List[T] [param]"),
+            "a generic collection parameter must retain its checked element type variable: {snapshot}"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn static_method_parameter_types_are_recorded_like_ordinary_methods() -> Result<(), Box<dyn std::error::Error>> {
+        let source = "model Counter:\n  value: int\n\n  def from_value(amount: int) -> Counter:\n    return Counter(value=amount)\n";
+        let module = build(source, &["m", "static_param"])?;
+        let snapshot = module.render_snapshot();
+
+        assert!(snapshot.contains("body from_value decl:m::static_param::Counter::from_value"));
+        assert!(
+            !snapshot.contains("[receiver"),
+            "a static/associated method (receiver: None) must not declare a receiver local: {snapshot}"
+        );
+        assert!(
+            snapshot.contains("local 0 amount : int [param]"),
+            "a static method's ordinary parameters must resolve the same way an instance method's do: {snapshot}"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn overloaded_method_declarations_retain_distinct_parameter_types_by_declaration_span()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // Two `add` methods on the same owner, distinguished only by adopting two instantiations of the same
+        // generic trait (RFC 042 multi-instantiation) -- the language surface's one legitimate way to declare
+        // same-name, same-owner method overloads with genuinely different parameter types. If the checked binding
+        // table were keyed by `(owner, method_name)` alone (like `decorated_method_bindings`), the second
+        // declaration would silently overwrite the first and both bodies would report the same parameter type.
+        let source = "trait Adder[T]:\n  def add(self, x: T) -> T: ...\n\nmodel Calc with Adder[int], Adder[str]:\n  count: int\n\n  def add(self, x: int) -> int:\n    return x\n\n  def add(self, x: str) -> str:\n    return x\n";
+        let module = build(source, &["m", "overload_param"])?;
+        let snapshot = module.render_snapshot();
+
+        assert!(
+            snapshot.contains("local 1 x : int [param]"),
+            "the int-instantiated overload must keep its own checked parameter type: {snapshot}"
+        );
+        assert!(
+            snapshot.contains("local 1 x : str [param]"),
+            "the str-instantiated overload must keep its own distinct checked parameter type, not collide with the \
+             int overload recorded under the same method name: {snapshot}"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn method_parameter_type_falls_back_to_unknown_only_when_the_typechecker_binding_is_absent()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // A successful typecheck always populates `method_bindings_by_span` for every method Body IR actually
+        // lowers a body for (see `TypeChecker::check_method_with_self_ty`), so the only way to observe the
+        // fallback honestly is to simulate the checked fact genuinely being absent -- exercising the same
+        // defence-in-depth path `lower_method_body` falls back to, rather than asserting on a state ordinary
+        // typechecking can never produce.
+        let source =
+            "model Counter:\n  value: int\n\n  def add(self, amount: int) -> int:\n    return self.value + amount\n";
+        let tokens = lexer::lex(source).map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+        let program = parser::parse(&tokens).map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+        let module_path: Vec<String> = vec!["m".to_string(), "fallback_param".to_string()];
+        let mut checker = TypeChecker::new();
+        checker.set_current_module_path(Some(module_path.clone()));
+        checker
+            .check_program(&program)
+            .map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+
+        let mut type_info = checker.type_info().clone();
+        type_info.declarations.method_bindings_by_span.clear();
+
+        let module = build_body_ir_module_v0(&program, &module_path, &type_info);
+        let snapshot = module.render_snapshot();
+
+        assert!(
+            snapshot.contains("local 1 amount : ? [param]"),
+            "with no recorded checked binding for this declaration, the parameter must fall back to the explicit \
+             Unknown type rather than guessing from the raw annotation: {snapshot}"
         );
 
         Ok(())

--- a/src/frontend/typechecker/check_decl.rs
+++ b/src/frontend/typechecker/check_decl.rs
@@ -16,7 +16,10 @@ use super::collect::decorators::resolve_decorator_id;
 use super::type_info::{
     RegistryDefinitionInfo, RegistryDescriptionInfo, RegistryDescriptionRegistry, RegistryExplicitEntryInfo,
 };
-use super::{DecoratedFunctionBindingInfo, DecoratedMethodBindingInfo, TestingFixtureInfo, TypeChecker, YieldContext};
+use super::{
+    DecoratedFunctionBindingInfo, DecoratedMethodBindingInfo, FunctionBindingInfo, TestingFixtureInfo, TypeChecker,
+    YieldContext,
+};
 use incan_core::interop::{RustItemKind, RustItemMetadata, RustTraitAssoc};
 use incan_core::lang::decorators::{self, DecoratorId};
 use incan_core::lang::derives::{self, DeriveId};
@@ -3212,7 +3215,7 @@ impl TypeChecker {
 
         // Check methods
         for method in &model.methods {
-            self.check_method_with_owner_type_params(&method.node, &model.name, &model.type_params);
+            self.check_method_with_owner_type_params(&method.node, method.span, &model.name, &model.type_params);
         }
         self.check_method_partials(&model.name, &model.method_partials);
         for property in &model.properties {
@@ -3627,7 +3630,7 @@ impl TypeChecker {
 
         // Check methods
         for method in &class.methods {
-            self.check_method_with_owner_type_params(&method.node, &class.name, &class.type_params);
+            self.check_method_with_owner_type_params(&method.node, method.span, &class.name, &class.type_params);
         }
         self.check_method_partials(&class.name, &class.method_partials);
         for property in &class.properties {
@@ -3790,6 +3793,7 @@ impl TypeChecker {
             // their parameter, return, target, and generic-bound annotations still form part of the public trait API.
             self.check_method_with_self_ty(
                 &method.node,
+                method.span,
                 ResolvedType::SelfType,
                 &trait_type_params,
                 &tr.type_params,
@@ -4147,7 +4151,7 @@ impl TypeChecker {
         // Check methods (reuse the standard method-checking logic so parameters are in scope).
         for method in &nt.methods {
             if method.node.body.is_some() {
-                self.check_method_with_owner_type_params(&method.node, &nt.name, &nt.type_params);
+                self.check_method_with_owner_type_params(&method.node, method.span, &nt.name, &nt.type_params);
             }
         }
         self.check_method_partials(&nt.name, &nt.method_partials);
@@ -4376,7 +4380,7 @@ impl TypeChecker {
         }
 
         for method in &en.methods {
-            self.check_method_with_owner_type_params(&method.node, &en.name, &en.type_params);
+            self.check_method_with_owner_type_params(&method.node, method.span, &en.name, &en.type_params);
         }
         if let Some(TypeInfo::Enum(info)) = self.lookup_type_info(&en.name).cloned() {
             let method_spans = Self::method_decl_spans_by_name(&en.methods);
@@ -5399,7 +5403,16 @@ impl TypeChecker {
     }
 
     /// Validate a model, class, enum, or newtype method body using the concrete nominal owner as `self`.
-    fn check_method_with_owner_type_params(&mut self, method: &MethodDecl, owner: &str, owner_params: &[TypeParam]) {
+    ///
+    /// `method_span` is forwarded to [`Self::check_method_with_self_ty`] unchanged; see that method's docs for why
+    /// it is required (#1121 declaration-identity keying).
+    fn check_method_with_owner_type_params(
+        &mut self,
+        method: &MethodDecl,
+        method_span: Span,
+        owner: &str,
+        owner_params: &[TypeParam],
+    ) {
         self.validate_decorators_allowing_user_defined(&method.decorators);
         let declaration_name = format!("{owner}.{}", method.name);
         self.check_registry_description_decorators(
@@ -5438,7 +5451,7 @@ impl TypeChecker {
                     .collect(),
             )
         };
-        self.check_method_with_self_ty(method, owner_self_ty, &owner_type_params, owner_params);
+        self.check_method_with_self_ty(method, method_span, owner_self_ty, &owner_type_params, owner_params);
         self.current_method_owner = previous_owner;
         self.apply_user_defined_method_decorators(method, owner);
     }
@@ -5521,9 +5534,17 @@ impl TypeChecker {
     /// Generic owners pass `Owner[T, ...]` here so return checking and `cls(...)` constructor calls see the same
     /// generic surface that call sites use. Trait default methods may still pass bare `Self` because their eventual
     /// adopter is resolved later during trait conformance and method-call substitution.
+    ///
+    /// `method_span` is the declaration span of `method` itself (the `Spanned<MethodDecl>` this `&MethodDecl` was
+    /// unwrapped from). It keys [`DeclarationArtifacts::method_bindings_by_span`](
+    /// super::type_info::DeclarationArtifacts::method_bindings_by_span), recorded below once ordinary parameters are
+    /// resolved, so Body IR lowering (#1121) can retrieve the checked callable signature for this exact declaration
+    /// instead of re-resolving raw AST annotations. Span is the only key that stays collision-safe across same-name
+    /// methods on different owners and same-owner overloads, mirroring `function_bindings_by_span`.
     fn check_method_with_self_ty(
         &mut self,
         method: &MethodDecl,
+        method_span: Span,
         self_ty: ResolvedType,
         owner_type_params: &[String],
         owner_params: &[TypeParam],
@@ -5588,9 +5609,18 @@ impl TypeChecker {
             self.current_classmethod_self_ty = Some(self_ty.clone());
         }
 
-        // Define parameters
+        // Define parameters, capturing each checked callable-parameter fact once so it can be recorded for Body IR
+        // lowering below without re-resolving the annotation (and re-emitting any of its diagnostics) a second time.
+        let mut checked_params = Vec::with_capacity(method.params.len());
         for param in &method.params {
-            let ty = local_type_for_param(param.node.kind, self.resolve_type_checked(&param.node.ty));
+            let resolved_ty = self.resolve_type_checked(&param.node.ty);
+            checked_params.push(CallableParam::named_with_default(
+                param.node.name.clone(),
+                resolved_ty.clone(),
+                param.node.kind,
+                param.node.default.is_some(),
+            ));
+            let ty = local_type_for_param(param.node.kind, resolved_ty);
             self.symbols.define(Symbol {
                 name: param.node.name.clone(),
                 kind: SymbolKind::Variable(VariableInfo {
@@ -5604,6 +5634,13 @@ impl TypeChecker {
         }
 
         let return_type = self.resolve_type_checked(&method.return_type);
+        self.type_info.declarations.method_bindings_by_span.insert(
+            (method_span.start, method_span.end),
+            FunctionBindingInfo {
+                params: checked_params,
+                return_type: return_type.clone(),
+            },
+        );
         let effective_return_type = Self::concretize_self_type_in_annotation(&return_type, &self_ty);
         let body_has_yield = method
             .body

--- a/src/frontend/typechecker/type_info.rs
+++ b/src/frontend/typechecker/type_info.rs
@@ -782,6 +782,19 @@ pub struct DeclarationArtifacts {
     pub function_bindings: HashMap<String, FunctionBindingInfo>,
     /// Module-local function declarations keyed by declaration span, preserving same-name overloads.
     pub function_bindings_by_span: HashMap<(usize, usize), FunctionBindingInfo>,
+    /// Concrete class/model/trait method declarations keyed by declaration span (#1121).
+    ///
+    /// Method names are not unique the way top-level function names are: two owners can declare a method with the
+    /// same name, and one owner can declare same-name overloads. Declaration span is therefore the only key that
+    /// stays collision-safe without inventing a separate declaration-identity scheme, mirroring
+    /// `function_bindings_by_span`. Body IR lowering (`src/frontend/body_ir.rs`) consumes this instead of
+    /// re-resolving raw AST parameter annotations, so aliased and generic method parameter types match the checked
+    /// callable signature exactly rather than a local re-parse. Populated for every method checked through
+    /// `TypeChecker::check_method_with_self_ty` (trait defaults included, keyed by the trait method's own span), so
+    /// static methods (no receiver) are covered the same as instance methods. Newtype and enum methods are checked
+    /// through the same function and so also populate this table, even though Body IR does not lower their bodies
+    /// (#1102's own deliberate scope) — the fact simply goes unread for those owners.
+    pub method_bindings_by_span: HashMap<(usize, usize), FunctionBindingInfo>,
     /// Function declaration emitted names keyed by source declaration span.
     ///
     /// Present when top-level overloads need Rust-level name disambiguation while preserving one source name.
@@ -1308,7 +1321,11 @@ pub struct StaticBindingInfo {
     pub is_imported: bool,
 }
 
-/// Lowering metadata for one source function declaration.
+/// Lowering metadata for one source function or method declaration.
+///
+/// Shared by [`DeclarationArtifacts::function_bindings`]/[`DeclarationArtifacts::function_bindings_by_span`] (top-
+/// level `def`) and [`DeclarationArtifacts::method_bindings_by_span`] (class/model/trait methods, #1121) rather than
+/// duplicating an equivalent struct per callable kind.
 #[derive(Debug, Clone, PartialEq)]
 pub struct FunctionBindingInfo {
     /// Typechecker-resolved source parameters, including default-presence markers.


### PR DESCRIPTION
## Summary

Body IR v0 method lowering (#1102) declared every ordinary method parameter's `LocalDecl` as `IncanType::Unknown`, because `TypeCheckInfo` only retained resolved parameter bindings for top-level `def` functions, never for `MethodDecl` items. This PR records the typechecker's resolved method callable signatures — keyed by declaration span, overload-safe — and consumes them during Body IR lowering, so ordinary method parameters carry their real checked type instead of `Unknown`.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: none. Internal compiler IR only.
- **Internals**: adds `DeclarationArtifacts::method_bindings_by_span`, reusing the existing `FunctionBindingInfo` shape (no parallel struct) and keyed by declaration span, mirroring `function_bindings_by_span`'s existing collision-safe keying for top-level overloads. `method_span: Span` is threaded through `check_method_with_owner_type_params`/`check_method_with_self_ty` (model, class, newtype, enum, and trait-default call sites), which now records one binding per checked method declaration after resolving each parameter's type exactly once — avoiding a double `resolve_type_checked()` call that would double-emit annotation diagnostics. `lower_method_body` in Body IR looks up the binding by declaration span and types ordinary parameter locals from it, falling back to `IncanType::Unknown` only when the typechecker genuinely produced no fact. The receiver local (`self`/`mut self`) is untouched — owned by #1102.
- **Risks**: low, additive. No existing binding table's shape changed; the new table is populated at the same choke point every method already passes through, so nothing that previously typechecked can now fail to. Newtype/enum methods also populate the table (they share the same choke point) but this is inert — Body IR still doesn't lower their bodies (#1102's own pre-existing exclusion).

## Testing / verification

- [x] `make test` / `cargo test` — targeted, not the full workspace suite (per this repo's slice-worktree policy: full suite is run once at slice-integration level, not per worker branch)
- [ ] `make examples` (not relevant — no user-facing/example-affecting change)
- [x] `incan fmt --check .` (via `cargo +nightly fmt -- --check`, clean)
- [x] Manual verification described below

Manual verification notes (rerun after rebasing onto `origin/0.6-dev` past #1150/#1123, current HEAD `bbcf94a5a`):

- `cargo test -p incan_semantics_core body_ir` — 22/22 passed
- `cargo test --lib frontend::body_ir` — 90/90 passed (includes the 6 new tests for this change: annotated parameter, aliased/type-alias parameter, generic owner type-variable parameter, static/associated method, overload-safe declaration-span keying via a genuine RFC 042 multi-instantiation, and an explicit fallback-to-`Unknown` test that clears the binding table to honestly exercise the fallback path)
- `cargo test --lib frontend::typechecker` — 914/914 passed
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo +nightly fmt -- --check` — clean
- `python3 scripts/check_changed_rustdocs.py --base origin/0.6-dev` — rustdoc gate passed
- `make pre-commit-fast` — passed (fmt-check 2s, rustdoc 0s, version-gate 0s, cargo check 8s, total 10s)
- `grep -n '\.unwrap(\|\.expect('` over all 3 touched files — zero matches
- Rebase onto `origin/0.6-dev` (past #1150/#1123) was clean, no conflicts; diff shape unchanged.

## Docs impact

- [x] No docs changes needed (internal compiler IR, no `pub` user-facing API surface change; every new/changed `pub` item has rustdoc per this repo's documentation gate)
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate (n/a — no user-facing docs surface)
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions (6 new tests, all meaningfully distinct)

Closes #1121.
