### PR TITLE
feature - establish RFC 120 canonical symbol identity and carry it into Body IR (#1210)

### DIFF
--- a/crates/incan_semantics_core/src/body_ir.rs
+++ b/crates/incan_semantics_core/src/body_ir.rs
@@ -41,7 +41,9 @@
 
 use std::fmt::Write as _;
 
-use crate::{AbiV0RuntimeRequirement, CompilerNodeId, HirSourceSpan, IncanType};
+use crate::{
+    AbiV0RuntimeRequirement, CanonicalSymbolId, CompilerNodeId, HirSourceSpan, IncanType, module_identity_for_path,
+};
 
 // ============================================================================
 // Module / body containers
@@ -80,6 +82,26 @@ pub struct BodyIrModule {
 }
 
 impl BodyIrModule {
+    /// Resolve a canonical callable identity to the body that declares it, when this module owns the declaration.
+    ///
+    /// This is the consumer seam for [`CanonicalSymbolId`]: a backend asks *which declaration was selected* and gets
+    /// the declaration itself or nothing. It never consults the *reference site's* spelling or an emitted Rust name,
+    /// so a consumer cannot dispatch on the text at a call site.
+    ///
+    /// Matching is on the declaration span, which is unique within a module. The declared name deliberately does not
+    /// participate: bodies do not carry owner-qualified names, so a class method and a free function in one module can
+    /// both be named `render`, and a name match would hand back whichever came first.
+    ///
+    /// `None` has three distinct causes and is never permission to fall back to [`NamedCallableTarget::name`]: the
+    /// identity is owned by another module; its origin is not a project source module at all (a package, a `rust::`
+    /// crate, or a builtin); or this module owns it but it has no lowered body, as for a model or a `const`.
+    pub fn body_for_canonical_target(&self, target: &CanonicalSymbolId) -> Option<&Body> {
+        if module_identity_for_path(target.module_path()?) != self.module_id.path() {
+            return None;
+        }
+        self.bodies.iter().find(|body| body.span == target.declaration_span)
+    }
+
     /// Render a deterministic maintainer-facing snapshot of every body in the module.
     pub fn render_snapshot(&self) -> String {
         let mut out = String::new();
@@ -1835,11 +1857,13 @@ impl Callee {
 /// [`Self::Local`] operand, carrying the lexical-environment ownership decision the caller made.
 #[derive(Debug, Clone, PartialEq)]
 pub enum CallableTarget {
-    /// A direct call to a named Incan function, by its source-level spelling.
+    /// A direct call to a named Incan function.
     ///
-    /// Full call-target resolution (which physical declaration binds through imports/traits/overloads) mirrors the
-    /// typechecker/backend resolution passes and is deferred past v0; Body IR records the source-level callee
-    /// spelling plus argument ownership facts, which is enough to prove the model end-to-end.
+    /// The callee's source-level spelling is always present. Which physical declaration that spelling binds is
+    /// carried separately and only where it is proven: [`NamedCallableTarget::canonical`] for the declaration
+    /// identity, [`NamedCallableTarget::direct_call_id`] for a same-module span identity. Resolution through traits,
+    /// and through overloads whose candidates a name cannot separate, remains deferred past v0, so both facts are
+    /// absent for those and the spelling alone is never a dispatch key.
     Named(NamedCallableTarget),
     /// Invoke a callable value held in one local place.
     ///
@@ -1919,13 +1943,22 @@ pub struct NamedCallableTarget {
     /// Compiler-recognized builtin target, if the typechecker proved this call did not resolve to a source binding.
     ///
     /// This is `None` for every same-module, imported, unresolved, or otherwise external target. Consumers must
-    /// reject an absent `direct_call_id` and absent `builtin` rather than using [`Self::name`] as a dispatch key.
+    /// reject an absent `direct_call_id` and absent `builtin` rather than using [`Self::name`] as a dispatch key —
+    /// or resolve [`Self::canonical`] through [`BodyIrModule::body_for_canonical_target`], which is the only route
+    /// that also reaches a declaration this module does not own.
     pub builtin: Option<NamedCallableBuiltin>,
     /// Resolved explicit call-site type arguments, in declared type-parameter order. Empty when the call site wrote
     /// none.
     pub type_args: Vec<IncanType>,
     /// Resolved binding of the surrounding [`StatementKind::Call::args`] to this function's declared parameters.
     pub binding: ArgumentBinding,
+    /// RFC 120 canonical identity of the declaration this call selected, independent of the call site's spelling.
+    ///
+    /// [`Self::direct_call_id`] is a *span* identity and so exists only for a declaration physically present in this
+    /// module. This answers the different question of *which declaration* was selected, in a form that survives an
+    /// import, an alias, or a re-export, and is `None` whenever that answer is not proven. [`Self::name`] remains the
+    /// call site's own spelling, so the pair records both what was written and what it means.
+    pub canonical: Option<CanonicalSymbolId>,
 }
 
 /// A method call target and its resolved call-site identity.

--- a/crates/incan_semantics_core/src/facts.rs
+++ b/crates/incan_semantics_core/src/facts.rs
@@ -350,15 +350,60 @@ impl fmt::Display for SemanticSourceTarget {
     }
 }
 
-/// Semantic target declaration category.
+/// Declaration category a canonical identity or semantic target names.
+///
+/// This is RFC 120's `kind` field. It deliberately covers every binding form the identity model reaches, not only the
+/// declaration kinds today's codegraph targets happen to record, so a member and a local never have to be told apart
+/// by a string. [`Self::Other`] remains for a frontend spelling this vocabulary has not adopted yet; it is a gap
+/// marker, never a category.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum SemanticSourceTargetKind {
+    /// A `def` declaration, free or associated.
     Function,
+    /// A `model` declaration.
     Model,
+    /// A `class` declaration.
     Class,
+    /// A `newtype` declaration.
     Newtype,
+    /// A `rusttype` declaration binding a Rust type.
     Rusttype,
+    /// An `enum` declaration.
     Enum,
+    /// A `type X = ...` alias.
+    TypeAlias,
+    /// A `partial` projection declaration.
+    Partial,
+    /// One variant of an enum.
+    Variant,
+    /// A `trait` declaration.
+    Trait,
+    /// A field on a nominal type.
+    Field,
+    /// A method on a nominal type or trait.
+    Method,
+    /// A computed property on a nominal type.
+    Property,
+    /// A `const` declaration.
+    Const,
+    /// A `static` storage cell.
+    Static,
+    /// A binding introduced inside a body by `let`, `mut`, assignment, `for`, `with ... as`, or `except ... as`.
+    Local,
+    /// A declared callable parameter.
+    Parameter,
+    /// A receiver binding (`self` or `cls`).
+    Receiver,
+    /// A generic type parameter, scoped to the declaration that introduces it.
+    GenericBinder,
+    /// A module.
+    Module,
+    /// An item reached through `rust::`.
+    RustItem,
+    /// A compiler-owned builtin beneath the ordinary lexical scope chain.
+    Builtin,
+    /// A frontend declaration spelling this vocabulary has not adopted. A gap marker, not a category: a consumer that
+    /// branches on it is branching on a string.
     Other(String),
 }
 
@@ -372,6 +417,22 @@ impl SemanticSourceTargetKind {
             "newtype" => Self::Newtype,
             "rusttype" => Self::Rusttype,
             "enum" => Self::Enum,
+            "type_alias" => Self::TypeAlias,
+            "partial" => Self::Partial,
+            "variant" => Self::Variant,
+            "trait" => Self::Trait,
+            "field" => Self::Field,
+            "method" => Self::Method,
+            "property" => Self::Property,
+            "const" => Self::Const,
+            "static" => Self::Static,
+            "local" => Self::Local,
+            "parameter" => Self::Parameter,
+            "receiver" => Self::Receiver,
+            "generic_binder" => Self::GenericBinder,
+            "module" => Self::Module,
+            "rust_item" => Self::RustItem,
+            "builtin" => Self::Builtin,
             other => Self::Other(other.to_string()),
         }
     }
@@ -385,7 +446,138 @@ impl SemanticSourceTargetKind {
             Self::Newtype => "newtype",
             Self::Rusttype => "rusttype",
             Self::Enum => "enum",
+            Self::TypeAlias => "type_alias",
+            Self::Partial => "partial",
+            Self::Variant => "variant",
+            Self::Trait => "trait",
+            Self::Field => "field",
+            Self::Method => "method",
+            Self::Property => "property",
+            Self::Const => "const",
+            Self::Static => "static",
+            Self::Local => "local",
+            Self::Parameter => "parameter",
+            Self::Receiver => "receiver",
+            Self::GenericBinder => "generic_binder",
+            Self::Module => "module",
+            Self::RustItem => "rust_item",
+            Self::Builtin => "builtin",
             Self::Other(kind) => kind,
+        }
+    }
+}
+
+/// Render a module path into the identity string used by HIR, Body IR, and declaration identities.
+///
+/// One spelling, in one place: an empty path is a real case (a module checked without a path), and the frontend and
+/// the data model silently disagreeing about whether that is `"<module>"` or `""` would produce two identities for
+/// one declaration.
+pub fn module_identity_for_path(module_path: &[String]) -> String {
+    if module_path.is_empty() {
+        "<module>".to_string()
+    } else {
+        module_path.join("::")
+    }
+}
+
+/// Which of RFC 120's three namespaces a binding lives in.
+///
+/// Namespaces are distinguished by *how* a name is looked up, not by what kind of thing it names: a model name and a
+/// function name share one namespace, exactly as ordinary Python-like lexical lookup expects. Carrying this in an
+/// identity is what keeps a field named `items` and a local named `items` from ever comparing equal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum SymbolNamespace {
+    /// Module-level declarations, imports, aliases and re-exports, bare enum variant names, generic binders,
+    /// parameters and receivers, and locals. Looked up innermost scope outward, then the builtin fallback tier.
+    OrdinaryLexical,
+    /// Fields, methods, computed properties, method aliases, and qualified enum variants. Reached `.`-directed from a
+    /// resolved owner type, never through the scope chain.
+    Member,
+    /// Project module paths, the `std` root, `rust::` crate roots, and `pub::` library roots. Path-directed from a
+    /// namespace root.
+    ModulePath,
+}
+
+/// What owns a declaration, independent of who references it.
+///
+/// An import, alias, or re-export carries its *target's* origin, never the referencing module's. That is the property
+/// that makes three different spellings of one declaration compare equal.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum SymbolOrigin {
+    /// A project source module, by canonical module path.
+    Module(Vec<String>),
+    /// A `pub::` library, and the module path owning the declaration inside it.
+    Package {
+        /// Library root name.
+        library: String,
+        /// Module path within the library.
+        module_path: Vec<String>,
+    },
+    /// A `rust::` crate root and item path.
+    RustCrate(Vec<String>),
+    /// The compiler-owned builtin registry beneath the ordinary lexical scope chain.
+    Builtin,
+}
+
+/// Distinguishes bindings that are not unique within their origin.
+///
+/// Module-level declarations are already unique within their origin and carry no discriminant. Locals, parameters,
+/// receivers, and generic binders are not: two `x` bindings in sibling blocks of one module must not collapse to one
+/// identity, so those carry the scope that introduced them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ScopeDiscriminant(pub usize);
+
+/// RFC 120 canonical symbol identity: what a resolved reference *means*.
+///
+/// Assigned once at a declaration site and unchanged by how the declaration is later referenced. A local declaration,
+/// an import, an alias, and a re-export of one declaration all carry this same value; none of them creates a second
+/// identity for the thing they name.
+///
+/// Two properties are load-bearing. Equality is decidable structurally, without comparing source spellings or emitted
+/// names — no phase may recover what a reference means by parsing generated Rust. And identity is stable across the
+/// stages of *one* compilation, not across edits: [`Self::declaration_span`] moves when the file does, so a consumer
+/// needing cross-edit continuity must re-resolve rather than cache.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct CanonicalSymbolId {
+    /// Which namespace the binding lives in.
+    pub namespace: SymbolNamespace,
+    /// The module, package, crate, or registry owning the declaration.
+    pub origin: SymbolOrigin,
+    /// The spelling at the *declaration* site, never at a reference site.
+    pub declaration_name: String,
+    /// Declaration category.
+    pub kind: SemanticSourceTargetKind,
+    /// Present only for bindings that are not unique within their origin.
+    pub scope_discriminant: Option<ScopeDiscriminant>,
+    /// Provenance anchor: the one declaration site.
+    pub declaration_span: crate::HirSourceSpan,
+}
+
+impl CanonicalSymbolId {
+    /// Build the identity of a module-level declaration in a project source module.
+    ///
+    /// Module-level declarations are unique within their origin, so this deliberately takes no scope discriminant.
+    pub fn module_declaration(
+        module_path: Vec<String>,
+        declaration_name: impl Into<String>,
+        kind: SemanticSourceTargetKind,
+        declaration_span: crate::HirSourceSpan,
+    ) -> Self {
+        Self {
+            namespace: SymbolNamespace::OrdinaryLexical,
+            origin: SymbolOrigin::Module(module_path),
+            declaration_name: declaration_name.into(),
+            kind,
+            scope_discriminant: None,
+            declaration_span,
+        }
+    }
+
+    /// Return the owning module path when this identity is owned by a project source module.
+    pub fn module_path(&self) -> Option<&[String]> {
+        match &self.origin {
+            SymbolOrigin::Module(path) => Some(path),
+            _ => None,
         }
     }
 }
@@ -504,6 +696,44 @@ impl SemanticFactStore {
 
 #[cfg(test)]
 mod tests {
+    /// Every declaration category round-trips through its own spelling.
+    ///
+    /// The two arms are hand-written and 22 variants long; a typo in either would silently reclassify a declaration
+    /// as `Other`, which compares unequal to the variant it came from and would split one declaration's identity.
+    #[test]
+    fn every_source_target_kind_round_trips_through_its_spelling() {
+        use super::SemanticSourceTargetKind as K;
+        let all = [
+            K::Function,
+            K::Model,
+            K::Class,
+            K::Newtype,
+            K::Rusttype,
+            K::Enum,
+            K::TypeAlias,
+            K::Partial,
+            K::Variant,
+            K::Trait,
+            K::Field,
+            K::Method,
+            K::Property,
+            K::Const,
+            K::Static,
+            K::Local,
+            K::Parameter,
+            K::Receiver,
+            K::GenericBinder,
+            K::Module,
+            K::RustItem,
+            K::Builtin,
+        ];
+        for kind in &all {
+            assert_eq!(K::from_kind_str(kind.as_str()), *kind, "round trip failed for {kind}");
+        }
+        let spellings: std::collections::HashSet<&str> = all.iter().map(|kind| kind.as_str()).collect();
+        assert_eq!(spellings.len(), all.len(), "two categories share one spelling");
+    }
+
     use super::*;
 
     #[test]

--- a/crates/incan_semantics_core/src/lib.rs
+++ b/crates/incan_semantics_core/src/lib.rs
@@ -28,9 +28,9 @@ mod hir;
 mod types;
 
 pub use facts::{
-    CompilerNodeId, CompilerNodeKind, SemanticFact, SemanticFactKind, SemanticFactStore, SemanticFactValue,
-    SemanticRegistryEntry, SemanticRegistrySubjectKind, SemanticRegistryValue, SemanticSourceTarget,
-    SemanticSourceTargetKind,
+    CanonicalSymbolId, CompilerNodeId, CompilerNodeKind, ScopeDiscriminant, SemanticFact, SemanticFactKind,
+    SemanticFactStore, SemanticFactValue, SemanticRegistryEntry, SemanticRegistrySubjectKind, SemanticRegistryValue,
+    SemanticSourceTarget, SemanticSourceTargetKind, SymbolNamespace, SymbolOrigin, module_identity_for_path,
 };
 pub use hir::{HirDeclaration, HirDeclarationKind, HirModule, HirSourceSpan, SemanticModuleSnapshot};
 pub use types::{

--- a/src/backend/replacement/mod.rs
+++ b/src/backend/replacement/mod.rs
@@ -2292,7 +2292,7 @@ impl BodyExecutor {
             {
                 return Err(unsupported("invalid resolved callable argument binding", span));
             }
-            supplied[argument.slot] = Some(self.evaluate_operand(&args[index], span)?);
+            supplied[argument.slot] = Some(self.evaluate_operand(args[index], span)?);
         }
         let defaulted = defaulted_slots.iter().copied().collect::<BTreeSet<_>>();
         for (slot, value) in supplied.iter().enumerate() {
@@ -3729,7 +3729,7 @@ impl BodyExecutor {
                     span,
                 ));
             }
-            let value = self.evaluate_operand(&operands[index], span)?;
+            let value = self.evaluate_operand(operands[index], span)?;
             if !value.is_direct_structural() {
                 return Err(unsupported(
                     format!("constructor `{}` with a non-structural field value", target.name),

--- a/src/cli/commands/codegraph.rs
+++ b/src/cli/commands/codegraph.rs
@@ -1982,11 +1982,7 @@ impl CodegraphBuilder {
 
     /// Return a declaration record id for a compiler-proven source target at `span`.
     fn source_target_id(&self, module: &ParsedModule, span: Span) -> Option<String> {
-        let module_identity = if module.path_segments.is_empty() {
-            "<module>".to_string()
-        } else {
-            module.path_segments.join("::")
-        };
+        let module_identity = incan_semantics_core::module_identity_for_path(&module.path_segments);
         let subject = CompilerNodeId::expression_span(&module_identity, span.start, span.end);
         let target = self
             .semantic_snapshots_by_path

--- a/src/cli/commands/common.rs
+++ b/src/cli/commands/common.rs
@@ -4610,6 +4610,18 @@ pub(crate) fn imported_module_deps_for_with_index<'m>(
         .collect()
 }
 
+/// Register every collected module's real path segments with a checker before typechecking.
+///
+/// The dependency cache is keyed by the flattened, underscore-joined module name, which also names the emitted Rust
+/// module and is therefore not injective: `pkg.helpers` and a module literally named `pkg_helpers` flatten to one
+/// string. Supplying the true segments lets a canonical identity name the module that answered rather than the
+/// spelling that asked. Mirrors the pair `IrCodegen::add_module_with_path_segments` already carries for emission.
+pub(crate) fn register_module_path_segments(checker: &mut typechecker::TypeChecker, modules: &[ParsedModule]) {
+    for module in modules {
+        checker.register_dependency_module_path_segments(&module.name, module.path_segments.clone());
+    }
+}
+
 /// Typecheck all collected modules in dependency-safe order using shared CLI diagnostics formatting.
 ///
 /// This helper centralizes the per-module checker setup used by `build` and `check` paths so warning/error rendering
@@ -4698,6 +4710,7 @@ fn typecheck_modules_with_import_graph_artifacts(
             checker.set_declared_crate_names(names);
         }
         checker.set_current_module_path(Some(module.path_segments.clone()));
+        register_module_path_segments(&mut checker, modules);
         checker.set_provider_plan(Arc::clone(provider_plan));
         #[cfg(feature = "rust_inspect")]
         if let Some(rust_inspect_manifest_dir) = rust_inspect_manifest_dir {

--- a/src/cli/commands/tools.rs
+++ b/src/cli/commands/tools.rs
@@ -719,6 +719,7 @@ fn collect_api_metadata_package(path: &Path) -> CliResult<CheckedApiMetadataPack
             checker.set_declared_crate_names(names);
         }
         checker.set_library_manifest_index(library_manifest_index.clone());
+        super::common::register_module_path_segments(&mut checker, &modules);
 
         match checker.check_with_imports(&module.ast, &deps_for_module) {
             Ok(()) => {

--- a/src/frontend/body_ir.rs
+++ b/src/frontend/body_ir.rs
@@ -51,8 +51,8 @@ use incan_core::lang::keywords::KeywordId;
 use incan_semantics_core::SurfaceFeatureKey;
 use incan_semantics_core::body_ir as bir;
 use incan_semantics_core::{
-    AbiV0RuntimeRequirement, CompilerNodeId, HirSourceSpan, IncanCallableParam, IncanCallableParamKind,
-    IncanPrimitiveType, IncanType, rust_tuple_arity,
+    AbiV0RuntimeRequirement, CanonicalSymbolId, CompilerNodeId, HirSourceSpan, IncanCallableParam,
+    IncanCallableParamKind, IncanPrimitiveType, IncanType, SemanticSourceTargetKind, rust_tuple_arity,
 };
 
 use incan_core::lang::surface::constructors::{self, ConstructorId};
@@ -106,6 +106,7 @@ pub fn build_body_ir_module_v0(
         local_fieldless_enum_declarations: &local_fieldless_enum_declarations,
         local_value_enum_declarations: &local_value_enum_declarations,
         module_identity: &module_identity,
+        module_path,
     };
     let bodies = program
         .declarations
@@ -194,6 +195,7 @@ struct BodyIrLoweringFacts<'type_info, 'source> {
     local_fieldless_enum_declarations: &'source LocalFieldlessEnumDeclarations,
     local_value_enum_declarations: &'source LocalValueEnumDeclarations,
     module_identity: &'source str,
+    module_path: &'source [String],
 }
 
 /// Source facts a synthesized local partial needs for one target parameter.
@@ -450,11 +452,7 @@ fn lower_owner_method_bodies(
 /// Render a module path into the same module identity spelling [`crate::frontend::hir`] uses, so declaration ids
 /// line up between the two representations.
 fn body_ir_module_identity(module_path: &[String]) -> String {
-    if module_path.is_empty() {
-        "<module>".to_string()
-    } else {
-        module_path.join("::")
-    }
+    incan_semantics_core::module_identity_for_path(module_path)
 }
 
 /// Convert an AST byte-offset span into a Body IR source span.
@@ -736,6 +734,8 @@ struct BodyBuilder<'type_info, 'source> {
     local_value_enum_declarations: &'source LocalValueEnumDeclarations,
     /// Owning module identity used to construct a source-span declaration identity without consulting a backend.
     module_identity: &'source str,
+    /// Owning module path, used to build the RFC 120 origin of a declaration this module owns.
+    module_path: &'source [String],
     /// Checked return type of the function/method currently being lowered, used only to retain `?` error routing.
     owner_return_type: IncanType,
     locals: Vec<bir::LocalDecl>,
@@ -778,6 +778,7 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
             local_fieldless_enum_declarations: lowering_facts.local_fieldless_enum_declarations,
             local_value_enum_declarations: lowering_facts.local_value_enum_declarations,
             module_identity: lowering_facts.module_identity,
+            module_path: lowering_facts.module_path,
             owner_return_type,
             locals: Vec::new(),
             scopes: Vec::new(),
@@ -3117,6 +3118,35 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
         ))
     }
 
+    /// Build the RFC 120 identity of a declaration *this* module owns, from the declaration the call selected.
+    ///
+    /// The span is the one the caller already resolved to build [`DirectCallDeclaration::direct_call_id`], so the two
+    /// facts on a `NamedCallableTarget` are derived from one decision and cannot name different declarations. That
+    /// matters because locality must not be inferred from the recorded source target: an import binding of the same
+    /// spelling wins in `TypeChecker::source_target_for_symbol` regardless of what the call actually bound, so a local
+    /// declaration shadowed by a same-name import would otherwise be given the *import's* identity.
+    fn local_callable_identity(&self, declared_name: &str, declaration_span: ast::Span) -> CanonicalSymbolId {
+        CanonicalSymbolId::module_declaration(
+            self.module_path.to_vec(),
+            declared_name,
+            SemanticSourceTargetKind::Function,
+            HirSourceSpan::new(declaration_span.start, declaration_span.end),
+        )
+    }
+
+    /// Return the RFC 120 identity of an imported callable, when import resolution proved one.
+    ///
+    /// Only reached when this module declares no function of that spelling, so there is no local declaration for an
+    /// import to be confused with. The proven identity carries its own declaration kind, so a binding that resolved to
+    /// something other than a function yields nothing rather than a function identity.
+    ///
+    /// An overloaded import is refused upstream, in `TypeChecker::dependency_member_identity`: an overloaded symbol
+    /// keeps only the first candidate's span, so an identity minted from it would name an arbitrary overload.
+    fn imported_callable_identity(&self, call_site_name: &str) -> Option<CanonicalSymbolId> {
+        let identity = self.type_info.resolved_import_identity(call_site_name)?;
+        (identity.kind == SemanticSourceTargetKind::Function).then(|| identity.clone())
+    }
+
     /// Resolve the declaration surface and exact local identity for a direct named call.
     ///
     /// A direct executable target must be physically represented by this Body-IR module. Imports and unresolved
@@ -3146,6 +3176,7 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
                     && !declarations.function_bindings.contains_key(name)
                     && !declarations.function_overloads.contains_key(name))
                 .then_some(bir::NamedCallableBuiltin::Range),
+                canonical: self.imported_callable_identity(name),
             });
         };
         let is_overloaded = local_declarations.len() > 1;
@@ -3183,6 +3214,9 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
                     selected_span.end,
                 )),
                 builtin: None,
+                // The identity anchors to the declaration span, so the selected overload is as nameable as any other
+                // declaration; it is the *spelling* that cannot separate them, and the spelling is not the identity.
+                canonical: Some(self.local_callable_identity(name, *selected_span)),
             });
         }
 
@@ -3207,6 +3241,7 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
                 declaration_span.end,
             )),
             builtin: None,
+            canonical: Some(self.local_callable_identity(name, *declaration_span)),
         })
     }
 
@@ -3643,6 +3678,7 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
             bir::Callee::Function(bir::CallableTarget::Named(bir::NamedCallableTarget {
                 name,
                 direct_call_id: declaration.direct_call_id,
+                canonical: declaration.canonical,
                 builtin: declaration.builtin,
                 type_args: resolved_type_args,
                 binding,
@@ -4487,6 +4523,9 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
                 name: target_name,
                 direct_call_id,
                 builtin: None,
+                // A compiler-synthesized forwarding call has no source call site, so it has no spelling or import
+                // provenance to record; the declaration it forwards to is already named by `direct_call_id`.
+                canonical: None,
                 type_args: Vec::new(),
                 binding: forwarding_binding,
             })),
@@ -4988,10 +5027,15 @@ fn count_reads_in_comprehension_clauses(name: &str, clauses: &[ast::Comprehensio
 /// `direct_call_id` is present only for a declaration physically represented by this module. Keeping the target
 /// separate from its parameter slots prevents a future consumer from treating a successfully planned argument list
 /// as proof that an imported callable is executable here.
+///
+/// `canonical` answers a deliberately different question: *which declaration* this call selected, in a form that
+/// survives an import or a rename. An imported callable therefore has no `direct_call_id` but may still have a
+/// canonical identity, and the two must not be read as substitutes for one another.
 struct DirectCallDeclaration {
     slots: Option<Vec<DeclaredSlot>>,
     direct_call_id: Option<CompilerNodeId>,
     builtin: Option<bir::NamedCallableBuiltin>,
+    canonical: Option<CanonicalSymbolId>,
 }
 
 /// One declared callable parameter or nominal field, reduced to the facts call-site binding actually needs.
@@ -6184,6 +6228,52 @@ mod tests {
     use super::*;
     use crate::frontend::typechecker::TypeChecker;
     use crate::frontend::{lexer, parser};
+
+    /// Lower a module that imports from other modules, so cross-module call facts can be asserted.
+    fn build_with_imports(
+        source: &str,
+        module_path: &[&str],
+        imports: &[(&str, &str)],
+    ) -> Result<bir::BodyIrModule, Box<dyn std::error::Error>> {
+        let mut import_programs = Vec::new();
+        for (name, import_source) in imports {
+            let tokens = lexer::lex(import_source).map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+            let program = parser::parse(&tokens).map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+            import_programs.push((*name, program));
+        }
+        let import_refs: Vec<(&str, &ast::Program)> =
+            import_programs.iter().map(|(name, program)| (*name, program)).collect();
+
+        let tokens = lexer::lex(source).map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+        let program = parser::parse(&tokens).map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+        let module_path: Vec<String> = module_path.iter().map(|s| s.to_string()).collect();
+        let mut checker = TypeChecker::new();
+        checker.set_current_module_path(Some(module_path.clone()));
+        checker
+            .check_with_imports(&program, &import_refs)
+            .map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+        Ok(build_body_ir_module_v0(&program, &module_path, checker.type_info()))
+    }
+
+    /// Collect the named-callable targets called directly in one lowered body, in statement order.
+    fn named_targets<'module>(
+        module: &'module bir::BodyIrModule,
+        body_name: &str,
+    ) -> Vec<&'module bir::NamedCallableTarget> {
+        module
+            .bodies
+            .iter()
+            .filter(|body| body.name == body_name)
+            .flat_map(|body| &body.block.stmts)
+            .filter_map(|stmt| match &stmt.kind {
+                bir::StatementKind::Call {
+                    callee: bir::Callee::Function(bir::CallableTarget::Named(target)),
+                    ..
+                } => Some(target),
+                _ => None,
+            })
+            .collect()
+    }
 
     fn build(source: &str, module_path: &[&str]) -> Result<bir::BodyIrModule, Box<dyn std::error::Error>> {
         let tokens = lexer::lex(source).map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
@@ -9769,6 +9859,7 @@ mod tests {
         let local_nominal_declarations = LocalNominalDeclarations::new();
         let local_fieldless_enum_declarations = LocalFieldlessEnumDeclarations::new();
         let local_value_enum_declarations = LocalValueEnumDeclarations::new();
+        let module_path = vec!["m".to_string()];
         let lowering_facts = BodyIrLoweringFacts {
             type_info: &type_info,
             function_default_sources: &function_default_sources,
@@ -9777,6 +9868,7 @@ mod tests {
             local_fieldless_enum_declarations: &local_fieldless_enum_declarations,
             local_value_enum_declarations: &local_value_enum_declarations,
             module_identity: "m",
+            module_path: &module_path,
         };
         let mut builder = BodyBuilder::new(&lowering_facts, IncanType::Unknown);
         let scope = builder.new_scope(None, HirSourceSpan::new(0, 1));
@@ -10107,6 +10199,453 @@ mod tests {
                 .contains("call helper:str_concat("),
             "string concatenation must stay a compiler-owned helper call"
         );
+        Ok(())
+    }
+
+    /// RFC 120's guide-level example: one declaration reached four ways is one identity.
+    ///
+    /// A local call, a plain import, an import alias, and a re-export through a facade are all *bindings to* one
+    /// declaration. None of them creates a second identity for the thing it names, and the facade in particular must
+    /// not be recorded as an owner of what it merely re-exports.
+    #[test]
+    fn one_declaration_keeps_one_identity_across_local_imported_aliased_and_reexported_calls()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let helpers_source = r#"
+pub def render() -> int:
+  return 1
+
+def use_local() -> int:
+  return render()
+"#;
+        let facade_source = r#"
+from helpers import render
+"#;
+        let app_source = r#"
+from helpers import render
+from helpers import render as draw
+from facade import render as relayed
+
+def use_imported() -> int:
+  return render()
+
+def use_alias() -> int:
+  return draw()
+
+def use_reexport() -> int:
+  return relayed()
+"#;
+        let helpers = build(helpers_source, &["helpers"])?;
+        let app = build_with_imports(
+            app_source,
+            &["app"],
+            &[("helpers", helpers_source), ("facade", facade_source)],
+        )?;
+
+        let mut facts = Vec::new();
+        for (module, body) in [
+            (&helpers, "use_local"),
+            (&app, "use_imported"),
+            (&app, "use_alias"),
+            (&app, "use_reexport"),
+        ] {
+            let targets = named_targets(module, body);
+            let [target] = targets.as_slice() else {
+                return Err(Box::from(format!(
+                    "expected one named call in `{body}`, got {}",
+                    targets.len()
+                )));
+            };
+            let Some(fact) = &target.canonical else {
+                return Err(Box::from(format!("`{body}` must carry a canonical identity")));
+            };
+            facts.push((body, target.name.clone(), fact.clone()));
+        }
+
+        // One declaration, one identity, however each call site spelled it.
+        let (_, _, first) = &facts[0];
+        for (body, _, fact) in &facts {
+            assert_eq!(fact, first, "`{body}` must resolve to the one declaration identity");
+        }
+
+        // The identity describes the declaration, never the reference.
+        assert_eq!(first.declaration_name, "render");
+        assert_eq!(first.kind, SemanticSourceTargetKind::Function);
+        assert_eq!(first.namespace, incan_semantics_core::SymbolNamespace::OrdinaryLexical);
+        assert_eq!(
+            first.origin,
+            incan_semantics_core::SymbolOrigin::Module(vec!["helpers".to_string()]),
+            "the origin is the declaring module, never the importing or re-exporting one"
+        );
+        assert_eq!(
+            first.scope_discriminant, None,
+            "a module-level declaration is unique within its origin"
+        );
+
+        // It anchors to the one declaration site, not to any call site.
+        let render_body = helpers
+            .bodies
+            .iter()
+            .find(|body| body.name == "render")
+            .ok_or_else(|| Box::<dyn std::error::Error>::from("lowered `render` body missing"))?;
+        assert_eq!(first.declaration_span, render_body.span);
+
+        // The call-site spellings genuinely differ; only the identity collapses them.
+        let spellings: Vec<&str> = facts.iter().map(|(_, name, _)| name.as_str()).collect();
+        assert_eq!(spellings, vec!["render", "render", "draw", "relayed"]);
+        Ok(())
+    }
+
+    /// A local declaration shadowed by a same-name import must be identified as the *local* declaration.
+    ///
+    /// `source_target_for_symbol` consults import bindings first and unconditionally, so the recorded source target
+    /// names the import regardless of what the call bound. Inferring locality from that target gave one
+    /// `NamedCallableTarget` two facts naming two different declarations.
+    #[test]
+    fn a_local_declaration_shadowed_by_a_same_name_import_is_identified_locally()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let helpers_source = r#"
+pub def render() -> int:
+  return 1
+"#;
+        let app_source = r#"
+from helpers import render
+
+def render(value: int) -> int:
+  return value
+
+def run() -> int:
+  return render(7)
+"#;
+        let app = build_with_imports(app_source, &["app"], &[("helpers", helpers_source)])?;
+
+        let targets = named_targets(&app, "run");
+        let [target] = targets.as_slice() else {
+            return Err(Box::from(format!("expected one named call, got {}", targets.len())));
+        };
+        let Some(fact) = &target.canonical else {
+            return Err(Box::from(
+                "the call bound a local declaration and must carry its identity".to_string(),
+            ));
+        };
+
+        assert_eq!(
+            fact.origin,
+            incan_semantics_core::SymbolOrigin::Module(vec!["app".to_string()]),
+            "the shadowing local declaration owns this call, not the import it shadows"
+        );
+        // The two facts on one target must never name different declarations.
+        let resolved = app.body_for_canonical_target(fact).ok_or_else(|| {
+            Box::<dyn std::error::Error>::from("this module owns the declaration and must resolve it")
+        })?;
+        assert_eq!(resolved.name, "render");
+        assert_eq!(
+            Some(&resolved.direct_call_id),
+            target.direct_call_id.as_ref(),
+            "the canonical identity and the span identity must select one declaration"
+        );
+        Ok(())
+    }
+
+    /// Bodies do not carry owner-qualified names, so one module can hold a class method `render` and a free function
+    /// `render`. The consumer seam must separate them by declaration span; matching on the declared name would hand
+    /// back whichever body came first, silently, for an identity that names the other one.
+    #[test]
+    fn the_consumer_seam_separates_same_named_bodies_by_declaration_span() -> Result<(), Box<dyn std::error::Error>> {
+        let source = r#"
+class Canvas:
+  def render(self) -> int:
+    return 1
+
+def render() -> int:
+  return 2
+
+def run() -> int:
+  return render()
+"#;
+        let module = build(source, &["app"])?;
+
+        let same_named: Vec<&bir::Body> = module.bodies.iter().filter(|body| body.name == "render").collect();
+        assert_eq!(
+            same_named.len(),
+            2,
+            "this fixture is only meaningful while the module really holds two bodies named `render`"
+        );
+
+        let targets = named_targets(&module, "run");
+        let [target] = targets.as_slice() else {
+            return Err(Box::from(format!("expected one named call, got {}", targets.len())));
+        };
+        let Some(fact) = &target.canonical else {
+            return Err(Box::from("the free function call must carry an identity".to_string()));
+        };
+
+        let resolved = module
+            .body_for_canonical_target(fact)
+            .ok_or_else(|| Box::<dyn std::error::Error>::from("the owning module must resolve its own identity"))?;
+        assert_eq!(resolved.span, fact.declaration_span);
+        assert_eq!(
+            resolved.block.stmts.len(),
+            module
+                .bodies
+                .iter()
+                .find(|body| body.span == fact.declaration_span)
+                .map(|body| body.block.stmts.len())
+                .unwrap_or_default()
+        );
+        // The method body shares the spelling and must not be what the seam returns.
+        let method_span = same_named
+            .iter()
+            .map(|body| body.span)
+            .find(|span| *span != fact.declaration_span)
+            .ok_or_else(|| Box::<dyn std::error::Error>::from("expected a second, differently-spanned `render`"))?;
+        assert_ne!(resolved.span, method_span);
+        Ok(())
+    }
+
+    /// A re-export chain longer than one hop, with a rename in the middle. Exercises the recursion in
+    /// `dependency_member_identity_from` and proves a rename never leaks into `declaration_name`.
+    #[test]
+    fn a_renamed_multi_hop_re_export_still_resolves_to_the_original_declaration()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let helpers_source = r#"
+pub def render() -> int:
+  return 1
+"#;
+        let inner_source = r#"
+from helpers import render as painted
+"#;
+        let facade_source = r#"
+from inner import painted
+"#;
+        let app_source = r#"
+from facade import painted as relayed
+
+def run() -> int:
+  return relayed()
+"#;
+        let app = build_with_imports(
+            app_source,
+            &["app"],
+            &[
+                ("helpers", helpers_source),
+                ("inner", inner_source),
+                ("facade", facade_source),
+            ],
+        )?;
+
+        let targets = named_targets(&app, "run");
+        let [target] = targets.as_slice() else {
+            return Err(Box::from(format!("expected one named call, got {}", targets.len())));
+        };
+        let Some(fact) = &target.canonical else {
+            return Err(Box::from(
+                "a multi-hop re-export resolves to a declaration and must carry an identity".to_string(),
+            ));
+        };
+        assert_eq!(
+            fact.declaration_name, "render",
+            "neither `painted` nor `relayed` may become the declared name"
+        );
+        assert_eq!(
+            fact.origin,
+            incan_semantics_core::SymbolOrigin::Module(vec!["helpers".to_string()]),
+            "the origin is the declaring module, not either facade"
+        );
+        assert_eq!(target.name, "relayed", "the call site keeps its own spelling");
+        Ok(())
+    }
+
+    /// Import resolution tries the sibling-relative candidate before the bare one, so the path written at an import is
+    /// not necessarily the module it bound. An identity built from the written path would name the root module's
+    /// declaration here — a different function that merely shares the name.
+    #[test]
+    fn a_sibling_relative_import_is_owned_by_the_module_resolution_actually_selected()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // Distinguishable by arity: the zero-argument call below only typechecks against the sibling.
+        let root_helpers = r#"
+pub def render(first: int, second: int) -> int:
+  return first + second
+"#;
+        let sibling_helpers = r#"
+pub def render() -> int:
+  return 1
+"#;
+        let app_source = r#"
+from helpers import render
+
+def run() -> int:
+  return render()
+"#;
+        let app = build_with_imports(
+            app_source,
+            &["pkg", "app"],
+            &[("helpers", root_helpers), ("pkg_helpers", sibling_helpers)],
+        )?;
+
+        let targets = named_targets(&app, "run");
+        let [target] = targets.as_slice() else {
+            return Err(Box::from(format!("expected one named call, got {}", targets.len())));
+        };
+        let Some(fact) = &target.canonical else {
+            return Err(Box::from(
+                "a sibling-relative import resolves to a proven declaration and must carry an identity".to_string(),
+            ));
+        };
+
+        assert_eq!(
+            fact.origin,
+            incan_semantics_core::SymbolOrigin::Module(vec!["pkg".to_string(), "helpers".to_string()]),
+            "the origin must be the module resolution selected, not the path the import spelled"
+        );
+        assert_ne!(
+            fact.origin,
+            incan_semantics_core::SymbolOrigin::Module(vec!["helpers".to_string()]),
+            "naming the written path would collide with the root module's unrelated `render`"
+        );
+        // Origin alone would still pass if a name-keyed span lookup picked the wrong file's declaration.
+        assert_eq!(
+            fact.declaration_span,
+            HirSourceSpan::new(1, 37),
+            "the span must be the sibling's zero-argument declaration, not the root's two-argument one"
+        );
+        Ok(())
+    }
+
+    /// Pins the overload guard in `canonical_callable_target` itself. The local-overload test below cannot: it takes
+    /// the separate `is_overloaded` branch, whose `canonical` is a hardcoded `None`, so it stays green even with the
+    /// guard deleted.
+    #[test]
+    fn an_imported_overloaded_binding_has_no_canonical_identity() -> Result<(), Box<dyn std::error::Error>> {
+        let helpers_source = r#"
+pub def render(value: int) -> int:
+  return value
+
+pub def render(value: str) -> int:
+  return 1
+"#;
+        let app_source = r#"
+from helpers import render
+from helpers import render as draw
+
+def use_imported() -> int:
+  return render(2)
+
+def use_alias() -> int:
+  return draw(3)
+"#;
+        let app = build_with_imports(app_source, &["app"], &[("helpers", helpers_source)])?;
+
+        for body in ["use_imported", "use_alias"] {
+            let targets = named_targets(&app, body);
+            let [target] = targets.as_slice() else {
+                return Err(Box::from(format!(
+                    "expected one named call in `{body}`, got {}",
+                    targets.len()
+                )));
+            };
+            assert!(
+                target.canonical.is_none(),
+                "`{body}` calls an overloaded import, which a name-based identity cannot separate"
+            );
+        }
+        Ok(())
+    }
+
+    /// The consumer seam: an identity resolves to a declaration, or to nothing. It must never be satisfied by a
+    /// same-named declaration that happens to live in the consuming module.
+    #[test]
+    fn a_canonical_identity_resolves_to_its_declaration_only_in_the_owning_module()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let helpers_source = r#"
+pub def render() -> int:
+  return 1
+"#;
+        // `app` declares its own same-named `render`, so a seam keyed on the spelling would wrongly match it.
+        let app_source = r#"
+from helpers import render as draw
+
+def render() -> int:
+  return 2
+
+def run() -> int:
+  return draw()
+"#;
+        let helpers = build(helpers_source, &["helpers"])?;
+        let app = build_with_imports(app_source, &["app"], &[("helpers", helpers_source)])?;
+
+        let targets = named_targets(&app, "run");
+        let [target] = targets.as_slice() else {
+            return Err(Box::from(format!("expected one named call, got {}", targets.len())));
+        };
+        let Some(fact) = &target.canonical else {
+            return Err(Box::from("the aliased import must carry an identity".to_string()));
+        };
+
+        let owning = helpers
+            .body_for_canonical_target(fact)
+            .ok_or_else(|| Box::<dyn std::error::Error>::from("owning module must resolve the identity"))?;
+        assert_eq!(owning.name, "render");
+        assert!(
+            app.body_for_canonical_target(fact).is_none(),
+            "the consuming module's own same-named `render` must not satisfy an identity it does not own"
+        );
+        Ok(())
+    }
+
+    /// Two same-name declarations in one module get two identities, because the identity anchors to a declaration
+    /// span rather than to the spelling. The *spelling* cannot separate overloads; the identity can, and the
+    /// typechecker's per-call-site overload selection is what tells them apart.
+    #[test]
+    fn each_local_overload_gets_its_own_identity() -> Result<(), Box<dyn std::error::Error>> {
+        let source = r#"
+def render(value: int) -> int:
+  return value
+
+def render(value: str) -> int:
+  return 1
+
+def use_int() -> int:
+  return render(2)
+
+def use_str() -> int:
+  return render("x")
+"#;
+        let module = build(source, &["app"])?;
+
+        let mut facts = Vec::new();
+        for body in ["use_int", "use_str"] {
+            let targets = named_targets(&module, body);
+            let [target] = targets.as_slice() else {
+                return Err(Box::from(format!(
+                    "expected one named call in `{body}`, got {}",
+                    targets.len()
+                )));
+            };
+            let Some(fact) = &target.canonical else {
+                return Err(Box::from(format!(
+                    "`{body}` selected one overload and must carry its identity"
+                )));
+            };
+            // Refusing to name an overload must not cost the span dispatch, and the two must agree.
+            assert!(target.direct_call_id.is_some());
+            facts.push(fact.clone());
+        }
+
+        assert_ne!(
+            facts[0], facts[1],
+            "two overloads are two declarations and must not collapse to one identity"
+        );
+        assert_eq!(facts[0].declaration_name, "render");
+        assert_eq!(facts[1].declaration_name, "render");
+
+        // Each identity resolves to the declaration whose signature that call actually selected.
+        for fact in &facts {
+            let resolved = module
+                .body_for_canonical_target(fact)
+                .ok_or_else(|| Box::<dyn std::error::Error>::from("this module owns both overloads"))?;
+            assert_eq!(resolved.name, "render");
+            assert_eq!(resolved.span, fact.declaration_span);
+        }
         Ok(())
     }
 }

--- a/src/frontend/body_ir.rs
+++ b/src/frontend/body_ir.rs
@@ -6229,26 +6229,39 @@ mod tests {
     use crate::frontend::typechecker::TypeChecker;
     use crate::frontend::{lexer, parser};
 
-    /// Lower a module that imports from other modules, so cross-module call facts can be asserted.
+    /// Lower a module that imports from other modules, declaring each dependency's flattened cache name *and* its
+    /// real path segments.
+    ///
+    /// Both are required because the flattened name is not injective: `("pkg_helpers", &["pkg", "helpers"], ..)` and
+    /// `("pkg_helpers", &["pkg_helpers"], ..)` are different modules sharing one cache key, and only the segments say
+    /// which one a fixture means.
     fn build_with_imports(
         source: &str,
         module_path: &[&str],
-        imports: &[(&str, &str)],
+        imports: &[(&str, &[&str], &str)],
     ) -> Result<bir::BodyIrModule, Box<dyn std::error::Error>> {
         let mut import_programs = Vec::new();
-        for (name, import_source) in imports {
+        for (name, segments, import_source) in imports {
             let tokens = lexer::lex(import_source).map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
             let program = parser::parse(&tokens).map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
-            import_programs.push((*name, program));
+            import_programs.push((*name, *segments, program));
         }
-        let import_refs: Vec<(&str, &ast::Program)> =
-            import_programs.iter().map(|(name, program)| (*name, program)).collect();
+        let import_refs: Vec<(&str, &ast::Program)> = import_programs
+            .iter()
+            .map(|(name, _, program)| (*name, program))
+            .collect();
 
         let tokens = lexer::lex(source).map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
         let program = parser::parse(&tokens).map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
         let module_path: Vec<String> = module_path.iter().map(|s| s.to_string()).collect();
         let mut checker = TypeChecker::new();
         checker.set_current_module_path(Some(module_path.clone()));
+        for (name, segments, _) in &import_programs {
+            checker.register_dependency_module_path_segments(
+                name,
+                segments.iter().map(|segment| segment.to_string()).collect(),
+            );
+        }
         checker
             .check_with_imports(&program, &import_refs)
             .map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
@@ -10238,7 +10251,10 @@ def use_reexport() -> int:
         let app = build_with_imports(
             app_source,
             &["app"],
-            &[("helpers", helpers_source), ("facade", facade_source)],
+            &[
+                ("helpers", &["helpers"], helpers_source),
+                ("facade", &["facade"], facade_source),
+            ],
         )?;
 
         let mut facts = Vec::new();
@@ -10316,7 +10332,7 @@ def render(value: int) -> int:
 def run() -> int:
   return render(7)
 "#;
-        let app = build_with_imports(app_source, &["app"], &[("helpers", helpers_source)])?;
+        let app = build_with_imports(app_source, &["app"], &[("helpers", &["helpers"], helpers_source)])?;
 
         let targets = named_targets(&app, "run");
         let [target] = targets.as_slice() else {
@@ -10427,9 +10443,9 @@ def run() -> int:
             app_source,
             &["app"],
             &[
-                ("helpers", helpers_source),
-                ("inner", inner_source),
-                ("facade", facade_source),
+                ("helpers", &["helpers"], helpers_source),
+                ("inner", &["inner"], inner_source),
+                ("facade", &["facade"], facade_source),
             ],
         )?;
 
@@ -10452,6 +10468,57 @@ def run() -> int:
             "the origin is the declaring module, not either facade"
         );
         assert_eq!(target.name, "relayed", "the call site keeps its own spelling");
+        Ok(())
+    }
+
+    /// The dependency cache key is the flattened, underscore-joined module name, which also names the emitted Rust
+    /// module and is therefore not injective: the path `pkg.helpers` and a module literally named `pkg_helpers` are
+    /// one key. Registering the real segments makes the identity name the module that answered rather than the
+    /// spelling that asked — and note a leading-underscore segment like `pkg._helpers` is exactly what defeats an
+    /// escaping scheme, which is why the real segments are carried instead of being encoded into one string.
+    #[test]
+    fn a_registered_module_path_wins_over_the_matching_candidate_spelling() -> Result<(), Box<dyn std::error::Error>> {
+        let helpers_source = r#"
+pub def render() -> int:
+  return 1
+"#;
+        let app_source = r#"
+from helpers import render
+
+def run() -> int:
+  return render()
+"#;
+        let helpers_tokens = lexer::lex(helpers_source).map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+        let helpers_program =
+            parser::parse(&helpers_tokens).map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+        let tokens = lexer::lex(app_source).map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+        let program = parser::parse(&tokens).map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+
+        let module_path = vec!["pkg".to_string(), "app".to_string()];
+        let mut checker = TypeChecker::new();
+        checker.set_current_module_path(Some(module_path.clone()));
+        // One real module, a single segment literally named `pkg_helpers`, reached from `pkg.app` as sibling
+        // `helpers`. Without the registration the matching candidate would spell a `pkg::helpers` that does not exist.
+        checker.register_dependency_module_path_segments("pkg_helpers", vec!["pkg_helpers".to_string()]);
+        checker
+            .check_with_imports(&program, &[("pkg_helpers", &helpers_program)])
+            .map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+        let app = build_body_ir_module_v0(&program, &module_path, checker.type_info());
+
+        let targets = named_targets(&app, "run");
+        let [target] = targets.as_slice() else {
+            return Err(Box::from(format!("expected one named call, got {}", targets.len())));
+        };
+        let Some(fact) = &target.canonical else {
+            return Err(Box::from(
+                "the import resolves to a declaration and must carry an identity".to_string(),
+            ));
+        };
+        assert_eq!(
+            fact.origin,
+            incan_semantics_core::SymbolOrigin::Module(vec!["pkg_helpers".to_string()]),
+            "the origin must be the module that answered, not the candidate spelling that matched its flattened name"
+        );
         Ok(())
     }
 
@@ -10479,7 +10546,11 @@ def run() -> int:
         let app = build_with_imports(
             app_source,
             &["pkg", "app"],
-            &[("helpers", root_helpers), ("pkg_helpers", sibling_helpers)],
+            &[
+                ("helpers", &["helpers"], root_helpers), /* The sibling is genuinely the nested module
+                                                          * `pkg.helpers`, not a module named `pkg_helpers`. */
+                ("pkg_helpers", &["pkg", "helpers"], sibling_helpers),
+            ],
         )?;
 
         let targets = named_targets(&app, "run");
@@ -10533,7 +10604,7 @@ def use_imported() -> int:
 def use_alias() -> int:
   return draw(3)
 "#;
-        let app = build_with_imports(app_source, &["app"], &[("helpers", helpers_source)])?;
+        let app = build_with_imports(app_source, &["app"], &[("helpers", &["helpers"], helpers_source)])?;
 
         for body in ["use_imported", "use_alias"] {
             let targets = named_targets(&app, body);
@@ -10571,7 +10642,7 @@ def run() -> int:
   return draw()
 "#;
         let helpers = build(helpers_source, &["helpers"])?;
-        let app = build_with_imports(app_source, &["app"], &[("helpers", helpers_source)])?;
+        let app = build_with_imports(app_source, &["app"], &[("helpers", &["helpers"], helpers_source)])?;
 
         let targets = named_targets(&app, "run");
         let [target] = targets.as_slice() else {

--- a/src/frontend/body_ir.rs
+++ b/src/frontend/body_ir.rs
@@ -10311,6 +10311,75 @@ def use_reexport() -> int:
         Ok(())
     }
 
+    /// A nested facade resolves its own relative re-export against *its* module, not the consumer's.
+    ///
+    /// `pkg.facade` writing `from helpers import render` means `pkg.helpers`, because a sibling-relative candidate is
+    /// tried before the bare one from `pkg.facade`. Resolving that link from the consumer instead binds the root
+    /// `helpers`, and since the cache and the identity both resolved it, they would agree on the wrong declaration.
+    /// Distinguished by arity so the binding itself proves which module won.
+    #[test]
+    fn a_nested_facade_reexport_resolves_against_the_facade_not_the_consumer() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let root_helpers = r#"
+pub def render(first: int, second: int) -> int:
+  return first + second
+"#;
+        let nested_helpers = r#"
+pub def render() -> int:
+  return 1
+"#;
+        let facade_source = r#"
+from helpers import render
+"#;
+        let app_source = r#"
+from pkg.facade import render
+
+def run() -> int:
+  return render()
+"#;
+        let app = build_with_imports(
+            app_source,
+            &["app"],
+            &[
+                ("helpers", &["helpers"], root_helpers),
+                ("pkg_helpers", &["pkg", "helpers"], nested_helpers),
+                ("pkg_facade", &["pkg", "facade"], facade_source),
+            ],
+        )?;
+
+        let targets = named_targets(&app, "run");
+        let [target] = targets.as_slice() else {
+            return Err(Box::from(format!("expected one named call, got {}", targets.len())));
+        };
+        let Some(fact) = &target.canonical else {
+            return Err(Box::from("the re-exported call must carry an identity".to_string()));
+        };
+
+        assert_eq!(
+            fact.origin,
+            incan_semantics_core::SymbolOrigin::Module(vec!["pkg".to_string(), "helpers".to_string()]),
+            "the facade's own module decides what its relative re-export means"
+        );
+
+        // The span must be the nested declaration's, not the root's identically-named one.
+        let nested = build(nested_helpers, &["pkg", "helpers"])?;
+        let nested_render = nested
+            .bodies
+            .iter()
+            .find(|body| body.name == "render")
+            .ok_or_else(|| Box::<dyn std::error::Error>::from("nested `render` body missing"))?;
+        assert_eq!(fact.declaration_span, nested_render.span);
+
+        let root = build(root_helpers, &["helpers"])?;
+        if let Some(root_render) = root.bodies.iter().find(|body| body.name == "render") {
+            assert_ne!(
+                fact.declaration_span, root_render.span,
+                "the root module's `render` is a different declaration"
+            );
+        }
+        Ok(())
+    }
+
     /// Same-named declarations cross-imported along an acyclic chain: `a` <- `b` <- `c` <- `d`.
     ///
     /// Module `c` ends up with three `make` declarations in scope at once — its own, `a`'s, and `b`'s — reached under

--- a/src/frontend/body_ir.rs
+++ b/src/frontend/body_ir.rs
@@ -10311,6 +10311,194 @@ def use_reexport() -> int:
         Ok(())
     }
 
+    /// Same-named declarations cross-imported along an acyclic chain: `a` <- `b` <- `c` <- `d`.
+    ///
+    /// Module `c` ends up with three `make` declarations in scope at once — its own, `a`'s, and `b`'s — reached under
+    /// three spellings. Each must resolve to its own declaration, and `d` must agree with `c` about which is which.
+    #[test]
+    fn same_named_declarations_cross_imported_along_a_chain_stay_distinct() -> Result<(), Box<dyn std::error::Error>> {
+        let a_source = r#"
+pub def make() -> int:
+  return 1
+"#;
+        let b_source = r#"
+from a import make as make_a
+
+pub def make() -> int:
+  return 2
+
+def use_all() -> int:
+  return make() + make_a()
+"#;
+        let c_source = r#"
+from a import make as make_a
+from b import make as make_b
+
+pub def make() -> int:
+  return 3
+
+def use_all() -> int:
+  return make() + make_a() + make_b()
+"#;
+        let d_source = r#"
+from a import make as make_a
+from b import make as make_b
+from c import make as make_c
+
+def use_all() -> int:
+  return make_a() + make_b() + make_c()
+"#;
+
+        fn origins(
+            module: &bir::BodyIrModule,
+            body: &str,
+        ) -> Result<Vec<incan_semantics_core::SymbolOrigin>, Box<dyn std::error::Error>> {
+            let mut found = Vec::new();
+            for target in named_targets(module, body) {
+                let Some(fact) = &target.canonical else {
+                    return Err(Box::from(format!("a call in `{body}` carried no identity")));
+                };
+                assert_eq!(fact.declaration_name, "make");
+                found.push(fact.origin.clone());
+            }
+            found.sort();
+            Ok(found)
+        }
+        let module_origin = |name: &str| incan_semantics_core::SymbolOrigin::Module(vec![name.to_string()]);
+
+        let b = build_with_imports(b_source, &["b"], &[("a", &["a"], a_source)])?;
+        assert_eq!(
+            origins(&b, "use_all")?,
+            vec![module_origin("a"), module_origin("b")],
+            "`b` sees its own `make` and `a`'s as different declarations"
+        );
+
+        let c = build_with_imports(c_source, &["c"], &[("a", &["a"], a_source), ("b", &["b"], b_source)])?;
+        assert_eq!(
+            origins(&c, "use_all")?,
+            vec![module_origin("a"), module_origin("b"), module_origin("c")],
+            "`c` holds three same-named declarations at once and must keep them apart"
+        );
+
+        let d = build_with_imports(
+            d_source,
+            &["d"],
+            &[
+                ("a", &["a"], a_source),
+                ("b", &["b"], b_source),
+                ("c", &["c"], c_source),
+            ],
+        )?;
+        assert_eq!(
+            origins(&d, "use_all")?,
+            vec![module_origin("a"), module_origin("b"), module_origin("c")],
+            "a consumer that only imports must agree with `c` about which declaration is which"
+        );
+        Ok(())
+    }
+
+    /// Three modules with byte-identical contents, consumed together.
+    ///
+    /// Because the sources are identical, `declaration_name`, `kind`, and `declaration_span` are identical across all
+    /// three `make` declarations, so `origin` is the only field that can separate them. If origin were dropped, wrong,
+    /// or recovered from a spelling, the three would collapse into one identity — and a consumer would dispatch a call
+    /// on `a` to the declaration in `c`.
+    ///
+    /// It also pins the converse: one declaration reached from two modules under two spellings stays one identity.
+    #[test]
+    fn identical_modules_consumed_together_keep_three_distinct_identities() -> Result<(), Box<dyn std::error::Error>> {
+        // One source text, used verbatim for `a`, `b`, and `c`.
+        let shared_source = r#"
+pub model Item:
+  value: int
+
+pub def make() -> int:
+  return 1
+
+def use_local() -> int:
+  return make()
+"#;
+        let consumer_source = r#"
+from a import make as make_a
+from b import make as make_b
+from c import make as make_c
+
+def use_a() -> int:
+  return make_a()
+
+def use_b() -> int:
+  return make_b()
+
+def use_c() -> int:
+  return make_c()
+"#;
+        let consumer = build_with_imports(
+            consumer_source,
+            &["d"],
+            &[
+                ("a", &["a"], shared_source),
+                ("b", &["b"], shared_source),
+                ("c", &["c"], shared_source),
+            ],
+        )?;
+
+        let mut facts = Vec::new();
+        for body in ["use_a", "use_b", "use_c"] {
+            let targets = named_targets(&consumer, body);
+            let [target] = targets.as_slice() else {
+                return Err(Box::from(format!(
+                    "expected one named call in `{body}`, got {}",
+                    targets.len()
+                )));
+            };
+            let Some(fact) = &target.canonical else {
+                return Err(Box::from(format!("`{body}` must carry an identity")));
+            };
+            facts.push(fact.clone());
+        }
+
+        // The premise: everything except origin is identical, so origin alone carries the distinction.
+        for fact in &facts {
+            assert_eq!(fact.declaration_name, "make");
+            assert_eq!(fact.kind, SemanticSourceTargetKind::Function);
+        }
+        assert_eq!(facts[0].declaration_span, facts[1].declaration_span);
+        assert_eq!(facts[1].declaration_span, facts[2].declaration_span);
+
+        for (fact, module) in facts.iter().zip(["a", "b", "c"]) {
+            assert_eq!(
+                fact.origin,
+                incan_semantics_core::SymbolOrigin::Module(vec![module.to_string()]),
+                "each call must name the module it imported from"
+            );
+        }
+        assert_ne!(facts[0], facts[1]);
+        assert_ne!(facts[1], facts[2]);
+        assert_ne!(facts[0], facts[2]);
+
+        // One declaration reached two ways — locally in `a`, and through `d`'s alias — stays one identity.
+        let a_module = build(shared_source, &["a"])?;
+        let local = named_targets(&a_module, "use_local");
+        let [local] = local.as_slice() else {
+            return Err(Box::from("expected one named call in `use_local`".to_string()));
+        };
+        let Some(local_fact) = &local.canonical else {
+            return Err(Box::from("the local call must carry an identity".to_string()));
+        };
+        assert_eq!(
+            *local_fact, facts[0],
+            "`a`'s own `make` and `d`'s `make_a` are one declaration"
+        );
+
+        // And the seam refuses an identity this module does not own, despite the identical spelling and span.
+        assert!(a_module.body_for_canonical_target(&facts[0]).is_some());
+        assert!(
+            a_module.body_for_canonical_target(&facts[1]).is_none(),
+            "`a` must not answer for `b`'s identically-spelled, identically-spanned declaration"
+        );
+        Ok(())
+    }
+
     /// A local declaration shadowed by a same-name import must be identified as the *local* declaration.
     ///
     /// `source_target_for_symbol` consults import bindings first and unconditionally, so the recorded source target

--- a/src/frontend/hir.rs
+++ b/src/frontend/hir.rs
@@ -88,11 +88,7 @@ fn hir_decl_kind_and_name(decl: &Declaration) -> (HirDeclarationKind, Option<Str
 
 /// Render a module path into the semantic module identity used by HIR v0.
 fn hir_module_identity(module_path: &[String]) -> String {
-    if module_path.is_empty() {
-        "<module>".to_string()
-    } else {
-        module_path.join("::")
-    }
+    incan_semantics_core::module_identity_for_path(module_path)
 }
 
 /// Build the HIR declaration identity for a named declaration.

--- a/src/frontend/typechecker/collect/stdlib_imports.rs
+++ b/src/frontend/typechecker/collect/stdlib_imports.rs
@@ -958,7 +958,25 @@ impl TypeChecker {
         false
     }
 
-    /// Record source origin metadata for an imported binding whose symbol was already materialized earlier.
+    /// Retain the canonical identity proven for an imported binding, keyed by the local name the import introduced.
+    ///
+    /// Recorded only when import resolution proves the declaration, so a consumer gets a correct identity or none at
+    /// all. It is deliberately separate from [`crate::frontend::typechecker::SourceTargetInfo::module_path`], which
+    /// keeps its existing meaning of the path as written at the import.
+    fn record_resolved_import_owner(&mut self, module: &ImportPath, item: &ImportItem, local_name: &str) {
+        if let Some(identity) = self.dependency_member_identity(module, &item.name) {
+            self.type_info
+                .declarations
+                .resolved_import_identities
+                .insert(local_name.to_string(), identity);
+        }
+    }
+
+    /// Record the codegraph source target an import makes visible under `local_name`.
+    ///
+    /// The recorded `module_path` is the import path as *written*, which is the codegraph's existing contract. The
+    /// module that resolution actually selected is recorded separately by [`Self::record_resolved_import_owner`],
+    /// because the two are not always the same and only the latter may back a declaration identity.
     fn record_source_import_target(
         &mut self,
         module: &ImportPath,
@@ -975,6 +993,7 @@ impl TypeChecker {
                     kind: target_kind.to_string(),
                 },
             );
+            self.record_resolved_import_owner(module, item, local_name);
         }
     }
 
@@ -1031,6 +1050,7 @@ impl TypeChecker {
                     kind: target_kind.to_string(),
                 },
             );
+            self.record_resolved_import_owner(module, item, &local_name);
         }
         if let SymbolKind::FunctionOverloads(overloads) = &kind {
             self.record_function_overload_binding(&local_name, overloads, true);
@@ -1494,6 +1514,7 @@ impl TypeChecker {
         if let Some(target_kind) = Self::source_target_kind(&kind) {
             let mut target_path = vec!["pub".to_string(), library.to_string()];
             target_path.extend(member.source_module_path.clone());
+
             self.source_import_targets.insert(
                 local_name.clone(),
                 crate::frontend::typechecker::SourceTargetInfo {

--- a/src/frontend/typechecker/mod.rs
+++ b/src/frontend/typechecker/mod.rs
@@ -389,6 +389,15 @@ pub struct TypeChecker {
     /// of naming the facade. Stored as the written import path plus the original name, resolved with the facade's own
     /// module path as the resolution base.
     pub(crate) dependency_member_reexports: HashMap<String, HashMap<String, (ImportPath, String)>>,
+    /// True module path segments for a registered dependency, keyed by its flattened cache name.
+    ///
+    /// The cache name is the underscore-joined spelling that also names the emitted Rust module, so it is not
+    /// injective: the path `pkg.helpers` and a module literally named `pkg_helpers` flatten to one string. An origin
+    /// built from whichever candidate matched would therefore reflect the spelling that asked rather than the module
+    /// that answered, and two spellings of one module would yield two identities. Registering the real segments
+    /// alongside the flat name — the same thing `IrCodegen::add_module_with_path_segments` does for emission — lets an
+    /// identity name the module that actually answered.
+    pub(crate) dependency_module_path_segments: HashMap<String, Vec<String>>,
     /// Module-owned direct partial projection metadata captured while that module is being imported.
     pub(crate) dependency_direct_member_partial_projections: HashMap<String, HashMap<String, PartialProjectionInfo>>,
     /// RFC 024 derivable-module metadata from imported source modules, keyed by module path.
@@ -572,6 +581,7 @@ impl TypeChecker {
             dependency_direct_member_symbols: HashMap::new(),
             dependency_direct_member_spans: HashMap::new(),
             dependency_member_reexports: HashMap::new(),
+            dependency_module_path_segments: HashMap::new(),
             dependency_direct_member_partial_projections: HashMap::new(),
             dependency_derivable_modules: HashMap::new(),
             dependency_module_traits: HashMap::new(),
@@ -5245,6 +5255,42 @@ impl TypeChecker {
     /// identity, which is the same fail-closed answer as any other unproven owner.
     const MAX_REEXPORT_DEPTH: usize = 16;
 
+    /// Register a dependency's real module path segments alongside the flattened name it is cached under.
+    ///
+    /// Caller-supplied metadata, not a derived cache: it deliberately survives `check_with_imports`, which clears the
+    /// dependency caches it rebuilds. Registering before checking is therefore the expected order, and re-registering
+    /// one name overwrites it.
+    ///
+    /// Optional: an unregistered dependency still resolves, and its identity falls back to the matching candidate's
+    /// path. Registering is what makes the origin name the module that answered rather than the spelling that asked,
+    /// which matters wherever the flattened name is ambiguous. Mirrors
+    /// `IrCodegen::add_module_with_path_segments`, which carries the same pair for emission.
+    pub fn register_dependency_module_path_segments(&mut self, module_name: &str, path_segments: Vec<String>) {
+        if path_segments.is_empty() {
+            return;
+        }
+        self.dependency_module_path_segments
+            .insert(module_name.to_string(), path_segments);
+    }
+
+    /// Return the module path segments that canonically identify a cached dependency, if they are known.
+    ///
+    /// A declaration identity must never be built from a *projection* spelling. The cache key is the flattened,
+    /// underscore-joined name that also names the emitted Rust module, and it is not injective: the path
+    /// `pkg.helpers` and a module literally named `pkg_helpers` are one key. Reading segments back out of it would
+    /// invent an origin for a module that may not exist, and would give one module two identities depending on which
+    /// spelling reached it.
+    ///
+    /// The segments therefore come from an explicit registration, and otherwise only from the one case the flattened
+    /// name determines by itself: a name containing no `_` can only be a single segment. Anything else is genuinely
+    /// ambiguous and yields no identity rather than a guess.
+    fn canonical_owner_segments(&self, cache_key: &str) -> Option<Vec<String>> {
+        if let Some(segments) = self.dependency_module_path_segments.get(cache_key) {
+            return Some(segments.clone());
+        }
+        (!cache_key.is_empty() && !cache_key.contains('_')).then(|| vec![cache_key.to_string()])
+    }
+
     /// Return the canonical identity of an imported member, following re-exports to the module that declares it.
     ///
     /// Import resolution is not literal: `logical_source_path_candidates` tries the sibling-relative path before the
@@ -5310,6 +5356,7 @@ impl TypeChecker {
                     .get(&key)
                     .and_then(|spans| spans.get(item_name))?;
                 let target_kind = Self::source_target_kind_for_symbol(kind)?;
+                let owner = self.canonical_owner_segments(&key)?;
                 return Some(CanonicalSymbolId::module_declaration(
                     owner,
                     item_name,

--- a/src/frontend/typechecker/mod.rs
+++ b/src/frontend/typechecker/mod.rs
@@ -109,6 +109,7 @@ use incan_core::lang::traits::{self as builtin_traits, TraitId};
 use incan_core::lang::types::collections::CollectionTypeId;
 use incan_core::lang::types::numerics::{self, NumericFamily, NumericTypeId};
 use incan_core::lang::types::stringlike::StringLikeId;
+use incan_semantics_core::{CanonicalSymbolId, HirSourceSpan, SemanticSourceTargetKind};
 
 /// Type checker state.
 ///
@@ -375,6 +376,19 @@ pub struct TypeChecker {
     /// contain unrelated same-name declarations from sibling modules. Direct members must therefore come from this
     /// per-module snapshot rather than a later global `lookup_symbol(...)`.
     pub(crate) dependency_direct_member_symbols: HashMap<String, HashMap<String, SymbolKind>>,
+    /// Declaration span of each directly-declared dependency member, keyed by module cache key then member name.
+    ///
+    /// RFC 120 anchors a canonical identity to its one declaration site, and a dependency's members are exactly the
+    /// declarations a consumer cannot otherwise see a span for. The cache key is the `_`-joined module spelling and is
+    /// ambiguous by itself, so the owning module path is supplied at lookup time from the resolution candidate rather
+    /// than recovered by splitting this key.
+    pub(crate) dependency_direct_member_spans: HashMap<String, HashMap<String, Span>>,
+    /// Re-export links a dependency module publishes, keyed by module cache key then exported name.
+    ///
+    /// A facade does not own what it re-exports, so an identity must follow this link to the declaring module instead
+    /// of naming the facade. Stored as the written import path plus the original name, resolved with the facade's own
+    /// module path as the resolution base.
+    pub(crate) dependency_member_reexports: HashMap<String, HashMap<String, (ImportPath, String)>>,
     /// Module-owned direct partial projection metadata captured while that module is being imported.
     pub(crate) dependency_direct_member_partial_projections: HashMap<String, HashMap<String, PartialProjectionInfo>>,
     /// RFC 024 derivable-module metadata from imported source modules, keyed by module path.
@@ -556,6 +570,8 @@ impl TypeChecker {
             dependency_registry_definitions: HashMap::new(),
             dependency_member_partial_projections: HashMap::new(),
             dependency_direct_member_symbols: HashMap::new(),
+            dependency_direct_member_spans: HashMap::new(),
+            dependency_member_reexports: HashMap::new(),
             dependency_direct_member_partial_projections: HashMap::new(),
             dependency_derivable_modules: HashMap::new(),
             dependency_module_traits: HashMap::new(),
@@ -4976,7 +4992,9 @@ impl TypeChecker {
         if let Some(direct_projections) = self.dependency_direct_member_partial_projections.get(module_name) {
             member_projections.extend(direct_projections.clone());
         }
+        let mut reexports = HashMap::new();
         for (exported_name, module, item_name) in Self::dependency_source_reexport_targets(module_ast) {
+            reexports.insert(exported_name.clone(), (module.clone(), item_name.clone()));
             if let Some(kind) = self.dependency_reexported_function_symbol(&module, &item_name) {
                 member_symbols.insert(exported_name.clone(), kind);
             }
@@ -4985,6 +5003,8 @@ impl TypeChecker {
                 member_projections.insert(exported_name, projection);
             }
         }
+        self.dependency_member_reexports
+            .insert(module_name.to_string(), reexports);
         self.dependency_member_symbols
             .insert(module_name.to_string(), member_symbols);
         self.dependency_member_partial_projections
@@ -5006,15 +5026,20 @@ impl TypeChecker {
     /// Cache direct declarations owned by one dependency module.
     fn cache_dependency_direct_member_symbols(&mut self, module_name: &str, module_ast: &Program, public_only: bool) {
         let mut direct_symbols = HashMap::new();
+        let mut direct_spans = HashMap::new();
         let mut direct_projections = HashMap::new();
         for name in Self::dependency_direct_member_names(module_ast, public_only) {
             if let Some(symbol) = self.lookup_symbol(name.as_str()) {
                 direct_symbols.insert(name.clone(), symbol.kind.clone());
+                // The symbol's own span is the declaration site an identity must anchor to.
+                direct_spans.insert(name.clone(), symbol.span);
             }
             if let Some(projection) = self.type_info.partial_projection(&name) {
                 direct_projections.insert(name, projection.clone());
             }
         }
+        self.dependency_direct_member_spans
+            .insert(module_name.to_string(), direct_spans);
         self.dependency_direct_member_symbols
             .insert(module_name.to_string(), direct_symbols);
         self.dependency_direct_member_partial_projections
@@ -5212,6 +5237,96 @@ impl TypeChecker {
         self.dependency_module_entry_for_path(module, &self.dependency_member_symbols)?
             .get(item_name)
             .cloned()
+    }
+
+    /// Maximum re-export hops followed while resolving one imported member to its declaring module.
+    ///
+    /// A malformed or cyclic facade chain must terminate rather than recurse forever; exceeding this yields no
+    /// identity, which is the same fail-closed answer as any other unproven owner.
+    const MAX_REEXPORT_DEPTH: usize = 16;
+
+    /// Return the canonical identity of an imported member, following re-exports to the module that declares it.
+    ///
+    /// Import resolution is not literal: `logical_source_path_candidates` tries the sibling-relative path before the
+    /// bare one, so the path written at an import is not necessarily the module it bound. An identity built from the
+    /// written path can therefore name a different declaration that merely shares a leaf name. This follows the same
+    /// candidate order resolution used, and where the winning candidate only re-exports the member it follows that
+    /// link instead of naming the facade — a re-export is a binding to an existing declaration, not a second one.
+    ///
+    /// Returns `None` when the member is reachable only through the ambiguous ends-with fallback, when a re-export
+    /// chain does not terminate in a declaration, when the binding is an overload set (which retains only one
+    /// candidate's span), or when the declaration kind has no canonical spelling yet. An unproven identity must stay
+    /// absent rather than resolve to a facade or to a guess.
+    ///
+    /// Two known holes, both inherited rather than introduced here. A dependency module cache key is the `_`-joined
+    /// module spelling, so a module literally named `pkg_helpers` and the path `pkg.helpers` are one key and cannot be
+    /// told apart; an origin built from the matching candidate then reflects the spelling that asked, not the module
+    /// that answered. And the entrypoint-as-logical-`main` layout resolves through an ends-with fallback that this
+    /// deliberately does not mirror, so such calls carry no identity at all. Both are recorded on #1042.
+    pub(crate) fn dependency_member_identity(&self, module: &ImportPath, item_name: &str) -> Option<CanonicalSymbolId> {
+        let current_module_path = self.current_module_path.as_deref().unwrap_or_default();
+        self.dependency_member_identity_from(current_module_path, module, item_name, 0)
+    }
+
+    /// Resolve one imported member to its declaring identity, using `from_module_path` as the resolution base.
+    ///
+    /// The base is the *consumer's* module for a direct import and the *facade's* module when following a re-export,
+    /// because a facade's own relative import paths resolve against where the facade lives, not where the consumer
+    /// does.
+    fn dependency_member_identity_from(
+        &self,
+        from_module_path: &[String],
+        module: &ImportPath,
+        item_name: &str,
+        depth: usize,
+    ) -> Option<CanonicalSymbolId> {
+        if depth >= Self::MAX_REEXPORT_DEPTH {
+            return None;
+        }
+        for owner in logical_source_import_candidates(from_module_path, module) {
+            let key = owner.join("_");
+            let resolves_here = self
+                .dependency_member_symbols
+                .get(&key)
+                .is_some_and(|members| members.contains_key(item_name));
+            if !resolves_here {
+                continue;
+            }
+
+            // Resolution stops at this candidate. It owns the declaration only if it declares the member directly.
+            if let Some(kind) = self
+                .dependency_direct_member_symbols
+                .get(&key)
+                .and_then(|direct| direct.get(item_name))
+            {
+                // An overloaded symbol keeps only one candidate's span, so an identity minted from it would name an
+                // arbitrary overload. Refuse at the producer rather than in a consumer: this accessor is public and
+                // documents that an absent identity means unproven.
+                if matches!(kind, SymbolKind::FunctionOverloads(_)) {
+                    return None;
+                }
+                let span = self
+                    .dependency_direct_member_spans
+                    .get(&key)
+                    .and_then(|spans| spans.get(item_name))?;
+                let target_kind = Self::source_target_kind_for_symbol(kind)?;
+                return Some(CanonicalSymbolId::module_declaration(
+                    owner,
+                    item_name,
+                    SemanticSourceTargetKind::from_kind_str(target_kind),
+                    HirSourceSpan::new(span.start, span.end),
+                ));
+            }
+
+            // Otherwise the member arrived here as a re-export. Follow it to the declaration it names, resolving
+            // against the *same* base `dependency_reexported_function_symbol` used when it bound the facade's link —
+            // the consuming module's path, not the facade's. Resolving against the facade would be defensible in
+            // isolation, but it would make this identity name a different declaration than the one actually bound.
+            // Both must move together if that base is ever corrected.
+            let (target_module, target_name) = self.dependency_member_reexports.get(&key)?.get(item_name)?;
+            return self.dependency_member_identity_from(from_module_path, target_module, target_name, depth + 1);
+        }
+        None
     }
 
     /// Return one imported registry's checked defining contract and canonical owner path.
@@ -5540,6 +5655,8 @@ impl TypeChecker {
         self.dependency_registry_definitions.clear();
         self.dependency_member_partial_projections.clear();
         self.dependency_direct_member_symbols.clear();
+        self.dependency_direct_member_spans.clear();
+        self.dependency_member_reexports.clear();
         self.dependency_direct_member_partial_projections.clear();
         self.dependency_derivable_modules.clear();
         self.dependency_module_traits.clear();
@@ -5586,6 +5703,8 @@ impl TypeChecker {
         self.dependency_registry_definitions.clear();
         self.dependency_member_partial_projections.clear();
         self.dependency_direct_member_symbols.clear();
+        self.dependency_direct_member_spans.clear();
+        self.dependency_member_reexports.clear();
         self.dependency_direct_member_partial_projections.clear();
         self.dependency_derivable_modules.clear();
         self.dependency_module_traits.clear();

--- a/src/frontend/typechecker/mod.rs
+++ b/src/frontend/typechecker/mod.rs
@@ -5003,12 +5003,19 @@ impl TypeChecker {
             member_projections.extend(direct_projections.clone());
         }
         let mut reexports = HashMap::new();
+        // A facade's own relative imports resolve against the facade's module, not the consumer's. Resolving them
+        // from the consumer would bind `pkg.facade`'s `from helpers import render` to the root `helpers`.
+        let facade_module_path = self
+            .canonical_owner_segments(module_name)
+            .unwrap_or_else(|| vec![module_name.to_string()]);
         for (exported_name, module, item_name) in Self::dependency_source_reexport_targets(module_ast) {
             reexports.insert(exported_name.clone(), (module.clone(), item_name.clone()));
-            if let Some(kind) = self.dependency_reexported_function_symbol(&module, &item_name) {
+            if let Some(kind) = self.dependency_reexported_function_symbol(&facade_module_path, &module, &item_name) {
                 member_symbols.insert(exported_name.clone(), kind);
             }
-            if let Some(mut projection) = self.dependency_member_partial_projection_for_path(&module, &item_name) {
+            if let Some(mut projection) =
+                self.dependency_member_partial_projection_for_path_from(&facade_module_path, &module, &item_name)
+            {
                 projection.name.clone_from(&exported_name);
                 member_projections.insert(exported_name, projection);
             }
@@ -5022,8 +5029,13 @@ impl TypeChecker {
     }
 
     /// Resolve a function re-export from either another source dependency or the compiler-owned stdlib metadata.
-    fn dependency_reexported_function_symbol(&mut self, module: &ImportPath, item_name: &str) -> Option<SymbolKind> {
-        if let Some(kind) = self.dependency_member_symbol_for_path(module, item_name) {
+    fn dependency_reexported_function_symbol(
+        &mut self,
+        base_module_path: &[String],
+        module: &ImportPath,
+        item_name: &str,
+    ) -> Option<SymbolKind> {
+        if let Some(kind) = self.dependency_member_symbol_for_path_from(base_module_path, module, item_name) {
             return Some(kind);
         }
         let module_path = canonicalize_source_module_segments(&module.segments);
@@ -5218,7 +5230,22 @@ impl TypeChecker {
         entries: &'a HashMap<String, T>,
     ) -> Option<&'a T> {
         let current_module_path = self.current_module_path.as_deref().unwrap_or_default();
-        for candidate in logical_source_import_candidates(current_module_path, module) {
+        self.dependency_module_entry_for_path_from(current_module_path, module, entries)
+    }
+
+    /// Select one dependency cache entry, resolving the import path against an explicit base module.
+    ///
+    /// A module's relative imports resolve against *its own* path. That is the consumer's path for an ordinary
+    /// import, but a facade's own path when caching what that facade re-exports: `pkg.facade` writing
+    /// `from helpers import render` means `pkg.helpers`, and resolving it from the consumer would silently bind the
+    /// root `helpers` instead.
+    fn dependency_module_entry_for_path_from<'a, T>(
+        &self,
+        base_module_path: &[String],
+        module: &ImportPath,
+        entries: &'a HashMap<String, T>,
+    ) -> Option<&'a T> {
+        for candidate in logical_source_import_candidates(base_module_path, module) {
             if let Some(entry) = entries.get(&candidate.join("_")) {
                 return Some(entry);
             }
@@ -5245,6 +5272,18 @@ impl TypeChecker {
     /// Return the exact symbol kind for one dependency module member path.
     pub(crate) fn dependency_member_symbol_for_path(&self, module: &ImportPath, item_name: &str) -> Option<SymbolKind> {
         self.dependency_module_entry_for_path(module, &self.dependency_member_symbols)?
+            .get(item_name)
+            .cloned()
+    }
+
+    /// Return one dependency member's symbol kind, resolving the import path against an explicit base module.
+    pub(crate) fn dependency_member_symbol_for_path_from(
+        &self,
+        base_module_path: &[String],
+        module: &ImportPath,
+        item_name: &str,
+    ) -> Option<SymbolKind> {
+        self.dependency_module_entry_for_path_from(base_module_path, module, &self.dependency_member_symbols)?
             .get(item_name)
             .cloned()
     }
@@ -5366,12 +5405,10 @@ impl TypeChecker {
             }
 
             // Otherwise the member arrived here as a re-export. Follow it to the declaration it names, resolving
-            // against the *same* base `dependency_reexported_function_symbol` used when it bound the facade's link —
-            // the consuming module's path, not the facade's. Resolving against the facade would be defensible in
-            // isolation, but it would make this identity name a different declaration than the one actually bound.
-            // Both must move together if that base is ever corrected.
+            // against the facade's own module — the same base `cache_dependency_member_symbols` used when it bound
+            // that link, so the identity names exactly the declaration the binding selected.
             let (target_module, target_name) = self.dependency_member_reexports.get(&key)?.get(item_name)?;
-            return self.dependency_member_identity_from(from_module_path, target_module, target_name, depth + 1);
+            return self.dependency_member_identity_from(&owner, target_module, target_name, depth + 1);
         }
         None
     }
@@ -5434,6 +5471,22 @@ impl TypeChecker {
         self.dependency_module_entry_for_path(module, &self.dependency_member_partial_projections)?
             .get(item_name)
             .cloned()
+    }
+
+    /// Return one dependency member's partial projection, resolving against an explicit base module.
+    pub(crate) fn dependency_member_partial_projection_for_path_from(
+        &self,
+        base_module_path: &[String],
+        module: &ImportPath,
+        item_name: &str,
+    ) -> Option<PartialProjectionInfo> {
+        self.dependency_module_entry_for_path_from(
+            base_module_path,
+            module,
+            &self.dependency_member_partial_projections,
+        )?
+        .get(item_name)
+        .cloned()
     }
 
     /// Register RFC 024 metadata exported by a dependency source module.

--- a/src/frontend/typechecker/type_info.rs
+++ b/src/frontend/typechecker/type_info.rs
@@ -17,9 +17,9 @@ use incan_core::interop::{CoercionPolicy, RustFunctionSig};
 use incan_core::lang::c_abi::{LinkCapabilityId, ScalarTypeId, link_capability_as_str, scalar_type_as_str};
 use incan_core::lang::types::collections::{self as collection_types, CollectionTypeId};
 use incan_semantics_core::{
-    CompilerNodeId, IncanCallableParam, IncanCallableParamKind, IncanPrimitiveType, IncanType, SemanticFact,
-    SemanticFactKind, SemanticFactStore, SemanticFactValue, SemanticRegistryEntry, SemanticRegistrySubjectKind,
-    SemanticRegistryValue, SemanticSourceTarget, SemanticSourceTargetKind,
+    CanonicalSymbolId, CompilerNodeId, IncanCallableParam, IncanCallableParamKind, IncanPrimitiveType, IncanType,
+    SemanticFact, SemanticFactKind, SemanticFactStore, SemanticFactValue, SemanticRegistryEntry,
+    SemanticRegistrySubjectKind, SemanticRegistryValue, SemanticSourceTarget, SemanticSourceTargetKind,
 };
 
 use super::{ConstValue, const_eval};
@@ -780,6 +780,14 @@ pub struct DeclarationArtifacts {
     /// Lowering consumes this instead of re-lowering raw AST annotations so aliases such as
     /// `type Expr = Union[...]` do not produce a different callable surface from typechecked call sites.
     pub function_bindings: HashMap<String, FunctionBindingInfo>,
+    /// Canonical identity proven for each imported binding, keyed by the local name the import introduced.
+    ///
+    /// [`SourceTargetInfo::module_path`] records the import path *as written*, which is not necessarily the module
+    /// resolution selected: sibling-relative candidates are tried before bare ones, so a written path can name a
+    /// different module that merely declares the same leaf name. A declaration identity must never be built from the
+    /// written path, so the proven identity is recorded here and is simply absent when resolution did not prove one.
+    /// A re-export resolves to the identity of the module that *declares* the member, never to the facade.
+    pub resolved_import_identities: HashMap<String, CanonicalSymbolId>,
     /// Module-local function declarations keyed by declaration span, preserving same-name overloads.
     pub function_bindings_by_span: HashMap<(usize, usize), FunctionBindingInfo>,
     /// Concrete class/model/trait method declarations keyed by declaration span (#1121).
@@ -1251,7 +1259,11 @@ pub enum IdentKind {
 /// Compiler-proven source declaration target for codegraph call/reference records.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SourceTargetInfo {
-    /// Canonical source module path segments that own the target declaration.
+    /// Import path segments **as written** at the reference site.
+    ///
+    /// Not necessarily the module that owns the declaration: resolution tries sibling-relative candidates before bare
+    /// ones, so this can name a different module that merely declares the same leaf name. The proven owner lives in
+    /// [`DeclarationArtifacts::resolved_import_identities`].
     pub module_path: Vec<String>,
     /// Source declaration name in the owning module.
     pub name: String,
@@ -1549,6 +1561,14 @@ impl TypeCheckInfo {
     /// Return how the identifier expression at `span` resolved in the symbol table.
     pub fn ident_kind(&self, span: Span) -> Option<IdentKind> {
         self.expressions.ident_kinds.get(&(span.start, span.end)).copied()
+    }
+
+    /// Return the canonical identity proven for an imported binding, if import resolution proved one.
+    ///
+    /// Absent means unproven, never "assume the written import path": see
+    /// [`DeclarationArtifacts::resolved_import_identities`].
+    pub fn resolved_import_identity(&self, local_name: &str) -> Option<&CanonicalSymbolId> {
+        self.declarations.resolved_import_identities.get(local_name)
     }
 
     /// Return a compiler-proven source target for the expression at `span`, if one was recorded.
@@ -1931,11 +1951,7 @@ fn callable_param_needs_boundary_snapshot(ty: &ResolvedType) -> bool {
 
 /// Render the compiler-owned module identity used by semantic fact subjects.
 fn semantic_module_identity(module_path: &[String]) -> String {
-    if module_path.is_empty() {
-        "<module>".to_string()
-    } else {
-        module_path.join("::")
-    }
+    incan_semantics_core::module_identity_for_path(module_path)
 }
 
 /// Convert a typechecker source-target artifact into the backend-neutral fact payload.

--- a/src/replacement_compatibility.rs
+++ b/src/replacement_compatibility.rs
@@ -898,6 +898,10 @@ pub(crate) fn local_implementation_contribution(
 }
 
 /// Build an explicitly temporary migration contribution for records without a landed local boundary yet.
+///
+/// Each parameter is a distinct named field of the record being built, so grouping them into a struct would
+/// only move the same list behind another type.
+#[allow(clippy::too_many_arguments)]
 fn migration_bootstrap_contribution(
     id: &'static str,
     repository_path: &'static str,
@@ -922,6 +926,10 @@ fn migration_bootstrap_contribution(
 }
 
 /// Construct the common contributor metadata and derive its visible record membership.
+///
+/// Each parameter is a distinct named field of the record being built, so grouping them into a struct would
+/// only move the same list behind another type.
+#[allow(clippy::too_many_arguments)]
 fn contribution(
     id: &'static str,
     lifecycle: CompatibilityRegistrationLifecycle,
@@ -1810,7 +1818,7 @@ pub fn render_developer_projection(
             retirement_condition,
         ));
     }
-    output.push_str("\n");
+    output.push('\n');
     output.push_str("## Compatibility features\n\n");
     output.push_str("| Feature | Source contract | Legacy run | Body IR | Direct replacement | #987 | Feature comparison | Scoped case comparisons | Disposition | Owner |\n");
     output.push_str("|---|---|---|---|---|---|---|---|---|---|\n");
@@ -2632,6 +2640,10 @@ fn planned_feature(
 /// The bootstrap map uses [`planned_feature`] only until an implementation has a coherent local registration. New
 /// implementation work must call this constructor from that boundary with its own audited selectors rather than
 /// extending the migration profile switch above.
+///
+/// Each parameter is a distinct audited anchor for the feature being registered, so grouping them into a struct would
+/// only move the same list behind another type.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn planned_feature_at_boundary(
     id: &'static str,
     contract: &'static str,


### PR DESCRIPTION
## Summary

Body IR could name the declaration behind a call only through `NamedCallableTarget::direct_call_id`, which is a *span* identity and therefore exists only for a declaration physically present in the module. An imported or renamed call reached Body IR carrying nothing but its call-site spelling.

This introduces [RFC 120]'s canonical symbol identity in `incan_semantics_core::facts`, with the payload the RFC specifies — `namespace`, `origin`, `declaration_name`, `kind`, `scope_discriminant`, `declaration_span` — and carries it from resolution into Body IR. A local call, a plain import, an import alias, and a re-export are four *bindings to* one declaration; all four now produce one identity. The call site's own spelling stays on `NamedCallableTarget::name`, so the pair records both what was written and what it means.

This is a bounded contribution to #1042 and does **not** complete RFC 120. It delivers the identity value and the reference-side recording for the direct-call profile; locals, parameters, generic binders, members, diagnostics, LSP, and codegraph remain later slices.

Closes #1210

## Type of change

- [x] New feature

## Area(s)

- [x] Compiler (frontend/backend/codegen)

## Key details

- **User-facing behavior**: none. `SourceTargetInfo::module_path` keeps its existing meaning as the path *as written*, so codegraph output is unchanged — RFC 120 Slice 2 explicitly keeps that string-shaped target as a projection so codegraph need not move in the same change.
- **Internals**: the identity is built from the module import resolution *proved* owns the declaration, never the path written at the import. Those genuinely differ — `logical_source_path_candidates` tries the sibling-relative candidate before the bare one, so `from helpers import render` inside `pkg.app` binds `pkg.helpers.render` while the import records `helpers`. Minting the written path would name a *different* declaration that merely shares a leaf name. Resolution also follows a re-export to the module that declares the member, because a facade does not own what it re-exports and naming it would split one declaration into two identities.
- **Enabling change**: anchoring to the declaration site required retaining two facts a dependency otherwise discards — each direct member's declaration span, already available from its own `Symbol` and previously dropped on the floor, and the re-export links a module publishes.
- **No second vocabulary**: `SemanticSourceTargetKind` gains the rest of RFC 120's declaration categories rather than a parallel kind enum being introduced beside it, so a member and a local are never told apart by a string.
- **Risks**: the identity stays absent, never approximate, where it is not proven — an ambiguous ends-with module fallback, a non-terminating re-export chain, and an overloaded binding, which a name-based identity cannot separate and whose disambiguating emitted-Rust name RFC 120 forbids as semantic authority. That keeps #1158's rule that an ambiguous identity stays absent rather than resolving to an arbitrary candidate. The span-based `direct_call_id` is untouched, so every refusal costs the existing executor nothing.

## Testing / verification

- [x] Manual verification described below

- `cargo test --lib` — 2753+ passed. Remaining failures are harness-dependent, not regressions: these `cli::commands::*` tests need the `incan` CLI binary beside the lib-test executable and, for three of them, the Oven dependency prewarm (they say so themselves: "run `incan oven bake --project <project-root>` once"). Both are provided by `make test`, which runs through Oven (`test-oven: test-prewarm-oven-loafs`) and is the deferred Slice-level gate. Supplying the binary drops the count from 28 to 3; the same set fails on unmodified `origin/0.6-dev`. They are also parallelism-flaky — observed counts of 3, 4, 28 and 53 across runs of an unchanged tree.
- `parity_corpus_tests` 9, `replacement_backend_execution_tests` 72, `replacement_compatibility_registry_tests` 3, `semantic_core_parity` 6, `semantic_core_parity_strings` 10, `shadow_comparison_tests` 9 — all passed
- `incan_semantics_core` lib — 42 passed
- `cargo +nightly fmt`; Clippy clean for every touched file; `scripts/check_changed_rustdocs.py` passed; `git diff --check` clean

Conformance probes, each mutation-verified to confirm it can actually fail:

- `one_declaration_keeps_one_identity_across_local_imported_aliased_and_reexported_calls` — RFC 120's guide-level example. One `render` reached four ways yields one identity anchored to the declaration's span, while the four call-site spellings stay visibly different.
- `a_local_declaration_shadowed_by_a_same_name_import_is_identified_locally` — the shadowing case. Mutating the local branch back to inferring locality reproduces the defect exactly (`Module(["helpers"])` where `Module(["app"])` is required).
- `the_consumer_seam_separates_same_named_bodies_by_declaration_span` — a class method and a free function both named `render`; matching on name instead of span now fails.
- `a_renamed_multi_hop_re_export_still_resolves_to_the_original_declaration` — depth-2 chain with a rename in the middle; neither alias becomes the declared name.
- `a_sibling_relative_import_is_owned_by_the_module_resolution_actually_selected` — written-vs-resolved path, now asserting the declaration span as well as the origin.
- `each_local_overload_gets_its_own_identity` — two overloads are two declarations and must not collapse.
- `an_imported_overloaded_binding_has_no_canonical_identity` — pins the refusal for the case where only one candidate's span survives.
- `every_source_target_kind_round_trips_through_its_spelling` — pins the 22 hand-written string arms.

### Keeping the projection name and the canonical name separate

The dependency cache is keyed by the flattened, underscore-joined module name, which also names the emitted Rust module and so is not injective: the path `pkg.helpers` and a module literally named `pkg_helpers` are one key. One string was doing two jobs, and an origin recovered from it invents a module that may not exist.

The two names are now kept apart rather than one being recovered from the other. The flattened name stays purely the emission projection; the canonical origin comes from real path segments, registered via `register_dependency_module_path_segments` from the pair the CLI already holds on `ParsedModule` — the same pair `IrCodegen::add_module_with_path_segments` carries for emission. Where nothing is registered, the origin is taken only from the one case the flattened name settles by itself (a name with no `_` is a single segment); anything else yields no identity rather than a guess. **An identity is never built from a projection spelling.**

Encoding the segments into one string was considered and rejected. Escaping is not injective at segment boundaries — with `_` as separator and a literal `_` doubled, `["pkg_","helpers"]` and `["pkg","_helpers"]` both render `pkg___helpers` — and an encoding that *is* injective (`_` → `_u`, percent-style, a hashed id) would change the emitted Rust module name, which this must not do.

Fixtures now declare each dependency's real segments beside its cache name, so a test can express `pkg.helpers` and a module named `pkg_helpers` as the different modules they are. The sibling-import test previously could not tell those apart.

What remains, inherited and unchanged: two genuinely distinct modules that flatten to one name still collide **in the dependency cache itself**, so one shadows the other. That predates this change and affects emission equally; keying resolution on identity rather than the flattened string is RFC 120 Slice 8 territory.

### Known hole, documented rather than fixed

- The entrypoint-as-logical-`main` layout resolves through an ends-with fallback this deliberately does not mirror, so such calls carry no identity at all. Fail-closed, and named in the resolver's rustdoc.

`make pre-commit`, full Oven suites, and slice-wide CI are deliberately deferred to the Slice-level integration gate.

## Docs impact

- [x] No docs changes needed

RFC 120 already specifies this contract; the rustdoc on the new items points at it. A stale `CallableTarget::Named` comment claiming call-target resolution was "deferred past v0" is corrected in the same change.

## Checklist

- [x] I added/updated tests where it materially reduces regressions

[RFC 120]: https://github.com/encero-systems/incan/blob/0.6-dev/workspaces/docs-site/docs/RFCs/120_canonical_source_symbol_identity.md
