### PR TITLE
feature - represent await and race for in Body IR (#1164)

### DIFF
--- a/crates/incan_semantics_core/src/body_ir.rs
+++ b/crates/incan_semantics_core/src/body_ir.rs
@@ -94,6 +94,14 @@ pub struct Body {
     pub runtime_requirements: Vec<AbiV0RuntimeRequirement>,
     /// Panic-interaction facts recorded for this body, without committing to a stable public panic strategy.
     pub panic_facts: Vec<PanicFact>,
+    /// Whether the source declaration was marked `async` (#1164).
+    ///
+    /// Deliberately a **stored** field, unlike the derived [`Self::is_generator`] next to it. Async-ness is a
+    /// declaration-level fact: an `async def` with no `await` in its body is still async, and its caller still gets
+    /// an awaitable. Deriving this by scanning for [`StatementKind::Await`] the way `is_generator` scans for
+    /// [`StatementKind::Yield`] would therefore be wrong, not merely a different implementation. This is the first
+    /// declaration-level fact `Body` carries; see [`Self::is_generator`]'s docs for why that one stayed derived.
+    pub is_async: bool,
 }
 
 impl Body {
@@ -143,9 +151,10 @@ impl Body {
     /// Render a deterministic maintainer-facing snapshot of this body.
     pub fn render_snapshot(&self) -> String {
         let mut out = String::new();
+        let async_marker = if self.is_async { " async" } else { "" };
         let _ = writeln!(
             &mut out,
-            "body {} {} span={}..{}",
+            "body{async_marker} {} {} span={}..{}",
             self.name, self.decl_id, self.span.start, self.span.end
         );
         for local in &self.locals {
@@ -198,6 +207,7 @@ fn render_runtime_requirement(req: &AbiV0RuntimeRequirement) -> String {
         AbiV0RuntimeRequirement::HostedStd => "hosted_std".to_string(),
         AbiV0RuntimeRequirement::Allocator => "allocator".to_string(),
         AbiV0RuntimeRequirement::PanicStrategy => "panic_strategy".to_string(),
+        AbiV0RuntimeRequirement::AsyncRuntime => "async_runtime".to_string(),
     }
 }
 
@@ -1277,6 +1287,46 @@ pub enum CallableTarget {
     Local(LocalCallableTarget),
 }
 
+/// One arm of a [`StatementKind::Race`].
+///
+/// The source spells a single binding name shared by every arm (`race for value:`), but each arm re-scopes it and
+/// arms may resolve it to different types, so each arm owns its own `binding` local rather than sharing one. The
+/// body is a full [`Block`] plus a `result` operand, mirroring how [`ClosureBody`] carries a nested statement
+/// sequence with an explicit value instead of relying on a trailing-statement convention.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RaceArm {
+    /// This arm's awaitable, evaluated before selection along with every other arm's.
+    pub awaitable: Operand,
+    /// The local this arm binds the winning value to, visible only inside `body`.
+    pub binding: LocalId,
+    /// Statements that run only if this arm wins.
+    pub body: Block,
+    /// This arm's result value, written to the race's destination when it wins.
+    pub result: Operand,
+}
+
+impl RaceArm {
+    /// Render a deterministic maintainer-facing spelling for this arm.
+    fn render_snapshot(&self) -> String {
+        format!(
+            "await {} => _{} {{ {} }} -> {}",
+            self.awaitable.render_snapshot(),
+            self.binding.0,
+            self.body
+                .stmts
+                .iter()
+                .map(|stmt| {
+                    let mut rendered = String::new();
+                    render_statement(&mut rendered, stmt, "", 0);
+                    rendered.trim_end().to_string()
+                })
+                .collect::<Vec<_>>()
+                .join("; "),
+            self.result.render_snapshot()
+        )
+    }
+}
+
 /// A locally stored callable target and the resolved binding of its call arguments.
 ///
 /// The binding makes a local partial's two source-level call conventions explicit: positional arguments skip
@@ -1501,6 +1551,21 @@ fn render_statement(out: &mut String, stmt: &Statement, indent: &str, depth: usi
                 args_str.join(", ")
             );
         }
+        StatementKind::Await { destination, awaited } => {
+            let dest = destination
+                .as_ref()
+                .map(|place| format!("{} = ", place.render_snapshot()))
+                .unwrap_or_default();
+            let _ = writeln!(out, "{indent}{dest}await {}", awaited.render_snapshot());
+        }
+        StatementKind::Race { destination, arms } => {
+            let dest = destination
+                .as_ref()
+                .map(|place| format!("{} = ", place.render_snapshot()))
+                .unwrap_or_default();
+            let rendered: Vec<String> = arms.iter().map(RaceArm::render_snapshot).collect();
+            let _ = writeln!(out, "{indent}{dest}race [{}]", rendered.join(", "));
+        }
         StatementKind::Drop { local } => {
             let _ = writeln!(out, "{indent}drop _{}", local.0);
         }
@@ -1658,6 +1723,42 @@ pub enum StatementKind {
     Continue,
     /// Return from the body, optionally with a value.
     Return { value: Option<Operand> },
+    /// `await operand` — a suspension point in an async body.
+    ///
+    /// Deliberately **not** [`Self::Yield`]. A generator `yield` produces a value outward and has no destination;
+    /// an `await` consumes an awaitable and writes the resumed value into `destination`. Sharing one node would make
+    /// two different contracts indistinguishable, and a task runtime needs exactly the fact that separates them:
+    /// where the body suspends and what it resumes with.
+    ///
+    /// Effect ordering across this point is source-observable — statements before it run before suspension,
+    /// statements after it run after resumption — and is preserved by this statement's position in its block. The
+    /// awaited operand carries its own [`OwnershipFact`] and last-use marker like any other read.
+    ///
+    /// This node says a suspension happens here. It says nothing about *how*: task/frame state, wake/resume routing,
+    /// and scheduling are the executing backend's, tracked by #1155.
+    Await {
+        /// Where the resumed value is written. `None` when the awaited result is discarded.
+        destination: Option<Place>,
+        /// The awaitable being suspended on.
+        awaited: Operand,
+    },
+    /// `race for value:` — concurrent await over several arms, resuming on the first to complete.
+    ///
+    /// The contract this node fixes, which arm ordering alone could not express:
+    ///
+    /// - every arm's awaitable is evaluated **before** any selection happens, in source order;
+    /// - arm order is source order and carries **no** priority — a consumer must not treat `arms[0]` as preferred;
+    /// - exactly one arm's `body` runs, the one whose awaitable completed first;
+    /// - every non-winning arm's awaitable is cancelled at this statement's boundary.
+    ///
+    /// As with [`Self::Await`], this records what the race *means*, not how it is driven: concurrent polling,
+    /// first-completion detection, and the cancellation mechanism belong to #1155.
+    Race {
+        /// Where the winning arm's result is written. `None` when the race's value is discarded.
+        destination: Option<Place>,
+        /// The arms, in source order. Order is not priority — see this variant's docs.
+        arms: Vec<RaceArm>,
+    },
     /// `yield value` in statement position, suspending a generator body to produce one value.
     ///
     /// Only the statement-position form with a value is modeled -- see the module docs and
@@ -1831,6 +1932,7 @@ mod tests {
             },
             runtime_requirements: Vec::new(),
             panic_facts: Vec::new(),
+            is_async: false,
         }
     }
 

--- a/crates/incan_semantics_core/src/body_ir.rs
+++ b/crates/incan_semantics_core/src/body_ir.rs
@@ -139,8 +139,9 @@ impl Body {
     /// `yield` only ever appears inside a function whose declared return type is `Generator[T]` (the typechecker
     /// enforces this), so this alone is already a reliable generator signal for a `Body` in isolation.
     ///
-    /// The walk recurses into nested [`StatementKind::If`]/[`StatementKind::Loop`] blocks (the only statement kinds
-    /// that themselves carry a nested [`Block`]) but does not recurse into a [`Rvalue::Closure`]'s
+    /// The walk recurses into every statement kind that carries a nested [`Block`] --
+    /// [`StatementKind::If`], [`StatementKind::Loop`], and each [`StatementKind::Race`] arm -- but does not recurse
+    /// into a [`Rvalue::Closure`]'s
     /// [`ClosureBody`] or a [`Rvalue::Generator`]'s [`GeneratorBody`]. A yield nested in either value does not make
     /// the *enclosing* function body a generator, matching how the existing backend's own `body_contains_yield`
     /// walker never descends into nested closure/function literals.
@@ -193,6 +194,10 @@ fn statement_contains_yield(stmt: &Statement) -> bool {
             then_block, else_block, ..
         } => block_contains_yield(then_block) || else_block.as_ref().is_some_and(block_contains_yield),
         StatementKind::Loop { body } => block_contains_yield(body),
+        // A race arm body is a nested block like any other. A body cannot currently be both async and a generator,
+        // so this is unreachable today; walking it anyway keeps the traversal total over the statement vocabulary
+        // rather than silently under-reporting if that ever changes.
+        StatementKind::Race { arms, .. } => arms.iter().any(|arm| block_contains_yield(&arm.body)),
         _ => false,
     }
 }
@@ -1306,24 +1311,10 @@ pub struct RaceArm {
 }
 
 impl RaceArm {
-    /// Render a deterministic maintainer-facing spelling for this arm.
-    fn render_snapshot(&self) -> String {
-        format!(
-            "await {} => _{} {{ {} }} -> {}",
-            self.awaitable.render_snapshot(),
-            self.binding.0,
-            self.body
-                .stmts
-                .iter()
-                .map(|stmt| {
-                    let mut rendered = String::new();
-                    render_statement(&mut rendered, stmt, "", 0);
-                    rendered.trim_end().to_string()
-                })
-                .collect::<Vec<_>>()
-                .join("; "),
-            self.result.render_snapshot()
-        )
+    /// Render this arm's header and result. Its block is rendered separately by the statement renderer, so nested
+    /// control flow inside an arm keeps the same line-oriented, indented shape it has anywhere else.
+    fn render_header(&self) -> String {
+        format!("await {} => _{}:", self.awaitable.render_snapshot(), self.binding.0)
     }
 }
 
@@ -1563,8 +1554,12 @@ fn render_statement(out: &mut String, stmt: &Statement, indent: &str, depth: usi
                 .as_ref()
                 .map(|place| format!("{} = ", place.render_snapshot()))
                 .unwrap_or_default();
-            let rendered: Vec<String> = arms.iter().map(RaceArm::render_snapshot).collect();
-            let _ = writeln!(out, "{indent}{dest}race [{}]", rendered.join(", "));
+            let _ = writeln!(out, "{indent}{dest}race:");
+            for arm in arms {
+                let _ = writeln!(out, "{indent}  {}", arm.render_header());
+                render_block(out, &arm.body, depth + 2);
+                let _ = writeln!(out, "{indent}  -> {}", arm.result.render_snapshot());
+            }
         }
         StatementKind::Drop { local } => {
             let _ = writeln!(out, "{indent}drop _{}", local.0);
@@ -1737,7 +1732,11 @@ pub enum StatementKind {
     /// This node says a suspension happens here. It says nothing about *how*: task/frame state, wake/resume routing,
     /// and scheduling are the executing backend's, tracked by #1155.
     Await {
-        /// Where the resumed value is written. `None` when the awaited result is discarded.
+        /// Where the resumed value is written.
+        ///
+        /// Frontend lowering always supplies a destination today, including for a discarded `await` in statement
+        /// position: the resumed value gets a temporary that the surrounding statement then ignores. The option
+        /// exists for a future producer that can prove the value is unobservable, not because one exists now.
         destination: Option<Place>,
         /// The awaitable being suspended on.
         awaited: Operand,
@@ -1754,7 +1753,8 @@ pub enum StatementKind {
     /// As with [`Self::Await`], this records what the race *means*, not how it is driven: concurrent polling,
     /// first-completion detection, and the cancellation mechanism belong to #1155.
     Race {
-        /// Where the winning arm's result is written. `None` when the race's value is discarded.
+        /// Where the winning arm's result is written. Always supplied by frontend lowering today, for the same
+        /// reason as [`StatementKind::Await::destination`].
         destination: Option<Place>,
         /// The arms, in source order. Order is not priority — see this variant's docs.
         arms: Vec<RaceArm>,

--- a/crates/incan_semantics_core/src/types.rs
+++ b/crates/incan_semantics_core/src/types.rs
@@ -287,6 +287,12 @@ pub enum AbiV0RuntimeRequirement {
     HostedStd,
     Allocator,
     PanicStrategy,
+    /// An async task runtime, required by a body containing `await` or `race for` (#1164).
+    ///
+    /// Mirrors the surface-level [`crate::RuntimeRequirement::AsyncRuntime`] fact so a consumer reads the
+    /// requirement off the body it applies to, instead of re-deriving it by scanning the program's imports and
+    /// declaration modifiers.
+    AsyncRuntime,
 }
 
 /// ABI representation category known to the compiler today.

--- a/src/backend/replacement/mod.rs
+++ b/src/backend/replacement/mod.rs
@@ -852,6 +852,11 @@ fn validate_statement_profile(
             validate_operand_profile(iterator, statement.span, tuple_iteration_locals)
         }
         StatementKind::Yield { .. } => Err(unsupported("generator yield", statement.span)),
+        // #1164 gave Body IR an async vocabulary. Executing it -- task state, suspension, wake/resume, arm
+        // selection, cancellation -- is #1155's. Until then these refuse by name at the original source span
+        // rather than leaving the executor unable to compile against the representation.
+        StatementKind::Await { .. } => Err(unsupported("async await suspension", statement.span)),
+        StatementKind::Race { .. } => Err(unsupported("async race selection", statement.span)),
         StatementKind::TryPropagate { .. } => Err(unsupported("try propagation", statement.span)),
         StatementKind::IterNext { .. } => Err(unsupported("non-range iteration", statement.span)),
         StatementKind::Unsupported { description } => Err(unsupported(description, statement.span)),
@@ -1189,6 +1194,9 @@ impl BodyExecutor {
                 statement.span,
             )),
             StatementKind::TryPropagate { .. } => Err(unsupported("try propagation", statement.span)),
+            // See the matching arms in `validate_statement_profile`: representation is #1164's, execution is #1155's.
+            StatementKind::Await { .. } => Err(unsupported("async await suspension", statement.span)),
+            StatementKind::Race { .. } => Err(unsupported("async race selection", statement.span)),
             StatementKind::IterNext { .. } => Err(unsupported("non-range iteration", statement.span)),
             StatementKind::Unsupported { description } => Err(unsupported(description, statement.span)),
         }
@@ -1940,6 +1948,7 @@ fn runtime_requirement_label(requirement: &AbiV0RuntimeRequirement) -> String {
         AbiV0RuntimeRequirement::HostedStd => "hosted_std".to_string(),
         AbiV0RuntimeRequirement::Allocator => "allocator".to_string(),
         AbiV0RuntimeRequirement::PanicStrategy => "panic_strategy".to_string(),
+        AbiV0RuntimeRequirement::AsyncRuntime => "async_runtime".to_string(),
     }
 }
 

--- a/src/frontend/body_ir.rs
+++ b/src/frontend/body_ir.rs
@@ -3282,9 +3282,14 @@ impl<'a> BodyBuilder<'a> {
                 .race_arm_binding_type(arm.awaitable.span)
                 .map(semantic_type_from_resolved)
                 .unwrap_or(IncanType::Unknown);
-            // Capture the enclosing binding *before* declaring: `declare_new_local` installs the new local itself,
-            // so reading `self.bindings` afterwards would capture the arm's own local and destroy the outer one.
-            let shadowed = self.bindings.get(&race.binding).copied();
+            // Snapshot the whole binding environment before the arm, not just the shared race binding. A block arm
+            // lowers ordinary statements, and every `x = ...` in it declares a local that
+            // `declare_new_local_with_reads` installs into `self.bindings`. Restoring only `race.binding`
+            // would leave those arm-locals visible to later arms and to code after the race, so a trailing
+            // read of a name an arm happened to shadow would silently resolve to the arm's local.
+            // `insert_scope_drops` handles the *drop* obligation; it does not touch name resolution, which
+            // is what this restores.
+            let enclosing_bindings = self.bindings.clone();
             let reads = match &arm.body {
                 ast::RaceForBody::Expr(expr) => count_reads_in_expr(&race.binding, &expr.node),
                 ast::RaceForBody::Block(stmts) => count_reads_in_stmts(&race.binding, stmts),
@@ -3301,16 +3306,10 @@ impl<'a> BodyBuilder<'a> {
             };
             self.insert_scope_drops(&mut arm_stmts, arm_scope);
 
-            // The arm binding is scoped to its own arm, exactly like a closure parameter: code after the race must
-            // keep resolving the name to whatever it meant outside.
-            match shadowed {
-                Some(previous) => {
-                    self.bindings.insert(race.binding.clone(), previous);
-                }
-                None => {
-                    self.bindings.remove(&race.binding);
-                }
-            }
+            // Every name an arm bound -- its winner binding and any local its block body declared -- is scoped to
+            // that arm, exactly like a closure body's. Code after the race, and each later arm, must keep resolving
+            // every name to whatever it meant outside.
+            self.bindings = enclosing_bindings;
 
             arms.push(bir::RaceArm {
                 awaitable,
@@ -7799,6 +7798,40 @@ mod tests {
         assert!(
             sum_line.contains("copy(_0)"),
             "a read after the race must resolve to the enclosing binding, not an arm local: {rendered}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn a_block_arm_local_does_not_leak_past_its_arm() -> Result<(), Box<dyn std::error::Error>> {
+        // A block arm lowers ordinary statements, so `total = ...` inside it declares a local through the same path
+        // any assignment uses. Restoring only the shared race binding would leave that arm-local installed, and the
+        // trailing read of `total` would silently resolve to it instead of the outer binding -- a wrong value with
+        // no unsupported node to show for it.
+        let source = format!(
+            "{ASYNC_PRELUDE}async def f() -> int:\n  total = 100\n  winner = race for value:\n    await fast() => value\n    await slow() =>\n      total = value * 2\n      total\n  return total + winner\n"
+        );
+        let module = build(&source, &["m", "race_arm_local"])?;
+        let body = body_named(&module, "f")?;
+        let rendered = body.render_snapshot();
+
+        // `total` is declared first, so the outer binding is local 0; the arm declares its own `total` separately.
+        let outer = local_for_binding(&rendered, "total").ok_or("missing outer binding")?;
+        assert_eq!(
+            outer, "_0",
+            "the outer binding should be the first declared local: {rendered}"
+        );
+        assert!(
+            rendered.matches("total : int [binding]").count() >= 2,
+            "the arm must declare its own `total` rather than reusing the outer one: {rendered}"
+        );
+        let sum_line = rendered
+            .lines()
+            .find(|line| line.contains(" + ") && !line.starts_with("      "))
+            .ok_or("missing the trailing sum")?;
+        assert!(
+            sum_line.contains("copy(_0)"),
+            "a read after the race must resolve to the enclosing local, not one an arm body declared: {rendered}"
         );
         Ok(())
     }

--- a/src/frontend/body_ir.rs
+++ b/src/frontend/body_ir.rs
@@ -44,6 +44,8 @@
 
 use std::collections::{HashMap, HashSet};
 
+use incan_core::lang::keywords::KeywordId;
+use incan_semantics_core::SurfaceFeatureKey;
 use incan_semantics_core::body_ir as bir;
 use incan_semantics_core::{
     AbiV0RuntimeRequirement, CompilerNodeId, HirSourceSpan, IncanCallableParam, IncanCallableParamKind,
@@ -211,6 +213,7 @@ fn lower_function_body(
         },
         runtime_requirements: builder.runtime_requirements,
         panic_facts: builder.panic_facts,
+        is_async: function.is_async(),
     }
 }
 
@@ -303,6 +306,7 @@ fn lower_method_body(
         },
         runtime_requirements: builder.runtime_requirements,
         panic_facts: builder.panic_facts,
+        is_async: method.is_async(),
     })
 }
 
@@ -2328,6 +2332,7 @@ impl<'a> BodyBuilder<'a> {
             ast::Expr::Closure(params, body) => self.lower_closure(params, body, expr.span, scope, out),
             ast::Expr::Partial(partial) => self.lower_partial(partial, expr.span, scope, out),
             ast::Expr::Match(subject, arms) => self.lower_match(subject, arms, expr.span, scope, out),
+            ast::Expr::Surface(surface) => self.lower_surface_expr(surface, expr.span, scope, out),
             other => self.unsupported_operand(unsupported_expr_label(other), scope, span, out),
         }
     }
@@ -3172,6 +3177,174 @@ impl<'a> BodyBuilder<'a> {
         out: &mut Vec<bir::Statement>,
     ) -> bir::Operand {
         self.lower_nominal_construction(name, args, span, scope, out)
+    }
+
+    // ---- Async surface (#1164) ----
+
+    /// Lower an `ast::Expr::Surface` node, accepting only the async pair this issue owns.
+    ///
+    /// Dispatch is on the surface **key**, not the payload shape. `SurfaceExprPayload::PrefixUnary` is generic over
+    /// any prefix soft keyword and `await` merely happens to be the only one registered today, so matching the
+    /// payload alone would silently accept a future prefix keyword as an await. The typechecker
+    /// (`check_expr/mod.rs`) and the existing Rust-emission backend (`backend/ir/lower/expr/mod.rs`) both dispatch
+    /// on the key/payload pair for exactly this reason.
+    ///
+    /// Every other payload -- the scoped-DSL surface nodes -- keeps its existing named refusal. Those reach this
+    /// module only when a caller skips the desugar pass the legacy pipeline runs first, and they belong to the Body
+    /// IR input-contract issue, not to this one.
+    fn lower_surface_expr(
+        &mut self,
+        surface: &ast::SurfaceExpr,
+        span: ast::Span,
+        scope: bir::ScopeId,
+        out: &mut Vec<bir::Statement>,
+    ) -> bir::Operand {
+        match (&surface.key, &surface.payload) {
+            (SurfaceFeatureKey::SoftKeyword(KeywordId::Await), ast::SurfaceExprPayload::PrefixUnary(awaited)) => {
+                self.lower_await(awaited, span, scope, out)
+            }
+            (_, ast::SurfaceExprPayload::RaceFor(race)) => self.lower_race_for(race, span, scope, out),
+            (_, payload) => self.unsupported_operand(surface_expr_label(payload), scope, hir_span(span), out),
+        }
+    }
+
+    /// Lower `await expr` into a [`bir::StatementKind::Await`] suspension point.
+    ///
+    /// The awaited operand is read through the ordinary ownership path, so the suspension carries the same
+    /// [`bir::OwnershipFact`]/last-use discipline as any other read. The resumed value lands in a fresh temporary,
+    /// which is what makes the suspension's destination explicit rather than implied by the surrounding statement.
+    ///
+    /// Records [`AbiV0RuntimeRequirement::AsyncRuntime`] on the enclosing body so a consumer reads the requirement
+    /// off the body it applies to instead of re-deriving it from the program's imports and declaration modifiers.
+    fn lower_await(
+        &mut self,
+        awaited: &ast::Spanned<ast::Expr>,
+        span: ast::Span,
+        scope: bir::ScopeId,
+        out: &mut Vec<bir::Statement>,
+    ) -> bir::Operand {
+        let hir_span_value = hir_span(span);
+        let operand = self.lower_expr_to_operand(awaited, scope, out);
+        self.record_runtime_requirement(AbiV0RuntimeRequirement::AsyncRuntime);
+        let ty = self.resolve_ty(span);
+        let destination = self.new_temp(ty.clone(), scope, hir_span_value);
+        out.push(bir::Statement {
+            kind: bir::StatementKind::Await {
+                destination: Some(bir::Place::from_local(destination)),
+                awaited: operand,
+            },
+            span: hir_span_value,
+        });
+        self.temp_operand(destination, &ty)
+    }
+
+    /// Lower `race for value:` into a [`bir::StatementKind::Race`].
+    ///
+    /// Each arm's awaitable is lowered into the enclosing block *before* any arm body, which is what makes "every
+    /// awaitable is evaluated before selection" observable in the statement sequence rather than a claim in prose.
+    /// Each arm then gets its own scope and its own binding local: the source spells one shared name, but arms
+    /// re-scope it and can resolve it to different types, so one local per arm is the faithful shape.
+    ///
+    /// An arm body containing an unsupported construct keeps its own `Unsupported` node *inside* the represented
+    /// race rather than collapsing the whole expression, so a consumer loses only the construct it cannot handle.
+    fn lower_race_for(
+        &mut self,
+        race: &ast::RaceForExpr,
+        span: ast::Span,
+        scope: bir::ScopeId,
+        out: &mut Vec<bir::Statement>,
+    ) -> bir::Operand {
+        let hir_span_value = hir_span(span);
+        self.record_runtime_requirement(AbiV0RuntimeRequirement::AsyncRuntime);
+
+        // Selection observes every awaitable, so all of them are evaluated first, in source order, into the
+        // enclosing block. Only the winning arm's body runs, so arm bodies are lowered into their own blocks below.
+        let mut awaitables = Vec::with_capacity(race.arms.len());
+        for arm in &race.arms {
+            awaitables.push(self.lower_expr_to_operand(&arm.awaitable, scope, out));
+        }
+
+        let mut arms = Vec::with_capacity(race.arms.len());
+        for (arm, awaitable) in race.arms.iter().zip(awaitables) {
+            let arm_scope = self.new_scope(Some(scope), hir_span_value);
+            let binding_ty = self.resolve_ty(arm.awaitable.span);
+            let binding = self.declare_new_local(race.binding.clone(), binding_ty, arm_scope, hir_span_value, &[]);
+            let shadowed = self.bindings.insert(race.binding.clone(), binding);
+
+            let mut arm_stmts = Vec::new();
+            let result = match &arm.body {
+                ast::RaceForBody::Expr(expr) => self.lower_expr_to_operand(expr, arm_scope, &mut arm_stmts),
+                ast::RaceForBody::Block(stmts) => self.lower_race_arm_block(stmts, arm_scope, &mut arm_stmts),
+            };
+
+            // The arm binding is scoped to its own arm, exactly like a closure parameter: code after the race must
+            // keep resolving the name to whatever it meant outside.
+            match shadowed {
+                Some(previous) => {
+                    self.bindings.insert(race.binding.clone(), previous);
+                }
+                None => {
+                    self.bindings.remove(&race.binding);
+                }
+            }
+
+            arms.push(bir::RaceArm {
+                awaitable,
+                binding,
+                body: bir::Block {
+                    scope: arm_scope,
+                    stmts: arm_stmts,
+                },
+                result,
+            });
+        }
+
+        let ty = self.resolve_ty(span);
+        let destination = self.new_temp(ty.clone(), scope, hir_span_value);
+        out.push(bir::Statement {
+            kind: bir::StatementKind::Race {
+                destination: Some(bir::Place::from_local(destination)),
+                arms,
+            },
+            span: hir_span_value,
+        });
+        self.temp_operand(destination, &ty)
+    }
+
+    /// Lower a race arm's block body, whose value is its trailing expression statement.
+    ///
+    /// That trailing-expression convention is the source contract the typechecker already applies
+    /// (`check_race_arm_block_body`), so lowering follows it rather than inventing a second rule. A block whose last
+    /// statement is not an expression has no value to produce, and yields an explicit unknown operand.
+    fn lower_race_arm_block(
+        &mut self,
+        stmts: &[ast::Spanned<ast::Statement>],
+        scope: bir::ScopeId,
+        out: &mut Vec<bir::Statement>,
+    ) -> bir::Operand {
+        let Some((last, leading)) = stmts.split_last() else {
+            return self.unsupported_operand(
+                "empty race arm body".to_string(),
+                scope,
+                hir_span(ast::Span { start: 0, end: 0 }),
+                out,
+            );
+        };
+        for (index, stmt) in leading.iter().enumerate() {
+            self.lower_stmt_into(stmt, &stmts[index + 1..], scope, out);
+        }
+        match &last.node {
+            ast::Statement::Expr(expr) => self.lower_expr_to_operand(expr, scope, out),
+            _ => {
+                self.lower_stmt_into(last, &[], scope, out);
+                self.unsupported_operand(
+                    "race arm body whose last statement produces no value".to_string(),
+                    scope,
+                    hir_span(last.span),
+                    out,
+                )
+            }
+        }
     }
 
     // ---- Closures and partial callables (#1101 bucket B4) ----
@@ -7400,6 +7573,266 @@ mod tests {
             "lowering must name the unresolvable parameter rather than accepting it silently: {snapshot}"
         );
         Ok(())
+    }
+
+    // ========================================================================
+    // #1164 -- `await` and `race for`
+    // ========================================================================
+
+    const ASYNC_PRELUDE: &str =
+        "import std.async\n\nasync def fast() -> int:\n  return 1\n\nasync def slow() -> int:\n  return 2\n\n";
+
+    #[test]
+    fn lowers_await_as_an_explicit_suspension_point_with_a_destination() -> Result<(), Box<dyn std::error::Error>> {
+        let source = format!("{ASYNC_PRELUDE}async def f() -> int:\n  v = await fast()\n  return v\n");
+        let module = build(&source, &["m", "await_one"])?;
+        let snapshot = module.render_snapshot();
+        assert_eq!(
+            snapshot,
+            build(&source, &["m", "await_one"])?.render_snapshot(),
+            "lowering must be deterministic"
+        );
+
+        assert!(!snapshot.contains("unsupported("), "await must lower: {snapshot}");
+        // The suspension carries a destination and the awaited operand's own ownership fact -- the two facts that
+        // distinguish it from a generator `yield`, which produces outward and has no destination.
+        assert!(
+            snapshot.contains("_1 = await copy(_0, last_use)"),
+            "await must record its destination and the awaited read's ownership fact: {snapshot}"
+        );
+        assert!(
+            !snapshot.contains("yield"),
+            "await must not be represented as a generator yield: {snapshot}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn records_the_async_runtime_requirement_on_the_awaiting_body() -> Result<(), Box<dyn std::error::Error>> {
+        let source = format!("{ASYNC_PRELUDE}async def f() -> int:\n  return await fast()\n");
+        let module = build(&source, &["m", "await_req"])?;
+        let snapshot = module.render_snapshot();
+
+        assert!(
+            snapshot.contains("async_runtime"),
+            "an awaiting body must record its async runtime requirement: {snapshot}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn an_async_body_without_any_await_is_still_marked_async() -> Result<(), Box<dyn std::error::Error>> {
+        // The reason `is_async` is a stored declaration fact rather than derived the way `is_generator` is: this
+        // body contains no `await` at all, yet its caller still gets an awaitable. Deriving async-ness by scanning
+        // for a suspension point would report this body as synchronous.
+        let source = "import std.async\n\nasync def f() -> int:\n  return 1\n";
+        let module = build(source, &["m", "async_plain"])?;
+        let snapshot = module.render_snapshot();
+
+        assert!(
+            snapshot.contains("body async f"),
+            "an `async def` with no await must still be marked async: {snapshot}"
+        );
+        assert!(
+            !snapshot.contains("await "),
+            "this body genuinely contains no suspension point, so the async fact cannot have been derived from one: {snapshot}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn a_synchronous_body_is_not_marked_async() -> Result<(), Box<dyn std::error::Error>> {
+        let module = build("def f() -> int:\n  return 1\n", &["m", "sync"])?;
+        let snapshot = module.render_snapshot();
+
+        assert!(
+            snapshot.contains("body f "),
+            "a plain function must render unmarked: {snapshot}"
+        );
+        assert!(
+            !snapshot.contains("body async"),
+            "a synchronous body must not be marked async: {snapshot}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn sequential_awaits_keep_their_effect_ordering_across_suspension() -> Result<(), Box<dyn std::error::Error>> {
+        let source =
+            format!("{ASYNC_PRELUDE}async def f() -> int:\n  x = await fast()\n  y = await slow()\n  return x + y\n");
+        let module = build(&source, &["m", "await_seq"])?;
+        let rendered = body_named(&module, "f")?.render_snapshot();
+
+        assert!(!rendered.contains("unsupported("), "both awaits must lower: {rendered}");
+        let first = rendered.find("call fn:fast(").ok_or("missing first awaitable")?;
+        let first_await = rendered.find("await ").ok_or("missing first suspension")?;
+        let second = rendered.find("call fn:slow(").ok_or("missing second awaitable")?;
+        assert!(
+            first < first_await && first_await < second,
+            "statements before a suspension must precede it and statements after must follow it: {rendered}"
+        );
+        assert_eq!(
+            rendered.matches("await ").count(),
+            2,
+            "each source `await` must produce its own suspension point: {rendered}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn await_inside_a_branch_stays_inside_that_branch() -> Result<(), Box<dyn std::error::Error>> {
+        let source = format!(
+            "{ASYNC_PRELUDE}async def f(flag: bool) -> int:\n  total = 0\n  if flag:\n    total = await fast()\n  else:\n    total = 7\n  return total\n"
+        );
+        let module = build(&source, &["m", "await_branch"])?;
+        let rendered = body_named(&module, "f")?.render_snapshot();
+
+        assert!(
+            !rendered.contains("unsupported("),
+            "await in a branch must lower: {rendered}"
+        );
+        let branch_line = rendered
+            .lines()
+            .find(|line| line.contains("await "))
+            .ok_or("missing suspension")?;
+        assert!(
+            branch_line.starts_with("    "),
+            "the suspension must stay nested inside the branch block: {rendered}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn await_inside_a_loop_stays_inside_the_loop_body() -> Result<(), Box<dyn std::error::Error>> {
+        let source = format!(
+            "{ASYNC_PRELUDE}async def f() -> int:\n  total = 0\n  i = 0\n  while i < 3:\n    total = total + await fast()\n    i = i + 1\n  return total\n"
+        );
+        let module = build(&source, &["m", "await_loop"])?;
+        let rendered = body_named(&module, "f")?.render_snapshot();
+
+        assert!(
+            !rendered.contains("unsupported("),
+            "await in a loop must lower: {rendered}"
+        );
+        let await_line = rendered
+            .lines()
+            .find(|line| line.contains("await "))
+            .ok_or("missing suspension")?;
+        assert!(
+            await_line.starts_with("    "),
+            "the suspension must stay inside the loop body: {rendered}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn lowers_a_two_arm_race_with_per_arm_bindings_and_pre_selection_awaitables()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let source = format!(
+            "{ASYNC_PRELUDE}async def f() -> int:\n  race for value:\n    await fast() => value\n    await slow() => value\n"
+        );
+        let module = build(&source, &["m", "race_two"])?;
+        let rendered = body_named(&module, "f")?.render_snapshot();
+
+        assert!(
+            !rendered.contains("unsupported("),
+            "a two-arm race must lower: {rendered}"
+        );
+        // Every awaitable is evaluated before selection, in source order -- observable here as both calls being
+        // emitted ahead of the race statement rather than inside an arm.
+        let fast_at = rendered.find("call fn:fast(").ok_or("missing first awaitable")?;
+        let slow_at = rendered.find("call fn:slow(").ok_or("missing second awaitable")?;
+        let race_at = rendered.find("race [").ok_or("missing race statement")?;
+        assert!(
+            fast_at < slow_at && slow_at < race_at,
+            "all arm awaitables must be evaluated, in source order, before selection: {rendered}"
+        );
+        // The source spells one binding name, but each arm re-scopes it, so each arm owns its own local.
+        assert_eq!(
+            rendered.matches("value : int [binding]").count(),
+            2,
+            "each arm must bind its own local rather than sharing one: {rendered}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn a_race_arm_block_body_lowers_its_statements_and_trailing_value() -> Result<(), Box<dyn std::error::Error>> {
+        let source = format!(
+            "{ASYNC_PRELUDE}async def f() -> int:\n  race for value:\n    await fast() => value\n    await slow() =>\n      doubled = value * 2\n      doubled\n"
+        );
+        let module = build(&source, &["m", "race_block"])?;
+        let rendered = body_named(&module, "f")?.render_snapshot();
+
+        assert!(
+            !rendered.contains("unsupported("),
+            "a block arm body must lower: {rendered}"
+        );
+        // The block arm's statements live inside that arm, not in the enclosing body: only the winning arm runs.
+        let race_line = rendered
+            .lines()
+            .find(|line| line.contains("race ["))
+            .ok_or("missing race statement")?;
+        assert!(
+            race_line.contains("* const(2)"),
+            "the arm body's own computation must stay inside the arm: {race_line}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn an_unsupported_construct_in_a_race_arm_does_not_collapse_the_whole_race()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // The issue's explicit requirement: a construct Body IR cannot represent keeps its own node *inside* a
+        // represented race, so a consumer loses only that construct rather than the entire expression.
+        let source = format!(
+            "{ASYNC_PRELUDE}async def f() -> int:\n  race for value:\n    await fast() => value\n    await slow() => value ** 2\n"
+        );
+        let module = build(&source, &["m", "race_partial"])?;
+        let rendered = body_named(&module, "f")?.render_snapshot();
+
+        assert!(
+            rendered.contains("race ["),
+            "the race itself must still be represented: {rendered}"
+        );
+        assert!(
+            rendered.contains("unsupported("),
+            "the unrepresentable arm construct must keep its own node: {rendered}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn a_prefix_surface_keyword_that_is_not_await_is_refused_rather_than_treated_as_a_suspension() {
+        // `SurfaceExprPayload::PrefixUnary` is generic over any prefix soft keyword; `await` is merely the only one
+        // registered today. Dispatching on the payload alone would silently lower a future prefix keyword as a
+        // suspension point, so lowering matches the surface *key*. This pins that.
+        let type_info = TypeCheckInfo::default();
+        let mut builder = BodyBuilder::new(&type_info);
+        let scope = builder.new_scope(None, HirSourceSpan::new(0, 1));
+        let mut out = Vec::new();
+        let surface = ast::SurfaceExpr {
+            key: SurfaceFeatureKey::SoftKeyword(KeywordId::Async),
+            payload: ast::SurfaceExprPayload::PrefixUnary(Box::new(ast::Spanned::new(
+                ast::Expr::Ident("placeholder".to_string()),
+                ast::Span::new(0, 1),
+            ))),
+        };
+
+        let _ = builder.lower_surface_expr(&surface, ast::Span::new(0, 1), scope, &mut out);
+
+        assert!(
+            out.iter().any(|stmt| matches!(
+                &stmt.kind,
+                bir::StatementKind::Unsupported { description } if description.contains("prefix-keyword")
+            )),
+            "a non-`await` prefix keyword must keep the generic surface refusal, not become an await: {out:?}"
+        );
+        assert!(
+            !out.iter()
+                .any(|stmt| matches!(&stmt.kind, bir::StatementKind::Await { .. })),
+            "no suspension point may be emitted for a keyword that is not `await`: {out:?}"
+        );
     }
 }
 

--- a/src/frontend/body_ir.rs
+++ b/src/frontend/body_ir.rs
@@ -7804,23 +7804,20 @@ mod tests {
 
     #[test]
     fn a_block_arm_local_does_not_leak_past_its_arm() -> Result<(), Box<dyn std::error::Error>> {
-        // A block arm lowers ordinary statements, so `total = ...` inside it declares a local through the same path
-        // any assignment uses. Restoring only the shared race binding would leave that arm-local installed, and the
-        // trailing read of `total` would silently resolve to it instead of the outer binding -- a wrong value with
-        // no unsupported node to show for it.
+        // A block arm lowers ordinary statements, so `let total = ...` inside it declares a lexical local through
+        // the same path any assignment uses. Restoring only the shared race binding would leave that arm-local
+        // installed, and the trailing read of `total` would silently resolve to it instead of the outer binding --
+        // a wrong value with no unsupported node to show for it.
         let source = format!(
-            "{ASYNC_PRELUDE}async def f() -> int:\n  total = 100\n  winner = race for value:\n    await fast() => value\n    await slow() =>\n      total = value * 2\n      total\n  return total + winner\n"
+            "{ASYNC_PRELUDE}async def f() -> int:\n  let total = 100\n  winner = race for value:\n    await fast() => value\n    await slow() =>\n      let total = value * 2\n      total\n  return total + winner\n"
         );
         let module = build(&source, &["m", "race_arm_local"])?;
         let body = body_named(&module, "f")?;
         let rendered = body.render_snapshot();
 
-        // `total` is declared first, so the outer binding is local 0; the arm declares its own `total` separately.
+        // The outer binding is distinct from the arm's `total`, and the post-race expression must use that outer
+        // local regardless of earlier parameters or temporaries that might affect local numbering.
         let outer = local_for_binding(&rendered, "total").ok_or("missing outer binding")?;
-        assert_eq!(
-            outer, "_0",
-            "the outer binding should be the first declared local: {rendered}"
-        );
         assert!(
             rendered.matches("total : int [binding]").count() >= 2,
             "the arm must declare its own `total` rather than reusing the outer one: {rendered}"
@@ -7830,7 +7827,7 @@ mod tests {
             .find(|line| line.contains(" + ") && !line.starts_with("      "))
             .ok_or("missing the trailing sum")?;
         assert!(
-            sum_line.contains("copy(_0)"),
+            sum_line.contains(&format!("copy({outer})")),
             "a read after the race must resolve to the enclosing local, not one an arm body declared: {rendered}"
         );
         Ok(())

--- a/src/frontend/body_ir.rs
+++ b/src/frontend/body_ir.rs
@@ -3203,7 +3203,15 @@ impl<'a> BodyBuilder<'a> {
             (SurfaceFeatureKey::SoftKeyword(KeywordId::Await), ast::SurfaceExprPayload::PrefixUnary(awaited)) => {
                 self.lower_await(awaited, span, scope, out)
             }
-            (_, ast::SurfaceExprPayload::RaceFor(race)) => self.lower_race_for(race, span, scope, out),
+            (
+                SurfaceFeatureKey::ScopedDslSurface {
+                    dependency_key,
+                    descriptor_key,
+                },
+                ast::SurfaceExprPayload::RaceFor(race),
+            ) if dependency_key == "std.async" && descriptor_key == "race_for" => {
+                self.lower_race_for(race, span, scope, out)
+            }
             (_, payload) => self.unsupported_operand(surface_expr_label(payload), scope, hir_span(span), out),
         }
     }
@@ -3255,7 +3263,6 @@ impl<'a> BodyBuilder<'a> {
         out: &mut Vec<bir::Statement>,
     ) -> bir::Operand {
         let hir_span_value = hir_span(span);
-        self.record_runtime_requirement(AbiV0RuntimeRequirement::AsyncRuntime);
 
         // Selection observes every awaitable, so all of them are evaluated first, in source order, into the
         // enclosing block. Only the winning arm's body runs, so arm bodies are lowered into their own blocks below.
@@ -3263,19 +3270,36 @@ impl<'a> BodyBuilder<'a> {
         for arm in &race.arms {
             awaitables.push(self.lower_expr_to_operand(&arm.awaitable, scope, out));
         }
+        self.record_runtime_requirement(AbiV0RuntimeRequirement::AsyncRuntime);
 
         let mut arms = Vec::with_capacity(race.arms.len());
         for (arm, awaitable) in race.arms.iter().zip(awaitables) {
             let arm_scope = self.new_scope(Some(scope), hir_span_value);
-            let binding_ty = self.resolve_ty(arm.awaitable.span);
-            let binding = self.declare_new_local(race.binding.clone(), binding_ty, arm_scope, hir_span_value, &[]);
-            let shadowed = self.bindings.insert(race.binding.clone(), binding);
+            // The arm binds the *awaited output* type, which only the typechecker computes: `Awaitable[T]` binds
+            // `T`, `JoinHandle[T]` binds `Result[T, TaskJoinError]`. The awaitable's own type would be wrong.
+            let binding_ty = self
+                .type_info
+                .race_arm_binding_type(arm.awaitable.span)
+                .map(semantic_type_from_resolved)
+                .unwrap_or(IncanType::Unknown);
+            // Capture the enclosing binding *before* declaring: `declare_new_local` installs the new local itself,
+            // so reading `self.bindings` afterwards would capture the arm's own local and destroy the outer one.
+            let shadowed = self.bindings.get(&race.binding).copied();
+            let reads = match &arm.body {
+                ast::RaceForBody::Expr(expr) => count_reads_in_expr(&race.binding, &expr.node),
+                ast::RaceForBody::Block(stmts) => count_reads_in_stmts(&race.binding, stmts),
+            };
+            let binding =
+                self.declare_new_local_with_reads(race.binding.clone(), binding_ty, arm_scope, hir_span_value, reads);
 
             let mut arm_stmts = Vec::new();
             let result = match &arm.body {
                 ast::RaceForBody::Expr(expr) => self.lower_expr_to_operand(expr, arm_scope, &mut arm_stmts),
-                ast::RaceForBody::Block(stmts) => self.lower_race_arm_block(stmts, arm_scope, &mut arm_stmts),
+                ast::RaceForBody::Block(stmts) => {
+                    self.lower_race_arm_block(stmts, arm.awaitable.span, arm_scope, &mut arm_stmts)
+                }
             };
+            self.insert_scope_drops(&mut arm_stmts, arm_scope);
 
             // The arm binding is scoped to its own arm, exactly like a closure parameter: code after the race must
             // keep resolving the name to whatever it meant outside.
@@ -3313,22 +3337,20 @@ impl<'a> BodyBuilder<'a> {
 
     /// Lower a race arm's block body, whose value is its trailing expression statement.
     ///
-    /// That trailing-expression convention is the source contract the typechecker already applies
-    /// (`check_race_arm_block_body`), so lowering follows it rather than inventing a second rule. A block whose last
-    /// statement is not an expression has no value to produce, and yields an explicit unknown operand.
+    /// That trailing-expression convention is the source contract the typechecker already applies, so lowering
+    /// matches `check_race_arm_block_body` exactly, including its two non-expression cases: an empty block and a
+    /// block whose last statement is not an expression both produce `Unit`, the same type the checker assigns them.
+    /// Refusing either would make a program the source language accepts unrepresentable, and the established
+    /// precedent for a valueless block arm is [`Self::lower_match`]'s own block body.
     fn lower_race_arm_block(
         &mut self,
         stmts: &[ast::Spanned<ast::Statement>],
+        arm_span: ast::Span,
         scope: bir::ScopeId,
         out: &mut Vec<bir::Statement>,
     ) -> bir::Operand {
         let Some((last, leading)) = stmts.split_last() else {
-            return self.unsupported_operand(
-                "empty race arm body".to_string(),
-                scope,
-                hir_span(ast::Span { start: 0, end: 0 }),
-                out,
-            );
+            return bir::Operand::Constant(bir::Constant::Unit);
         };
         for (index, stmt) in leading.iter().enumerate() {
             self.lower_stmt_into(stmt, &stmts[index + 1..], scope, out);
@@ -3336,13 +3358,9 @@ impl<'a> BodyBuilder<'a> {
         match &last.node {
             ast::Statement::Expr(expr) => self.lower_expr_to_operand(expr, scope, out),
             _ => {
+                let _ = arm_span;
                 self.lower_stmt_into(last, &[], scope, out);
-                self.unsupported_operand(
-                    "race arm body whose last statement produces no value".to_string(),
-                    scope,
-                    hir_span(last.span),
-                    out,
-                )
+                bir::Operand::Constant(bir::Constant::Unit)
             }
         }
     }
@@ -7611,11 +7629,11 @@ mod tests {
     fn records_the_async_runtime_requirement_on_the_awaiting_body() -> Result<(), Box<dyn std::error::Error>> {
         let source = format!("{ASYNC_PRELUDE}async def f() -> int:\n  return await fast()\n");
         let module = build(&source, &["m", "await_req"])?;
-        let snapshot = module.render_snapshot();
+        let rendered = body_named(&module, "f")?.render_snapshot();
 
         assert!(
-            snapshot.contains("async_runtime"),
-            "an awaiting body must record its async runtime requirement: {snapshot}"
+            rendered.contains("async_runtime"),
+            "the requirement must be recorded on the awaiting body itself, not merely somewhere in the module: {rendered}"
         );
         Ok(())
     }
@@ -7742,7 +7760,7 @@ mod tests {
         // emitted ahead of the race statement rather than inside an arm.
         let fast_at = rendered.find("call fn:fast(").ok_or("missing first awaitable")?;
         let slow_at = rendered.find("call fn:slow(").ok_or("missing second awaitable")?;
-        let race_at = rendered.find("race [").ok_or("missing race statement")?;
+        let race_at = rendered.find("race:").ok_or("missing race statement")?;
         assert!(
             fast_at < slow_at && slow_at < race_at,
             "all arm awaitables must be evaluated, in source order, before selection: {rendered}"
@@ -7752,6 +7770,35 @@ mod tests {
             rendered.matches("value : int [binding]").count(),
             2,
             "each arm must bind its own local rather than sharing one: {rendered}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn a_race_arm_binding_does_not_escape_its_arm() -> Result<(), Box<dyn std::error::Error>> {
+        // The arm binding shadows an enclosing name only for the duration of its own arm. Restoring it is the same
+        // discipline `lower_closure` follows, and getting it wrong is silent: reads after the race would resolve to
+        // the last arm's local, so the body would compute the wrong value with no unsupported node to show for it.
+        let source = format!(
+            "{ASYNC_PRELUDE}async def f() -> int:\n  value = 100\n  winner = race for value:\n    await fast() => value\n    await slow() => value\n  return value + winner\n"
+        );
+        let module = build(&source, &["m", "race_shadow"])?;
+        let body = body_named(&module, "f")?;
+        let rendered = body.render_snapshot();
+
+        // `value` is declared first, so it is local 0; the trailing `value + winner` must read exactly that local.
+        let outer = local_for_binding(&rendered, "value").ok_or("missing outer binding")?;
+        assert_eq!(
+            outer, "_0",
+            "the outer binding should be the first declared local: {rendered}"
+        );
+        let sum_line = rendered
+            .lines()
+            .find(|line| line.contains(" + "))
+            .ok_or("missing the trailing sum")?;
+        assert!(
+            sum_line.contains("copy(_0)"),
+            "a read after the race must resolve to the enclosing binding, not an arm local: {rendered}"
         );
         Ok(())
     }
@@ -7768,14 +7815,20 @@ mod tests {
             !rendered.contains("unsupported("),
             "a block arm body must lower: {rendered}"
         );
-        // The block arm's statements live inside that arm, not in the enclosing body: only the winning arm runs.
-        let race_line = rendered
+        // The arm body's statements live inside the arm, indented under it -- only the winning arm runs, so they
+        // must not be hoisted into the enclosing block alongside the awaitables.
+        let arm_stmt = rendered
             .lines()
-            .find(|line| line.contains("race ["))
-            .ok_or("missing race statement")?;
+            .find(|line| line.contains("* const(2)"))
+            .ok_or("missing the arm body computation")?;
         assert!(
-            race_line.contains("* const(2)"),
-            "the arm body's own computation must stay inside the arm: {race_line}"
+            arm_stmt.starts_with("      "),
+            "an arm body statement must stay nested inside its arm: {rendered}"
+        );
+        // The block's trailing expression becomes the arm's result, not merely a statement inside it.
+        assert!(
+            rendered.contains("-> copy(_5)"),
+            "the block's trailing expression must become the arm's result operand: {rendered}"
         );
         Ok(())
     }
@@ -7792,12 +7845,31 @@ mod tests {
         let rendered = body_named(&module, "f")?.render_snapshot();
 
         assert!(
-            rendered.contains("race ["),
+            rendered.contains("race:"),
             "the race itself must still be represented: {rendered}"
         );
+        // Asserting the node exists somewhere in the body would also pass if it had been hoisted into the enclosing
+        // block -- the exact regression this test exists to catch -- so require it to be indented inside an arm.
+        let refusal = rendered
+            .lines()
+            .find(|line| line.contains("unsupported("))
+            .ok_or("missing the refusal for the unrepresentable arm construct")?;
         assert!(
-            rendered.contains("unsupported("),
-            "the unrepresentable arm construct must keep its own node: {rendered}"
+            refusal.starts_with("      "),
+            "the refusal must stay inside its arm rather than collapsing or escaping the race: {rendered}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn an_async_method_body_is_marked_async() -> Result<(), Box<dyn std::error::Error>> {
+        let source = "import std.async\n\nclass C:\n  async def m(self) -> int:\n    return 1\n";
+        let module = build(source, &["m", "async_method"])?;
+        let snapshot = module.render_snapshot();
+
+        assert!(
+            snapshot.contains("body async m"),
+            "an async method body must carry the same async fact as an async function: {snapshot}"
         );
         Ok(())
     }

--- a/src/frontend/typechecker/check_expr/control_flow.rs
+++ b/src/frontend/typechecker/check_expr/control_flow.rs
@@ -238,6 +238,9 @@ impl TypeChecker {
                 arm_body_types.push(ResolvedType::Unknown);
                 continue;
             };
+            // Body IR lowering consumes this instead of re-deriving the unwrap from the awaitable's own type.
+            self.type_info
+                .record_race_arm_binding_type(arm.awaitable.span, binding_ty.clone());
             arm_body_types.push(self.check_race_arm_body(&race.binding, binding_ty, &arm.body));
         }
 

--- a/src/frontend/typechecker/type_info.rs
+++ b/src/frontend/typechecker/type_info.rs
@@ -1064,6 +1064,13 @@ pub struct CallArtifacts {
     /// Function-value calls can recover this from the callee expression type, but method calls need a snapshot because
     /// lowering does not retain the frontend method table.
     pub call_site_callable_params: HashMap<(usize, usize), Vec<CallableParam>>,
+    /// Resolved winner-binding type for one `race for` arm, keyed by that arm's awaitable expression span (#1164).
+    ///
+    /// A race arm binds the shared `race for value:` name to the *awaited output* type, not to the awaitable's own
+    /// type: `Awaitable[T]` binds `T`, and `JoinHandle[T]` binds `Result[T, TaskJoinError]`. Only the typechecker
+    /// performs that unwrapping (`await_output_type`), and the arm binding has no `await X` expression span of its
+    /// own for lowering to look up, so the decision is recorded here instead of being re-derived.
+    pub race_arm_binding_types: HashMap<(usize, usize), ResolvedType>,
     /// Resolved `model`/`class` construction field binding, keyed by full call expression span (#1158).
     ///
     /// Source-level construction is named-only, so the constructor check is the stage that decides which declared
@@ -1704,6 +1711,16 @@ impl TypeCheckInfo {
             .call_site_callable_params
             .get(&(span.start, span.end))
             .map(Vec::as_slice)
+    }
+
+    /// Return the resolved winner-binding type for the `race for` arm whose awaitable is at `span` (#1164).
+    pub fn race_arm_binding_type(&self, span: Span) -> Option<&ResolvedType> {
+        self.calls.race_arm_binding_types.get(&(span.start, span.end))
+    }
+
+    /// Record the resolved winner-binding type for one `race for` arm (#1164).
+    pub(crate) fn record_race_arm_binding_type(&mut self, span: Span, ty: ResolvedType) {
+        self.calls.race_arm_binding_types.insert((span.start, span.end), ty);
     }
 
     /// Return the resolved `model`/`class` construction field binding recorded for `span`, if any (#1158).

--- a/tests/parity_corpus_tests.rs
+++ b/tests/parity_corpus_tests.rs
@@ -326,6 +326,60 @@ fn case_supported_named_call_arguments_reach_body_ir() -> ComparisonOutcome {
 }
 
 // ============================================================================
+// Cases 10 and 11 — Supported language contract: async surface reaches Body IR (#1164)
+// ============================================================================
+
+// `AsyncAwait` is a public capability in the release-pinned baseline. Before #1164 an `await` lowered to a
+// placeholder labelled only "prefix-keyword surface expression", so the suspension point — the one fact a task
+// runtime needs — did not exist in Body IR at all. The cutover must keep both the source form and its
+// representation, including the body-level async fact for a body that awaits nothing.
+const CASE_10_SRC: &str = r#"
+import std.async
+
+async def fetch() -> int:
+    return 7
+
+async def main() -> None:
+    value = await fetch()
+    println(value)
+"#;
+
+fn case_supported_await_reaches_body_ir() -> ComparisonOutcome {
+    outcome_from_body_ir(
+        CASE_10_SRC,
+        "`await` to lower to a real Body IR suspension point rather than an unsupported placeholder",
+    )
+}
+
+// `AsyncRace` collapsed even harder: the whole `race for` expression became one placeholder, erasing every arm,
+// arm body, and the shared binding. Both arm forms — a bare expression and a block with a trailing value — are
+// part of the source contract.
+const CASE_11_SRC: &str = r#"
+import std.async
+
+async def fast() -> int:
+    return 1
+
+async def slow() -> int:
+    return 2
+
+async def main() -> None:
+    winner = race for value:
+        await fast() => value
+        await slow() =>
+            doubled = value * 2
+            doubled
+    println(winner)
+"#;
+
+fn case_supported_race_for_reaches_body_ir() -> ComparisonOutcome {
+    outcome_from_body_ir(
+        CASE_11_SRC,
+        "`race for` to lower to a real Body IR race with its arms, arm bodies, and bindings intact",
+    )
+}
+
+// ============================================================================
 // Case 6 — Diagnostic behavior: dead code after `return` warns (migrated from a silent accept)
 // ============================================================================
 
@@ -625,6 +679,28 @@ fn seed_corpus() -> Vec<ParityCase> {
             disposition: Disposition::Preserved,
             source: CASE_9_SRC,
             evaluate: Some(case_supported_named_call_arguments_reach_body_ir),
+            replacement_execution: None,
+        },
+        ParityCase {
+            id: "parity-987-0010",
+            title: "`await` lowers to a Body IR suspension point with a destination",
+            category: BehaviorCategory::SupportedLanguageContract,
+            lane: EvidenceLane::DirectParserTypechecker,
+            evidence: "#1164; src/frontend/body_ir.rs::tests::lowers_await_as_an_explicit_suspension_point_with_a_destination",
+            disposition: Disposition::Preserved,
+            source: CASE_10_SRC,
+            evaluate: Some(case_supported_await_reaches_body_ir),
+            replacement_execution: None,
+        },
+        ParityCase {
+            id: "parity-987-0011",
+            title: "`race for` lowers to a Body IR race with per-arm bindings and bodies",
+            category: BehaviorCategory::SupportedLanguageContract,
+            lane: EvidenceLane::DirectParserTypechecker,
+            evidence: "#1164; src/frontend/body_ir.rs::tests::lowers_a_two_arm_race_with_per_arm_bindings_and_pre_selection_awaitables",
+            disposition: Disposition::Preserved,
+            source: CASE_11_SRC,
+            evaluate: Some(case_supported_race_for_reaches_body_ir),
             replacement_execution: None,
         },
         ParityCase {


### PR DESCRIPTION
## Summary

Body IR had no async vocabulary. `await expr` and `race for value:` both fell to the expression catch-all and lowered to a placeholder. `race for` was worse than incomplete: the whole expression collapsed into a single node, erasing every arm, arm body, and the shared binding. #1155 owns async execution and cannot execute what is not represented, so representation lands first.

Closes #1164.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [x] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

### User-facing behavior

None. This is a compiler-internal representation change; no source-language rule moves and no generated Rust changes (220 codegen snapshots pass with zero drift).

### Internals

**`await` is its own suspension statement, never `Yield`.** It carries a destination place and the awaited operand's ownership fact. A generator `yield` produces a value outward and has no destination; an `await` consumes an awaitable and writes one. Separate variants keep the two contracts non-interchangeable at the type level — sharing a node would make them indistinguishable, which the issue rejects explicitly.

**`race for` carries per-arm awaitables, bindings, bodies, and results.** Its contract is stated rather than left implicit in arm order: every awaitable is evaluated before selection, in source order (structurally realized — all awaitables are emitted into the enclosing block ahead of the race statement); arm order carries no priority; exactly one arm's body runs; every non-winning arm's awaitable is cancelled at the statement boundary. Each arm owns its own binding local, because the source spells one shared name that arms re-scope and may resolve to different types.

**`is_async` is a stored `Body` field, deliberately unlike the derived `is_generator` beside it.** An `async def` with no `await` is still async and its caller still gets an awaitable, so deriving async-ness by scanning for a suspension point would be wrong rather than merely different. A test pins that exact body. This is the first declaration-level fact `Body` carries, and the divergence is documented at both sites.

**Dispatch is on the surface key, not the payload shape.** `SurfaceExprPayload::PrefixUnary` is generic over any prefix soft keyword and `await` merely happens to be the only one registered today, so matching the payload alone would silently lower a future prefix keyword as a suspension point. A test constructs a non-`await` prefix key and asserts no suspension is emitted. The three scoped-DSL payloads keep their existing named refusals.

**One new typechecker fact.** A race arm binds the *awaited output* type — `Awaitable[T]` binds `T`, `JoinHandle[T]` binds `Result[T, TaskJoinError]`. Only the typechecker performs that unwrap, and the arm binding has no `await X` span for lowering to look up, so `check_race_for` records the resolved per-arm binding type and lowering consumes it instead of re-deriving it.

### Executor compatibility

Extending the statement vocabulary broke two exhaustive matches in `src/backend/replacement/mod.rs`. Both gain an explicit refusal by name at the original source span, mirroring that file's existing `generator yield` precedent, plus one label arm for the new runtime requirement. Nine lines, all refusal or label — **no behavior**.

That file is otherwise the replacement-runtime lane's. This is compatibility maintenance for the vocabulary this issue introduces, not an implementation of #1155. Task/frame state, suspension and local save/restore, wake/resume routing, concurrent arm polling, first-completion detection, and cancellation all remain #1155's and are untouched; `ReplacementValue` is unchanged.

### Risks

`StatementKind` gained two variants. Only three files in the repo match on it, all accounted for. `Body` gained a field; nothing outside the two owning files constructs `Body`. The race arm snapshot rendering is new, so any future line-based consumer of a race sees a nested block rather than a flattened line.

## Testing / verification

- [x] `cargo test` (focused — see below)
- [ ] `make examples` (not relevant: no emission path changes)
- [ ] `incan fmt --check .` (not relevant: no `.incn` changes)
- [x] Manual verification described below

| Gate | Result |
| --- | --- |
| `cargo test -p incan --lib frontend::` | 1151 passed / 0 failed (14 new) |
| `cargo test -p incan_semantics_core` | 38 passed / 0 failed |
| `cargo test --test parity_corpus_tests` | 9 passed / 0 failed |
| `cargo test --test replacement_backend_execution_tests` | 23 passed / 0 failed |
| `cargo test --test codegen_snapshot_tests` | 220 passed, **zero drift** |
| `cargo check -p incan --all-targets` | clean |
| `cargo clippy -p incan -p incan_semantics_core --all-targets` | no new warnings |
| `make fmt-check` | clean |
| `scripts/check_changed_rustdocs.py` | passed |

Representation is proved with direct `build_body_ir_module_v0` probes asserted on `render_snapshot()`. The two new #987 rows were mutation-checked — breaking a case source turns the corpus red — to confirm they execute rather than passing vacuously.

**Deferred gates**, per the maintainer's standing instruction that the expensive shared Oven/CI gate belongs to Slice-level integration rather than each PR: `make pre-commit`, `make smoke-tests` / full Oven CI.

**Pre-existing, not from this change:** `cargo clippy` reports 4 warnings in `src/replacement_compatibility.rs`, a file this PR never touches.

## Review record

An independent review of the first commit found a blocker and five majors, all fixed in `ee520f0b0` before this PR opened:

- **Blocker** — the race arm binding permanently destroyed any enclosing binding of the same name, because the shadowed binding was captured *after* `declare_new_local` had already installed the arm's local. Reads after a `race for` resolved to the last arm's local: wrong results, and in the non-Copy case a double move plus a cross-scope read.
- The arm binding carried the awaitable's type instead of the awaited output type.
- Arm bindings were seeded with zero remaining reads, producing `move(..., last_use)` on every read of a non-Copy binding.
- Race arm scopes emitted no scope-exit drops, unlike every other nested block this file lowers.
- A block arm whose last statement is not an expression lowered to an unsupported node, contradicting both the typechecker and this issue's own criterion.
- The #987 rows below were omitted.

A second review pass found that the fix above restored only the shared race binding: a block arm's own locals stayed installed and leaked past the arm. Fixed in `9ebe800e2`, with a regression confirmed to fail against the binding-only restore.

## Docs impact

- [x] Docs updated (rustdoc)
- [ ] No docs changes needed

Module and item docs in `crates/incan_semantics_core/src/body_ir.rs` and `src/frontend/body_ir.rs`. Three stale or overstated claims from the first commit were corrected rather than left: `is_generator`'s walk description, the `destination: None` case, and the "dispatch on the key" claim (the code now genuinely does it for both arms).

**Deferred:** `workspaces/docs-site/docs/release_notes/0_6.md` — the maintainer holds an in-flight edit to that file in the primary worktree.

## #987 disposition

Adds `parity-987-0010` (`await`) and `parity-987-0011` (`race for`) as `Disposition::Preserved` with `EvidenceLane::DirectParserTypechecker`, both with `replacement_execution: None`.

**What these rows establish.** Each row's `evaluate` function asserts one thing: the source is accepted by the frontend and lowers with no `unsupported(...)` placeholder. That is lowering evidence only. It establishes **neither replacement execution nor comparison parity**, and these rows must not be described as proving either. The `DirectReplacementBodyIr` execution rows belong to #1155. Comparison stays non-green until the owning runtime/execution issue produces paired evidence through the completed comparison route #1146 already delivered — #1146 is finished infrastructure, not the owner of new evidence for these rows.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions
