### PR TITLE
feature - represent pattern and raises assert forms in Body IR (#1167)

### DIFF
--- a/crates/incan_semantics_core/src/body_ir.rs
+++ b/crates/incan_semantics_core/src/body_ir.rs
@@ -41,6 +41,9 @@
 
 use std::fmt::Write as _;
 
+use incan_core::errors::ErrorKind;
+use incan_core::lang::errors;
+
 use crate::{
     AbiV0RuntimeRequirement, CanonicalSymbolId, CompilerNodeId, HirSourceSpan, IncanType, module_identity_for_path,
 };
@@ -2213,7 +2216,7 @@ fn render_statement(out: &mut String, stmt: &Statement, indent: &str, depth: usi
             let _ = writeln!(out, "{indent}yield {}", value.render_snapshot());
         }
         StatementKind::Assert {
-            cond,
+            kind,
             message,
             may_panic,
         } => {
@@ -2222,7 +2225,7 @@ fn render_statement(out: &mut String, stmt: &Statement, indent: &str, depth: usi
                 .map(|m| format!(", {}", m.render_snapshot()))
                 .unwrap_or_default();
             let panic_marker = if *may_panic { " may_panic" } else { "" };
-            let _ = writeln!(out, "{indent}assert {}{msg}{panic_marker}", cond.render_snapshot());
+            let _ = writeln!(out, "{indent}assert {}{msg}{panic_marker}", kind.render_snapshot());
         }
         StatementKind::Expr { value } => {
             let _ = writeln!(out, "{indent}expr {}", value.render_snapshot());
@@ -2396,9 +2399,19 @@ pub enum StatementKind {
     /// iterator-adapter runtime path. Neither representation asks a consumer to infer a suspension point from a
     /// target-language closure shape.
     Yield { value: Operand },
-    /// `assert cond[, message]`.
+    /// One RFC 018 assertion in any of its three source forms, with the optional failure message and panic marker
+    /// every form shares.
+    ///
+    /// The form-specific payload lives in [`AssertionKind`] rather than in three sibling statement kinds, because
+    /// `message` and `may_panic` are invariant across all three forms and every assertion records the same
+    /// [`PanicReason::AssertFailure`] fact and [`crate::AbiV0RuntimeRequirement::PanicStrategy`] requirement. Three
+    /// sibling kinds would repeat those shared fields three times, let them drift apart, and force every exhaustive
+    /// walk over this vocabulary to grow three arms for one concept; a consumer that only needs "is this an
+    /// assertion" still matches one variant here, and one that cares which form matches the payload.
     Assert {
-        cond: Operand,
+        /// Which assertion form this is, plus the operands and facts only that form carries.
+        kind: AssertionKind,
+        /// Optional failure message, applicable to all three forms.
         message: Option<Operand>,
         may_panic: bool,
     },
@@ -2450,6 +2463,46 @@ pub enum StatementKind {
     /// A source construct v0 lowering does not yet model. Keeps the model total over real programs instead of
     /// panicking or silently dropping the construct.
     Unsupported { description: String },
+}
+
+/// The form-specific payload of one [`StatementKind::Assert`], covering all three RFC 018 assertion spellings.
+///
+/// See [`StatementKind::Assert`] for why the three forms are one variant with this payload rather than three
+/// sibling statement kinds.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AssertionKind {
+    /// `assert cond`: panics when `cond` is false.
+    Condition { cond: Operand },
+    /// `assert value is P`: panics when `value` does not match `P`, and on the matching path binds `P`'s names for
+    /// the remainder of the enclosing block.
+    ///
+    /// The bindings are ordinary declared locals carried inside `pattern`'s [`PatternBinding`]s, exactly as a
+    /// `match` arm's are, so a consumer reading one of those names later finds a local this body declared rather
+    /// than an unresolved name. `scrutinee` is read as [`OwnershipFact::Borrow`] for the same reason
+    /// [`Rvalue::Match::scrutinee`] is: the overall read must not risk an unconditional move while individual
+    /// bindings compute their own, more precise facts against places projected out of it.
+    Pattern { scrutinee: Operand, pattern: Pattern },
+    /// `assert call() raises E`: evaluates `call`, expecting it to raise a runtime error of type `E`, and panics
+    /// when it does not.
+    ///
+    /// `expected_error` is the resolved builtin-exception identity, not the source spelling after `raises`, so a
+    /// consumer never has to re-resolve a name against the exception registry to know which error is expected.
+    Raises { call: Operand, expected_error: ErrorKind },
+}
+
+impl AssertionKind {
+    /// Render the form-specific part of an assertion's snapshot line, without the shared message/panic suffix.
+    fn render_snapshot(&self) -> String {
+        match self {
+            Self::Condition { cond } => cond.render_snapshot(),
+            Self::Pattern { scrutinee, pattern } => {
+                format!("{} is {}", scrutinee.render_snapshot(), pattern.render_snapshot())
+            }
+            Self::Raises { call, expected_error } => {
+                format!("{} raises {}", call.render_snapshot(), errors::as_str(*expected_error))
+            }
+        }
+    }
 }
 
 /// Typechecker-proven error routing selected for one `?` operation.

--- a/src/backend/replacement/mod.rs
+++ b/src/backend/replacement/mod.rs
@@ -28,13 +28,13 @@ use incan_core::{
     python_floor_div_i64, python_mod_i64,
 };
 use incan_semantics_core::body_ir::{
-    AggregateKind, ArgumentBinding, ArgumentElement, BinOp, Body, BodyIrModule, CallableParam, CallableParamDefault,
-    CallableTarget, Callee, ClosureBody, Constant, ConstructorTarget, DefaultComputation, FieldlessEnumDeclaration,
-    FieldlessEnumVariantDeclaration, FieldlessEnumVariantTarget, GeneratorBody, HelperOp, IterProtocol,
-    LocalCallableTarget, LocalId, LocalOrigin, MatchArm, NamedCallableBuiltin, NamedCallableTarget, NominalDeclaration,
-    NominalPatternTarget, Operand, OwnershipFact, Pattern, PatternBinding, Place, PlaceElem, ResultVariant,
-    ResultVariantKind, Rvalue, ScopeId, Statement, StatementKind, TryErrorRouting, UnOp, ValueEnumBacking,
-    ValueEnumDeclaration, ValueEnumVariantDeclaration, ValueEnumVariantTarget,
+    AggregateKind, ArgumentBinding, ArgumentElement, AssertionKind, BinOp, Body, BodyIrModule, CallableParam,
+    CallableParamDefault, CallableTarget, Callee, ClosureBody, Constant, ConstructorTarget, DefaultComputation,
+    FieldlessEnumDeclaration, FieldlessEnumVariantDeclaration, FieldlessEnumVariantTarget, GeneratorBody, HelperOp,
+    IterProtocol, LocalCallableTarget, LocalId, LocalOrigin, MatchArm, NamedCallableBuiltin, NamedCallableTarget,
+    NominalDeclaration, NominalPatternTarget, Operand, OwnershipFact, Pattern, PatternBinding, Place, PlaceElem,
+    ResultVariant, ResultVariantKind, Rvalue, ScopeId, Statement, StatementKind, TryErrorRouting, UnOp,
+    ValueEnumBacking, ValueEnumDeclaration, ValueEnumVariantDeclaration, ValueEnumVariantTarget,
 };
 use incan_semantics_core::{
     AbiV0RuntimeRequirement, CompilerNodeId, CompilerNodeKind, HirSourceSpan, IncanPrimitiveType, IncanType,
@@ -1501,8 +1501,12 @@ fn validate_statement_profile(
         StatementKind::Return { value } => value.as_ref().map_or(Ok(()), |value| {
             validate_operand_profile(value, statement.span, tuple_iteration_locals)
         }),
+        // #1167 gave Body IR the pattern and `raises` assertion forms. Executing them -- match-and-bind on the
+        // panicking path, and catching a raised runtime error -- stays bounded by #1154's value-state work, so
+        // they refuse by name at the original source span rather than leaving the executor unable to compile
+        // against the representation, the same treatment `Await`/`Race` get above.
         StatementKind::Assert {
-            cond,
+            kind: AssertionKind::Condition { cond },
             message,
             may_panic: _,
         } => {
@@ -1511,6 +1515,14 @@ fn validate_statement_profile(
                 validate_operand_profile(message, statement.span, tuple_iteration_locals)
             })
         }
+        StatementKind::Assert {
+            kind: AssertionKind::Pattern { .. },
+            ..
+        } => Err(unsupported("pattern assertion", statement.span)),
+        StatementKind::Assert {
+            kind: AssertionKind::Raises { .. },
+            ..
+        } => Err(unsupported("raises assertion", statement.span)),
         StatementKind::Expr { value } => validate_operand_profile(value, statement.span, tuple_iteration_locals),
         StatementKind::IterNext {
             destination,
@@ -2453,7 +2465,7 @@ impl BodyExecutor {
                     .transpose()?,
             )),
             StatementKind::Assert {
-                cond,
+                kind: AssertionKind::Condition { cond },
                 message,
                 may_panic: _,
             } => {
@@ -2470,6 +2482,15 @@ impl BodyExecutor {
                     Err(runtime_failure(detail, statement.span))
                 }
             }
+            // Refused by `validate_statement_profile` before execution starts -- see its own `Assert` arms.
+            StatementKind::Assert {
+                kind: AssertionKind::Pattern { .. },
+                ..
+            } => Err(unsupported("pattern assertion", statement.span)),
+            StatementKind::Assert {
+                kind: AssertionKind::Raises { .. },
+                ..
+            } => Err(unsupported("raises assertion", statement.span)),
             StatementKind::Expr { value } => {
                 let _ = self.evaluate_operand(value, statement.span)?;
                 Ok(Flow::Next)

--- a/src/frontend/body_ir.rs
+++ b/src/frontend/body_ir.rs
@@ -14,7 +14,9 @@
 //! assignment, `return`, `if`/`elif`/`else`, `while`, `for` (both a `start..end` range and a general iterable --
 //! builtin collections or a resolved `__iter__`/`__next__` protocol, including the fallible `for item in
 //! iterable?:` form), expression statements, statement-position `yield value` (see [`BodyBuilder::lower_stmt_into`]
-//! and [`bir::Body::is_generator`]), `assert`, `pass`, `break` (including a value-producing `break` inside a `loop`
+//! and [`bir::Body::is_generator`]), all three RFC 018 `assert` forms -- plain condition, `assert value is P`
+//! (whose bindings stay live for the rest of the enclosing block), and `assert call() raises E` (see
+//! [`BodyBuilder::lower_assert`]) -- `pass`, `break` (including a value-producing `break` inside a `loop`
 //! expression), `continue`. Expressions fully lowered: identifiers, literals (int/float/decimal/bool/string),
 //! arithmetic/comparison/boolean binary operators and all three unary operators, calls and method calls (including
 //! named, out-of-order, defaulted, and explicitly generic argument spellings -- see [`BodyBuilder::lower_call`]),
@@ -35,7 +37,7 @@
 //! establish; a spread to a locally held callable value; the `**`, bitwise, shift, `in`/`not
 //! in`, and `is`/`is not` operators and their compound forms; `if let`/`while let` conditions and destructuring
 //! comprehension/generator clauses; statement-position `loop:`; `unsafe:` regions; `await` and `race for`; bytes
-//! literals and a `Range` used as a value outside a `for` header; the pattern and `raises` `assert` forms; and
+//! literals and a `Range` used as a value outside a `for` header; and
 //! vocab/scoped-DSL surface nodes, which reach this module only when a caller skips the desugar pass the legacy
 //! pipeline runs first. The sub-issues are #1158 through #1167, plus #1172 for evaluable callable defaults.
 //!

--- a/src/frontend/body_ir/assertions.rs
+++ b/src/frontend/body_ir/assertions.rs
@@ -1,26 +1,37 @@
 //! Lowering for `assert` forms and their explicit panic facts.
 
+use incan_core::lang::errors as runtime_errors;
+
+use super::match_::PatternReadScope;
+use super::refusals::*;
 use super::*;
 
 impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
-    /// Lower `assert cond[, message]`, recording an [`bir::PanicReason::AssertFailure`] panic fact and a
-    /// [`AbiV0RuntimeRequirement::PanicStrategy`] runtime requirement since every assert can panic. The pattern
-    /// (`assert value is Some(name)`) and `raises` (`assert call() raises E`) forms are not modeled by v0 and lower
-    /// to an explicit unsupported placeholder instead (#1167). The pattern form's placeholder is lossy rather than
-    /// merely incomplete: it discards the names the pattern would bind, so a later read of one lowers against a
-    /// local this body never declared.
+    /// Lower any of RFC 018's three `assert` forms into one [`bir::StatementKind::Assert`], recording a
+    /// [`bir::PanicReason::AssertFailure`] panic fact and an [`AbiV0RuntimeRequirement::PanicStrategy`] runtime
+    /// requirement, because every form can panic. The optional failure message applies to all three and is lowered
+    /// after the form's own operands, matching source evaluation order.
+    ///
+    /// `remaining` is the statement suffix following this assertion in its enclosing block. Only the
+    /// `assert value is P` form uses it: unlike a `match` arm, a pattern assertion binds `P`'s names for the rest
+    /// of that block, so the suffix is what seeds each binding's last-use countdown (see [`PatternReadScope`]).
+    ///
+    /// The pattern form reuses [`Self::lower_match_pattern`] rather than approximating the binding, so `v` in
+    /// `assert value is Some(v)` becomes a declared local carrying the same [`bir::PatternBinding`]
+    /// ownership/last-use facts `match value: case Some(v)` would produce. Lowering deliberately does *not* restore
+    /// `self.bindings` afterwards the way [`Self::lower_match`] does at an arm boundary — that persistence is the
+    /// whole point of the form.
     pub(super) fn lower_assert(
         &mut self,
         assert_stmt: &ast::AssertStmt,
+        remaining: &[ast::Spanned<ast::Statement>],
         scope: bir::ScopeId,
         span: HirSourceSpan,
         out: &mut Vec<bir::Statement>,
     ) {
-        let ast::AssertKind::Condition(cond_expr) = &assert_stmt.kind else {
-            self.push_unsupported_stmt("assert pattern/raises form".to_string(), span, out);
+        let Some(kind) = self.lower_assert_kind(&assert_stmt.kind, remaining, scope, span, out) else {
             return;
         };
-        let cond = self.lower_expr_to_operand(cond_expr, scope, out);
         let message = assert_stmt
             .message
             .as_ref()
@@ -32,7 +43,7 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
         self.record_runtime_requirement(AbiV0RuntimeRequirement::PanicStrategy);
         out.push(bir::Statement {
             kind: bir::StatementKind::Assert {
-                cond,
+                kind,
                 message,
                 may_panic: true,
             },
@@ -40,5 +51,97 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
         });
     }
 
+    /// Lower the form-specific payload of one assertion, or push an explicit refusal and return `None`.
+    ///
+    /// Each refusal names the form it hit, so a placeholder left in a lowered body says which assertion spelling
+    /// lowering could not represent instead of lumping two unrelated forms under one label. Both refusals are
+    /// decided *before* any of the form's operands are lowered — the same "check before partially lowering"
+    /// precedent [`Self::lower_match`] and [`Self::lower_binary`] follow — so a refused assertion never leaves
+    /// half-lowered reads behind it.
+    fn lower_assert_kind(
+        &mut self,
+        kind: &ast::AssertKind,
+        remaining: &[ast::Spanned<ast::Statement>],
+        scope: bir::ScopeId,
+        span: HirSourceSpan,
+        out: &mut Vec<bir::Statement>,
+    ) -> Option<bir::AssertionKind> {
+        match kind {
+            ast::AssertKind::Condition(cond_expr) => {
+                let cond = self.lower_expr_to_operand(cond_expr, scope, out);
+                Some(bir::AssertionKind::Condition { cond })
+            }
+            ast::AssertKind::IsPattern { value, pattern } => {
+                // The same rule `lower_match` applies to every arm pattern, for the same reason: a byte-string
+                // literal is the one shape `bir::Constant` cannot represent. RFC 018's parser only ever produces
+                // `Some`/`Ok`/`Err` with a single binding or `_`, plus bare `None`, so this is unreachable from
+                // real source and stands as defence in depth for a hand-built AST -- the same standing
+                // `unsupported_for_pattern`'s own type-agreement check has.
+                if !match_pattern_is_supported(&pattern.node) {
+                    self.push_unsupported_stmt(
+                        "assert `is` form with a byte-string literal pattern".to_string(),
+                        span,
+                        out,
+                    );
+                    return None;
+                }
+
+                let scrutinee_ty = self.resolve_ty(value.span);
+                let scrutinee_place = self.lower_expr_to_place(value, scope, out);
+                // Read the whole scrutinee as `Borrow`, exactly as `lower_match` does and for the same reason: the
+                // overall read must not risk an unconditional move while the pattern's own bindings compute more
+                // precise facts against places projected out of it.
+                let scrutinee = bir::Operand::place(scrutinee_place.clone(), bir::OwnershipFact::Borrow, false);
+
+                // Binding into `scope` rather than a fresh child scope is what makes the names outlive the
+                // assertion, and leaving `saved_bindings` unrestored is what keeps them visible to the statements
+                // that follow. `seen` still dedupes repeated names within this one pattern.
+                let mut seen: HashMap<String, bir::LocalId> = HashMap::new();
+                let mut saved_bindings: Vec<(String, Option<bir::LocalId>)> = Vec::new();
+                let pattern = self.lower_match_pattern(
+                    pattern,
+                    &scrutinee_ty,
+                    &scrutinee_place,
+                    scope,
+                    &PatternReadScope::FollowingStatements(remaining),
+                    &mut seen,
+                    &mut saved_bindings,
+                );
+                Some(bir::AssertionKind::Pattern { scrutinee, pattern })
+            }
+            ast::AssertKind::Raises { call, error_type } => {
+                let Some(expected_error) = expected_runtime_error(&error_type.node) else {
+                    self.push_unsupported_stmt(
+                        format!(
+                            "assert `raises` form with an unresolved error type `{}`",
+                            error_type.node
+                        ),
+                        span,
+                        out,
+                    );
+                    return None;
+                };
+                let call = self.lower_expr_to_operand(call, scope, out);
+                Some(bir::AssertionKind::Raises { call, expected_error })
+            }
+        }
+    }
+
     // ---- Callable defaults ----
+}
+
+/// Resolve the type named after `raises` to its builtin-exception identity, or `None` when it is not one.
+///
+/// Body IR stores the resolved [`incan_core::errors::ErrorKind`] instead of the source spelling, so a consumer
+/// never has to re-resolve a name against the exception registry to know which error an assertion expects. The
+/// accepted set is exactly the registry the typechecker validates this position against (its own
+/// `check_assert_stmt`), so the two stages cannot disagree about which `raises` spellings are meaningful. A
+/// non-simple type spelling, or a name outside the registry, yields `None` and refuses; the typechecker has
+/// already reported such a program as an unknown symbol, so this only decides how lowering represents a body it
+/// was asked to lower anyway.
+fn expected_runtime_error(error_type: &ast::Type) -> Option<incan_core::errors::ErrorKind> {
+    match error_type {
+        ast::Type::Simple(name) => runtime_errors::from_str(name),
+        _ => None,
+    }
 }

--- a/src/frontend/body_ir/free_vars.rs
+++ b/src/frontend/body_ir/free_vars.rs
@@ -369,8 +369,16 @@ pub(super) fn collect_free_vars_in_stmt(stmt: &ast::Statement, bound: &mut HashS
         }
         ast::Statement::Expr(e) => collect_free_vars_in_expr(&e.node, bound, free),
         ast::Statement::Assert(a) => {
-            if let ast::AssertKind::Condition(e) = &a.kind {
-                collect_free_vars_in_expr(&e.node, bound, free);
+            // All three assertion forms lower their payload expression (#1167), and the pattern form additionally
+            // binds its names for the rest of the block -- so a closure containing one must capture what the
+            // payload reads, and must not mistake a name the pattern itself bound for a capture.
+            match &a.kind {
+                ast::AssertKind::Condition(e) => collect_free_vars_in_expr(&e.node, bound, free),
+                ast::AssertKind::Raises { call, .. } => collect_free_vars_in_expr(&call.node, bound, free),
+                ast::AssertKind::IsPattern { value, pattern } => {
+                    collect_free_vars_in_expr(&value.node, bound, free);
+                    bind_pattern_names(&pattern.node, bound);
+                }
             }
             if let Some(message) = &a.message {
                 collect_free_vars_in_expr(&message.node, bound, free);

--- a/src/frontend/body_ir/match_.rs
+++ b/src/frontend/body_ir/match_.rs
@@ -5,6 +5,31 @@ use super::reads::*;
 use super::refusals::*;
 use super::*;
 
+/// Where the names a pattern binds can still be read once that pattern has matched.
+///
+/// [`BodyBuilder::lower_match_pattern`] seeds each fresh binding's last-use countdown from this, and its two
+/// callers disagree about what "afterwards" means. A `match` arm's bindings are visible only inside that arm, so
+/// its guard and body are the whole live range. An `assert value is P` binding instead stays live for the rest of
+/// the enclosing block, so its live range is the statement suffix following the assertion. Passing the counting
+/// context in rather than hard-coding one keeps a single pattern lowerer serving both.
+pub(super) enum PatternReadScope<'ast> {
+    /// A `match` arm: its guard plus its body.
+    MatchArm(&'ast ast::MatchArm),
+    /// The statement suffix following an `assert value is P` in its enclosing block.
+    FollowingStatements(&'ast [ast::Spanned<ast::Statement>]),
+}
+
+impl PatternReadScope<'_> {
+    /// Count reads of `name` reachable from this scope, using the same source-order over-approximation
+    /// [`count_reads_in_stmts`] documents.
+    fn count_reads(&self, name: &str) -> usize {
+        match self {
+            Self::MatchArm(arm) => count_reads_in_match_arm(name, arm),
+            Self::FollowingStatements(stmts) => count_reads_in_stmts(name, stmts),
+        }
+    }
+}
+
 impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
     /// Lower a `match` expression (`ast::Expr::Match`) into a single [`bir::Rvalue::Match`], mirroring the existing
     /// Rust-emission backend's own `IrExprKind::Match { scrutinee, arms }` node -- see [`bir::Rvalue::Match`]'s docs
@@ -57,7 +82,7 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
                 &scrutinee_ty,
                 &scrutinee_place,
                 arm_scope,
-                &arm.node,
+                &PatternReadScope::MatchArm(&arm.node),
                 &mut seen,
                 &mut saved_bindings,
             );
@@ -119,14 +144,21 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
         )
     }
 
-    /// Recursively lower one source `ast::Pattern` node into a [`bir::Pattern`], declaring a fresh arm-scoped local
-    /// the first time a bound name is encountered and reusing it for any later `Or`-alternative occurrence of the
-    /// same name (`seen`) -- Incan's typechecker (RFC 071) requires every alternative of an `A(x) | B(x)` pattern to
-    /// bind an identical name/type set, so Rust's own single shared binding slot per name is the correct target
-    /// shape, not one local per occurrence. `saved_bindings` accumulates `(name, previous_local)` pairs so
-    /// [`Self::lower_match`] can restore `self.bindings` to the enclosing scope once this arm's guard/body have
-    /// both been lowered, the same save/restore shape [`Self::lower_closure`] already uses around its own
-    /// params/captures.
+    /// Recursively lower one source `ast::Pattern` node into a [`bir::Pattern`], declaring a fresh local in
+    /// `arm_scope` the first time a bound name is encountered and reusing it for any later `Or`-alternative
+    /// occurrence of the same name (`seen`) -- Incan's typechecker (RFC 071) requires every alternative of an
+    /// `A(x) | B(x)` pattern to bind an identical name/type set, so Rust's own single shared binding slot per name
+    /// is the correct target shape, not one local per occurrence. `saved_bindings` accumulates
+    /// `(name, previous_local)` pairs so [`Self::lower_match`] can restore `self.bindings` to the enclosing scope
+    /// once this arm's guard/body have both been lowered, the same save/restore shape [`Self::lower_closure`]
+    /// already uses around its own params/captures.
+    ///
+    /// Both `match` arms and `assert value is P` (RFC 018) lower their patterns here, so "arm" below means
+    /// whichever construct owns this pattern. The two differ in binding lifetime, and `arm_scope`/`reads` are the
+    /// two knobs that express the difference: an arm binds into its own fresh scope and is read only within that
+    /// arm, while an assertion binds into the enclosing block's scope and is read by the statements that follow it
+    /// (see [`PatternReadScope`]). An assertion also keeps its bindings afterwards rather than restoring
+    /// `saved_bindings`, which is [`Self::lower_assert`]'s decision to make, not this method's.
     ///
     /// `place` is the (possibly already-projected) scrutinee place this pattern node corresponds to; each
     /// recursive call into a `Tuple`/`Struct`/`Enum` sub-pattern extends it with one more
@@ -149,7 +181,7 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
         expected_ty: &IncanType,
         place: &bir::Place,
         arm_scope: bir::ScopeId,
-        arm: &ast::MatchArm,
+        reads: &PatternReadScope<'_>,
         seen: &mut HashMap<String, bir::LocalId>,
         saved_bindings: &mut Vec<(String, Option<bir::LocalId>)>,
     ) -> bir::Pattern {
@@ -160,7 +192,7 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
                 let local = match seen.get(name) {
                     Some(&local) => local,
                     None => {
-                        let total_reads = count_reads_in_match_arm(name, arm);
+                        let total_reads = reads.count_reads(name);
                         let previous = self.bindings.get(name).copied();
                         let local = self.declare_new_local_with_reads(
                             name.clone(),
@@ -191,7 +223,7 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
                     .map(|(index, (item, element_ty))| {
                         let mut field_place = place.clone();
                         field_place.projection.push(bir::PlaceElem::Field(index.to_string()));
-                        self.lower_match_pattern(item, element_ty, &field_place, arm_scope, arm, seen, saved_bindings)
+                        self.lower_match_pattern(item, element_ty, &field_place, arm_scope, reads, seen, saved_bindings)
                     })
                     .collect();
                 bir::Pattern::Tuple(fields)
@@ -218,7 +250,7 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
                                         &IncanType::Unknown,
                                         &field_place,
                                         arm_scope,
-                                        arm,
+                                        reads,
                                         seen,
                                         saved_bindings,
                                     ),
@@ -260,7 +292,7 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
                         bir::ResultVariantKind::Err => error_type,
                     };
                     let lowered_payload =
-                        self.lower_match_pattern(payload, payload_type, place, arm_scope, arm, seen, saved_bindings);
+                        self.lower_match_pattern(payload, payload_type, place, arm_scope, reads, seen, saved_bindings);
                     return bir::Pattern::Result {
                         variant,
                         fields: vec![lowered_payload],
@@ -286,7 +318,7 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
                                 &IncanType::Unknown,
                                 &field_place,
                                 arm_scope,
-                                arm,
+                                reads,
                                 seen,
                                 saved_bindings,
                             );
@@ -303,7 +335,7 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
                                 &IncanType::Unknown,
                                 &field_place,
                                 arm_scope,
-                                arm,
+                                reads,
                                 seen,
                                 saved_bindings,
                             );
@@ -325,13 +357,13 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
                 }
             }
             ast::Pattern::Group(inner) => {
-                self.lower_match_pattern(inner, expected_ty, place, arm_scope, arm, seen, saved_bindings)
+                self.lower_match_pattern(inner, expected_ty, place, arm_scope, reads, seen, saved_bindings)
             }
             ast::Pattern::Or(items) => {
                 let alternatives = items
                     .iter()
                     .map(|item| {
-                        self.lower_match_pattern(item, expected_ty, place, arm_scope, arm, seen, saved_bindings)
+                        self.lower_match_pattern(item, expected_ty, place, arm_scope, reads, seen, saved_bindings)
                     })
                     .collect();
                 bir::Pattern::Or(alternatives)

--- a/src/frontend/body_ir/reads.rs
+++ b/src/frontend/body_ir/reads.rs
@@ -71,9 +71,13 @@ pub(super) fn count_reads_in_stmt(name: &str, stmt: &ast::Statement) -> usize {
         ast::Statement::For(f) => count_reads_in_expr(name, &f.iter.node) + count_reads_in_stmts(name, &f.body),
         ast::Statement::Expr(e) => count_reads_in_expr(name, &e.node),
         ast::Statement::Assert(a) => {
+            // Every assertion form lowers its own payload expression (#1167), so all three are counted here.
+            // Missing one would let an earlier read of the same name be selected as its last use and moved out
+            // from under the assertion, which is the one direction this approximation must never take.
             let mut total = match &a.kind {
                 ast::AssertKind::Condition(e) => count_reads_in_expr(name, &e.node),
-                _ => 0,
+                ast::AssertKind::IsPattern { value, .. } => count_reads_in_expr(name, &value.node),
+                ast::AssertKind::Raises { call, .. } => count_reads_in_expr(name, &call.node),
             };
             total += a
                 .message

--- a/src/frontend/body_ir/stmt.rs
+++ b/src/frontend/body_ir/stmt.rs
@@ -75,7 +75,7 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
                     });
                 }
             }
-            ast::Statement::Assert(assert_stmt) => self.lower_assert(assert_stmt, scope, span, out),
+            ast::Statement::Assert(assert_stmt) => self.lower_assert(assert_stmt, remaining, scope, span, out),
             ast::Statement::Pass => {}
             ast::Statement::Break(value) => self.lower_break(value.as_ref(), scope, span, out),
             ast::Statement::Continue => out.push(bir::Statement {

--- a/src/frontend/body_ir/tests.rs
+++ b/src/frontend/body_ir/tests.rs
@@ -4970,3 +4970,192 @@ enum Signal:
     );
     Ok(())
 }
+
+/// Return the [`bir::LocalId`] of the single local named `name` in `body`, failing when the body declares none or
+/// more than one.
+///
+/// Used by the `assert value is P` binding tests: the defect those cover is a *missing* declaration, so a test that
+/// merely found "some local mentioning `v`" would pass against the broken lowering, where a later read of `v`
+/// synthesizes an [`bir::LocalOrigin::External`] local under the same name.
+fn sole_local_named(body: &bir::Body, name: &str) -> Result<bir::LocalId, Box<dyn std::error::Error>> {
+    let matches: Vec<&bir::LocalDecl> = body
+        .locals
+        .iter()
+        .filter(|local| local.name.as_deref() == Some(name))
+        .collect();
+    match matches.as_slice() {
+        [local] => Ok(local.id),
+        found => Err(format!("expected exactly one local named `{name}`, found {found:?}").into()),
+    }
+}
+
+/// Return the [`bir::AssertionKind`]s of every assertion in `body`'s top-level block, in statement order.
+fn assertion_kinds(body: &bir::Body) -> Vec<&bir::AssertionKind> {
+    body.block
+        .stmts
+        .iter()
+        .filter_map(|stmt| match &stmt.kind {
+            bir::StatementKind::Assert { kind, .. } => Some(kind),
+            _ => None,
+        })
+        .collect()
+}
+
+#[test]
+fn a_pattern_assertion_binding_is_a_declared_local_read_by_the_statements_after_it()
+-> Result<(), Box<dyn std::error::Error>> {
+    // The defect #1167 closes: `assert o is Some(v)` used to lower to a bare placeholder, which dropped `v`
+    // entirely. `print(v)` then lowered against a name this body never declared, and `local_for_name` invented an
+    // `External` local for it -- so Body IR described a read of something outside the body rather than of the
+    // value the assertion had just bound.
+    let source = "def run(o: Option[str]) -> None:\n  assert o is Some(v)\n  print(v)\n";
+    let module = build(source, &["m", "assert_pattern"])?;
+    let body = body_named(&module, "run")?;
+
+    let bound = sole_local_named(body, "v")?;
+    let declaration = body
+        .locals
+        .get(bound.index())
+        .ok_or("the bound local must be present in the body's locals")?;
+    assert!(
+        matches!(declaration.origin, bir::LocalOrigin::UserBinding),
+        "the assertion must declare `v` as an ordinary source binding, not an external reference: {declaration:?}"
+    );
+
+    let [bir::AssertionKind::Pattern { pattern, .. }] = assertion_kinds(body).as_slice() else {
+        return Err(format!("expected exactly one pattern assertion: {:?}", body.block.stmts).into());
+    };
+    let bir::Pattern::Enum { variant, fields, .. } = pattern else {
+        return Err(format!("expected `Some(..)` to lower to a constructor pattern: {pattern:?}").into());
+    };
+    assert_eq!(variant, "Some");
+    let [bir::Pattern::Var(binding)] = fields.as_slice() else {
+        return Err(format!("expected one `PatternBinding` payload: {fields:?}").into());
+    };
+    assert_eq!(
+        binding.local, bound,
+        "the pattern binding must name the same local the body declared"
+    );
+
+    // The read that follows the assertion resolves to that same local, and consumes it: `print(v)` is the only
+    // read, so the last-use countdown seeded from the assertion's statement suffix must reach zero here.
+    let snapshot = module.render_snapshot();
+    assert!(
+        snapshot.contains(&format!("call fn:print unbound(move(_{}, last_use))", bound.0)),
+        "the following read must resolve to the bound local: {snapshot}"
+    );
+    Ok(())
+}
+
+#[test]
+fn a_pattern_assertion_over_a_result_resolves_its_payload_type_and_carries_a_message()
+-> Result<(), Box<dyn std::error::Error>> {
+    let source = "def run(r: Result[int, str]) -> None:\n  assert r is Ok(n), \"needed a value\"\n  print(n)\n";
+    let module = build(source, &["m", "assert_ok"])?;
+    let body = body_named(&module, "run")?;
+    let bound = sole_local_named(body, "n")?;
+    assert_eq!(
+        body.locals.get(bound.index()).map(|local| &local.ty),
+        Some(&IncanType::Primitive(IncanPrimitiveType::Int)),
+        "an intrinsic `Result` pattern resolves its payload type rather than falling back to unknown"
+    );
+
+    let snapshot = module.render_snapshot();
+    assert!(
+        snapshot.contains(&format!(
+            "assert borrow(_0) is Result::ok(bind(_{}, copy)), const(\"needed a value\") may_panic",
+            bound.0
+        )),
+        "the pattern form must carry its failure message alongside the binding: {snapshot}"
+    );
+    Ok(())
+}
+
+#[test]
+fn a_raises_assertion_retains_the_resolved_expected_error_rather_than_its_spelling()
+-> Result<(), Box<dyn std::error::Error>> {
+    let source = "def boom() -> int:\n  return 1\n\ndef run() -> None:\n  assert boom() raises ValueError\n  assert boom() raises IndexError, \"wanted an index error\"\n";
+    let module = build(source, &["m", "assert_raises"])?;
+    let body = body_named(&module, "run")?;
+
+    let expected: Vec<incan_core::errors::ErrorKind> = assertion_kinds(body)
+        .into_iter()
+        .filter_map(|kind| match kind {
+            bir::AssertionKind::Raises { expected_error, .. } => Some(*expected_error),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        expected,
+        vec![
+            incan_core::errors::ErrorKind::ValueError,
+            incan_core::errors::ErrorKind::IndexError
+        ],
+        "the expected error must be the resolved registry identity, not a source spelling"
+    );
+
+    let snapshot = module.render_snapshot();
+    assert!(
+        snapshot.contains("raises ValueError may_panic"),
+        "a `raises` assertion without a message: {snapshot}"
+    );
+    assert!(
+        snapshot.contains("raises IndexError, const(\"wanted an index error\") may_panic"),
+        "a `raises` assertion with a message: {snapshot}"
+    );
+    Ok(())
+}
+
+#[test]
+fn every_assert_form_records_a_panic_fact_and_the_panic_strategy_requirement() -> Result<(), Box<dyn std::error::Error>>
+{
+    let source = "def boom() -> int:\n  return 1\n\ndef run(o: Option[str]) -> None:\n  assert 1 == 1\n  assert o is Some(v)\n  assert boom() raises ValueError\n  print(v)\n";
+    let module = build(source, &["m", "assert_panic_facts"])?;
+    let body = body_named(&module, "run")?;
+
+    assert_eq!(
+        body.panic_facts
+            .iter()
+            .filter(|fact| matches!(fact.reason, bir::PanicReason::AssertFailure))
+            .count(),
+        3,
+        "all three assertion forms can panic: {:?}",
+        body.panic_facts
+    );
+    assert!(
+        body.runtime_requirements
+            .contains(&AbiV0RuntimeRequirement::PanicStrategy),
+        "an assertion of any form needs a panic strategy: {:?}",
+        body.runtime_requirements
+    );
+    let snapshot = module.render_snapshot();
+    assert!(
+        !snapshot.contains("unsupported("),
+        "no accepted assertion form may leave a placeholder behind: {snapshot}"
+    );
+    Ok(())
+}
+
+#[test]
+fn an_unresolved_raises_error_type_refuses_by_naming_the_assert_form() -> Result<(), Box<dyn std::error::Error>> {
+    // The source checker rejects an error type outside the builtin-exception registry, so lowering only reaches
+    // this for a program that was already reported. What it must not do is fall back to the old shared
+    // `assert pattern/raises form` label, which said nothing about which of the two forms was hit.
+    let source = "def boom() -> int:\n  return 1\n\ndef run() -> None:\n  assert boom() raises NotAnError\n";
+    let (module, diagnostics) = build_after_expected_typecheck_errors(source, &["m", "assert_refusal"])?;
+    assert!(
+        diagnostics.iter().any(|message| message.contains("NotAnError")),
+        "the source checker owns the diagnostic for an unknown error type: {diagnostics:?}"
+    );
+
+    let snapshot = module.render_snapshot();
+    assert!(
+        snapshot.contains("unsupported(assert `raises` form with an unresolved error type `NotAnError`)"),
+        "the refusal must name the `raises` form and the type it could not resolve: {snapshot}"
+    );
+    assert!(
+        !snapshot.contains("assert pattern/raises form"),
+        "the shared label that could not distinguish the two forms is gone: {snapshot}"
+    );
+    Ok(())
+}

--- a/tests/parity_corpus_tests.rs
+++ b/tests/parity_corpus_tests.rs
@@ -414,6 +414,97 @@ def main() -> None:
     log(1, *xs, b=2, **kw)
 "#;
 
+// ============================================================================
+// Cases 20 and 21 — Pattern and `raises` assert forms reach Body IR (#1167)
+// ============================================================================
+
+// Both rows existed as refusals before #1167: `AssertKind::IsPattern` and `AssertKind::Raises` lowered to
+// `unsupported(assert pattern/raises form)`. The pattern row is the one that mattered most, because the refusal was
+// not merely incomplete -- `assert o is Some(v)` *binds* `v`, so lowering it to a placeholder dropped the binding
+// and every later read of `v` lowered against a name the body never declared.
+const CASE_20_SRC: &str = r#"
+def run(o: Option[str]) -> None:
+    assert o is Some(v)
+    print(v)
+"#;
+
+const CASE_21_SRC: &str = r#"
+def boom() -> int:
+    return 1
+
+def run() -> None:
+    assert boom() raises ValueError
+    assert boom() raises IndexError, "wanted an index error"
+"#;
+
+/// Render one case's Body IR snapshot, or the reason it could not be produced.
+fn body_ir_snapshot_for(src: &str, expect_desc: &str) -> Result<String, ComparisonOutcome> {
+    let tokens = lexer::lex(src).map_err(|errors| ComparisonOutcome::Incompatible {
+        reason: format!("expected {expect_desc}, but lexing failed: {errors:?}"),
+    })?;
+    let program = parser::parse(&tokens).map_err(|errors| ComparisonOutcome::Incompatible {
+        reason: format!("expected {expect_desc}, but parsing failed: {errors:?}"),
+    })?;
+    let module_path = vec!["parity_987_body_ir".to_string()];
+    let mut checker = typechecker::TypeChecker::new();
+    checker.set_current_module_path(Some(module_path.clone()));
+    checker
+        .check_program(&program)
+        .map_err(|errors| ComparisonOutcome::Mismatch {
+            detail: format!("expected {expect_desc}, but typechecking reported {errors:?}"),
+        })?;
+    Ok(build_body_ir_module_v0(&program, &module_path, checker.type_info()).render_snapshot())
+}
+
+fn case_pattern_assertion_binding_reaches_body_ir() -> ComparisonOutcome {
+    let outcome = outcome_from_body_ir(CASE_20_SRC, "a pattern assertion to lower without a placeholder");
+    if !matches!(outcome, ComparisonOutcome::Match) {
+        return outcome;
+    }
+    let snapshot = match body_ir_snapshot_for(CASE_20_SRC, "a pattern assertion to lower") {
+        Ok(snapshot) => snapshot,
+        Err(outcome) => return outcome,
+    };
+    // Absence of a placeholder is not the property this row exists for. The binding has to survive as a declared
+    // source binding, because the defect was a silently dropped one -- a body that lowered cleanly while describing
+    // a read of something it never declared.
+    if !snapshot.contains("is Some(bind(") {
+        return ComparisonOutcome::Mismatch {
+            detail: format!("the pattern assertion did not bind its payload:\n{snapshot}"),
+        };
+    }
+    if !snapshot.contains("[binding]") {
+        return ComparisonOutcome::Mismatch {
+            detail: format!("the assertion's binding is not a declared source binding:\n{snapshot}"),
+        };
+    }
+    ComparisonOutcome::Match
+}
+
+fn case_raises_assertion_reaches_body_ir() -> ComparisonOutcome {
+    let outcome = outcome_from_body_ir(CASE_21_SRC, "a `raises` assertion to lower without a placeholder");
+    if !matches!(outcome, ComparisonOutcome::Match) {
+        return outcome;
+    }
+    let snapshot = match body_ir_snapshot_for(CASE_21_SRC, "a `raises` assertion to lower") {
+        Ok(snapshot) => snapshot,
+        Err(outcome) => return outcome,
+    };
+    // The expected error type is part of the assertion, so it must be carried as a resolved fact rather than left
+    // for a consumer to re-resolve from the source spelling. The optional message rides along with it.
+    if !snapshot.contains("raises ValueError may_panic") {
+        return ComparisonOutcome::Mismatch {
+            detail: format!("a `raises` assertion lost its expected error type:\n{snapshot}"),
+        };
+    }
+    if !snapshot.contains("raises IndexError, const(\"wanted an index error\") may_panic") {
+        return ComparisonOutcome::Mismatch {
+            detail: format!("a `raises` assertion lost its failure message:\n{snapshot}"),
+        };
+    }
+    ComparisonOutcome::Match
+}
+
 fn case_supported_call_spreads_reach_body_ir() -> ComparisonOutcome {
     outcome_from_body_ir(
         CASE_13_SRC,
@@ -1023,6 +1114,30 @@ fn seed_corpus() -> Vec<ParityCase> {
             disposition: Disposition::Preserved,
             source: CASE_13_SRC,
             evaluate: Some(case_supported_call_spreads_reach_body_ir),
+            replacement_execution: None,
+        },
+        ParityCase {
+            id: "parity-987-0020",
+            title: "A pattern assertion binds its payload as a declared local",
+            category: BehaviorCategory::SupportedLanguageContract,
+            lane: EvidenceLane::DirectParserTypechecker,
+            evidence: "#1167; src/frontend/body_ir/tests.rs::\
+                       a_pattern_assertion_binding_is_a_declared_local_read_by_the_statements_after_it",
+            disposition: Disposition::Preserved,
+            source: CASE_20_SRC,
+            evaluate: Some(case_pattern_assertion_binding_reaches_body_ir),
+            replacement_execution: None,
+        },
+        ParityCase {
+            id: "parity-987-0021",
+            title: "A `raises` assertion carries its resolved expected error type",
+            category: BehaviorCategory::SupportedLanguageContract,
+            lane: EvidenceLane::DirectParserTypechecker,
+            evidence: "#1167; src/frontend/body_ir/tests.rs::\
+                       a_raises_assertion_retains_the_resolved_expected_error_rather_than_its_spelling",
+            disposition: Disposition::Preserved,
+            source: CASE_21_SRC,
+            evaluate: Some(case_raises_assertion_reaches_body_ir),
             replacement_execution: None,
         },
         ParityCase {


### PR DESCRIPTION
## Summary

`ast::AssertKind` has three forms and Body IR represented one. `assert value is P` and `assert call() raises E` both lowered to `unsupported(assert pattern/raises form)`.

The `raises` gap was a missing spelling. The pattern gap was worse: `assert o is Some(v)` **binds `v`** for the rest of the block, so lowering it to a placeholder dropped the binding, and every later read of `v` lowered against a name Body IR never declared.

Closes #1167.

## Type of change

- [x] New feature

## Area(s)

- [x] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)

## Key details

- **User-facing behavior**: all three assertion forms now have a Body IR representation. `assert value is P` binds `P`'s names as real declared locals with `OwnershipFact`/last-use facts, reusing `lower_match`'s `PatternBinding` machinery rather than a parallel path. `assert call() raises E` carries a resolved error kind rather than a source spelling a consumer would have to re-resolve.
- **Internals**: `StatementKind::Assert` gained an `AssertionKind` payload rather than splitting into three sibling kinds. `message`, `may_panic`, `PanicReason::AssertFailure` and the `PanicStrategy` requirement are invariant across all three forms — three kinds would repeat those fields and let them drift, and would turn every exhaustive walk over the statement vocabulary into three arms where one says "is this an assertion". `lower_match_pattern`'s arm-specific parameter became `PatternReadScope` so one pattern lowerer serves both match arms and assertions.
- **Risks**: two changes outside the obvious blast radius are load-bearing rather than incidental. `count_reads_in_stmt` previously returned `0` for the two unrepresented forms; now that they lower their payload expressions, leaving it at `0` would let an earlier read be chosen as a name's last use and moved out from under the assertion — an unsound double move. `collect_free_vars_in_stmt` likewise needed the payload's free vars, plus `bind_pattern_names` so a closure containing a pattern assertion neither misses a capture nor mistakes the pattern's own binding for one. The replacement executor refuses the two new forms by name, following the `Await`/`Race` precedent in the same match.

## Testing / verification

- [x] Manual verification described below

Manual verification notes:

- `cargo test --lib frontend::body_ir` — 178 passed, 0 failed
- `cargo test -p incan_semantics_core --lib body_ir` — 25 passed, 0 failed
- `cargo test --lib backend::replacement` — 2 passed, 0 failed
- `cargo clippy --lib` clean; `cargo +nightly fmt` clean; rustdoc gate passed
- **Mutation check**: re-adding the `saved_bindings` restore loop — i.e. making the assertion drop its bindings at the statement boundary the way a match arm does — failed both binding tests, and for the right reason: the follow-on `print(v)` synthesized an `External` local, which is exactly the defect this issue describes.

## Docs impact

- [x] No docs changes needed

Body IR is an internal backend-facing representation; the assertion forms themselves are already documented language surface.

## Checklist

- [x] I added/updated tests where it materially reduces regressions

## Known gap, deliberately left

`assert o is Some(v)` gives `v` type `?`, while `assert r is Ok(n)` resolves `n` to `int`. That asymmetry is inherited verbatim from `lower_match_pattern` — intrinsic `Result` patterns go through `result_type_parts`, but `Option`/`Some` takes the generic constructor path whose fields are documented as `Unknown`. Closing it would change `match o: case Some(x)` lowering and its existing ownership snapshots, which reads as #1101 scope rather than this issue's. The binding is a real declared local with real `PatternBinding` facts either way.
