### PR TITLE
bugfix - repair the lib test target on 0.6-dev

### DIFF
--- a/src/frontend/body_ir.rs
+++ b/src/frontend/body_ir.rs
@@ -6361,7 +6361,7 @@ mod tests {
         // A source default can construct a closure or generator, or evaluate a match, whose structured Body IR owns
         // more statements than the outer assignment exposes. Those statement sequences are still part of the direct
         // default contract: a consumer must receive their original refusal span instead of a misleading `Source`.
-        let unsupported = |span, description| bir::Statement {
+        let unsupported = |span: HirSourceSpan, description: &str| bir::Statement {
             kind: bir::StatementKind::Unsupported {
                 description: description.to_string(),
             },
@@ -6481,7 +6481,7 @@ mod tests {
         let second = choose
             .locals
             .iter()
-            .find(|local| local.name == "second")
+            .find(|local| local.name.as_deref() == Some("second"))
             .ok_or("expected second binding after refused default")?;
         assert!(
             choose.block.stmts.iter().any(|statement| matches!(
@@ -8773,7 +8773,8 @@ mod tests {
         // registered today. Dispatching on the payload alone would silently lower a future prefix keyword as a
         // suspension point, so lowering matches the surface *key*. This pins that.
         let type_info = TypeCheckInfo::default();
-        let mut builder = BodyBuilder::new(&type_info);
+        let default_sources = FunctionDefaultSources::new();
+        let mut builder = BodyBuilder::new(&type_info, &default_sources);
         let scope = builder.new_scope(None, HirSourceSpan::new(0, 1));
         let mut out = Vec::new();
         let surface = ast::SurfaceExpr {


### PR DESCRIPTION
## Summary

`cargo check -p incan --all-targets` does not compile on `0.6-dev`. Three call sites in `src/frontend/body_ir.rs`'s test module were left behind by changes to the code they exercise, so the lib test target fails to build.

This blocks more than `--all-targets`: `cargo test --lib <filter>` builds the whole test target too, so every filtered test run on the branch is currently red.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [x] Compiler (frontend/backend/codegen)

## Key details

- **User-facing behavior**: none. Test-side call sites only; no production code touched.
- **Internals**: three mechanical repairs —
  - `BodyBuilder::new` gained a second `FunctionDefaultSources` parameter; one caller still passed a single argument. The test lowers no partial callables, so an empty map is the correct stand-in.
  - `LocalDecl::name` became `Option<String>`; a test still compared it against a `&str`. Now compared through `as_deref`.
  - A test closure's parameter types are no longer inferable and need explicit annotations.
- **Risks**: none — no behaviour change.

## How this happened

Two of the three sites are in tests added by #1164. The signature change to `BodyBuilder::new` and the type change to `LocalDecl::name` landed afterwards and updated the library without updating those tests. A filtered `cargo test --lib` on an unrelated module would not have surfaced it, since the failure is at build time for the whole target rather than in any one test.

Worth considering whether the local gate should include `cargo check --all-targets`, which would have caught this at the point of change.

## Testing / verification

- [x] `cargo check -p incan --all-targets` — 0 errors (was 3)
- [x] `cargo test -p incan --lib frontend::body_ir` — 134 passed
- [x] `make fmt-check` clean

Full Oven/CI gate intentionally deferred to slice-level integration, per the standing arrangement for this lane.

## Docs impact

- [x] No docs changes needed

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions