### PR TITLE
feature - establish RFC 104 authority-decision facts for compiler consumers (#1211)

### DIFF
--- a/crates/incan_core/src/lang/highlighting.rs
+++ b/crates/incan_core/src/lang/highlighting.rs
@@ -38,6 +38,7 @@ const CONST_KEYWORDS: &[KeywordId] = &[KeywordId::Const, KeywordId::Static];
 const ASYNC_KEYWORDS: &[KeywordId] = &[KeywordId::Async, KeywordId::Await];
 const DECLARATION_KEYWORDS: &[KeywordId] = &[
     KeywordId::Def,
+    KeywordId::Capability,
     KeywordId::Class,
     KeywordId::Model,
     KeywordId::Trait,

--- a/crates/incan_core/src/lang/keywords.rs
+++ b/crates/incan_core/src/lang/keywords.rs
@@ -59,6 +59,7 @@ pub enum KeywordId {
     Def,
     Async,
     Await,
+    Capability,
     Class,
     Model,
     Trait,
@@ -343,6 +344,15 @@ pub const KEYWORDS: &[KeywordDescriptor] = &[
         RFC::_000,
         Since(0, 1),
         Stability::Stable,
+    ),
+    info(
+        KeywordId::Capability,
+        "capability",
+        &[],
+        KeywordCategory::Definition,
+        &[KeywordUsage::Statement],
+        RFC::_104,
+        Since(0, 6),
     ),
     info(
         KeywordId::Class,

--- a/crates/incan_core/src/lang/keywords.rs
+++ b/crates/incan_core/src/lang/keywords.rs
@@ -345,14 +345,14 @@ pub const KEYWORDS: &[KeywordDescriptor] = &[
         Since(0, 1),
         Stability::Stable,
     ),
-    info(
+    info_contextual_binding(
         KeywordId::Capability,
         "capability",
-        &[],
         KeywordCategory::Definition,
         &[KeywordUsage::Statement],
         RFC::_104,
         Since(0, 6),
+        Stability::Draft,
     ),
     info(
         KeywordId::Class,

--- a/crates/incan_core/src/lang/registry.rs
+++ b/crates/incan_core/src/lang/registry.rs
@@ -214,6 +214,9 @@ pub const RFC_113: RfcId = "RFC 113";
 /// RFC 102 — semantic layer inspection surface.
 pub const RFC_102: RfcId = "RFC 102";
 
+/// RFC 104 — ambient runtime capabilities and receipts.
+pub const RFC_104: RfcId = "RFC 104";
+
 /// RFC 106 — compiler-backed agent context graph.
 pub const RFC_106: RfcId = "RFC 106";
 
@@ -362,6 +365,8 @@ impl RFC {
     pub const _113: RfcId = RFC_113;
     /// RFC 102 — semantic layer inspection surface.
     pub const _102: RfcId = RFC_102;
+    /// RFC 104 — ambient runtime capabilities and receipts.
+    pub const _104: RfcId = RFC_104;
     /// RFC 106 — compiler-backed agent context graph.
     pub const _106: RfcId = RFC_106;
     /// RFC 107 — type-directed library APIs and compile-time type tokens.

--- a/crates/incan_semantics_core/src/authority.rs
+++ b/crates/incan_semantics_core/src/authority.rs
@@ -1,0 +1,254 @@
+//! The compiler-to-runtime seam for RFC 104 authority decisions.
+//!
+//! [`crate::facts`] defines what an authority decision *is*. This module defines how a consumer *obtains* one, and it
+//! exists so that no consumer has to define grant semantics of its own. A provider-operation plan, a runtime
+//! entrypoint, and a test harness all ask the same question through [`AuthorityDecisionSource`] and all receive the
+//! same [`AuthorityDecision`].
+//!
+//! The seam is deliberately narrow. A consumer supplies an [`AuthorityRequest`] — which capability, which operation
+//! asked, where it asked, and with what scope — and receives a decision. It never inspects a grant set, never
+//! intersects a ceiling, and never decides what a mode means; those belong to whoever implements this trait.
+
+use std::collections::BTreeSet;
+
+use crate::facts::{
+    AuthorityDecision, AuthorityDenialReason, AuthorityGrantContext, AuthorityMode, AuthorityProvenance,
+    CanonicalSymbolId,
+};
+
+/// One operation's request for a capability's authority.
+///
+/// The requesting operation is identified canonically rather than by name so a decision stays reportable without a
+/// consumer re-reading source, and so the same request shape works for a stdlib call, a package-defined domain
+/// operation, and a provider operation alike.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct AuthorityRequest {
+    /// The capability whose authority is being requested.
+    pub capability: CanonicalSymbolId,
+    /// The operation making the request.
+    pub operation: CanonicalSymbolId,
+    /// The use site, which is where a denial is reported.
+    pub request_span: crate::HirSourceSpan,
+    /// Scope dimensions the operation is requesting, as `(dimension, value)`.
+    pub requested_scope: Vec<(String, String)>,
+    /// The grant spelling to suggest if this request is denied, such as `host.http.request`.
+    pub suggested_grant: String,
+}
+
+impl AuthorityRequest {
+    /// Build the provenance a decision about this request carries.
+    fn provenance(&self) -> AuthorityProvenance {
+        AuthorityProvenance {
+            operation: self.operation.clone(),
+            request_span: self.request_span,
+            suggested_grant: self.suggested_grant.clone(),
+        }
+    }
+
+    /// Build the grant context a decision about this request carries.
+    fn grant_context(&self, ceiling_applied: bool) -> AuthorityGrantContext {
+        AuthorityGrantContext {
+            requested_scope: self.requested_scope.clone(),
+            ceiling_applied,
+        }
+    }
+}
+
+/// Whatever decides RFC 104 authority for a run.
+///
+/// This is the one seam between the compiler's canonical facts and a runtime's policy. Implementors own mode
+/// semantics, grant resolution, and ceiling intersection; consumers own none of it. Keeping the trait object-safe is
+/// deliberate: a consumer holds `&dyn AuthorityDecisionSource` so a governed host, a permissive local run, and a test
+/// double are interchangeable without the consumer knowing which it has.
+pub trait AuthorityDecisionSource {
+    /// Decide whether one operation may exercise one capability's authority.
+    fn decide(&self, request: &AuthorityRequest) -> AuthorityDecision;
+}
+
+/// An authority source backed by a fixed grant set and an optional host ceiling.
+///
+/// This is the reference implementation of RFC 104's resolution rules, and the one a test or a simple local run uses.
+/// It is not a policy engine: it holds no budgets and no scope matchers, so it denies for the two reasons a grant set
+/// alone can establish.
+#[derive(Debug, Clone)]
+pub struct StaticAuthority {
+    mode: AuthorityMode,
+    granted: BTreeSet<String>,
+    ceiling: Option<BTreeSet<String>>,
+}
+
+impl StaticAuthority {
+    /// Build an authority source for `mode` granting exactly `granted`, with no host ceiling.
+    pub fn new(mode: AuthorityMode, granted: impl IntoIterator<Item = String>) -> Self {
+        Self {
+            mode,
+            granted: granted.into_iter().collect(),
+            ceiling: None,
+        }
+    }
+
+    /// Bound this source by a host-supplied ceiling.
+    ///
+    /// RFC 104 makes the ceiling a grant source distinct from the invocation's own request, combined by
+    /// **intersection and never union**: an invocation can only ever receive less than its ceiling allows, however
+    /// much it asks for. A grant outside the ceiling is therefore denied even though it was requested.
+    pub fn with_ceiling(mut self, ceiling: impl IntoIterator<Item = String>) -> Self {
+        self.ceiling = Some(ceiling.into_iter().collect());
+        self
+    }
+
+    /// The effective grant set: the request bounded by the ceiling, when one is supplied.
+    pub fn effective_grants(&self) -> BTreeSet<String> {
+        match &self.ceiling {
+            Some(ceiling) => self.granted.intersection(ceiling).cloned().collect(),
+            None => self.granted.clone(),
+        }
+    }
+}
+
+impl AuthorityDecisionSource for StaticAuthority {
+    fn decide(&self, request: &AuthorityRequest) -> AuthorityDecision {
+        let ceiling_applied = self.ceiling.is_some();
+        let grant = request.grant_context(ceiling_applied);
+        let provenance = request.provenance();
+
+        // Permissive and observe runs never deny; the difference between them is whether receipts are emitted, which
+        // is a reporting concern rather than an authority one.
+        if !matches!(self.mode, AuthorityMode::Governed) {
+            return AuthorityDecision::allowed(request.capability.clone(), self.mode, grant, provenance);
+        }
+
+        let requested = &request.suggested_grant;
+        let outside_ceiling = self
+            .ceiling
+            .as_ref()
+            .is_some_and(|ceiling| !ceiling.contains(requested));
+
+        // Report the ceiling first: an invocation that asked for authority its host never permitted is a different
+        // failure from one that simply never asked, and only the former tells the caller their request was capped.
+        let reason = if outside_ceiling {
+            Some(AuthorityDenialReason::OutsideCeiling)
+        } else if !self.granted.contains(requested) {
+            Some(AuthorityDenialReason::NotGranted)
+        } else {
+            None
+        };
+
+        match reason {
+            Some(reason) => AuthorityDecision::denied(request.capability.clone(), self.mode, reason, grant, provenance),
+            None => AuthorityDecision::allowed(request.capability.clone(), self.mode, grant, provenance),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::facts::SemanticSourceTargetKind;
+
+    /// Build a request for `host.http.request` made by `app.billing.charge`.
+    fn request() -> AuthorityRequest {
+        AuthorityRequest {
+            capability: CanonicalSymbolId::module_declaration(
+                vec!["host".to_string(), "http".to_string()],
+                "request",
+                SemanticSourceTargetKind::Capability,
+                crate::HirSourceSpan::new(10, 20),
+            ),
+            operation: CanonicalSymbolId::module_declaration(
+                vec!["app".to_string(), "billing".to_string()],
+                "charge",
+                SemanticSourceTargetKind::Function,
+                crate::HirSourceSpan::new(80, 96),
+            ),
+            request_span: crate::HirSourceSpan::new(120, 140),
+            requested_scope: vec![("host".to_string(), "api.example.com".to_string())],
+            suggested_grant: "host.http.request".to_string(),
+        }
+    }
+
+    /// A permissive run never denies, so a consumer needs no grant set to run locally.
+    #[test]
+    fn a_permissive_run_allows_an_ungranted_capability() {
+        let authority = StaticAuthority::new(AuthorityMode::Permissive, Vec::new());
+
+        let decision = authority.decide(&request());
+
+        assert!(decision.is_allowed());
+        assert_eq!(decision.mode, AuthorityMode::Permissive);
+    }
+
+    /// A governed run denies what was never granted, and says so in a way a consumer can branch on.
+    #[test]
+    fn a_governed_run_denies_a_capability_that_was_never_granted() {
+        let authority = StaticAuthority::new(AuthorityMode::Governed, Vec::new());
+
+        let decision = authority.decide(&request());
+
+        assert!(!decision.is_allowed());
+        assert_eq!(decision.denial_reason(), Some(AuthorityDenialReason::NotGranted));
+        assert_eq!(decision.provenance.suggested_grant, "host.http.request");
+    }
+
+    /// A governed run allows what was granted, and preserves the requested scope on the decision.
+    #[test]
+    fn a_governed_run_allows_a_granted_capability_and_keeps_its_scope() {
+        let authority = StaticAuthority::new(AuthorityMode::Governed, ["host.http.request".to_string()]);
+
+        let decision = authority.decide(&request());
+
+        assert!(decision.is_allowed());
+        assert_eq!(
+            decision.grant.requested_scope,
+            vec![("host".to_string(), "api.example.com".to_string())],
+        );
+    }
+
+    /// A ceiling bounds the grant by intersection: requesting more than the ceiling allows yields less, never more.
+    #[test]
+    fn a_ceiling_denies_a_grant_the_invocation_requested_but_the_host_did_not_permit() {
+        let authority = StaticAuthority::new(AuthorityMode::Governed, ["host.http.request".to_string()])
+            .with_ceiling(["host.fs.read".to_string()]);
+
+        let decision = authority.decide(&request());
+
+        assert!(
+            !decision.is_allowed(),
+            "an invocation cannot widen its own authority past its ceiling",
+        );
+        assert_eq!(decision.denial_reason(), Some(AuthorityDenialReason::OutsideCeiling));
+        assert!(decision.grant.ceiling_applied);
+        assert!(
+            authority.effective_grants().is_empty(),
+            "the effective grant is the intersection of ceiling and request, not their union",
+        );
+    }
+
+    /// A grant present in both the request and the ceiling survives the intersection.
+    #[test]
+    fn a_ceiling_keeps_a_grant_that_both_sides_permit() {
+        let authority = StaticAuthority::new(
+            AuthorityMode::Governed,
+            ["host.http.request".to_string(), "host.fs.read".to_string()],
+        )
+        .with_ceiling(["host.http.request".to_string()]);
+
+        let decision = authority.decide(&request());
+
+        assert!(decision.is_allowed());
+        assert_eq!(
+            authority.effective_grants(),
+            ["host.http.request".to_string()].into_iter().collect(),
+            "only the capability both sides permit survives",
+        );
+    }
+
+    /// The seam must be usable through a trait object so a host, a local run, and a test double are interchangeable.
+    #[test]
+    fn the_seam_is_object_safe() {
+        let authority = StaticAuthority::new(AuthorityMode::Governed, ["host.http.request".to_string()]);
+        let source: &dyn AuthorityDecisionSource = &authority;
+
+        assert!(source.decide(&request()).is_allowed());
+    }
+}

--- a/crates/incan_semantics_core/src/facts.rs
+++ b/crates/incan_semantics_core/src/facts.rs
@@ -378,6 +378,8 @@ pub enum SemanticSourceTargetKind {
     Variant,
     /// A `trait` declaration.
     Trait,
+    /// A `capability` declaration naming an RFC 104 ambient runtime authority.
+    Capability,
     /// A field on a nominal type.
     Field,
     /// A method on a nominal type or trait.
@@ -421,6 +423,7 @@ impl SemanticSourceTargetKind {
             "partial" => Self::Partial,
             "variant" => Self::Variant,
             "trait" => Self::Trait,
+            "capability" => Self::Capability,
             "field" => Self::Field,
             "method" => Self::Method,
             "property" => Self::Property,
@@ -450,6 +453,7 @@ impl SemanticSourceTargetKind {
             Self::Partial => "partial",
             Self::Variant => "variant",
             Self::Trait => "trait",
+            Self::Capability => "capability",
             Self::Field => "field",
             Self::Method => "method",
             Self::Property => "property",
@@ -714,6 +718,7 @@ mod tests {
             K::Partial,
             K::Variant,
             K::Trait,
+            K::Capability,
             K::Field,
             K::Method,
             K::Property,

--- a/crates/incan_semantics_core/src/facts.rs
+++ b/crates/incan_semantics_core/src/facts.rs
@@ -132,6 +132,7 @@ pub enum SemanticFactKind {
     RuntimeRequirement,
     Diagnostic,
     BackendObligation,
+    AuthorityDecision,
 }
 
 impl SemanticFactKind {
@@ -144,6 +145,7 @@ impl SemanticFactKind {
             Self::RuntimeRequirement => "runtime_requirement",
             Self::Diagnostic => "diagnostic",
             Self::BackendObligation => "backend_obligation",
+            Self::AuthorityDecision => "authority_decision",
         }
     }
 }
@@ -159,6 +161,7 @@ pub enum SemanticFactValue {
     Type(IncanType),
     SourceTarget(SemanticSourceTarget),
     RegistryEntry(SemanticRegistryEntry),
+    AuthorityDecision(AuthorityDecision),
     Flag(bool),
 }
 
@@ -183,6 +186,11 @@ impl SemanticFactValue {
         Self::RegistryEntry(value)
     }
 
+    /// Build one RFC 104 authority-decision fact value.
+    pub fn authority_decision(value: AuthorityDecision) -> Self {
+        Self::AuthorityDecision(value)
+    }
+
     /// Render a deterministic maintainer-facing fact payload snapshot.
     pub fn render_snapshot(&self) -> String {
         match self {
@@ -190,6 +198,7 @@ impl SemanticFactValue {
             Self::Type(value) => value.to_string(),
             Self::SourceTarget(value) => value.to_string(),
             Self::RegistryEntry(value) => value.to_string(),
+            Self::AuthorityDecision(value) => value.to_string(),
             Self::Flag(value) => value.to_string(),
         }
     }
@@ -471,6 +480,188 @@ impl SemanticSourceTargetKind {
     }
 }
 
+/// RFC 104 run mode.
+///
+/// The mode is part of the decision rather than ambient context: the same request produces a different outcome under
+/// `Governed` than under `Permissive`, and a consumer reading a stored decision must be able to tell which rule
+/// produced it without re-deriving the run's configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum AuthorityMode {
+    /// Operations run normally and receipts may be disabled.
+    Permissive,
+    /// Operations run normally and receipts are emitted.
+    Observe,
+    /// Operations require granted capabilities and receipts are emitted.
+    Governed,
+}
+
+impl AuthorityMode {
+    /// Return the compact snapshot spelling for this mode.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Permissive => "permissive",
+            Self::Observe => "observe",
+            Self::Governed => "governed",
+        }
+    }
+}
+
+/// Why a governed authority request was denied.
+///
+/// This is the machine-usable denial reason RFC 104 requires. A consumer branches on the variant; the prose belongs to
+/// the diagnostic that renders it, never to this fact.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum AuthorityDenialReason {
+    /// The invocation never requested this capability.
+    NotGranted,
+    /// The invocation requested the capability, but a host ceiling did not permit it.
+    OutsideCeiling,
+    /// The capability was granted, but not for the scope this operation requested.
+    OutOfScope,
+    /// A budget for this capability was exhausted before the operation ran.
+    BudgetExhausted,
+    /// Replay required a recorded fixture that was not available.
+    FixtureRequired,
+}
+
+impl AuthorityDenialReason {
+    /// Return the compact snapshot spelling for this denial reason.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::NotGranted => "not_granted",
+            Self::OutsideCeiling => "outside_ceiling",
+            Self::OutOfScope => "out_of_scope",
+            Self::BudgetExhausted => "budget_exhausted",
+            Self::FixtureRequired => "fixture_required",
+        }
+    }
+}
+
+/// The effect of an authority decision on one operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum AuthorityOutcome {
+    /// The operation may perform its authority-bearing behavior.
+    Allowed,
+    /// The operation must fail before performing its authority-bearing behavior.
+    Denied(AuthorityDenialReason),
+}
+
+/// The grant context a decision was reached against.
+///
+/// RFC 104 makes the ceiling a distinct grant source from the per-invocation request, and requires the effective grant
+/// to be their **intersection, never their union**: an invocation can only ever receive less than its ceiling allows,
+/// regardless of what it asks for. Recording whether a ceiling applied is therefore part of the decision, because
+/// `Allowed` under a ceiling and `Allowed` with no ceiling are different facts about the run.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct AuthorityGrantContext {
+    /// Scope dimensions the operation requested, as `(dimension, value)` in the capability's declaration order.
+    pub requested_scope: Vec<(String, String)>,
+    /// Whether a host ceiling bounded this invocation.
+    pub ceiling_applied: bool,
+}
+
+/// Enough provenance to raise a source-owned governed denial diagnostic.
+///
+/// RFC 104 requires a denial to identify the required capability and to be reportable against the source that asked
+/// for it. The requesting operation's canonical identity and the use-site span are what make that possible without a
+/// consumer re-reading source text.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct AuthorityProvenance {
+    /// Canonical identity of the operation that requested the authority.
+    pub operation: CanonicalSymbolId,
+    /// The use site the request came from, which is where a denial is reported.
+    pub request_span: crate::HirSourceSpan,
+    /// Grant spelling to suggest in a denial diagnostic, such as `host.http.request`.
+    pub suggested_grant: String,
+}
+
+/// One RFC 104 authority decision about one operation.
+///
+/// This is deliberately generic over capability publishers and provider operations: both the capability and the
+/// requesting operation are named by [`CanonicalSymbolId`], so the stdlib, a library-defined domain capability, and a
+/// provider operation all produce the same fact. A consumer can act on an allowed or denied decision without
+/// consulting source text or emitted Rust, which is what lets a provider backend avoid inventing its own grant model.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct AuthorityDecision {
+    /// The capability whose authority was requested.
+    pub capability: CanonicalSymbolId,
+    /// The mode this decision was reached under.
+    pub mode: AuthorityMode,
+    /// Whether the operation may proceed.
+    pub outcome: AuthorityOutcome,
+    /// The grant context the decision was reached against.
+    pub grant: AuthorityGrantContext,
+    /// Where the decision can be reported in source.
+    pub provenance: AuthorityProvenance,
+}
+
+impl AuthorityDecision {
+    /// Build an allowed decision.
+    pub fn allowed(
+        capability: CanonicalSymbolId,
+        mode: AuthorityMode,
+        grant: AuthorityGrantContext,
+        provenance: AuthorityProvenance,
+    ) -> Self {
+        Self {
+            capability,
+            mode,
+            outcome: AuthorityOutcome::Allowed,
+            grant,
+            provenance,
+        }
+    }
+
+    /// Build a denied decision carrying its machine-usable reason.
+    pub fn denied(
+        capability: CanonicalSymbolId,
+        mode: AuthorityMode,
+        reason: AuthorityDenialReason,
+        grant: AuthorityGrantContext,
+        provenance: AuthorityProvenance,
+    ) -> Self {
+        Self {
+            capability,
+            mode,
+            outcome: AuthorityOutcome::Denied(reason),
+            grant,
+            provenance,
+        }
+    }
+
+    /// Whether the operation may perform its authority-bearing behavior.
+    pub const fn is_allowed(&self) -> bool {
+        matches!(self.outcome, AuthorityOutcome::Allowed)
+    }
+
+    /// The denial reason, when this decision denied the operation.
+    pub const fn denial_reason(&self) -> Option<AuthorityDenialReason> {
+        match self.outcome {
+            AuthorityOutcome::Allowed => None,
+            AuthorityOutcome::Denied(reason) => Some(reason),
+        }
+    }
+}
+
+impl std::fmt::Display for AuthorityDecision {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let outcome = match self.outcome {
+            AuthorityOutcome::Allowed => "allowed".to_string(),
+            AuthorityOutcome::Denied(reason) => format!("denied:{}", reason.as_str()),
+        };
+        let ceiling = if self.grant.ceiling_applied { " ceiling" } else { "" };
+        write!(
+            f,
+            "{} {} {}{} <- {}",
+            self.capability.declaration_name,
+            self.mode.as_str(),
+            outcome,
+            ceiling,
+            self.provenance.operation.declaration_name
+        )
+    }
+}
+
 /// Render a module path into the identity string used by HIR, Body IR, and declaration identities.
 ///
 /// One spelling, in one place: an empty path is a real case (a module checked without a path), and the frontend and
@@ -704,6 +895,141 @@ mod tests {
     ///
     /// The two arms are hand-written and 22 variants long; a typo in either would silently reclassify a declaration
     /// as `Other`, which compares unequal to the variant it came from and would split one declaration's identity.
+    /// Build a capability identity and a requesting-operation identity for authority-decision tests.
+    fn authority_fixture() -> (super::CanonicalSymbolId, super::AuthorityProvenance) {
+        use super::{AuthorityProvenance, CanonicalSymbolId, SemanticSourceTargetKind};
+
+        let capability = CanonicalSymbolId::module_declaration(
+            vec!["host".to_string(), "http".to_string()],
+            "request",
+            SemanticSourceTargetKind::Capability,
+            crate::HirSourceSpan::new(10, 20),
+        );
+        let operation = CanonicalSymbolId::module_declaration(
+            vec!["app".to_string(), "billing".to_string()],
+            "charge",
+            SemanticSourceTargetKind::Function,
+            crate::HirSourceSpan::new(80, 96),
+        );
+        let provenance = AuthorityProvenance {
+            operation,
+            request_span: crate::HirSourceSpan::new(120, 140),
+            suggested_grant: "host.http.request".to_string(),
+        };
+        (capability, provenance)
+    }
+
+    /// An allowed decision must be actionable without a consumer re-reading source or emitted Rust.
+    #[test]
+    fn an_allowed_authority_decision_carries_its_mode_and_grant_context() {
+        use super::{AuthorityDecision, AuthorityGrantContext, AuthorityMode};
+
+        let (capability, provenance) = authority_fixture();
+        let decision = AuthorityDecision::allowed(
+            capability,
+            AuthorityMode::Governed,
+            AuthorityGrantContext {
+                requested_scope: vec![("host".to_string(), "api.example.com".to_string())],
+                ceiling_applied: true,
+            },
+            provenance,
+        );
+
+        assert!(decision.is_allowed());
+        assert_eq!(decision.denial_reason(), None);
+        assert_eq!(decision.mode, AuthorityMode::Governed);
+        assert!(
+            decision.grant.ceiling_applied,
+            "a ceiling bounds the effective grant by intersection, so whether one applied is part of the decision",
+        );
+        assert_eq!(decision.provenance.suggested_grant, "host.http.request");
+    }
+
+    /// A denied decision must carry a machine-usable reason and enough provenance to raise a source-owned diagnostic.
+    #[test]
+    fn a_denied_authority_decision_carries_a_machine_usable_reason_and_its_use_site() {
+        use super::{AuthorityDecision, AuthorityDenialReason, AuthorityGrantContext, AuthorityMode};
+
+        let (capability, provenance) = authority_fixture();
+        let decision = AuthorityDecision::denied(
+            capability,
+            AuthorityMode::Governed,
+            AuthorityDenialReason::OutsideCeiling,
+            AuthorityGrantContext {
+                requested_scope: Vec::new(),
+                ceiling_applied: true,
+            },
+            provenance,
+        );
+
+        assert!(!decision.is_allowed());
+        assert_eq!(decision.denial_reason(), Some(AuthorityDenialReason::OutsideCeiling));
+        assert_eq!(
+            decision.provenance.request_span,
+            crate::HirSourceSpan::new(120, 140),
+            "a denial is reported at the use site, not at the capability declaration",
+        );
+        assert_eq!(
+            decision.provenance.operation.declaration_name, "charge",
+            "the requesting operation stays identified so the diagnostic can name it",
+        );
+    }
+
+    /// The fact must be generic over capability publishers rather than assuming a stdlib host capability.
+    #[test]
+    fn authority_decisions_work_for_a_library_defined_capability() {
+        use super::{
+            AuthorityDecision, AuthorityDenialReason, AuthorityGrantContext, AuthorityMode, CanonicalSymbolId,
+            SemanticSourceTargetKind,
+        };
+
+        let (_, provenance) = authority_fixture();
+        let package_capability = CanonicalSymbolId::module_declaration(
+            vec!["acme".to_string(), "ledger".to_string()],
+            "post_entry",
+            SemanticSourceTargetKind::Capability,
+            crate::HirSourceSpan::new(4, 14),
+        );
+        let decision = AuthorityDecision::denied(
+            package_capability,
+            AuthorityMode::Governed,
+            AuthorityDenialReason::NotGranted,
+            AuthorityGrantContext {
+                requested_scope: Vec::new(),
+                ceiling_applied: false,
+            },
+            provenance,
+        );
+
+        assert_eq!(decision.capability.kind, SemanticSourceTargetKind::Capability);
+        assert_eq!(decision.capability.declaration_name, "post_entry");
+        assert_eq!(decision.denial_reason(), Some(AuthorityDenialReason::NotGranted));
+    }
+
+    /// Every mode and denial reason needs a distinct snapshot spelling.
+    #[test]
+    fn authority_modes_and_denial_reasons_have_distinct_spellings() {
+        use super::{AuthorityDenialReason as R, AuthorityMode as M};
+
+        let modes = [M::Permissive, M::Observe, M::Governed];
+        let mode_spellings: std::collections::HashSet<&str> = modes.iter().map(|m| m.as_str()).collect();
+        assert_eq!(mode_spellings.len(), modes.len(), "two modes share one spelling");
+
+        let reasons = [
+            R::NotGranted,
+            R::OutsideCeiling,
+            R::OutOfScope,
+            R::BudgetExhausted,
+            R::FixtureRequired,
+        ];
+        let reason_spellings: std::collections::HashSet<&str> = reasons.iter().map(|r| r.as_str()).collect();
+        assert_eq!(
+            reason_spellings.len(),
+            reasons.len(),
+            "two denial reasons share one spelling",
+        );
+    }
+
     #[test]
     fn every_source_target_kind_round_trips_through_its_spelling() {
         use super::SemanticSourceTargetKind as K;

--- a/crates/incan_semantics_core/src/hir.rs
+++ b/crates/incan_semantics_core/src/hir.rs
@@ -90,6 +90,8 @@ pub enum HirDeclarationKind {
     Const,
     Static,
     Model,
+    /// An RFC 104 runtime authority declaration.
+    Capability,
     Class,
     Trait,
     Alias,
@@ -111,6 +113,7 @@ impl HirDeclarationKind {
             Self::Const => "const",
             Self::Static => "static",
             Self::Model => "model",
+            Self::Capability => "capability",
             Self::Class => "class",
             Self::Trait => "trait",
             Self::Alias => "alias",

--- a/crates/incan_semantics_core/src/lib.rs
+++ b/crates/incan_semantics_core/src/lib.rs
@@ -28,9 +28,11 @@ mod hir;
 mod types;
 
 pub use facts::{
-    CanonicalSymbolId, CompilerNodeId, CompilerNodeKind, ScopeDiscriminant, SemanticFact, SemanticFactKind,
-    SemanticFactStore, SemanticFactValue, SemanticRegistryEntry, SemanticRegistrySubjectKind, SemanticRegistryValue,
-    SemanticSourceTarget, SemanticSourceTargetKind, SymbolNamespace, SymbolOrigin, module_identity_for_path,
+    AuthorityDecision, AuthorityDenialReason, AuthorityGrantContext, AuthorityMode, AuthorityOutcome,
+    AuthorityProvenance, CanonicalSymbolId, CompilerNodeId, CompilerNodeKind, ScopeDiscriminant, SemanticFact,
+    SemanticFactKind, SemanticFactStore, SemanticFactValue, SemanticRegistryEntry, SemanticRegistrySubjectKind,
+    SemanticRegistryValue, SemanticSourceTarget, SemanticSourceTargetKind, SymbolNamespace, SymbolOrigin,
+    module_identity_for_path,
 };
 pub use hir::{HirDeclaration, HirDeclarationKind, HirModule, HirSourceSpan, SemanticModuleSnapshot};
 pub use types::{

--- a/crates/incan_semantics_core/src/lib.rs
+++ b/crates/incan_semantics_core/src/lib.rs
@@ -22,6 +22,7 @@
 use incan_core::lang::decorators::DecoratorId;
 use incan_core::lang::keywords::KeywordId;
 
+pub mod authority;
 pub mod body_ir;
 mod facts;
 mod hir;

--- a/crates/incan_syntax/src/ast/core.rs
+++ b/crates/incan_syntax/src/ast/core.rs
@@ -129,6 +129,7 @@ pub enum Declaration {
     Const(super::ConstDecl),
     Static(super::StaticDecl),
     Model(super::ModelDecl),
+    Capability(super::CapabilityDecl),
     Class(super::ClassDecl),
     Trait(super::TraitDecl),
     Alias(super::AliasDecl),

--- a/crates/incan_syntax/src/ast/decls.rs
+++ b/crates/incan_syntax/src/ast/decls.rs
@@ -46,6 +46,46 @@ pub struct FieldDecl {
 }
 
 // ============================================================================
+// Capabilities (RFC 104 runtime authority declarations)
+// ============================================================================
+
+/// One named scope dimension a capability accepts, such as `tenant: str`.
+///
+/// A grant may constrain zero or more of a capability's declared dimensions. A grant naming a dimension the
+/// capability did not declare is a checked error rather than a silently ignored key, which is why the declared set
+/// is retained here rather than inferred at grant time.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CapabilityScopeDim {
+    pub name: Ident,
+    pub ty: Spanned<Type>,
+}
+
+/// A `capability` declaration: a named runtime authority to perform a side-effecting operation (RFC 104).
+///
+/// This is authority ("may this run?"), which is a different thing from a *feature* ("does Incan have this?") and a
+/// *toolchain requirement* ("can this compile here?"). See #1228 for why those three words are kept apart.
+///
+/// The declaration site is what gives the capability its identity: RFC 104 requires a capability identity to be a
+/// checked symbol whose fully-qualified path derives from where it is declared, exactly as any other Incan
+/// declaration's does, never a string an author types out.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CapabilityDecl {
+    pub visibility: Visibility,
+    pub decorators: Vec<Spanned<Decorator>>,
+    pub name: Ident,
+    pub docstring: Option<String>,
+    /// Required human-readable description of what the capability authorizes.
+    pub description: Option<Spanned<Expr>>,
+    /// Typed scope dimensions a grant may constrain. Empty when the capability declares no scope.
+    pub scope: Vec<Spanned<CapabilityScopeDim>>,
+    /// Other capabilities this one's implementation needs, as checked symbol references.
+    ///
+    /// Documentation for a policy or host to inspect, never an implicit grant: holding this capability never grants
+    /// what it `requires`, which must always be granted separately.
+    pub requires: Vec<Spanned<Expr>>,
+}
+
+// ============================================================================
 // Classes (general-purpose types with inheritance and traits)
 // ============================================================================
 

--- a/crates/incan_syntax/src/ast/visitor.rs
+++ b/crates/incan_syntax/src/ast/visitor.rs
@@ -21,6 +21,7 @@ pub trait Visitor {
             Declaration::Const(c) => self.visit_const(c),
             Declaration::Static(s) => self.visit_static(s),
             Declaration::Model(m) => self.visit_model(m),
+            Declaration::Capability(c) => self.visit_capability(c),
             Declaration::Class(c) => self.visit_class(c),
             Declaration::Trait(t) => self.visit_trait(t),
             Declaration::Alias(a) => self.visit_alias(a),
@@ -40,6 +41,8 @@ pub trait Visitor {
     fn visit_static(&mut self, _static_decl: &StaticDecl) {}
     fn visit_docstring(&mut self, _doc: &str) {}
     fn visit_model(&mut self, _model: &ModelDecl) {}
+    /// Visit an RFC 104 runtime authority declaration.
+    fn visit_capability(&mut self, _capability: &CapabilityDecl) {}
     fn visit_class(&mut self, _class: &ClassDecl) {}
     fn visit_trait(&mut self, _trait: &TraitDecl) {}
     /// Visit a module-level symbol alias declaration.

--- a/crates/incan_syntax/src/diagnostics/catalog/errors/types.rs
+++ b/crates/incan_syntax/src/diagnostics/catalog/errors/types.rs
@@ -2069,3 +2069,17 @@ pub fn capability_requirement_not_a_capability(path: &str, found: &str, span: Sp
     )
     .with_hint("Reference a `capability` declaration, or remove the entry")
 }
+
+/// Build the error emitted when a `description` clause is present but is not compile-time text.
+///
+/// The description's audience is a person deciding whether to grant the capability, and there is no later moment at
+/// which that review happens — so an expression to be evaluated at runtime cannot serve as one. Accepting a
+/// non-string would also record no description at all, leaving a declaration that looks documented while carrying
+/// nothing, which is worse than an obviously missing clause.
+pub fn capability_description_must_be_text(name: &str, span: Span) -> CompileError {
+    CompileError::type_error(
+        format!("Capability '{name}' has a `description` that is not a text literal"),
+        span,
+    )
+    .with_hint("Write the description as a quoted string, such as `description = \"Issue a refund\"`")
+}

--- a/crates/incan_syntax/src/diagnostics/catalog/errors/types.rs
+++ b/crates/incan_syntax/src/diagnostics/catalog/errors/types.rs
@@ -2020,3 +2020,52 @@ pub fn tuple_unpack_count_mismatch(expected: usize, found: usize, span: Span) ->
         span,
     )
 }
+
+// -- RFC 104 capabilities -----------------------------------------------------
+
+/// Build the error emitted when a `capability` declaration omits its `description` clause.
+///
+/// The grammar accepts the omission so that a missing description is reported here, against the declaration's own
+/// span, rather than as a parse failure that cannot say which clause is missing. RFC 104 treats the description as
+/// part of the authority's public contract: a policy author deciding whether to grant a capability reads it, so a
+/// capability without one cannot be reviewed.
+pub fn capability_description_required(name: &str, span: Span) -> CompileError {
+    CompileError::type_error(format!("Capability '{name}' has no `description`"), span)
+        .with_hint("Add `description = \"...\"` saying what granting this capability authorizes")
+}
+
+/// Build the error emitted when a `requires` entry is not a symbol reference.
+///
+/// RFC 104 requires these to be checked references to other capabilities rather than strings, so that a misspelling
+/// is a compile error instead of a runtime denial discovered later. An entry that is a call, a literal, or any other
+/// expression cannot name a declaration at all.
+pub fn capability_requirement_not_a_reference(span: Span) -> CompileError {
+    CompileError::type_error(
+        "A capability `requires` entry must be a capability reference".to_string(),
+        span,
+    )
+    .with_hint("Write the capability's name or dotted path, such as `host.http.request`, not an expression")
+}
+
+/// Build the error emitted when a `requires` entry names nothing the compiler can find.
+///
+/// This is deliberately an unresolved-symbol error at compile time. RFC 104 is explicit that a misspelled or
+/// nonexistent capability reference must fail here rather than surviving to become a runtime capability denial,
+/// which would surface far from the declaration that caused it.
+pub fn capability_requirement_unresolved(path: &str, span: Span) -> CompileError {
+    CompileError::type_error(format!("Unknown capability '{path}' in `requires`"), span)
+        .with_hint("Declare the capability, or import the module that declares it")
+}
+
+/// Build the error emitted when a `requires` entry resolves to something that is not a capability.
+///
+/// Holding a capability never grants what it requires, so the entries are a documentation and policy surface rather
+/// than a dispatch mechanism. A `requires` list naming a function or a type would describe an authority relationship
+/// that cannot exist, and a policy reading it would draw a false conclusion.
+pub fn capability_requirement_not_a_capability(path: &str, found: &str, span: Span) -> CompileError {
+    CompileError::type_error(
+        format!("`requires` entry '{path}' is a {found}, not a capability"),
+        span,
+    )
+    .with_hint("Reference a `capability` declaration, or remove the entry")
+}

--- a/crates/incan_syntax/src/parser/decl/capabilities.rs
+++ b/crates/incan_syntax/src/parser/decl/capabilities.rs
@@ -21,7 +21,14 @@ impl<'a> Parser<'a> {
         decorators: Vec<Spanned<Decorator>>,
         visibility: Visibility,
     ) -> Result<CapabilityDecl, CompileError> {
-        self.expect_keyword(KeywordId::Capability, "Expected 'capability'")?;
+        if !self.is_capability_declaration_keyword() {
+            return Err(errors::expected_token_message(
+                "Expected 'capability'",
+                &format!("{:?}", self.peek().kind),
+                self.peek().span,
+            ));
+        }
+        self.advance();
         let name = self.identifier()?;
         self.expect_punct(PunctuationId::Colon, "Expected ':' after capability name")?;
         self.expect(&TokenKind::Newline, "Expected newline after ':'")?;
@@ -80,6 +87,22 @@ impl<'a> Parser<'a> {
             scope,
             requires,
         })
+    }
+
+    /// Return `true` when the current token opens a `capability` declaration.
+    ///
+    /// RFC 104's `capability` is contextual rather than reserved, so it lexes as an ordinary identifier and stays
+    /// usable as a variable, field, or method name. Only the declaration shape — the spelling followed by a name —
+    /// claims it as a keyword; `capability = x`, `capability(x)`, and `capability: T` all remain identifiers.
+    fn is_capability_declaration_keyword(&self) -> bool {
+        if !matches!(
+            &self.peek().kind,
+            TokenKind::Ident(name) if name == incan_core::lang::keywords::as_str(KeywordId::Capability)
+        ) {
+            return false;
+        }
+
+        matches!(self.peek_next().kind, TokenKind::Ident(_))
     }
 
     /// Parse the typed scope dimensions inside a capability's `scope:` block.

--- a/crates/incan_syntax/src/parser/decl/capabilities.rs
+++ b/crates/incan_syntax/src/parser/decl/capabilities.rs
@@ -1,0 +1,123 @@
+/// Parsing for RFC 104 `capability` declarations.
+impl<'a> Parser<'a> {
+    /// Parse a `capability` declaration.
+    ///
+    /// ```text
+    /// capability refund:
+    ///     description = "Issue a refund for a captured charge"
+    ///     scope:
+    ///         tenant: str
+    ///     requires = [host.http.request]
+    /// ```
+    ///
+    /// The body's three clauses are all optional at the grammar level and may appear in any order; which of them are
+    /// *required* is a checked-semantics question rather than a syntax one, so an omitted `description` parses here
+    /// and is reported by the typechecker with the declaration's own span.
+    ///
+    /// `requires` entries are parsed as ordinary expressions rather than strings, because RFC 104 requires them to be
+    /// checked symbol references to other capabilities. Holding a capability never grants what it `requires`.
+    fn capability_decl(
+        &mut self,
+        decorators: Vec<Spanned<Decorator>>,
+        visibility: Visibility,
+    ) -> Result<CapabilityDecl, CompileError> {
+        self.expect_keyword(KeywordId::Capability, "Expected 'capability'")?;
+        let name = self.identifier()?;
+        self.expect_punct(PunctuationId::Colon, "Expected ':' after capability name")?;
+        self.expect(&TokenKind::Newline, "Expected newline after ':'")?;
+        self.expect_suite_indent("Expected indented block")?;
+
+        let docstring = self.optional_leading_block_docstring();
+
+        let mut description = None;
+        let mut scope = Vec::new();
+        let mut requires = Vec::new();
+
+        loop {
+            self.skip_newlines();
+            if self.check(&TokenKind::Dedent) || self.is_at_end() {
+                break;
+            }
+            let clause_span = self.current_span();
+            let clause = self.identifier()?;
+            match clause.as_str() {
+                "description" => {
+                    self.expect(
+                        &TokenKind::Operator(OperatorId::Eq),
+                        "Expected '=' after `description`",
+                    )?;
+                    description = Some(self.expression()?);
+                }
+                "requires" => {
+                    self.expect(&TokenKind::Operator(OperatorId::Eq), "Expected '=' after `requires`")?;
+                    requires = self.capability_requires_list()?;
+                }
+                "scope" => {
+                    self.expect_punct(PunctuationId::Colon, "Expected ':' after `scope`")?;
+                    self.expect(&TokenKind::Newline, "Expected newline after `scope:`")?;
+                    self.expect_suite_indent("Expected indented scope block")?;
+                    scope = self.capability_scope_dims()?;
+                    self.expect(&TokenKind::Dedent, "Expected dedent after scope block")?;
+                }
+                other => {
+                    return Err(CompileError::syntax(
+                        format!("Unknown capability clause `{other}`; expected `description`, `scope`, or `requires`"),
+                        clause_span,
+                    ));
+                }
+            }
+            self.match_token(&TokenKind::Newline);
+        }
+
+        self.expect(&TokenKind::Dedent, "Expected dedent after capability body")?;
+
+        Ok(CapabilityDecl {
+            visibility,
+            decorators,
+            name,
+            docstring,
+            description,
+            scope,
+            requires,
+        })
+    }
+
+    /// Parse the typed scope dimensions inside a capability's `scope:` block.
+    fn capability_scope_dims(&mut self) -> Result<Vec<Spanned<CapabilityScopeDim>>, CompileError> {
+        let mut dims = Vec::new();
+        loop {
+            self.skip_newlines();
+            if self.check(&TokenKind::Dedent) || self.is_at_end() {
+                break;
+            }
+            let start = self.current_span().start;
+            let name = self.identifier()?;
+            self.expect_punct(PunctuationId::Colon, "Expected ':' after scope dimension name")?;
+            let ty = self.type_expr()?;
+            let end = self.tokens[self.pos - 1].span.end;
+            dims.push(Spanned::new(CapabilityScopeDim { name, ty }, Span::new(start, end)));
+            self.match_token(&TokenKind::Newline);
+        }
+        Ok(dims)
+    }
+
+    /// Parse the bracketed capability references in a `requires = [...]` clause.
+    fn capability_requires_list(&mut self) -> Result<Vec<Spanned<Expr>>, CompileError> {
+        self.expect_punct(PunctuationId::LBracket, "Expected '[' to start `requires` list")?;
+        let mut entries = Vec::new();
+        loop {
+            self.skip_newlines();
+            if self.match_token(&TokenKind::Punctuation(PunctuationId::RBracket)) {
+                break;
+            }
+            entries.push(self.expression()?);
+            self.skip_newlines();
+            if self.match_token(&TokenKind::Punctuation(PunctuationId::Comma)) {
+                continue;
+            }
+            self.expect_punct(PunctuationId::RBracket, "Expected ',' or ']' in `requires` list")?;
+            break;
+        }
+        Ok(entries)
+    }
+}

--- a/crates/incan_syntax/src/parser/decl/entrypoints.rs
+++ b/crates/incan_syntax/src/parser/decl/entrypoints.rs
@@ -137,7 +137,7 @@ impl<'a> Parser<'a> {
             Declaration::Static(self.static_decl_with_visibility(visibility)?)
         } else if self.check_keyword(KeywordId::Model) {
             Declaration::Model(self.model_decl(decorators, visibility)?)
-        } else if self.check_keyword(KeywordId::Capability) {
+        } else if self.is_capability_declaration_keyword() {
             Declaration::Capability(self.capability_decl(decorators, visibility)?)
         } else if self.check_keyword(KeywordId::Class) {
             Declaration::Class(self.class_decl(decorators, visibility)?)

--- a/crates/incan_syntax/src/parser/decl/entrypoints.rs
+++ b/crates/incan_syntax/src/parser/decl/entrypoints.rs
@@ -137,6 +137,8 @@ impl<'a> Parser<'a> {
             Declaration::Static(self.static_decl_with_visibility(visibility)?)
         } else if self.check_keyword(KeywordId::Model) {
             Declaration::Model(self.model_decl(decorators, visibility)?)
+        } else if self.check_keyword(KeywordId::Capability) {
+            Declaration::Capability(self.capability_decl(decorators, visibility)?)
         } else if self.check_keyword(KeywordId::Class) {
             Declaration::Class(self.class_decl(decorators, visibility)?)
         } else if self.check_keyword(KeywordId::Trait) {

--- a/crates/incan_syntax/src/parser/decl/mod.rs
+++ b/crates/incan_syntax/src/parser/decl/mod.rs
@@ -9,6 +9,7 @@
 // - The implementation is split into focused include files to avoid a god-module.
 
 include!("entrypoints.rs");
+include!("capabilities.rs");
 include!("decorators.rs");
 include!("imports.rs");
 include!("models.rs");

--- a/crates/incan_syntax/src/parser/tests.rs
+++ b/crates/incan_syntax/src/parser/tests.rs
@@ -6383,4 +6383,54 @@ Bad = partial Target(1)
             "expected keyword-only partial preset diagnostic, got {err:?}"
         );
     }
+
+    /// The full RFC 104 shape: docstring, description, a typed scope block, and checked `requires` references.
+    #[test]
+    fn parses_a_capability_declaration_with_scope_and_requires() -> Result<(), Box<dyn std::error::Error>> {
+        let source = concat!(
+            "capability refund:\n",
+            "    \"\"\"Issue a refund for a captured charge.\"\"\"\n",
+            "    description = \"Issue a refund for a captured charge\"\n",
+            "    scope:\n",
+            "        tenant: str\n",
+            "        region: str\n",
+            "    requires = [host.http.request]\n",
+        );
+        let program = parse_str(source).map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+        let Declaration::Capability(cap) = &program.declarations[0].node else {
+            return Err(Box::from("expected a capability declaration".to_string()));
+        };
+        assert_eq!(cap.name, "refund");
+        assert!(cap.docstring.is_some());
+        assert!(cap.description.is_some());
+        assert_eq!(cap.scope.len(), 2);
+        assert_eq!(cap.scope[0].node.name, "tenant");
+        assert_eq!(cap.scope[1].node.name, "region");
+        assert_eq!(cap.requires.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn parses_a_capability_declaration_without_scope_or_requires() -> Result<(), Box<dyn std::error::Error>> {
+        let source = "capability ping:\n    description = \"Reach a host\"\n";
+        let program = parse_str(source).map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+        let Declaration::Capability(cap) = &program.declarations[0].node else {
+            return Err(Box::from("expected a capability declaration".to_string()));
+        };
+        assert_eq!(cap.name, "ping");
+        assert!(cap.scope.is_empty());
+        assert!(cap.requires.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn an_unknown_capability_clause_is_a_syntax_error() -> Result<(), Box<dyn std::error::Error>> {
+        let source = "capability ping:\n    describe = \"typo\"\n";
+        let errors = parse_str_err(source, "an unknown clause must not parse");
+        assert!(
+            errors.iter().any(|error| error.message.contains("Unknown capability clause")),
+            "expected a clause-specific error, got {errors:?}"
+        );
+        Ok(())
+    }
 }

--- a/src/backend/ir/codegen/dependency_metadata.rs
+++ b/src/backend/ir/codegen/dependency_metadata.rs
@@ -1025,6 +1025,7 @@ pub(super) fn collect_dependency_symbol_metadata(
                     | Declaration::Enum(_)
                     | Declaration::TestModule(_)
                     | Declaration::VocabBlock(_)
+                    | Declaration::Capability(_)
                     | Declaration::Docstring(_) => None,
                 }
             {

--- a/src/backend/ir/lower/decl/mod.rs
+++ b/src/backend/ir/lower/decl/mod.rs
@@ -212,6 +212,14 @@ impl AstLowering {
                     span: IrSpan::default(),
                 });
             }
+            ast::Declaration::Capability(_) => {
+                // A capability declares authority, not code. It carries no body to lower and emits no Rust item;
+                // consumers reach it through its checked identity, not through IR.
+                return Err(LoweringError {
+                    message: "capability declarations are not lowered to IR".to_string(),
+                    span: IrSpan::default(),
+                });
+            }
             ast::Declaration::Docstring(_) => {
                 // Skip docstrings in codegen
                 return Err(LoweringError {

--- a/src/cli/commands/build.rs
+++ b/src/cli/commands/build.rs
@@ -11330,6 +11330,7 @@ fn provider_declaration_name(declaration: &Declaration) -> Option<&str> {
         Declaration::Enum(item) => Some(&item.name),
         Declaration::Function(item) => Some(&item.name),
         Declaration::TestModule(item) => Some(&item.name),
+        Declaration::Capability(item) => Some(&item.name),
         Declaration::Import(_) | Declaration::VocabBlock(_) | Declaration::Docstring(_) => None,
     }
 }
@@ -11337,6 +11338,7 @@ fn provider_declaration_name(declaration: &Declaration) -> Option<&str> {
 /// Return whether one declaration contributes to the package's public checked surface.
 fn provider_declaration_is_public(declaration: &Declaration) -> bool {
     let visibility = match declaration {
+        Declaration::Capability(item) => item.visibility,
         Declaration::Const(item) => item.visibility,
         Declaration::Static(item) => item.visibility,
         Declaration::Model(item) => item.visibility,

--- a/src/cli/commands/codegraph.rs
+++ b/src/cli/commands/codegraph.rs
@@ -1289,6 +1289,7 @@ impl CodegraphBuilder {
             | Declaration::Partial(_)
             | Declaration::TypeAlias(_)
             | Declaration::VocabBlock(_)
+            | Declaration::Capability(_)
             | Declaration::Docstring(_) => {}
         }
     }
@@ -2465,6 +2466,13 @@ fn declaration_summary(declaration: &Declaration) -> Option<DeclarationSummary> 
             visibility: decl.visibility,
             type_params: Vec::new(),
             signature: decl.ty.as_ref().map(|ty| format!("const {}: {}", decl.name, ty.node)),
+        }),
+        Declaration::Capability(decl) => Some(DeclarationSummary {
+            kind: "capability".to_string(),
+            name: decl.name.clone(),
+            visibility: decl.visibility,
+            type_params: Vec::new(),
+            signature: Some(format!("capability {}", decl.name)),
         }),
         Declaration::Static(decl) => Some(DeclarationSummary {
             kind: "static".to_string(),

--- a/src/format/formatter/declarations.rs
+++ b/src/format/formatter/declarations.rs
@@ -78,6 +78,7 @@ impl Formatter {
             Declaration::Static(static_decl) => self.format_static(static_decl),
             Declaration::Model(model) => self.format_model(model),
             Declaration::Class(class) => self.format_class(class),
+            Declaration::Capability(cap) => self.format_capability(cap),
             Declaration::Trait(tr) => self.format_trait(tr),
             Declaration::Alias(alias) => self.format_alias(alias),
             Declaration::Partial(partial) => self.format_partial(partial),
@@ -546,6 +547,58 @@ impl Formatter {
     }
 
     /// Format a trait declaration, including same-trait method aliases.
+    /// Format an RFC 104 `capability` declaration.
+    ///
+    /// Clause order is normalized to description, scope, then requires, regardless of how the source ordered them:
+    /// the parser accepts any order, and a formatter that preserved it would make two identical capabilities format
+    /// differently.
+    fn format_capability(&mut self, cap: &CapabilityDecl) {
+        for dec in &cap.decorators {
+            self.format_decorator(&dec.node);
+        }
+
+        self.write_visibility(cap.visibility);
+        self.writer.write("capability ");
+        self.writer.write(&cap.name);
+        self.writer.writeln(":");
+        self.writer.indent();
+
+        if let Some(docstring) = &cap.docstring {
+            self.format_docstring(docstring);
+        }
+
+        if let Some(description) = &cap.description {
+            self.writer.write("description = ");
+            self.format_expr(&description.node);
+            self.writer.newline();
+        }
+
+        if !cap.scope.is_empty() {
+            self.writer.writeln("scope:");
+            self.writer.indent();
+            for dim in &cap.scope {
+                self.writer.write(&dim.node.name);
+                self.writer.write(": ");
+                self.writer.write(&dim.node.ty.node.to_string());
+                self.writer.newline();
+            }
+            self.writer.dedent();
+        }
+
+        if !cap.requires.is_empty() {
+            self.writer.write("requires = [");
+            for (index, entry) in cap.requires.iter().enumerate() {
+                if index > 0 {
+                    self.writer.write(", ");
+                }
+                self.format_expr(&entry.node);
+            }
+            self.writer.writeln("]");
+        }
+
+        self.writer.dedent();
+    }
+
     fn format_trait(&mut self, tr: &TraitDecl) {
         for dec in &tr.decorators {
             self.format_decorator(&dec.node);

--- a/src/format/formatter/mod.rs
+++ b/src/format/formatter/mod.rs
@@ -408,7 +408,8 @@ impl Formatter {
             }
             Declaration::Docstring(_) => DeclSpacingClass::Docstring,
             Declaration::TypeAlias(_) | Declaration::Newtype(_) => DeclSpacingClass::TypeLike,
-            Declaration::Model(_)
+            Declaration::Capability(_)
+            | Declaration::Model(_)
             | Declaration::Class(_)
             | Declaration::Trait(_)
             | Declaration::Enum(_)

--- a/src/frontend/ast_walk.rs
+++ b/src/frontend/ast_walk.rs
@@ -65,6 +65,7 @@ where
         | Declaration::Alias(_)
         | Declaration::Partial(_)
         | Declaration::TypeAlias(_)
+        | Declaration::Capability(_)
         | Declaration::Docstring(_) => false,
         Declaration::VocabBlock(block) => any_expr_in_body_impl(&block.body, pred),
         Declaration::Const(c) => expr_has(&c.value.node, pred),

--- a/src/frontend/hir.rs
+++ b/src/frontend/hir.rs
@@ -65,6 +65,7 @@ fn hir_decl_kind_and_name(decl: &Declaration) -> (HirDeclarationKind, Option<Str
         Declaration::Const(decl) => (HirDeclarationKind::Const, Some(decl.name.clone())),
         Declaration::Static(decl) => (HirDeclarationKind::Static, Some(decl.name.clone())),
         Declaration::Model(decl) => (HirDeclarationKind::Model, Some(decl.name.clone())),
+        Declaration::Capability(decl) => (HirDeclarationKind::Capability, Some(decl.name.clone())),
         Declaration::Class(decl) => (HirDeclarationKind::Class, Some(decl.name.clone())),
         Declaration::Trait(decl) => (HirDeclarationKind::Trait, Some(decl.name.clone())),
         Declaration::Alias(decl) => (HirDeclarationKind::Alias, Some(decl.name.clone())),

--- a/src/frontend/library_exports.rs
+++ b/src/frontend/library_exports.rs
@@ -778,6 +778,7 @@ fn checked_partial_target_kind(partial: &PartialDecl, checker: &TypeChecker) -> 
         | Some(SymbolKind::Module(_))
         | Some(SymbolKind::Variant(_))
         | Some(SymbolKind::RustItem(_))
+        | Some(SymbolKind::Capability(_))
         | None => CheckedPartialTargetKind::Unknown,
     }
 }

--- a/src/frontend/module.rs
+++ b/src/frontend/module.rs
@@ -608,10 +608,12 @@ pub fn exported_symbols(ast: &Program) -> Vec<ExportedSymbol> {
                     }
                 }
             }
-            Declaration::Capability(_)
-            | Declaration::Docstring(_)
-            | Declaration::TestModule(_)
-            | Declaration::VocabBlock(_) => {}
+            Declaration::Capability(cap) => {
+                if matches!(cap.visibility, Visibility::Public) {
+                    exports.push(ExportedSymbol::Capability(cap.name.clone()));
+                }
+            }
+            Declaration::Docstring(_) | Declaration::TestModule(_) | Declaration::VocabBlock(_) => {}
         }
     }
 
@@ -706,11 +708,21 @@ pub fn exported_type_like_docs(ast: &Program) -> Vec<ExportedTypeLikeDoc> {
 pub enum ExportedSymbol {
     Type(String),
     Trait(String),
+    /// A `pub capability` declaration (RFC 104).
+    ///
+    /// A capability is exported like any other public declaration because the stdlib is only the *first* capability
+    /// publisher: a library author declares domain capabilities in their own module and consumers reference them by
+    /// import. Withholding them from the export set would make `pub` meaningless on the one declaration form whose
+    /// entire purpose is to be referenced from elsewhere.
+    Capability(String),
     Function(String),
     Const(String),
     Static(String),
     Reexported(String),
-    Variant { enum_name: String, variant_name: String },
+    Variant {
+        enum_name: String,
+        variant_name: String,
+    },
 }
 
 #[cfg(test)]

--- a/src/frontend/module.rs
+++ b/src/frontend/module.rs
@@ -608,7 +608,10 @@ pub fn exported_symbols(ast: &Program) -> Vec<ExportedSymbol> {
                     }
                 }
             }
-            Declaration::Docstring(_) | Declaration::TestModule(_) | Declaration::VocabBlock(_) => {}
+            Declaration::Capability(_)
+            | Declaration::Docstring(_)
+            | Declaration::TestModule(_)
+            | Declaration::VocabBlock(_) => {}
         }
     }
 

--- a/src/frontend/symbols.rs
+++ b/src/frontend/symbols.rs
@@ -508,6 +508,8 @@ pub enum SymbolKind {
     Property(PropertyInfo),
     /// Rust dependency import (`import rust::...` / `from rust::... import ...`, RFC 005 / RFC 041).
     RustItem(RustItemInfo),
+    /// `capability` declaration naming an ambient runtime authority (RFC 104).
+    Capability(CapabilityInfo),
 }
 
 /// Variable information
@@ -788,6 +790,39 @@ pub struct TraitInfo {
     pub method_aliases: HashMap<String, String>,
     pub properties: HashMap<String, PropertyInfo>,
     pub requires: Vec<(String, ResolvedType)>, // Required fields
+}
+
+/// A `capability` declaration's collected shape (RFC 104).
+///
+/// A capability names an authority to perform a side-effecting operation, not a value and not a type, so it carries no
+/// `ResolvedType`: no expression in the language ever holds a capability. What it does carry is the authority's own
+/// description, the typed dimensions a grant may constrain, and the other capabilities its implementation needs.
+///
+/// `requires` is deliberately unresolved at collection time. Capabilities may reference each other in any order within
+/// a module, so resolving those references is a checking concern; collection records what was written and where, and
+/// checking turns each into a symbol reference. Holding this capability never grants what it requires — that is the
+/// invariant the separate list exists to preserve.
+#[derive(Debug, Clone)]
+pub struct CapabilityInfo {
+    /// Prose from the `description` clause, when the declaration supplied a string literal.
+    pub description: Option<String>,
+    /// Typed scope dimensions from the `scope:` block, in declaration order.
+    pub scope: Vec<(String, ResolvedType)>,
+    /// Other capabilities this one needs, as written, in declaration order.
+    pub requires: Vec<CapabilityRequirement>,
+    pub is_public: bool,
+}
+
+/// One entry of a capability's `requires` list, before it is resolved to a capability symbol.
+///
+/// The span is kept so a later diagnostic can point at the reference the author wrote rather than at the enclosing
+/// declaration.
+#[derive(Debug, Clone)]
+pub struct CapabilityRequirement {
+    /// Dotted path exactly as written, split into segments — `host.http.request` becomes three segments.
+    pub path: Vec<String>,
+    /// Span of the reference itself.
+    pub span: Span,
 }
 
 /// Module/import information

--- a/src/frontend/typechecker/check_decl.rs
+++ b/src/frontend/typechecker/check_decl.rs
@@ -13,7 +13,7 @@ use crate::frontend::testing_markers::{
 use crate::frontend::typechecker::helpers::{collection_type_id, dict_ty, list_ty};
 
 use super::collect::decorators::resolve_decorator_id;
-use super::collect::dotted_path_segments;
+use super::collect::{capability_description_text, dotted_path_segments};
 use super::type_info::{
     RegistryDefinitionInfo, RegistryDescriptionInfo, RegistryDescriptionRegistry, RegistryExplicitEntryInfo,
 };
@@ -2218,9 +2218,17 @@ impl TypeChecker {
         self.validate_decorators_rejecting_user_defined(&cap.decorators, "capability");
         self.reject_registry_description_decorators(&cap.decorators, "capability");
 
-        if cap.description.is_none() {
-            self.errors
-                .push(errors::capability_description_required(&cap.name, span));
+        match cap.description.as_ref() {
+            None => self
+                .errors
+                .push(errors::capability_description_required(&cap.name, span)),
+            // Presence is not enough. Collection stores only compile-time text, so a clause it cannot read leaves
+            // the declaration carrying no description while appearing to have one -- the same silent drop the
+            // `requires` list had.
+            Some(expr) if capability_description_text(&expr.node).is_none() => self
+                .errors
+                .push(errors::capability_description_must_be_text(&cap.name, expr.span)),
+            Some(_) => {}
         }
 
         for entry in &cap.requires {

--- a/src/frontend/typechecker/check_decl.rs
+++ b/src/frontend/typechecker/check_decl.rs
@@ -13,6 +13,7 @@ use crate::frontend::testing_markers::{
 use crate::frontend::typechecker::helpers::{collection_type_id, dict_ty, list_ty};
 
 use super::collect::decorators::resolve_decorator_id;
+use super::collect::dotted_path_segments;
 use super::type_info::{
     RegistryDefinitionInfo, RegistryDescriptionInfo, RegistryDescriptionRegistry, RegistryExplicitEntryInfo,
 };
@@ -29,6 +30,7 @@ use incan_core::lang::surface::constructors::{self, ConstructorId};
 use incan_core::lang::testing;
 use incan_core::lang::traits::{self as builtin_traits, TraitId};
 use incan_core::lang::types::collections::CollectionTypeId;
+use incan_semantics_core::SemanticSourceTargetKind;
 use incan_semantics_core::{SemanticRegistrySubjectKind, SemanticRegistryValue, SurfaceModifierTypeCheck};
 use std::collections::{HashMap, HashSet};
 
@@ -2198,9 +2200,94 @@ impl TypeChecker {
                 "raw vocabulary declarations must be desugared before type checking".to_string(),
                 decl.span,
             )),
-            // Capability checking lands with this issue's typechecker phase; parsing it is phase 1.
-            Declaration::Capability(_) => {}
+            Declaration::Capability(cap) => self.check_capability_decl(cap, decl.span),
             Declaration::Docstring(_) => {} // Docstrings don't need checking
+        }
+    }
+
+    /// Check one RFC 104 `capability` declaration.
+    ///
+    /// Collection records what the declaration wrote; this decides whether what it wrote means anything. The two are
+    /// separate passes because capabilities may reference each other in any order within a module, so resolution
+    /// cannot happen while the symbols are still being collected.
+    ///
+    /// Every `requires` entry is validated from the AST rather than from the collected symbol, because collection
+    /// keeps only the entries that parsed as a reference. Re-walking the source list is what lets an entry that is
+    /// not a reference at all be reported instead of silently disappearing.
+    fn check_capability_decl(&mut self, cap: &CapabilityDecl, span: Span) {
+        self.validate_decorators_rejecting_user_defined(&cap.decorators, "capability");
+        self.reject_registry_description_decorators(&cap.decorators, "capability");
+
+        if cap.description.is_none() {
+            self.errors
+                .push(errors::capability_description_required(&cap.name, span));
+        }
+
+        for entry in &cap.requires {
+            let Some(path) = dotted_path_segments(&entry.node) else {
+                self.errors
+                    .push(errors::capability_requirement_not_a_reference(entry.span));
+                continue;
+            };
+            self.check_capability_requirement(&path, entry.span);
+        }
+    }
+
+    /// Resolve one `requires` entry and confirm it names a capability.
+    ///
+    /// A bare name resolves against the current module's own symbols; a dotted path resolves as a member of the
+    /// module its leading segments name, the same way an import resolves against a definition. RFC 104 asks for
+    /// exactly that equivalence, so that a misspelled capability is an unresolved-symbol error at the reference
+    /// rather than a runtime denial reported somewhere else entirely.
+    fn check_capability_requirement(&mut self, path: &[String], span: Span) {
+        let rendered = path.join(".");
+        let Some((item_name, module_segments)) = path.split_last() else {
+            return;
+        };
+
+        if module_segments.is_empty() {
+            match self.lookup_symbol(item_name).map(|symbol| &symbol.kind) {
+                Some(SymbolKind::Capability(_)) => {}
+                Some(other) => {
+                    let found = Self::symbol_kind_noun(other);
+                    self.errors
+                        .push(errors::capability_requirement_not_a_capability(&rendered, found, span));
+                }
+                None => self
+                    .errors
+                    .push(errors::capability_requirement_unresolved(&rendered, span)),
+            }
+            return;
+        }
+
+        let module = ImportPath::simple(module_segments.to_vec());
+        match self.dependency_member_identity(&module, item_name) {
+            Some(identity) if identity.kind == SemanticSourceTargetKind::Capability => {}
+            Some(identity) => {
+                let found = identity.kind.as_str();
+                self.errors
+                    .push(errors::capability_requirement_not_a_capability(&rendered, found, span));
+            }
+            None => self
+                .errors
+                .push(errors::capability_requirement_unresolved(&rendered, span)),
+        }
+    }
+
+    /// Name a symbol kind for a diagnostic that reports the wrong kind was referenced.
+    fn symbol_kind_noun(kind: &SymbolKind) -> &'static str {
+        match kind {
+            SymbolKind::Variable(_) => "variable",
+            SymbolKind::Static(_) => "static",
+            SymbolKind::Function(_) | SymbolKind::FunctionOverloads(_) => "function",
+            SymbolKind::Type(_) => "type",
+            SymbolKind::Trait(_) => "trait",
+            SymbolKind::Module(_) => "module",
+            SymbolKind::Variant(_) => "enum variant",
+            SymbolKind::Field(_) => "field",
+            SymbolKind::Property(_) => "property",
+            SymbolKind::RustItem(_) => "rust import",
+            SymbolKind::Capability(_) => "capability",
         }
     }
 

--- a/src/frontend/typechecker/check_decl.rs
+++ b/src/frontend/typechecker/check_decl.rs
@@ -2198,6 +2198,8 @@ impl TypeChecker {
                 "raw vocabulary declarations must be desugared before type checking".to_string(),
                 decl.span,
             )),
+            // Capability checking lands with this issue's typechecker phase; parsing it is phase 1.
+            Declaration::Capability(_) => {}
             Declaration::Docstring(_) => {} // Docstrings don't need checking
         }
     }

--- a/src/frontend/typechecker/check_expr/basics.rs
+++ b/src/frontend/typechecker/check_expr/basics.rs
@@ -152,6 +152,17 @@ impl TypeChecker {
                     (IdentKind::Module, ResolvedType::Named(name.to_string()))
                 }
             }
+            SymbolKind::Capability(_) => {
+                // RFC 104 capabilities name an authority to perform an operation. Nothing in the language holds one as
+                // a value, so a bare reference is always a mistake rather than a use this stage should type.
+                self.errors.push(CompileError::type_error(
+                    format!(
+                        "Capability '{name}' names a runtime authority, not a value; grant it or list it under `requires` instead of referencing it directly"
+                    ),
+                    span,
+                ));
+                return ResolvedType::Unknown;
+            }
             SymbolKind::Trait(_) => {
                 if !self.is_type_receiver_span(span) {
                     self.errors.push(errors::type_name_used_as_value(name, span));

--- a/src/frontend/typechecker/collect.rs
+++ b/src/frontend/typechecker/collect.rs
@@ -28,7 +28,7 @@ use self::decl_helpers::{
 /// A capability's `requires` entries parse as ordinary expressions so they can be checked symbol references rather
 /// than strings. Only a bare name or a chain of field accesses spells a reference; anything else — a call, a literal,
 /// a subscript — is not a path, and returning `None` lets the caller report it against the entry's own span.
-fn dotted_path_segments(expr: &Expr) -> Option<Vec<String>> {
+pub(super) fn dotted_path_segments(expr: &Expr) -> Option<Vec<String>> {
     match expr {
         Expr::Ident(name) => Some(vec![name.clone()]),
         Expr::Field(base, name) => {

--- a/src/frontend/typechecker/collect.rs
+++ b/src/frontend/typechecker/collect.rs
@@ -23,6 +23,23 @@ use self::decl_helpers::{
     collect_properties, inject_validate_methods, owner_resolved_type, resolve_declared_type, type_param_name_set,
 };
 
+/// Flatten a dotted reference expression into its path segments.
+///
+/// A capability's `requires` entries parse as ordinary expressions so they can be checked symbol references rather
+/// than strings. Only a bare name or a chain of field accesses spells a reference; anything else — a call, a literal,
+/// a subscript — is not a path, and returning `None` lets the caller report it against the entry's own span.
+fn dotted_path_segments(expr: &Expr) -> Option<Vec<String>> {
+    match expr {
+        Expr::Ident(name) => Some(vec![name.clone()]),
+        Expr::Field(base, name) => {
+            let mut segments = dotted_path_segments(&base.node)?;
+            segments.push(name.clone());
+            Some(segments)
+        }
+        _ => None,
+    }
+}
+
 type InheritedMembers = (
     HashMap<String, FieldInfo>,
     HashMap<String, Spanned<Expr>>,
@@ -148,11 +165,11 @@ impl TypeChecker {
                 self.validate_root_namespace(&func.name, decl.span);
                 self.collect_function(func, decl.span);
             }
-            // Capability collection lands with this issue's typechecker phase; parsing it is phase 1.
-            Declaration::Capability(_)
-            | Declaration::Docstring(_)
-            | Declaration::TestModule(_)
-            | Declaration::VocabBlock(_) => {}
+            Declaration::Capability(cap) => {
+                self.validate_root_namespace(&cap.name, decl.span);
+                self.collect_capability(cap, decl.span);
+            }
+            Declaration::Docstring(_) | Declaration::TestModule(_) | Declaration::VocabBlock(_) => {}
         }
     }
 
@@ -953,6 +970,44 @@ impl TypeChecker {
                 method_aliases,
                 properties,
                 requires,
+            }),
+            span,
+            scope: 0,
+        });
+    }
+
+    /// Register a `capability` declaration with its description, typed scope dimensions, and requirements (RFC 104).
+    ///
+    /// The scope dimensions are resolved here because they are ordinary type expressions, but the `requires` entries
+    /// are only recorded: a capability may require one declared later in the same module, so resolving them during
+    /// collection would make declaration order significant.
+    fn collect_capability(&mut self, cap: &CapabilityDecl, span: Span) {
+        let description = cap.description.as_ref().and_then(|expr| match &expr.node {
+            Expr::Literal(Literal::String(text)) => Some(text.clone()),
+            _ => None,
+        });
+
+        let scope = cap
+            .scope
+            .iter()
+            .map(|dim| (dim.node.name.clone(), self.resolve_type_checked(&dim.node.ty)))
+            .collect();
+
+        let requires = cap
+            .requires
+            .iter()
+            .filter_map(|entry| {
+                dotted_path_segments(&entry.node).map(|path| CapabilityRequirement { path, span: entry.span })
+            })
+            .collect();
+
+        self.symbols.define(Symbol {
+            name: cap.name.clone(),
+            kind: SymbolKind::Capability(CapabilityInfo {
+                description,
+                scope,
+                requires,
+                is_public: matches!(cap.visibility, Visibility::Public),
             }),
             span,
             scope: 0,

--- a/src/frontend/typechecker/collect.rs
+++ b/src/frontend/typechecker/collect.rs
@@ -23,6 +23,22 @@ use self::decl_helpers::{
     collect_properties, inject_validate_methods, owner_resolved_type, resolve_declared_type, type_param_name_set,
 };
 
+/// Read a capability's `description` clause as compile-time text.
+///
+/// Shared by collection and checking so the two cannot disagree about what counts as a description. Collection uses
+/// it to decide what to store; checking uses it to decide whether the clause is acceptable. When the two carried
+/// separate rules, `description = 42` satisfied checking and stored nothing, leaving a declaration that looked
+/// documented while carrying no description at all.
+///
+/// The text has to exist at compile time because the audience is a person deciding whether to grant the capability.
+/// There is no later moment at which that review happens, so an expression to be evaluated at runtime cannot serve.
+pub(super) fn capability_description_text(expr: &Expr) -> Option<&str> {
+    match expr {
+        Expr::Literal(Literal::String(text)) => Some(text.as_str()),
+        _ => None,
+    }
+}
+
 /// Flatten a dotted reference expression into its path segments.
 ///
 /// A capability's `requires` entries parse as ordinary expressions so they can be checked symbol references rather
@@ -982,10 +998,11 @@ impl TypeChecker {
     /// are only recorded: a capability may require one declared later in the same module, so resolving them during
     /// collection would make declaration order significant.
     fn collect_capability(&mut self, cap: &CapabilityDecl, span: Span) {
-        let description = cap.description.as_ref().and_then(|expr| match &expr.node {
-            Expr::Literal(Literal::String(text)) => Some(text.clone()),
-            _ => None,
-        });
+        let description = cap
+            .description
+            .as_ref()
+            .and_then(|expr| capability_description_text(&expr.node))
+            .map(str::to_string);
 
         let scope = cap
             .scope

--- a/src/frontend/typechecker/collect.rs
+++ b/src/frontend/typechecker/collect.rs
@@ -148,7 +148,11 @@ impl TypeChecker {
                 self.validate_root_namespace(&func.name, decl.span);
                 self.collect_function(func, decl.span);
             }
-            Declaration::Docstring(_) | Declaration::TestModule(_) | Declaration::VocabBlock(_) => {} /* Docstrings/tests don't need root collection */
+            // Capability collection lands with this issue's typechecker phase; parsing it is phase 1.
+            Declaration::Capability(_)
+            | Declaration::Docstring(_)
+            | Declaration::TestModule(_)
+            | Declaration::VocabBlock(_) => {}
         }
     }
 

--- a/src/frontend/typechecker/collect/stdlib_imports.rs
+++ b/src/frontend/typechecker/collect/stdlib_imports.rs
@@ -2379,6 +2379,7 @@ impl TypeChecker {
             SymbolKind::Field(_) => "field",
             SymbolKind::Property(_) => "property",
             SymbolKind::RustItem(_) => "rust import",
+            SymbolKind::Capability(_) => "capability",
         };
         Some(kind)
     }
@@ -2500,6 +2501,11 @@ impl TypeChecker {
         }
 
         match kind {
+            SymbolKind::Capability(info) => {
+                for (_, ty) in &mut info.scope {
+                    Self::remap_resolved_type_with_import_aliases(ty, imported_type_aliases);
+                }
+            }
             SymbolKind::Variable(info) => {
                 Self::remap_resolved_type_with_import_aliases(&mut info.ty, imported_type_aliases);
             }
@@ -3213,6 +3219,9 @@ impl TypeChecker {
     /// Apply a consumer namespace grant to provider-local trait provenance carried by checked artifact facts.
     fn qualify_provider_symbol_bounds(kind: &mut SymbolKind, namespace_prefix: &[String]) {
         match kind {
+            // A capability declares an authority rather than a callable or a nominal type, so it carries no trait
+            // bounds for a consumer namespace grant to qualify.
+            SymbolKind::Capability(_) => {}
             SymbolKind::Function(info) => Self::qualify_provider_function_bounds(info, namespace_prefix),
             SymbolKind::FunctionOverloads(overloads) => {
                 for overload in overloads {

--- a/src/frontend/typechecker/collect/stdlib_imports.rs
+++ b/src/frontend/typechecker/collect/stdlib_imports.rs
@@ -3646,6 +3646,7 @@ impl TypeChecker {
                 | ExportedSymbol::Type(name)
                 | ExportedSymbol::Trait(name)
                 | ExportedSymbol::Function(name)
+                | ExportedSymbol::Capability(name)
                 | ExportedSymbol::Reexported(name) => {
                     exported_names.insert(name.clone());
                 }

--- a/src/frontend/typechecker/mod.rs
+++ b/src/frontend/typechecker/mod.rs
@@ -1996,6 +1996,7 @@ impl TypeChecker {
         match kind {
             SymbolKind::Function(_) | SymbolKind::FunctionOverloads(_) => Some("function"),
             SymbolKind::Type(info) => Self::source_target_kind_for_type_info(info),
+            SymbolKind::Capability(_) => Some("capability"),
             _ => None,
         }
     }

--- a/src/frontend/typechecker/mod.rs
+++ b/src/frontend/typechecker/mod.rs
@@ -5162,7 +5162,8 @@ impl TypeChecker {
                     | ExportedSymbol::Static(name)
                     | ExportedSymbol::Type(name)
                     | ExportedSymbol::Trait(name)
-                    | ExportedSymbol::Function(name) => Some(name),
+                    | ExportedSymbol::Function(name)
+                    | ExportedSymbol::Capability(name) => Some(name),
                     ExportedSymbol::Variant { variant_name, .. } => Some(variant_name),
                     ExportedSymbol::Reexported(_) => None,
                 })
@@ -5191,8 +5192,8 @@ impl TypeChecker {
                 Declaration::Newtype(decl) => Some(decl.name.clone()),
                 Declaration::Enum(decl) => Some(decl.name.clone()),
                 Declaration::Function(decl) => Some(decl.name.clone()),
+                Declaration::Capability(decl) => Some(decl.name.clone()),
                 Declaration::Import(_)
-                | Declaration::Capability(_)
                 | Declaration::Docstring(_)
                 | Declaration::TestModule(_)
                 | Declaration::VocabBlock(_) => None,

--- a/src/frontend/typechecker/mod.rs
+++ b/src/frontend/typechecker/mod.rs
@@ -5191,6 +5191,7 @@ impl TypeChecker {
                 Declaration::Enum(decl) => Some(decl.name.clone()),
                 Declaration::Function(decl) => Some(decl.name.clone()),
                 Declaration::Import(_)
+                | Declaration::Capability(_)
                 | Declaration::Docstring(_)
                 | Declaration::TestModule(_)
                 | Declaration::VocabBlock(_) => None,
@@ -6388,6 +6389,7 @@ impl Default for TypeChecker {
 /// Return whether a declaration participates in public module import collection.
 fn is_public_decl(decl: &Spanned<Declaration>) -> bool {
     match &decl.node {
+        Declaration::Capability(c) => matches!(c.visibility, Visibility::Public),
         Declaration::Const(c) => matches!(c.visibility, Visibility::Public),
         Declaration::Static(s) => matches!(s.visibility, Visibility::Public),
         Declaration::Model(m) => matches!(m.visibility, Visibility::Public),
@@ -6409,6 +6411,7 @@ fn is_public_decl(decl: &Spanned<Declaration>) -> bool {
 /// Return the root symbol name declared by a declaration, when it has one.
 fn declaration_name(decl: &Spanned<Declaration>) -> Option<&str> {
     match &decl.node {
+        Declaration::Capability(c) => Some(c.name.as_str()),
         Declaration::Const(c) => Some(c.name.as_str()),
         Declaration::Static(s) => Some(s.name.as_str()),
         Declaration::Model(m) => Some(m.name.as_str()),

--- a/src/frontend/typechecker/tests.rs
+++ b/src/frontend/typechecker/tests.rs
@@ -22486,3 +22486,158 @@ def read(m: Meter) -> int:
 "#;
     check_str(source).map_err(|errs| format!("`capability` must stay an ordinary identifier: {errs:?}"))
 }
+
+/// RFC 104 treats the description as part of the authority's public contract, so its absence is a checked error
+/// rather than a parse failure — the grammar accepts the omission precisely so this can report it by name.
+#[test]
+fn a_capability_without_a_description_is_rejected() {
+    let errs = check_str_err(
+        r#"
+capability refund:
+    scope:
+        tenant: str
+"#,
+        "capability without a description",
+    );
+    assert!(
+        errs.iter().any(|e| e.message.contains("has no `description`")),
+        "expected the missing-description diagnostic; got: {errs:?}"
+    );
+}
+
+/// A `requires` entry is a checked symbol reference, so an expression that cannot name a declaration is refused at
+/// the entry's own span rather than being dropped during collection.
+#[test]
+fn a_requires_entry_that_is_not_a_reference_is_rejected() {
+    let errs = check_str_err(
+        r#"
+capability refund:
+    description = "Refund a captured charge"
+    requires = ["host.http.request"]
+"#,
+        "capability requiring a string",
+    );
+    assert!(
+        errs.iter()
+            .any(|e| e.message.contains("must be a capability reference")),
+        "expected the non-reference diagnostic; got: {errs:?}"
+    );
+}
+
+/// RFC 104 is explicit that a misspelled capability reference must fail at compile time rather than surviving to
+/// become a runtime denial reported far from the declaration that caused it.
+#[test]
+fn an_unknown_capability_requirement_is_rejected() {
+    let errs = check_str_err(
+        r#"
+capability refund:
+    description = "Refund a captured charge"
+    requires = [nonexistent]
+"#,
+        "capability requiring an unknown name",
+    );
+    assert!(
+        errs.iter()
+            .any(|e| e.message.contains("Unknown capability 'nonexistent'")),
+        "expected the unresolved-requirement diagnostic; got: {errs:?}"
+    );
+}
+
+/// A `requires` list naming a function describes an authority relationship that cannot exist, and a policy reading
+/// it would draw a false conclusion — so the wrong kind is refused as firmly as a missing one.
+#[test]
+fn a_requires_entry_naming_a_non_capability_is_rejected() {
+    let errs = check_str_err(
+        r#"
+def helper() -> int:
+    return 1
+
+capability refund:
+    description = "Refund a captured charge"
+    requires = [helper]
+"#,
+        "capability requiring a function",
+    );
+    assert!(
+        errs.iter()
+            .any(|e| e.message.contains("is a function, not a capability")),
+        "expected the wrong-kind diagnostic; got: {errs:?}"
+    );
+}
+
+/// Capabilities may reference each other in any order, which is why resolution is a checking pass rather than part
+/// of collection: requiring one declared further down the file must not depend on declaration order.
+#[test]
+fn a_capability_may_require_another_declared_later_in_the_module() -> Result<(), String> {
+    check_str(
+        r#"
+capability refund:
+    description = "Refund a captured charge"
+    requires = [audit_write]
+
+capability audit_write:
+    description = "Append to the audit log"
+"#,
+    )
+    .map_err(|errs| format!("declaration order must not matter for `requires`: {errs:?}"))
+}
+
+/// A `pub capability` is exported and referenceable across a module boundary.
+///
+/// The stdlib is only the first capability publisher: a library author declares domain capabilities in their own
+/// module and consumers reference them by import. Withholding capabilities from the export set would make `pub`
+/// meaningless on the one declaration form whose entire purpose is to be referenced from elsewhere.
+#[test]
+fn a_public_capability_crosses_a_module_boundary() -> Result<(), Box<dyn std::error::Error>> {
+    let dependency = parse_program(
+        r#"
+pub capability audit_write:
+    description = "Append to the audit log"
+"#,
+        "capability publisher",
+    );
+    let consumer = parse_program(
+        r#"
+capability refund:
+    description = "Refund a captured charge"
+    requires = [publisher.audit_write]
+"#,
+        "capability consumer",
+    );
+
+    let mut checker = TypeChecker::new();
+    checker
+        .check_with_imports(&consumer, &[("publisher", &dependency)])
+        .map_err(|errs| format!("a `pub capability` must be referenceable across modules: {errs:?}"))?;
+    Ok(())
+}
+
+/// A capability that is *not* `pub` stays private, so a consumer referencing it fails to resolve.
+#[test]
+fn a_private_capability_does_not_cross_a_module_boundary() {
+    let dependency = parse_program(
+        r#"
+capability audit_write:
+    description = "Append to the audit log"
+"#,
+        "private capability publisher",
+    );
+    let consumer = parse_program(
+        r#"
+capability refund:
+    description = "Refund a captured charge"
+    requires = [publisher.audit_write]
+"#,
+        "private capability consumer",
+    );
+
+    let mut checker = TypeChecker::new();
+    let Err(errs) = checker.check_with_imports(&consumer, &[("publisher", &dependency)]) else {
+        panic!("a private capability must not be referenceable from another module");
+    };
+    assert!(
+        errs.iter()
+            .any(|e| e.message.contains("Unknown capability 'publisher.audit_write'")),
+        "expected the unresolved-requirement diagnostic; got: {errs:?}"
+    );
+}

--- a/src/frontend/typechecker/tests.rs
+++ b/src/frontend/typechecker/tests.rs
@@ -22641,3 +22641,49 @@ capability refund:
         "expected the unresolved-requirement diagnostic; got: {errs:?}"
     );
 }
+
+/// A `description` clause that is not compile-time text is rejected rather than silently stored as nothing.
+///
+/// Presence alone was not enough: collection keeps only text it can read, so a clause it cannot read left the
+/// declaration carrying no description while appearing to have one.
+#[test]
+fn a_capability_description_that_is_not_text_is_rejected() {
+    for source in [
+        "\ncapability refund:\n    description = 42\n",
+        "\ncapability refund:\n    description = [\"a\", \"b\"]\n",
+    ] {
+        let errs = check_str_err(source, "capability with a non-text description");
+        assert!(
+            errs.iter()
+                .any(|e| e.message.contains("`description` that is not a text literal")),
+            "expected the non-text description diagnostic for {source:?}; got: {errs:?}"
+        );
+    }
+}
+
+/// Collection and checking must agree about what counts as a description, so a rejected clause never reaches the
+/// symbol table as a silently absent one while the declaration still typechecks.
+#[test]
+fn a_rejected_description_never_leaves_a_capability_looking_documented() -> Result<(), String> {
+    let source = "\ncapability refund:\n    description = 42\n";
+    let tokens = lexer::lex(source).map_err(|errs| format!("lex failed: {errs:?}"))?;
+    let program = parser::parse(&tokens).map_err(|errs| format!("parse failed: {errs:?}"))?;
+    let mut checker = TypeChecker::new();
+    let result = checker.check_program(&program);
+
+    assert!(result.is_err(), "a non-text description must not typecheck");
+
+    let symbol_id = checker
+        .symbols
+        .lookup("refund")
+        .ok_or("the capability was not collected")?;
+    let symbol = checker.symbols.get(symbol_id).ok_or("the symbol id did not resolve")?;
+    let SymbolKind::Capability(info) = &symbol.kind else {
+        return Err(format!("expected a capability symbol, got {:?}", symbol.kind));
+    };
+    assert_eq!(
+        info.description, None,
+        "collection stores nothing it cannot read, which is exactly why checking must reject the clause"
+    );
+    Ok(())
+}

--- a/src/frontend/typechecker/tests.rs
+++ b/src/frontend/typechecker/tests.rs
@@ -22387,3 +22387,102 @@ fn test_statement_tuple_unpack_of_an_opaque_rust_value_is_refused() {
         other => panic!("a readable Rust tuple must still destructure, got {other:?}"),
     }
 }
+
+/// A `capability` declaration must reach the symbol table with its RFC 104 clauses intact.
+///
+/// `requires` is deliberately checked as unresolved path segments: collection records what was written so that a
+/// capability may reference one declared later in the same module.
+#[test]
+fn capability_declarations_collect_their_description_scope_and_requires() -> Result<(), String> {
+    let source = r#"
+capability http_request:
+    description = "Issue an outbound HTTP request"
+    scope:
+        host: str
+    requires = [process.spawn]
+"#;
+    let tokens = lexer::lex(source).map_err(|errs| format!("lex failed: {errs:?}"))?;
+    let program = parser::parse(&tokens).map_err(|errs| format!("parse failed: {errs:?}"))?;
+    let mut checker = TypeChecker::new();
+    let _ = checker.check_program(&program);
+
+    let symbol_id = checker
+        .symbols
+        .lookup("http_request")
+        .ok_or("the capability declaration was not collected into the symbol table")?;
+    let symbol = checker
+        .symbols
+        .get(symbol_id)
+        .ok_or("the collected symbol id did not resolve")?;
+    let SymbolKind::Capability(info) = &symbol.kind else {
+        return Err(format!("expected a capability symbol, got {:?}", symbol.kind));
+    };
+
+    assert_eq!(info.description.as_deref(), Some("Issue an outbound HTTP request"));
+    assert_eq!(info.scope.len(), 1, "one declared scope dimension");
+    assert_eq!(info.scope[0].0, "host");
+    assert_eq!(
+        info.scope[0].1,
+        ResolvedType::Str,
+        "scope dimension types are resolved at collection"
+    );
+    assert_eq!(info.requires.len(), 1);
+    assert_eq!(info.requires[0].path, vec!["process".to_string(), "spawn".to_string()]);
+    Ok(())
+}
+
+/// A capability must carry RFC 120's `Capability` identity kind rather than falling through to a gap marker.
+#[test]
+fn a_capability_symbol_carries_the_canonical_capability_identity_kind() {
+    use incan_semantics_core::SemanticSourceTargetKind;
+
+    let kind = SymbolKind::Capability(CapabilityInfo {
+        description: None,
+        scope: Vec::new(),
+        requires: Vec::new(),
+        is_public: false,
+    });
+
+    let spelling = TypeChecker::source_target_kind_for_symbol(&kind);
+    assert_eq!(spelling, Some("capability"));
+    assert_eq!(
+        SemanticSourceTargetKind::from_kind_str("capability"),
+        SemanticSourceTargetKind::Capability,
+        "the frontend spelling must decode to the canonical kind, not to Other",
+    );
+}
+
+/// A capability names an authority, so a bare reference to one is never a value use.
+#[test]
+fn referencing_a_capability_as_a_value_is_rejected() {
+    let source = r#"
+capability refund:
+    description = "Refund a captured charge"
+
+def use_it() -> int:
+    x = refund
+    return 1
+"#;
+    let Err(errs) = check_str(source) else {
+        panic!("referencing a capability as a value must fail");
+    };
+    assert!(
+        errs.iter()
+            .any(|e| e.message.contains("names a runtime authority, not a value")),
+        "expected the capability-as-value diagnostic; got: {errs:?}"
+    );
+}
+
+/// `capability` is contextual, so every non-declaration position keeps it an ordinary identifier.
+#[test]
+fn capability_remains_usable_as_an_ordinary_identifier() -> Result<(), String> {
+    let source = r#"
+model Meter:
+    capability: int
+
+def read(m: Meter) -> int:
+    capability = m.capability
+    return capability
+"#;
+    check_str(source).map_err(|errs| format!("`capability` must stay an ordinary identifier: {errs:?}"))
+}

--- a/tests/property_tests.rs
+++ b/tests/property_tests.rs
@@ -37,6 +37,36 @@ def main() -> ():
         Ok(())
     }
 
+    /// A `capability` declaration survives a format round-trip unchanged, and reformatting is idempotent.
+    ///
+    /// The formatter normalizes clause order, so a capability written description/scope/requires must come back the
+    /// same way it went in when it was already in that order -- and a second pass must change nothing.
+    #[test]
+    fn format_is_idempotent_for_a_capability_declaration() -> Result<(), String> {
+        let source = concat!(
+            "capability refund:\n",
+            "    description = \"Issue a refund\"\n",
+            "    scope:\n",
+            "        tenant: str\n",
+            "    requires = [host.http.request]\n",
+        );
+
+        let once = format_source(source).map_err(|e| e.to_string())?;
+        let twice = format_source(&once).map_err(|e| e.to_string())?;
+
+        assert_eq!(once, twice, "formatting a capability should be idempotent");
+        for fragment in [
+            "capability refund:",
+            "description = ",
+            "scope:",
+            "tenant: str",
+            "requires = [",
+        ] {
+            assert!(once.contains(fragment), "formatted output lost `{fragment}`:\n{once}");
+        }
+        Ok(())
+    }
+
     /// Property: Formatting preserves semantic meaning (can parse before and after)
     #[test]
     fn format_preserves_parseability() -> Result<(), String> {


### PR DESCRIPTION
## Summary

#1156 needs to consume an RFC 104 authority decision without inventing a provider-local grant model. A narrow allow/deny adapter would lose RFC 104's mode, grant, ceiling, scope and provenance, and would be incompatible with later runtime consumers.

This delivers the durable authority-decision fact and its consumer seam, plus the `capability` declaration form the fact needs in order to have anything to identify.

Closes #1211. Contributes to #1029; does not close it.

## Type of change

- [x] New feature

## Area(s)

- [x] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Runtime / Core crates (stdlib/core/derive)

## Key details

- **User-facing behavior**: `capability name:` parses, with optional `description`, a typed `scope:` block, and a `requires` list, in any order. The keyword is **contextual**, not hard — `capability` stays usable as a variable, field, parameter and method name.
- **Internals**, in six commits:
  1. `KeywordId::Capability` and an `RFC::_104` registry entry, which was missing entirely — a gap between 102 and 106.
  2. The `CapabilityDecl` AST node and its parser.
  3. Contextual activation (see Risks).
  4. `SymbolKind::Capability(CapabilityInfo)` plus `SemanticSourceTargetKind::Capability`, so a capability decodes to a real RFC 120 category instead of the `Other` gap marker.
  5. `AuthorityDecision`: capability and requesting operation both named by `CanonicalSymbolId`, so the stdlib, a library-defined domain capability and a provider operation produce one fact rather than three parallel ones.
  6. `AuthorityDecisionSource`, the compiler-to-runtime seam.
- **Risks**: registering `capability` as a *hard* keyword — matching every other declaration form — reserved the spelling in every position and silently stole it as an identifier. `def capability(self) -> int` stopped parsing and four typechecker trait-bound tests broke. It is now recognized by the declaration shape (the spelling followed by a name), so `capability = x`, `capability(x)` and `capability: T` remain ordinary identifiers. There is a regression test for exactly that.

## Design notes worth reviewing

- **`requires` is deliberately unresolved at collection.** Capabilities may reference each other in any order within a module, so resolving during collection would make declaration order significant. Collection records the written path segments and their spans; resolution is a checking concern.
- **Mode is part of the decision**, not ambient context: the same request resolves differently under governed than under permissive, and a consumer reading a stored decision must be able to tell which rule produced it.
- **`ceiling_applied` is recorded** because RFC 104 makes a host ceiling a grant source distinct from the invocation's own request, combined by **intersection and never union**. Allowed-under-a-ceiling and allowed-with-no-ceiling are different facts about the run. A grant the invocation requested but the ceiling excluded is denied as `OutsideCeiling` rather than as a plain missing grant — being capped is a different failure from never having asked.
- **Two boundaries fell out of the new symbol kind rather than being skipped**: capability scope-dimension types now participate in import-alias remapping, and a bare reference to a capability is rejected, because it names an authority rather than a value.

## Testing / verification

- [x] Manual verification described below

Manual verification notes:

- `cargo test --lib frontend::` — 1211 passed, 0 failed
- `cargo test -p incan_semantics_core --lib` — 46 passed, 0 failed, including the identity round-trip and the authority seam
- `cargo test -p incan_core --lib lang::keywords` and `cargo test -p incan_syntax --lib capability` — green
- The four typechecker trait-bound tests that the hard keyword broke are green again
- `cargo clippy` clean; `cargo +nightly fmt` clean; rustdoc gate passed
- **Mutation check**: emptying the collected `requires` paths failed the collection test with `left: [] right: ["process", "spawn"]`, and it passed again on restore.

Slice-level gates (`make pre-commit`, full Oven suites, slice-wide CI) are deliberately deferred.

## Docs impact

- [x] No docs changes needed

The `capability` declaration form is RFC 104 surface that is not yet reachable end to end; the authority seam is an internal compiler-to-runtime boundary documented in module rustdoc. User-facing docs belong with the #1029 work that makes the surface usable.

## Checklist

- [x] I added/updated tests where it materially reduces regressions
