### PR TITLE
feature - lower newtype and enum method bodies in Body IR (#1163)

### DIFF
--- a/src/frontend/body_ir.rs
+++ b/src/frontend/body_ir.rs
@@ -135,8 +135,10 @@ pub fn build_body_ir_module_v0(
                     &lowering_facts,
                 ),
                 // A newtype's receiver is the newtype itself, not its underlying type: a method reading the wrapped
-                // value goes through the nominal receiver. A `rusttype` needs no separate arm — its methods are
-                // bodyless, and `lower_method_body` already contributes nothing for those.
+                // value goes through the nominal receiver. `rusttype` is a flag on the same declaration rather than a
+                // separate kind, so its methods take this arm too: one with a body (a `for Trait` implementation, say)
+                // lowers like any other newtype method, and one without contributes nothing through
+                // `lower_method_body`'s existing `body: None` check.
                 ast::Declaration::Newtype(newtype) => lower_owner_method_bodies(
                     &newtype.methods,
                     &newtype.name,

--- a/src/frontend/body_ir.rs
+++ b/src/frontend/body_ir.rs
@@ -134,6 +134,21 @@ pub fn build_body_ir_module_v0(
                     IncanType::SelfType,
                     &lowering_facts,
                 ),
+                // A newtype's receiver is the newtype itself, not its underlying type: a method reading the wrapped
+                // value goes through the nominal receiver. A `rusttype` needs no separate arm — its methods are
+                // bodyless, and `lower_method_body` already contributes nothing for those.
+                ast::Declaration::Newtype(newtype) => lower_owner_method_bodies(
+                    &newtype.methods,
+                    &newtype.name,
+                    owner_self_type(&newtype.name, &newtype.type_params),
+                    &lowering_facts,
+                ),
+                ast::Declaration::Enum(enum_decl) => lower_owner_method_bodies(
+                    &enum_decl.methods,
+                    &enum_decl.name,
+                    owner_self_type(&enum_decl.name, &enum_decl.type_params),
+                    &lowering_facts,
+                ),
                 _ => Vec::new(),
             }
         })

--- a/src/frontend/body_ir/bodies.rs
+++ b/src/frontend/body_ir/bodies.rs
@@ -2,16 +2,17 @@
 
 use super::*;
 
-/// Lower every non-abstract method in `methods` (owned by the class/model/trait named `owner_name`) into one
+/// Lower every non-abstract method in `methods` (owned by the declaration named `owner_name`) into one
 /// [`bir::Body`] each, skipping abstract methods (`body: None`). `receiver_ty` is the typechecker-equivalent type
-/// for a declared receiver: a concrete nominal type for models/classes or [`IncanType::SelfType`] for trait defaults.
+/// for a declared receiver: a concrete nominal type for models, classes, newtypes, and enums, or
+/// [`IncanType::SelfType`] for trait defaults.
 ///
-/// Newtype and enum declarations also carry a `methods` field in the AST (see `crates/incan_syntax/src/ast/
-/// decls.rs`), but #1102's own scope names only class/model/trait bodies, so this function is deliberately not
-/// called for those two declaration kinds. #1163 owns extending it. Until then this is the module's only *silent*
-/// coverage gap: every other unsupported construct leaves a `StatementKind::Unsupported` or `Operand::Unknown`
-/// marker behind, while a newtype or enum method produces no [`bir::Body`] at all, so a consumer counting bodies
-/// reads a program using one as fully represented.
+/// Exactly five declaration kinds carry a `methods` field -- model, class, trait, newtype, and enum (see
+/// `crates/incan_syntax/src/ast/decls.rs`) -- and all five reach this function. No kind that carries methods is
+/// skipped, which matters because a skipped kind is the one failure this module cannot make visible: every other
+/// unsupported construct leaves a `StatementKind::Unsupported` or `Operand::Unknown` marker behind, while a skipped
+/// declaration produces no [`bir::Body`] at all and a consumer counting bodies reads the program as fully
+/// represented. `every_declaration_kind_that_carries_methods_lowers_its_bodies` pins that.
 pub(super) fn lower_owner_method_bodies(
     methods: &[ast::Spanned<ast::MethodDecl>],
     owner_name: &str,

--- a/src/frontend/body_ir/tests.rs
+++ b/src/frontend/body_ir/tests.rs
@@ -4732,3 +4732,124 @@ def use_str() -> int:
     }
     Ok(())
 }
+
+/// Newtype and enum methods lower like any other owner's methods.
+///
+/// The body count is asserted explicitly so a future regression shows up as a mismatch rather than a silent
+/// absence, which is how this gap went unnoticed: nothing failed when these bodies were simply never produced.
+#[test]
+fn newtype_and_enum_methods_contribute_bodies() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+type Meters = newtype int:
+    def value(self) -> int:
+        return self.0
+
+    def scale(mut self, factor: int) -> None:
+        self.0 = self.0 * factor
+
+enum Signal:
+    Idle
+    Active(int)
+
+    def code(self) -> int:
+        return 0
+
+def run() -> int:
+    return 1
+"#;
+    let module = build(source, &["app"])?;
+
+    let names: Vec<&str> = module.bodies.iter().map(|body| body.name.as_str()).collect();
+    assert!(
+        names.contains(&"value"),
+        "newtype method `value` must lower, got {names:?}"
+    );
+    assert!(
+        names.contains(&"scale"),
+        "newtype `mut self` method must lower, got {names:?}"
+    );
+    assert!(names.contains(&"code"), "enum method `code` must lower, got {names:?}");
+    assert!(names.contains(&"run"));
+    assert_eq!(
+        module.bodies.len(),
+        4,
+        "one body per method plus the free function, and nothing else: {names:?}"
+    );
+
+    // Each method's identity is scoped under its owning declaration, so two owners may share a method name.
+    for (owner, method) in [("Meters", "value"), ("Meters", "scale"), ("Signal", "code")] {
+        let body = module
+            .bodies
+            .iter()
+            .find(|body| body.name == method)
+            .ok_or_else(|| Box::<dyn std::error::Error>::from(format!("`{method}` body missing")))?;
+        assert!(
+            body.decl_id.path().ends_with(&format!("{owner}::{method}")),
+            "`{method}` must be scoped under `{owner}`, got {}",
+            body.decl_id.path()
+        );
+    }
+    Ok(())
+}
+
+/// An enum method that dispatches on `self`, including a payload variant, lowers a real body rather than an
+/// empty or placeholder one.
+#[test]
+fn an_enum_method_dispatching_on_self_lowers_its_match() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+enum Signal:
+    Idle
+    Active(int)
+
+    def level(self) -> int:
+        match self:
+            case Signal.Idle:
+                return 0
+            case Signal.Active(amount):
+                return amount
+"#;
+    let module = build(source, &["app"])?;
+
+    let body = module
+        .bodies
+        .iter()
+        .find(|body| body.name == "level")
+        .ok_or_else(|| Box::<dyn std::error::Error>::from("enum method `level` must lower"))?;
+
+    assert!(!body.block.stmts.is_empty(), "the method must lower a real body");
+    // A refused construct also produces statements, so an empty check proves nothing on its own. The snapshot
+    // carrying no `unsupported(` node is what distinguishes a lowered match from a placeholder.
+    let rendered = module.render_snapshot();
+    assert!(
+        !rendered.contains("unsupported("),
+        "the match and its payload binding must lower, not refuse:\n{rendered}"
+    );
+    Ok(())
+}
+
+/// A newtype method reading its wrapped value lowers through the nominal receiver.
+#[test]
+fn a_newtype_method_reads_its_wrapped_value() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+type Meters = newtype int:
+    def doubled(self) -> int:
+        return self.0 * 2
+"#;
+    let module = build(source, &["app"])?;
+    let body = module
+        .bodies
+        .iter()
+        .find(|body| body.name == "doubled")
+        .ok_or_else(|| Box::<dyn std::error::Error>::from("newtype method `doubled` must lower"))?;
+    assert!(!body.block.stmts.is_empty());
+    assert!(
+        !module.render_snapshot().contains("unsupported("),
+        "reading the wrapped value must lower, not refuse"
+    );
+    assert!(
+        body.decl_id.path().ends_with("Meters::doubled"),
+        "identity is scoped under the newtype, got {}",
+        body.decl_id.path()
+    );
+    Ok(())
+}

--- a/src/frontend/body_ir/tests.rs
+++ b/src/frontend/body_ir/tests.rs
@@ -4853,3 +4853,120 @@ type Meters = newtype int:
     );
     Ok(())
 }
+
+/// A newtype method's receiver is the newtype itself, and `mut self` stays a mutable receiver.
+#[test]
+fn newtype_method_receivers_are_receiver_locals() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+type Meters = newtype int:
+    def value(self) -> int:
+        return self.0
+
+    def scale(mut self, factor: int) -> None:
+        self.0 = self.0 * factor
+"#;
+    let module = build(source, &["m", "newtype_receiver"])?;
+    let snapshot = module.render_snapshot();
+
+    assert!(snapshot.contains("local 0 self : Meters [receiver]"), "{snapshot}");
+    assert!(snapshot.contains("local 0 self : Meters [receiver_mut]"), "{snapshot}");
+    assert!(
+        !snapshot.contains("unsupported("),
+        "newtype receiver reads and mutation must lower without a placeholder: {snapshot}"
+    );
+    Ok(())
+}
+
+/// An enum method's receiver is the enum value it dispatches on.
+#[test]
+fn enum_method_receiver_is_a_receiver_local() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+enum Signal:
+    Idle
+    Active(int)
+
+    def code(self) -> int:
+        return 0
+"#;
+    let module = build(source, &["m", "enum_receiver"])?;
+    let snapshot = module.render_snapshot();
+
+    assert!(snapshot.contains("local 0 self : Signal [receiver]"), "{snapshot}");
+    Ok(())
+}
+
+/// A bodyless newtype or enum method never reaches lowering: the source checker rejects it first.
+///
+/// Only a trait declaration admits a bodyless method, so the "abstract method contributes nothing" boundary sits
+/// upstream for these two kinds rather than in the lowering walk. Lowering still has to stay total for the rejected
+/// program, which is what this pins — no body, and no `Unsupported` placeholder standing in for one.
+#[test]
+fn a_bodyless_newtype_or_enum_method_is_a_source_error_and_lowers_nothing() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+enum Signal:
+    Idle
+
+    def label(self) -> str: ...
+"#;
+    let (module, errors) = build_after_expected_typecheck_errors(source, &["m", "bodyless"])?;
+
+    assert!(
+        errors
+            .iter()
+            .any(|error| error.contains("must have a body outside trait declarations")),
+        "the source checker owns this refusal: {errors:?}"
+    );
+    assert!(
+        module.bodies.is_empty(),
+        "a rejected bodyless method must produce neither a body nor a placeholder: {:?}",
+        module.bodies.iter().map(|body| body.name.as_str()).collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
+/// Every declaration kind that carries a `methods` field lowers its bodies.
+///
+/// A skipped kind is the one coverage failure this module cannot make visible — it produces no `Body` at all rather
+/// than an `Unsupported` marker — so the exhaustive set is pinned here rather than left to the walk's `_ => ` arm.
+#[test]
+fn every_declaration_kind_that_carries_methods_lowers_its_bodies() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+trait Describable:
+    def describe(self) -> int:
+        return 0
+
+model Point:
+    x: int
+
+    def get_x(self) -> int:
+        return self.x
+
+class Counter:
+    total: int
+
+    def total_now(self) -> int:
+        return self.total
+
+type Meters = newtype int:
+    def raw(self) -> int:
+        return self.0
+
+enum Signal:
+    Idle
+
+    def code(self) -> int:
+        return 1
+"#;
+    let module = build(source, &["m", "all_owners"])?;
+    let names: Vec<&str> = module.bodies.iter().map(|body| body.name.as_str()).collect();
+
+    for method in ["describe", "get_x", "total_now", "raw", "code"] {
+        assert!(names.contains(&method), "`{method}` must lower, got {names:?}");
+    }
+    assert_eq!(
+        module.bodies.len(),
+        5,
+        "one body per methods-carrying declaration kind and nothing else: {names:?}"
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary

`build_body_ir_module_v0` called `lower_owner_method_bodies` for model, class, and trait only. Newtype and enum also carry a `methods` field, and their methods were **skipped entirely** — producing no `bir::Body` at all.

That was the module's only *silent* coverage gap. Every other unsupported construct leaves a `StatementKind::Unsupported` or `Operand::Unknown` marker behind; a skipped declaration leaves nothing, so a consumer counting bodies reads the program as fully represented.

Closes #1163

## Type of change

- [x] New feature

## Area(s)

- [x] Compiler (frontend/backend/codegen)

## Key details

- **User-facing behavior**: none. Body IR gains bodies it should always have had; executing them is deliberately out of scope.
- **Internals**: two arms on the existing declaration walk, with the newtype's own nominal type as the receiver rather than its underlying type. No new lowering machinery — `Body`, `LocalOrigin::Receiver`, and the method id construction all already existed.
- **Exhaustiveness**: exactly five declaration kinds carry a `methods` field, and all five now reach the walk. The rustdoc records that contract, and a test pins the set rather than leaving it to the walk's catch-all arm.
- **`rusttype`**: needs no separate arm — `lower_method_body` opens with `let body_stmts = method.body.as_ref()?;`, so a bodyless method contributes nothing through the existing contract. This resolves the question left open on the issue.

## Two findings worth recording

**The "abstract method contributes nothing" criterion is not a lowering case.** The source checker rejects a bodyless method outside a trait declaration — *"Method 'label' must have a body outside trait declarations"* — so for newtype and enum that boundary sits upstream. The test asserts the real behavior rather than a lowering path that cannot be reached: the source error owns the refusal, and lowering still produces neither a body nor a placeholder for the rejected program.

**A non-empty body proves nothing on its own.** A *refused* construct also produces statements, so the lowering tests assert the snapshot carries no `unsupported(` node.

## Testing / verification

- [x] Manual verification described below

- `cargo test --lib -- body_ir hir::` — 176 passed
- `parity_corpus_tests` 9, `replacement_backend_execution_tests` 72, `replacement_compatibility_registry_tests` 3, `shadow_comparison_tests` 9 — passed
- `cargo +nightly fmt`; Clippy clean for touched files; rustdoc gate passed; `git diff --check` clean

Tests, one per acceptance criterion:

| Criterion | Test |
| --- | --- |
| newtype method reading its wrapped value | `a_newtype_method_reads_its_wrapped_value` |
| newtype `mut self` method | `newtype_method_receivers_are_receiver_locals` (asserts `[receiver]` **and** `[receiver_mut]`) |
| enum method dispatching on `self`, payload variant | `an_enum_method_dispatching_on_self_lowers_its_match` |
| enum receiver local | `enum_method_receiver_is_a_receiver_local` |
| abstract/bodyless contributes nothing | `a_bodyless_newtype_or_enum_method_is_a_source_error_and_lowers_nothing` |
| body count includes newtype and enum methods | `newtype_and_enum_methods_contribute_bodies` — **mutation-verified**: removing the two arms fails it |
| no methods-carrying kind silently skipped | `every_declaration_kind_that_carries_methods_lowers_its_bodies` |

`make pre-commit` and full Oven suites are the Slice-level gate and were not run here.

## Docs impact

- [x] No docs changes needed

The stale rustdoc on `lower_owner_method_bodies` — which still said newtype and enum were "deliberately not called ... #1163 owns extending it" — is corrected in the same change.

## Checklist

- [x] I added/updated tests where it materially reduces regressions
