### PR TITLE
feature - establish RFC 104 operation-receipt facts for provider consumers (#1212)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1520,6 +1520,8 @@ name = "incan_semantics_core"
 version = "0.6.0-dev.0"
 dependencies = [
  "incan_core",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/incan_semantics_core/Cargo.toml
+++ b/crates/incan_semantics_core/Cargo.toml
@@ -11,3 +11,7 @@ authors.workspace = true
 
 [dependencies]
 incan_core = { path = "../incan_core" }
+serde = { version = "1.0", features = ["derive"] }
+
+[dev-dependencies]
+serde_json = "1.0"

--- a/crates/incan_semantics_core/src/facts.rs
+++ b/crates/incan_semantics_core/src/facts.rs
@@ -7,6 +7,8 @@
 use std::collections::BTreeMap;
 use std::fmt::{self, Write};
 
+use serde::{Deserialize, Serialize};
+
 use crate::IncanType;
 
 /// Kind of compiler-owned node that can receive semantic facts.
@@ -365,7 +367,8 @@ impl fmt::Display for SemanticSourceTarget {
 /// declaration kinds today's codegraph targets happen to record, so a member and a local never have to be told apart
 /// by a string. [`Self::Other`] remains for a frontend spelling this vocabulary has not adopted yet; it is a gap
 /// marker, never a category.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum SemanticSourceTargetKind {
     /// A `def` declaration, free or associated.
     Function,
@@ -485,7 +488,8 @@ impl SemanticSourceTargetKind {
 /// The mode is part of the decision rather than ambient context: the same request produces a different outcome under
 /// `Governed` than under `Permissive`, and a consumer reading a stored decision must be able to tell which rule
 /// produced it without re-deriving the run's configuration.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum AuthorityMode {
     /// Operations run normally and receipts may be disabled.
     Permissive,
@@ -510,7 +514,8 @@ impl AuthorityMode {
 ///
 /// This is the machine-usable denial reason RFC 104 requires. A consumer branches on the variant; the prose belongs to
 /// the diagnostic that renders it, never to this fact.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum AuthorityDenialReason {
     /// The invocation never requested this capability.
     NotGranted,
@@ -538,7 +543,8 @@ impl AuthorityDenialReason {
 }
 
 /// The effect of an authority decision on one operation.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum AuthorityOutcome {
     /// The operation may perform its authority-bearing behavior.
     Allowed,
@@ -552,7 +558,7 @@ pub enum AuthorityOutcome {
 /// to be their **intersection, never their union**: an invocation can only ever receive less than its ceiling allows,
 /// regardless of what it asks for. Recording whether a ceiling applied is therefore part of the decision, because
 /// `Allowed` under a ceiling and `Allowed` with no ceiling are different facts about the run.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct AuthorityGrantContext {
     /// Scope dimensions the operation requested, as `(dimension, value)` in the capability's declaration order.
     pub requested_scope: Vec<(String, String)>,
@@ -565,7 +571,7 @@ pub struct AuthorityGrantContext {
 /// RFC 104 requires a denial to identify the required capability and to be reportable against the source that asked
 /// for it. The requesting operation's canonical identity and the use-site span are what make that possible without a
 /// consumer re-reading source text.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct AuthorityProvenance {
     /// Canonical identity of the operation that requested the authority.
     pub operation: CanonicalSymbolId,
@@ -581,7 +587,7 @@ pub struct AuthorityProvenance {
 /// requesting operation are named by [`CanonicalSymbolId`], so the stdlib, a library-defined domain capability, and a
 /// provider operation all produce the same fact. A consumer can act on an allowed or denied decision without
 /// consulting source text or emitted Rust, which is what lets a provider backend avoid inventing its own grant model.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct AuthorityDecision {
     /// The capability whose authority was requested.
     pub capability: CanonicalSymbolId,
@@ -680,7 +686,8 @@ pub fn module_identity_for_path(module_path: &[String]) -> String {
 /// Namespaces are distinguished by *how* a name is looked up, not by what kind of thing it names: a model name and a
 /// function name share one namespace, exactly as ordinary Python-like lexical lookup expects. Carrying this in an
 /// identity is what keeps a field named `items` and a local named `items` from ever comparing equal.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum SymbolNamespace {
     /// Module-level declarations, imports, aliases and re-exports, bare enum variant names, generic binders,
     /// parameters and receivers, and locals. Looked up innermost scope outward, then the builtin fallback tier.
@@ -697,7 +704,8 @@ pub enum SymbolNamespace {
 ///
 /// An import, alias, or re-export carries its *target's* origin, never the referencing module's. That is the property
 /// that makes three different spellings of one declaration compare equal.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum SymbolOrigin {
     /// A project source module, by canonical module path.
     Module(Vec<String>),
@@ -719,7 +727,7 @@ pub enum SymbolOrigin {
 /// Module-level declarations are already unique within their origin and carry no discriminant. Locals, parameters,
 /// receivers, and generic binders are not: two `x` bindings in sibling blocks of one module must not collapse to one
 /// identity, so those carry the scope that introduced them.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct ScopeDiscriminant(pub usize);
 
 /// RFC 120 canonical symbol identity: what a resolved reference *means*.
@@ -732,7 +740,7 @@ pub struct ScopeDiscriminant(pub usize);
 /// names — no phase may recover what a reference means by parsing generated Rust. And identity is stable across the
 /// stages of *one* compilation, not across edits: [`Self::declaration_span`] moves when the file does, so a consumer
 /// needing cross-edit continuity must re-resolve rather than cache.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct CanonicalSymbolId {
     /// Which namespace the binding lives in.
     pub namespace: SymbolNamespace,

--- a/crates/incan_semantics_core/src/hir.rs
+++ b/crates/incan_semantics_core/src/hir.rs
@@ -6,10 +6,12 @@
 
 use std::fmt::Write;
 
+use serde::{Deserialize, Serialize};
+
 use crate::{CompilerNodeId, SemanticFactStore};
 
 /// A source byte range attached to a HIR node.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct HirSourceSpan {
     pub start: usize,
     pub end: usize,

--- a/crates/incan_semantics_core/src/lib.rs
+++ b/crates/incan_semantics_core/src/lib.rs
@@ -26,6 +26,7 @@ pub mod authority;
 pub mod body_ir;
 mod facts;
 mod hir;
+pub mod receipts;
 mod types;
 
 pub use facts::{

--- a/crates/incan_semantics_core/src/lib.rs
+++ b/crates/incan_semantics_core/src/lib.rs
@@ -11,6 +11,9 @@
 //! generic `Surface` AST nodes tagged with [`SurfaceFeatureKey`] without knowing *which* stdlib features are enabled,
 //! while the stdlib pack crate implements the feature logic without importing the parser.
 //!
+//! RFC 104 authority decisions and operation receipts also live here, so compiler and runtime consumers exchange one
+//! validated canonical contract rather than reconstructing authority or receipt facts at their boundary.
+//!
 //! ## Extension model
 //!
 //! To support a new soft keyword or decorator family:

--- a/crates/incan_semantics_core/src/receipts.rs
+++ b/crates/incan_semantics_core/src/receipts.rs
@@ -1,38 +1,44 @@
 //! RFC 104 operation receipts.
 //!
-//! A receipt is the durable record of what one capability-aware operation actually did. It is the counterpart to
-//! [`crate::facts::AuthorityDecision`]: the decision says whether an operation was permitted, and the receipt says
-//! what happened once that decision was applied — including the case where the decision was a denial and the
-//! operation never ran.
+//! An operation receipt is the durable, machine-readable record of what one capability-aware operation actually did.
+//! It is the counterpart to [`crate::facts::AuthorityDecision`]: a decision records whether a *requesting* source
+//! operation may proceed; this receipt records the distinct, canonical provider operation that actually ran (or would
+//! have run), together with the decision's caller/use-site provenance.
 //!
-//! The receipt is deliberately one shape for every publisher. A stdlib host boundary, a package-defined domain
-//! operation, and a provider operation all emit this, so a backend execution receipt can *reference* a receipt
-//! without copying or reinterpreting its authority, redaction, or replay semantics. Two owners for redaction would
-//! mean two chances to disagree about what was persisted.
+//! This module owns one validated, versioned shape for every publisher. A stdlib host boundary, a package-defined
+//! domain operation, and a provider operation all use it. Run-report correlation and any backend-execution linkage
+//! belong to their owning report/producer contracts: a sequence number alone is intentionally not exported as a
+//! standalone cross-run reference.
 
-use crate::facts::{AuthorityDecision, CanonicalSymbolId};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::facts::{AuthorityDecision, AuthorityMode, CanonicalSymbolId};
+
+/// Current wire format for [`OperationReceipt`].
+pub const OPERATION_RECEIPT_SCHEMA_VERSION: u32 = 1;
 
 /// What happened to one capability-aware operation.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum ReceiptStatus {
-    /// The operation ran and was recorded, without authority being enforced.
+    /// The operation ran and was recorded without governed authority being enforced.
     Observed,
-    /// Authority was granted and the operation ran to completion.
+    /// Governed authority was granted and the operation ran to completion.
     Allowed,
-    /// Authority was refused, so the operation never performed its behavior.
+    /// Governed authority was refused, so the operation never performed its behavior.
     Denied,
-    /// Authority was granted but the operation itself failed.
+    /// Authority permitted the operation, but the operation itself failed.
     Failed,
     /// The operation ran, but its recorded attributes were redacted before reaching a sink.
     Redacted,
-    /// The operation was not attempted, for a reason other than a denial.
+    /// Authority permitted the operation, but it was not attempted for another reason.
     Skipped,
     /// The operation performed part of its work before stopping.
     Partial,
 }
 
 impl ReceiptStatus {
-    /// Return the compact snapshot spelling for this status.
+    /// Return the stable wire spelling for this status.
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::Observed => "observed",
@@ -50,7 +56,8 @@ impl ReceiptStatus {
 ///
 /// RFC 104 does not require the runtime to implement replay. It requires the runtime not to make dishonest replay
 /// claims, which is why this is recorded per receipt rather than inferred later from the operation kind.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum ReplayClassification {
     /// Replayable from recorded local inputs, such as a filesystem write determined by its recorded arguments.
     Deterministic,
@@ -65,7 +72,7 @@ pub enum ReplayClassification {
 }
 
 impl ReplayClassification {
-    /// Return the compact snapshot spelling for this classification.
+    /// Return the stable wire spelling for this classification.
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::Deterministic => "deterministic",
@@ -80,19 +87,21 @@ impl ReplayClassification {
 /// How sensitive one recorded attribute's value is.
 ///
 /// This travels with the attribute rather than being decided at the sink, so a receipt that crosses a boundary keeps
-/// the provenance a redaction policy needs (RFC 103).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+/// the provenance a redaction policy needs. Only [`Self::Public`] attributes may retain a cleartext value in this
+/// contract; `Internal` and `Secret` require the separate, explicit reveal policy RFC 104 reserves for a later slice.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum AttributeSensitivity {
     /// Safe to record as written.
     Public,
-    /// Recorded locally, but not intended for export.
+    /// Must be redacted until an explicit reveal policy permits otherwise.
     Internal,
     /// Never recorded in the clear.
     Secret,
 }
 
 impl AttributeSensitivity {
-    /// Return the compact snapshot spelling for this sensitivity level.
+    /// Return the stable wire spelling for this sensitivity level.
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::Public => "public",
@@ -100,21 +109,46 @@ impl AttributeSensitivity {
             Self::Secret => "secret",
         }
     }
+
+    /// Whether a value at this sensitivity may be persisted by this baseline contract.
+    const fn permits_cleartext(self) -> bool {
+        matches!(self, Self::Public)
+    }
 }
 
 /// One attribute recorded on a receipt.
 ///
-/// A redacted attribute keeps its key and its sensitivity and drops only the value. That is what lets a reader see
-/// *that* an HTTP URL was recorded and deliberately withheld, rather than being unable to tell a withheld value from
-/// an operation that never had one.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+/// A redacted attribute keeps its key and sensitivity and drops only the value. That lets a reader distinguish a
+/// deliberately withheld HTTP URL from an operation that never recorded one, while a downstream policy still knows
+/// why the value is absent.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 pub struct ReceiptAttribute {
-    /// The attribute's name, such as `http.method` or `fs.path_policy`.
-    pub key: String,
-    /// The recorded value, or `None` when it was redacted.
-    pub value: Option<String>,
-    /// How sensitive the value is, recorded whether or not it was persisted.
-    pub sensitivity: AttributeSensitivity,
+    key: String,
+    value: Option<String>,
+    sensitivity: AttributeSensitivity,
+}
+
+#[derive(Deserialize)]
+struct ReceiptAttributeWire {
+    key: String,
+    value: Option<String>,
+    sensitivity: AttributeSensitivity,
+}
+
+impl<'de> Deserialize<'de> for ReceiptAttribute {
+    /// Decode only an attribute that satisfies the redaction invariant.
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let wire = ReceiptAttributeWire::deserialize(deserializer)?;
+        let attribute = Self {
+            key: wire.key,
+            value: wire.value,
+            sensitivity: wire.sensitivity,
+        };
+        attribute
+            .validate()
+            .map_err(|violation| serde::de::Error::custom(violation.to_string()))?;
+        Ok(attribute)
+    }
 }
 
 impl ReceiptAttribute {
@@ -128,9 +162,6 @@ impl ReceiptAttribute {
     }
 
     /// Record an attribute whose value was withheld.
-    ///
-    /// RFC 104 redacts sensitive values by default, so this is the constructor a publisher reaches for whenever the
-    /// value is not `Public`; persisting one takes a deliberate call to [`Self::public`].
     pub fn redacted(key: impl Into<String>, sensitivity: AttributeSensitivity) -> Self {
         Self {
             key: key.into(),
@@ -139,34 +170,70 @@ impl ReceiptAttribute {
         }
     }
 
+    /// The attribute's stable name.
+    pub fn key(&self) -> &str {
+        &self.key
+    }
+
+    /// The persisted public value, when one exists.
+    pub fn value(&self) -> Option<&str> {
+        self.value.as_deref()
+    }
+
+    /// The sensitivity retained whether or not the value was persisted.
+    pub const fn sensitivity(&self) -> AttributeSensitivity {
+        self.sensitivity
+    }
+
     /// Whether this attribute's value was withheld.
     pub const fn is_redacted(&self) -> bool {
         self.value.is_none()
     }
+
+    /// Reject cleartext whose sensitivity requires a future explicit reveal policy.
+    fn validate(&self) -> Result<(), ReceiptContractViolation> {
+        if self.value.is_some() && !self.sensitivity.permits_cleartext() {
+            return Err(ReceiptContractViolation::CleartextSensitiveAttribute {
+                key: self.key.clone(),
+                sensitivity: self.sensitivity,
+            });
+        }
+        Ok(())
+    }
 }
 
-/// A reference from another receipt to this one.
-///
-/// A backend execution receipt holds this rather than a copy. Copying would give redaction and replay two owners, and
-/// two owners eventually disagree.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct OperationReceiptRef {
-    /// The referenced receipt's sequence id within its run.
-    pub sequence_id: u64,
-}
-
-/// Ways a receipt can contradict itself.
+/// Ways a receipt can contradict its own durable contract.
 ///
 /// These are contract violations rather than runtime errors: each one means the receipt claims something its own
-/// other fields deny, which is exactly the dishonesty RFC 104 asks the runtime to avoid.
+/// authority, identity, sensitivity, or persistence fields deny.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ReceiptContractViolation {
-    /// The status says denied but the linked authority decision allowed the operation, or the reverse.
+    /// A receipt used a schema version this compiler does not understand.
+    UnsupportedSchemaVersion {
+        /// Version recorded by the receipt.
+        found: u32,
+        /// Version this compiler supports.
+        expected: u32,
+    },
+    /// A status is incompatible with the linked authority decision's mode or outcome.
     StatusContradictsAuthority {
         /// The status the receipt claims.
         status: ReceiptStatus,
-        /// Whether the linked decision actually allowed the operation.
+        /// The mode under which the authority decision was made.
+        authority_mode: AuthorityMode,
+        /// Whether the linked decision allowed the operation.
         authority_allowed: bool,
+    },
+    /// The receipt's capability differs from the capability the authority decision evaluated.
+    CapabilityContradictsAuthority,
+    /// The receipt's source span differs from the authority decision's requesting use site.
+    SourceSpanContradictsAuthority,
+    /// A non-public attribute retained a cleartext value without an explicit reveal policy.
+    CleartextSensitiveAttribute {
+        /// The offending attribute key.
+        key: String,
+        /// The sensitivity that required redaction.
+        sensitivity: AttributeSensitivity,
     },
     /// The receipt withheld attribute values yet claims replay from recorded local inputs.
     DeterministicReplayOverRedactedAttributes {
@@ -178,14 +245,31 @@ pub enum ReceiptContractViolation {
 impl std::fmt::Display for ReceiptContractViolation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::UnsupportedSchemaVersion { found, expected } => write!(
+                f,
+                "unsupported operation-receipt schema version {found}; expected {expected}"
+            ),
             Self::StatusContradictsAuthority {
                 status,
+                authority_mode,
                 authority_allowed,
             } => write!(
                 f,
-                "receipt status `{}` contradicts an authority decision that {}",
+                "receipt status `{}` contradicts a {} authority decision that {}",
                 status.as_str(),
+                authority_mode.as_str(),
                 if *authority_allowed { "allowed" } else { "denied" },
+            ),
+            Self::CapabilityContradictsAuthority => {
+                f.write_str("receipt capability contradicts its authority decision")
+            }
+            Self::SourceSpanContradictsAuthority => {
+                f.write_str("receipt source span contradicts its authority decision")
+            }
+            Self::CleartextSensitiveAttribute { key, sensitivity } => write!(
+                f,
+                "receipt attribute `{key}` retains cleartext despite {} sensitivity",
+                sensitivity.as_str(),
             ),
             Self::DeterministicReplayOverRedactedAttributes { redacted_keys } => write!(
                 f,
@@ -197,62 +281,209 @@ impl std::fmt::Display for ReceiptContractViolation {
 }
 
 /// The durable record of one capability-aware operation.
+///
+/// Construction derives the capability and source use site from the linked [`AuthorityDecision`], while the distinct
+/// `operation` identity names the provider/callable operation that actually ran. This keeps authority requester
+/// provenance from being mistaken for the invoked provider operation.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct OperationReceipt {
-    /// Position within the emitting run, which is also this receipt's identity for references.
-    pub sequence_id: u64,
-    /// The capability whose authority the operation needed.
-    pub capability: CanonicalSymbolId,
-    /// The operation that ran, or would have run.
-    pub operation: CanonicalSymbolId,
-    /// The publisher's own name for what kind of operation this was, such as `http.request`.
-    pub operation_kind: String,
-    /// What happened.
-    pub status: ReceiptStatus,
-    /// The authority decision this receipt records the outcome of.
-    pub authority: AuthorityDecision,
-    /// Where the operation was written.
-    pub source_span: crate::HirSourceSpan,
-    /// The enclosing context's sequence id, when the operation ran inside one.
-    pub parent_context: Option<u64>,
-    /// Operation-specific attributes, redacted or not.
-    pub attributes: Vec<ReceiptAttribute>,
-    /// How replayable this operation is.
-    pub replay: ReplayClassification,
+    schema_version: u32,
+    sequence_id: u64,
+    capability: CanonicalSymbolId,
+    operation: CanonicalSymbolId,
+    operation_kind: String,
+    status: ReceiptStatus,
+    authority: AuthorityDecision,
+    source_span: crate::HirSourceSpan,
+    parent_context: Option<u64>,
+    attributes: Vec<ReceiptAttribute>,
+    replay: ReplayClassification,
+}
+
+#[derive(Serialize)]
+struct OperationReceiptWireRef<'a> {
+    schema_version: u32,
+    sequence_id: u64,
+    capability: &'a CanonicalSymbolId,
+    operation: &'a CanonicalSymbolId,
+    operation_kind: &'a str,
+    status: ReceiptStatus,
+    authority: &'a AuthorityDecision,
+    source_span: crate::HirSourceSpan,
+    parent_context: Option<u64>,
+    attributes: &'a [ReceiptAttribute],
+    replay: ReplayClassification,
+}
+
+#[derive(Deserialize)]
+struct OperationReceiptWire {
+    schema_version: u32,
+    sequence_id: u64,
+    capability: CanonicalSymbolId,
+    operation: CanonicalSymbolId,
+    operation_kind: String,
+    status: ReceiptStatus,
+    authority: AuthorityDecision,
+    source_span: crate::HirSourceSpan,
+    parent_context: Option<u64>,
+    attributes: Vec<ReceiptAttribute>,
+    replay: ReplayClassification,
+}
+
+impl Serialize for OperationReceipt {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.validate()
+            .map_err(|violation| serde::ser::Error::custom(violation.to_string()))?;
+        OperationReceiptWireRef {
+            schema_version: self.schema_version,
+            sequence_id: self.sequence_id,
+            capability: &self.capability,
+            operation: &self.operation,
+            operation_kind: &self.operation_kind,
+            status: self.status,
+            authority: &self.authority,
+            source_span: self.source_span,
+            parent_context: self.parent_context,
+            attributes: &self.attributes,
+            replay: self.replay,
+        }
+        .serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for OperationReceipt {
+    /// Decode and validate the complete versioned receipt before exposing it to a consumer.
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let wire = OperationReceiptWire::deserialize(deserializer)?;
+        let receipt = Self {
+            schema_version: wire.schema_version,
+            sequence_id: wire.sequence_id,
+            capability: wire.capability,
+            operation: wire.operation,
+            operation_kind: wire.operation_kind,
+            status: wire.status,
+            authority: wire.authority,
+            source_span: wire.source_span,
+            parent_context: wire.parent_context,
+            attributes: wire.attributes,
+            replay: wire.replay,
+        };
+        receipt
+            .validate()
+            .map_err(|violation| serde::de::Error::custom(violation.to_string()))?;
+        Ok(receipt)
+    }
 }
 
 impl OperationReceipt {
-    /// Build the receipt for a governed denial.
+    /// Build a validated receipt for an operation outcome.
     ///
-    /// A denial produces a receipt without the provider ever being invoked, which is the point: RFC 104 treats a
-    /// refusal as a first-class outcome to be recorded, not as an absence of one. The status and replay
-    /// classification both follow from the decision, so a caller cannot accidentally record a denial as a success.
-    pub fn denied(
+    /// `operation` is the canonical identity of the provider/callable operation that ran. The linked decision owns
+    /// the requester and the source use-site, so this constructor derives the capability and span rather than asking
+    /// a publisher to repeat facts that could drift.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
         sequence_id: u64,
-        authority: AuthorityDecision,
+        operation: CanonicalSymbolId,
         operation_kind: impl Into<String>,
-        source_span: crate::HirSourceSpan,
-    ) -> Self {
-        Self {
+        status: ReceiptStatus,
+        authority: AuthorityDecision,
+        parent_context: Option<u64>,
+        attributes: Vec<ReceiptAttribute>,
+        replay: ReplayClassification,
+    ) -> Result<Self, ReceiptContractViolation> {
+        let receipt = Self {
+            schema_version: OPERATION_RECEIPT_SCHEMA_VERSION,
             sequence_id,
             capability: authority.capability.clone(),
-            operation: authority.provenance.operation.clone(),
+            operation,
             operation_kind: operation_kind.into(),
-            status: ReceiptStatus::Denied,
+            status,
+            source_span: authority.provenance.request_span,
             authority,
-            source_span,
-            parent_context: None,
-            attributes: Vec::new(),
-            // Nothing ran, so there are no recorded inputs to replay from.
-            replay: ReplayClassification::Unavailable,
-        }
+            parent_context,
+            attributes,
+            replay,
+        };
+        receipt.validate()?;
+        Ok(receipt)
     }
 
-    /// A reference other receipts can hold instead of a copy.
-    pub const fn reference(&self) -> OperationReceiptRef {
-        OperationReceiptRef {
-            sequence_id: self.sequence_id,
-        }
+    /// Build the receipt for a governed denial.
+    ///
+    /// A denial produces a receipt without the provider ever being invoked. The method is fallible because it refuses
+    /// to turn an allowed or non-governed authority decision into a durable governed-denial claim.
+    pub fn denied(
+        sequence_id: u64,
+        operation: CanonicalSymbolId,
+        authority: AuthorityDecision,
+        operation_kind: impl Into<String>,
+    ) -> Result<Self, ReceiptContractViolation> {
+        Self::new(
+            sequence_id,
+            operation,
+            operation_kind,
+            ReceiptStatus::Denied,
+            authority,
+            None,
+            Vec::new(),
+            ReplayClassification::Unavailable,
+        )
+    }
+
+    /// The receipt wire-schema version.
+    pub const fn schema_version(&self) -> u32 {
+        self.schema_version
+    }
+
+    /// Position within the containing run report.
+    pub const fn sequence_id(&self) -> u64 {
+        self.sequence_id
+    }
+
+    /// The capability whose authority the operation required.
+    pub fn capability(&self) -> &CanonicalSymbolId {
+        &self.capability
+    }
+
+    /// The canonical provider/callable operation that ran, or would have run.
+    pub fn operation(&self) -> &CanonicalSymbolId {
+        &self.operation
+    }
+
+    /// The publisher's stable kind label, such as `http.request`.
+    pub fn operation_kind(&self) -> &str {
+        &self.operation_kind
+    }
+
+    /// What happened.
+    pub const fn status(&self) -> ReceiptStatus {
+        self.status
+    }
+
+    /// The authority decision this receipt records the outcome of.
+    pub fn authority(&self) -> &AuthorityDecision {
+        &self.authority
+    }
+
+    /// The source use-site that requested the operation's authority.
+    pub const fn source_span(&self) -> crate::HirSourceSpan {
+        self.source_span
+    }
+
+    /// The enclosing context sequence id, when the operation ran inside one.
+    pub const fn parent_context(&self) -> Option<u64> {
+        self.parent_context
+    }
+
+    /// Operation-specific attributes, redacted or public.
+    pub fn attributes(&self) -> &[ReceiptAttribute] {
+        &self.attributes
+    }
+
+    /// How replayable this operation is.
+    pub const fn replay(&self) -> ReplayClassification {
+        self.replay
     }
 
     /// The keys whose values were withheld.
@@ -264,18 +495,33 @@ impl OperationReceipt {
             .collect()
     }
 
-    /// Check that this receipt does not contradict itself.
-    ///
-    /// Both rules exist because a receipt is read long after the run that produced it, by a consumer with no way to
-    /// re-derive the truth: a status that disagrees with its own authority decision, or a deterministic replay claim
-    /// over inputs that were never persisted, would each be believed.
+    /// Check that this receipt does not contradict its own durable contract.
     pub fn validate(&self) -> Result<(), ReceiptContractViolation> {
-        let authority_allowed = self.authority.is_allowed();
-        if (self.status == ReceiptStatus::Denied) == authority_allowed {
+        if self.schema_version != OPERATION_RECEIPT_SCHEMA_VERSION {
+            return Err(ReceiptContractViolation::UnsupportedSchemaVersion {
+                found: self.schema_version,
+                expected: OPERATION_RECEIPT_SCHEMA_VERSION,
+            });
+        }
+
+        if self.capability != self.authority.capability {
+            return Err(ReceiptContractViolation::CapabilityContradictsAuthority);
+        }
+
+        if self.source_span != self.authority.provenance.request_span {
+            return Err(ReceiptContractViolation::SourceSpanContradictsAuthority);
+        }
+
+        if !status_matches_authority(self.status, &self.authority) {
             return Err(ReceiptContractViolation::StatusContradictsAuthority {
                 status: self.status,
-                authority_allowed,
+                authority_mode: self.authority.mode,
+                authority_allowed: self.authority.is_allowed(),
             });
+        }
+
+        for attribute in &self.attributes {
+            attribute.validate()?;
         }
 
         if self.replay == ReplayClassification::Deterministic {
@@ -289,6 +535,32 @@ impl OperationReceipt {
     }
 }
 
+/// Whether this status is truthful for the decision's authority mode and outcome.
+fn status_matches_authority(status: ReceiptStatus, authority: &AuthorityDecision) -> bool {
+    matches!(
+        (authority.mode, authority.is_allowed(), status),
+        (AuthorityMode::Governed, false, ReceiptStatus::Denied)
+            | (
+                AuthorityMode::Governed,
+                true,
+                ReceiptStatus::Allowed
+                    | ReceiptStatus::Failed
+                    | ReceiptStatus::Redacted
+                    | ReceiptStatus::Skipped
+                    | ReceiptStatus::Partial,
+            )
+            | (
+                AuthorityMode::Permissive | AuthorityMode::Observe,
+                true,
+                ReceiptStatus::Observed
+                    | ReceiptStatus::Failed
+                    | ReceiptStatus::Redacted
+                    | ReceiptStatus::Skipped
+                    | ReceiptStatus::Partial,
+            )
+    )
+}
+
 impl std::fmt::Display for OperationReceipt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
@@ -296,7 +568,7 @@ impl std::fmt::Display for OperationReceipt {
             "#{} {} {} {} replay={}",
             self.sequence_id,
             self.operation_kind,
-            self.capability.declaration_name,
+            self.operation.declaration_name,
             self.status.as_str(),
             self.replay.as_str(),
         )?;
@@ -311,12 +583,10 @@ impl std::fmt::Display for OperationReceipt {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::facts::{
-        AuthorityDenialReason, AuthorityGrantContext, AuthorityMode, AuthorityProvenance, SemanticSourceTargetKind,
-    };
+    use crate::facts::{AuthorityDenialReason, AuthorityGrantContext, AuthorityProvenance, SemanticSourceTargetKind};
 
     /// Build an authority decision for `host.http.request` requested by `app.billing.charge`.
-    fn authority(allowed: bool) -> AuthorityDecision {
+    fn authority(allowed: bool, mode: AuthorityMode) -> AuthorityDecision {
         let capability = CanonicalSymbolId::module_declaration(
             vec!["host".to_string(), "http".to_string()],
             "request",
@@ -338,71 +608,85 @@ mod tests {
             ceiling_applied: false,
         };
         if allowed {
-            AuthorityDecision::allowed(capability, AuthorityMode::Governed, grant, provenance)
+            AuthorityDecision::allowed(capability, mode, grant, provenance)
         } else {
-            AuthorityDecision::denied(
-                capability,
-                AuthorityMode::Governed,
-                AuthorityDenialReason::NotGranted,
-                grant,
-                provenance,
-            )
+            AuthorityDecision::denied(capability, mode, AuthorityDenialReason::NotGranted, grant, provenance)
         }
     }
 
-    /// Build an allowed receipt with the given attributes and replay classification.
-    fn allowed_receipt(attributes: Vec<ReceiptAttribute>, replay: ReplayClassification) -> OperationReceipt {
-        let decision = authority(true);
-        OperationReceipt {
-            sequence_id: 7,
-            capability: decision.capability.clone(),
-            operation: decision.provenance.operation.clone(),
-            operation_kind: "http.request".to_string(),
-            status: ReceiptStatus::Allowed,
-            authority: decision,
-            source_span: crate::HirSourceSpan::new(120, 140),
-            parent_context: None,
+    /// The provider operation is distinct from the caller that requested its capability.
+    fn provider_operation() -> CanonicalSymbolId {
+        CanonicalSymbolId::module_declaration(
+            vec!["std".to_string(), "http".to_string()],
+            "request",
+            SemanticSourceTargetKind::Function,
+            crate::HirSourceSpan::new(200, 214),
+        )
+    }
+
+    /// Build a governed allowed receipt with the given attributes and replay classification.
+    fn allowed_receipt(
+        attributes: Vec<ReceiptAttribute>,
+        replay: ReplayClassification,
+    ) -> Result<OperationReceipt, ReceiptContractViolation> {
+        OperationReceipt::new(
+            7,
+            provider_operation(),
+            "http.request",
+            ReceiptStatus::Allowed,
+            authority(true, AuthorityMode::Governed),
+            None,
             attributes,
             replay,
-        }
+        )
     }
 
-    /// A governed denial must produce a receipt without the provider ever being invoked.
+    /// A governed denial produces a receipt without the provider ever being invoked.
     #[test]
-    fn a_governed_denial_produces_a_denied_receipt_with_nothing_executed() -> Result<(), String> {
-        let receipt =
-            OperationReceipt::denied(1, authority(false), "http.request", crate::HirSourceSpan::new(120, 140));
+    fn a_governed_denial_preserves_the_provider_target_and_request_provenance() -> Result<(), String> {
+        let decision = authority(false, AuthorityMode::Governed);
+        let receipt = OperationReceipt::denied(1, provider_operation(), decision.clone(), "http.request")
+            .map_err(|violation| violation.to_string())?;
 
-        assert_eq!(receipt.status, ReceiptStatus::Denied);
-        assert!(receipt.attributes.is_empty(), "nothing ran, so nothing was recorded");
-        assert_eq!(
-            receipt.replay,
-            ReplayClassification::Unavailable,
-            "there are no recorded inputs to replay from",
-        );
-        assert_eq!(receipt.capability.declaration_name, "request");
-        assert_eq!(receipt.operation.declaration_name, "charge");
+        assert_eq!(receipt.status(), ReceiptStatus::Denied);
+        assert!(receipt.attributes().is_empty(), "nothing ran, so nothing was recorded");
+        assert_eq!(receipt.replay(), ReplayClassification::Unavailable);
+        assert_eq!(receipt.capability(), &decision.capability);
+        assert_eq!(receipt.operation(), &provider_operation());
+        assert_ne!(receipt.operation(), &decision.provenance.operation);
+        assert_eq!(receipt.source_span(), decision.provenance.request_span);
         receipt.validate().map_err(|violation| violation.to_string())
     }
 
-    /// An allowed receipt validates and carries its recorded attributes.
+    /// An allowed receipt validates and carries its recorded public attributes.
     #[test]
     fn an_allowed_receipt_records_its_attributes() -> Result<(), String> {
         let receipt = allowed_receipt(
             vec![ReceiptAttribute::public("http.method", "GET")],
             ReplayClassification::External,
-        );
+        )
+        .map_err(|violation| violation.to_string())?;
 
-        assert_eq!(receipt.status, ReceiptStatus::Allowed);
+        assert_eq!(receipt.status(), ReceiptStatus::Allowed);
         assert!(receipt.redacted_keys().is_empty());
+        assert_eq!(receipt.attributes()[0].value(), Some("GET"));
         receipt.validate().map_err(|violation| violation.to_string())
     }
 
-    /// A failed operation is still an allowed one: authority was granted, the operation itself did not succeed.
+    /// A failed operation is still authority-permitted: the operation itself did not succeed.
     #[test]
     fn a_failed_operation_keeps_its_allowed_authority() -> Result<(), String> {
-        let mut receipt = allowed_receipt(Vec::new(), ReplayClassification::External);
-        receipt.status = ReceiptStatus::Failed;
+        let receipt = OperationReceipt::new(
+            7,
+            provider_operation(),
+            "http.request",
+            ReceiptStatus::Failed,
+            authority(true, AuthorityMode::Governed),
+            None,
+            Vec::new(),
+            ReplayClassification::External,
+        )
+        .map_err(|violation| violation.to_string())?;
 
         receipt.validate().map_err(|violation| violation.to_string())
     }
@@ -410,99 +694,322 @@ mod tests {
     /// A redacted attribute keeps its key and sensitivity, and drops only the value.
     #[test]
     fn a_redacted_attribute_keeps_its_key_and_sensitivity() -> Result<(), String> {
-        let receipt = allowed_receipt(
+        let receipt = OperationReceipt::new(
+            7,
+            provider_operation(),
+            "http.request",
+            ReceiptStatus::Redacted,
+            authority(true, AuthorityMode::Governed),
+            None,
             vec![
                 ReceiptAttribute::public("http.method", "GET"),
                 ReceiptAttribute::redacted("http.url", AttributeSensitivity::Secret),
             ],
             ReplayClassification::Redacted,
-        );
+        )
+        .map_err(|violation| violation.to_string())?;
 
         assert_eq!(receipt.redacted_keys(), vec!["http.url".to_string()]);
         let withheld = receipt
-            .attributes
+            .attributes()
             .iter()
-            .find(|attribute| attribute.key == "http.url")
+            .find(|attribute| attribute.key() == "http.url")
             .ok_or("the redacted attribute is missing")?;
-        assert_eq!(withheld.value, None);
-        assert_eq!(
-            withheld.sensitivity,
-            AttributeSensitivity::Secret,
-            "sensitivity survives redaction, so a policy downstream still knows why the value is absent",
-        );
+        assert_eq!(withheld.value(), None);
+        assert_eq!(withheld.sensitivity(), AttributeSensitivity::Secret);
         receipt.validate().map_err(|violation| violation.to_string())
     }
 
-    /// A status that disagrees with its own authority decision is a contract violation.
+    /// A denial constructor refuses a decision that did not make a governed denial.
     #[test]
-    fn a_denied_status_over_an_allowing_decision_is_rejected() {
-        let mut receipt = allowed_receipt(Vec::new(), ReplayClassification::External);
-        receipt.status = ReceiptStatus::Denied;
-
+    fn a_denial_constructor_refuses_an_allowing_or_non_governed_decision() {
+        let allowed = OperationReceipt::denied(
+            1,
+            provider_operation(),
+            authority(true, AuthorityMode::Governed),
+            "http.request",
+        );
         assert_eq!(
-            receipt.validate(),
+            allowed,
             Err(ReceiptContractViolation::StatusContradictsAuthority {
                 status: ReceiptStatus::Denied,
+                authority_mode: AuthorityMode::Governed,
                 authority_allowed: true,
             }),
         );
+
+        let observed = OperationReceipt::denied(
+            1,
+            provider_operation(),
+            authority(false, AuthorityMode::Observe),
+            "http.request",
+        );
+        assert_eq!(
+            observed,
+            Err(ReceiptContractViolation::StatusContradictsAuthority {
+                status: ReceiptStatus::Denied,
+                authority_mode: AuthorityMode::Observe,
+                authority_allowed: false,
+            }),
+        );
+    }
+
+    /// The durable contract rejects cleartext sensitive attributes, including corrupted in-memory construction.
+    #[test]
+    fn cleartext_sensitive_attributes_are_refused_before_persistence() -> Result<(), String> {
+        let mut receipt =
+            allowed_receipt(Vec::new(), ReplayClassification::External).map_err(|violation| violation.to_string())?;
+        receipt.attributes = vec![ReceiptAttribute {
+            key: "http.authorization".to_string(),
+            value: Some("Bearer secret".to_string()),
+            sensitivity: AttributeSensitivity::Secret,
+        }];
+
+        assert_eq!(
+            receipt.validate(),
+            Err(ReceiptContractViolation::CleartextSensitiveAttribute {
+                key: "http.authorization".to_string(),
+                sensitivity: AttributeSensitivity::Secret,
+            }),
+        );
+        assert!(serde_json::to_string(&receipt).is_err());
+        Ok(())
+    }
+
+    /// Linked authority facts cannot drift in a receipt assembled from untrusted persisted data.
+    #[test]
+    fn a_corrupted_authority_link_is_rejected() -> Result<(), String> {
+        let mut receipt =
+            allowed_receipt(Vec::new(), ReplayClassification::External).map_err(|violation| violation.to_string())?;
+        receipt.capability = provider_operation();
+        assert_eq!(
+            receipt.validate(),
+            Err(ReceiptContractViolation::CapabilityContradictsAuthority)
+        );
+
+        let mut receipt =
+            allowed_receipt(Vec::new(), ReplayClassification::External).map_err(|violation| violation.to_string())?;
+        receipt.source_span = crate::HirSourceSpan::new(1, 2);
+        assert_eq!(
+            receipt.validate(),
+            Err(ReceiptContractViolation::SourceSpanContradictsAuthority)
+        );
+        Ok(())
     }
 
     /// Claiming deterministic replay over withheld inputs is the dishonest claim RFC 104 forbids.
     #[test]
     fn deterministic_replay_over_redacted_attributes_is_rejected() {
-        let receipt = allowed_receipt(
+        let receipt = OperationReceipt::new(
+            7,
+            provider_operation(),
+            "http.request",
+            ReceiptStatus::Redacted,
+            authority(true, AuthorityMode::Governed),
+            None,
             vec![ReceiptAttribute::redacted("http.url", AttributeSensitivity::Secret)],
             ReplayClassification::Deterministic,
         );
 
         assert_eq!(
-            receipt.validate(),
+            receipt,
             Err(ReceiptContractViolation::DeterministicReplayOverRedactedAttributes {
                 redacted_keys: vec!["http.url".to_string()],
             }),
         );
     }
 
-    /// A backend receipt references this one rather than copying it.
+    /// Only the authority-mode/status combinations RFC 104 defines can construct a receipt.
     #[test]
-    fn a_receipt_reference_carries_only_the_sequence_id() {
-        let receipt = allowed_receipt(Vec::new(), ReplayClassification::External);
+    fn authority_mode_and_status_form_a_checked_truth_table() {
+        let valid = [
+            (AuthorityMode::Governed, false, ReceiptStatus::Denied),
+            (AuthorityMode::Governed, true, ReceiptStatus::Allowed),
+            (AuthorityMode::Governed, true, ReceiptStatus::Failed),
+            (AuthorityMode::Governed, true, ReceiptStatus::Redacted),
+            (AuthorityMode::Governed, true, ReceiptStatus::Skipped),
+            (AuthorityMode::Governed, true, ReceiptStatus::Partial),
+            (AuthorityMode::Permissive, true, ReceiptStatus::Observed),
+            (AuthorityMode::Permissive, true, ReceiptStatus::Failed),
+            (AuthorityMode::Permissive, true, ReceiptStatus::Redacted),
+            (AuthorityMode::Permissive, true, ReceiptStatus::Skipped),
+            (AuthorityMode::Permissive, true, ReceiptStatus::Partial),
+            (AuthorityMode::Observe, true, ReceiptStatus::Observed),
+            (AuthorityMode::Observe, true, ReceiptStatus::Failed),
+            (AuthorityMode::Observe, true, ReceiptStatus::Redacted),
+            (AuthorityMode::Observe, true, ReceiptStatus::Skipped),
+            (AuthorityMode::Observe, true, ReceiptStatus::Partial),
+        ];
+        for (mode, allowed, status) in valid {
+            assert!(
+                OperationReceipt::new(
+                    1,
+                    provider_operation(),
+                    "http.request",
+                    status,
+                    authority(allowed, mode),
+                    None,
+                    Vec::new(),
+                    ReplayClassification::External,
+                )
+                .is_ok(),
+                "{mode:?} {allowed} {status:?} should be accepted",
+            );
+        }
 
-        assert_eq!(receipt.reference(), OperationReceiptRef { sequence_id: 7 });
+        let invalid = [
+            (AuthorityMode::Governed, true, ReceiptStatus::Observed),
+            (AuthorityMode::Governed, false, ReceiptStatus::Failed),
+            (AuthorityMode::Permissive, true, ReceiptStatus::Allowed),
+            (AuthorityMode::Observe, true, ReceiptStatus::Denied),
+        ];
+        for (mode, allowed, status) in invalid {
+            assert!(
+                OperationReceipt::new(
+                    1,
+                    provider_operation(),
+                    "http.request",
+                    status,
+                    authority(allowed, mode),
+                    None,
+                    Vec::new(),
+                    ReplayClassification::External,
+                )
+                .is_err(),
+                "{mode:?} {allowed} {status:?} should be rejected",
+            );
+        }
     }
 
-    /// Every status and replay classification needs a distinct snapshot spelling.
+    /// The wire contract is versioned and round-trips every first-version receipt outcome.
     #[test]
-    fn statuses_and_replay_classifications_have_distinct_spellings() {
-        let statuses = [
-            ReceiptStatus::Observed,
-            ReceiptStatus::Allowed,
-            ReceiptStatus::Denied,
+    fn versioned_json_round_trips_allowed_denied_failed_and_redacted_receipts() -> Result<(), String> {
+        let allowed = allowed_receipt(
+            vec![ReceiptAttribute::public("http.method", "GET")],
+            ReplayClassification::External,
+        )
+        .map_err(|violation| violation.to_string())?;
+        let denied = OperationReceipt::denied(
+            8,
+            provider_operation(),
+            authority(false, AuthorityMode::Governed),
+            "http.request",
+        )
+        .map_err(|violation| violation.to_string())?;
+        let failed = OperationReceipt::new(
+            9,
+            provider_operation(),
+            "http.request",
             ReceiptStatus::Failed,
+            authority(true, AuthorityMode::Governed),
+            None,
+            Vec::new(),
+            ReplayClassification::External,
+        )
+        .map_err(|violation| violation.to_string())?;
+        let redacted = OperationReceipt::new(
+            10,
+            provider_operation(),
+            "http.request",
             ReceiptStatus::Redacted,
-            ReceiptStatus::Skipped,
-            ReceiptStatus::Partial,
+            authority(true, AuthorityMode::Governed),
+            None,
+            vec![ReceiptAttribute::redacted("http.url", AttributeSensitivity::Secret)],
+            ReplayClassification::Redacted,
+        )
+        .map_err(|violation| violation.to_string())?;
+
+        for (receipt, expected_status, expected_replay) in [
+            (allowed, "allowed", "external"),
+            (denied, "denied", "unavailable"),
+            (failed, "failed", "external"),
+            (redacted, "redacted", "redacted"),
+        ] {
+            let value = serde_json::to_value(&receipt).map_err(|error| error.to_string())?;
+            assert_eq!(value["schema_version"], OPERATION_RECEIPT_SCHEMA_VERSION);
+            assert_eq!(value["status"], expected_status);
+            assert_eq!(value["replay"], expected_replay);
+            let decoded: OperationReceipt = serde_json::from_value(value).map_err(|error| error.to_string())?;
+            assert_eq!(decoded, receipt);
+        }
+        Ok(())
+    }
+
+    /// Unknown receipt versions and cleartext sensitive JSON are rejected at deserialization.
+    #[test]
+    fn persisted_receipts_refuse_unknown_schemas_and_cleartext_secrets() -> Result<(), String> {
+        let receipt =
+            allowed_receipt(Vec::new(), ReplayClassification::External).map_err(|violation| violation.to_string())?;
+        let mut unknown_version = serde_json::to_value(&receipt).map_err(|error| error.to_string())?;
+        unknown_version["schema_version"] = serde_json::json!(OPERATION_RECEIPT_SCHEMA_VERSION + 1);
+        let error = serde_json::from_value::<OperationReceipt>(unknown_version)
+            .err()
+            .ok_or("unknown schema unexpectedly deserialized")?;
+        assert!(
+            error
+                .to_string()
+                .contains("unsupported operation-receipt schema version")
+        );
+
+        let mut cleartext_secret = serde_json::to_value(&receipt).map_err(|error| error.to_string())?;
+        cleartext_secret["attributes"] = serde_json::json!([{
+            "key": "http.authorization",
+            "value": "Bearer secret",
+            "sensitivity": "secret"
+        }]);
+        let error = serde_json::from_value::<OperationReceipt>(cleartext_secret)
+            .err()
+            .ok_or("cleartext secret unexpectedly deserialized")?;
+        assert!(
+            error
+                .to_string()
+                .contains("retains cleartext despite secret sensitivity")
+        );
+        Ok(())
+    }
+
+    /// Every status and replay classification has an exact, unique stable wire spelling.
+    #[test]
+    fn statuses_and_replay_classifications_have_exact_wire_spellings() -> Result<(), String> {
+        let statuses = [
+            (ReceiptStatus::Observed, "observed"),
+            (ReceiptStatus::Allowed, "allowed"),
+            (ReceiptStatus::Denied, "denied"),
+            (ReceiptStatus::Failed, "failed"),
+            (ReceiptStatus::Redacted, "redacted"),
+            (ReceiptStatus::Skipped, "skipped"),
+            (ReceiptStatus::Partial, "partial"),
         ];
-        let status_spellings: std::collections::HashSet<&str> = statuses.iter().map(|s| s.as_str()).collect();
+        let status_spellings: std::collections::HashSet<&str> =
+            statuses.iter().map(|(status, _)| status.as_str()).collect();
         assert_eq!(
             status_spellings.len(),
             statuses.len(),
             "two statuses share one spelling"
         );
+        for (status, wire) in statuses {
+            assert_eq!(status.as_str(), wire);
+            assert_eq!(serde_json::to_value(status).map_err(|error| error.to_string())?, wire);
+        }
 
         let replays = [
-            ReplayClassification::Deterministic,
-            ReplayClassification::External,
-            ReplayClassification::FixtureRequired,
-            ReplayClassification::Redacted,
-            ReplayClassification::Unavailable,
+            (ReplayClassification::Deterministic, "deterministic"),
+            (ReplayClassification::External, "external"),
+            (ReplayClassification::FixtureRequired, "fixture-required"),
+            (ReplayClassification::Redacted, "redacted"),
+            (ReplayClassification::Unavailable, "unavailable"),
         ];
-        let replay_spellings: std::collections::HashSet<&str> = replays.iter().map(|r| r.as_str()).collect();
+        let replay_spellings: std::collections::HashSet<&str> =
+            replays.iter().map(|(replay, _)| replay.as_str()).collect();
         assert_eq!(
             replay_spellings.len(),
             replays.len(),
-            "two replay classifications share one spelling",
+            "two replay classifications share one spelling"
         );
+        for (replay, wire) in replays {
+            assert_eq!(replay.as_str(), wire);
+            assert_eq!(serde_json::to_value(replay).map_err(|error| error.to_string())?, wire);
+        }
+        Ok(())
     }
 }

--- a/crates/incan_semantics_core/src/receipts.rs
+++ b/crates/incan_semantics_core/src/receipts.rs
@@ -1,0 +1,508 @@
+//! RFC 104 operation receipts.
+//!
+//! A receipt is the durable record of what one capability-aware operation actually did. It is the counterpart to
+//! [`crate::facts::AuthorityDecision`]: the decision says whether an operation was permitted, and the receipt says
+//! what happened once that decision was applied — including the case where the decision was a denial and the
+//! operation never ran.
+//!
+//! The receipt is deliberately one shape for every publisher. A stdlib host boundary, a package-defined domain
+//! operation, and a provider operation all emit this, so a backend execution receipt can *reference* a receipt
+//! without copying or reinterpreting its authority, redaction, or replay semantics. Two owners for redaction would
+//! mean two chances to disagree about what was persisted.
+
+use crate::facts::{AuthorityDecision, CanonicalSymbolId};
+
+/// What happened to one capability-aware operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ReceiptStatus {
+    /// The operation ran and was recorded, without authority being enforced.
+    Observed,
+    /// Authority was granted and the operation ran to completion.
+    Allowed,
+    /// Authority was refused, so the operation never performed its behavior.
+    Denied,
+    /// Authority was granted but the operation itself failed.
+    Failed,
+    /// The operation ran, but its recorded attributes were redacted before reaching a sink.
+    Redacted,
+    /// The operation was not attempted, for a reason other than a denial.
+    Skipped,
+    /// The operation performed part of its work before stopping.
+    Partial,
+}
+
+impl ReceiptStatus {
+    /// Return the compact snapshot spelling for this status.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Observed => "observed",
+            Self::Allowed => "allowed",
+            Self::Denied => "denied",
+            Self::Failed => "failed",
+            Self::Redacted => "redacted",
+            Self::Skipped => "skipped",
+            Self::Partial => "partial",
+        }
+    }
+}
+
+/// How replayable an operation is.
+///
+/// RFC 104 does not require the runtime to implement replay. It requires the runtime not to make dishonest replay
+/// claims, which is why this is recorded per receipt rather than inferred later from the operation kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ReplayClassification {
+    /// Replayable from recorded local inputs, such as a filesystem write determined by its recorded arguments.
+    Deterministic,
+    /// Replay depends on an external system and cannot be exact without a recording.
+    External,
+    /// Replay needs a recorded fixture or test double.
+    FixtureRequired,
+    /// Replay data existed but was intentionally not persisted.
+    Redacted,
+    /// Replay is not supported for this operation.
+    Unavailable,
+}
+
+impl ReplayClassification {
+    /// Return the compact snapshot spelling for this classification.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Deterministic => "deterministic",
+            Self::External => "external",
+            Self::FixtureRequired => "fixture-required",
+            Self::Redacted => "redacted",
+            Self::Unavailable => "unavailable",
+        }
+    }
+}
+
+/// How sensitive one recorded attribute's value is.
+///
+/// This travels with the attribute rather than being decided at the sink, so a receipt that crosses a boundary keeps
+/// the provenance a redaction policy needs (RFC 103).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum AttributeSensitivity {
+    /// Safe to record as written.
+    Public,
+    /// Recorded locally, but not intended for export.
+    Internal,
+    /// Never recorded in the clear.
+    Secret,
+}
+
+impl AttributeSensitivity {
+    /// Return the compact snapshot spelling for this sensitivity level.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Public => "public",
+            Self::Internal => "internal",
+            Self::Secret => "secret",
+        }
+    }
+}
+
+/// One attribute recorded on a receipt.
+///
+/// A redacted attribute keeps its key and its sensitivity and drops only the value. That is what lets a reader see
+/// *that* an HTTP URL was recorded and deliberately withheld, rather than being unable to tell a withheld value from
+/// an operation that never had one.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ReceiptAttribute {
+    /// The attribute's name, such as `http.method` or `fs.path_policy`.
+    pub key: String,
+    /// The recorded value, or `None` when it was redacted.
+    pub value: Option<String>,
+    /// How sensitive the value is, recorded whether or not it was persisted.
+    pub sensitivity: AttributeSensitivity,
+}
+
+impl ReceiptAttribute {
+    /// Record an attribute whose value is safe to persist as written.
+    pub fn public(key: impl Into<String>, value: impl Into<String>) -> Self {
+        Self {
+            key: key.into(),
+            value: Some(value.into()),
+            sensitivity: AttributeSensitivity::Public,
+        }
+    }
+
+    /// Record an attribute whose value was withheld.
+    ///
+    /// RFC 104 redacts sensitive values by default, so this is the constructor a publisher reaches for whenever the
+    /// value is not `Public`; persisting one takes a deliberate call to [`Self::public`].
+    pub fn redacted(key: impl Into<String>, sensitivity: AttributeSensitivity) -> Self {
+        Self {
+            key: key.into(),
+            value: None,
+            sensitivity,
+        }
+    }
+
+    /// Whether this attribute's value was withheld.
+    pub const fn is_redacted(&self) -> bool {
+        self.value.is_none()
+    }
+}
+
+/// A reference from another receipt to this one.
+///
+/// A backend execution receipt holds this rather than a copy. Copying would give redaction and replay two owners, and
+/// two owners eventually disagree.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct OperationReceiptRef {
+    /// The referenced receipt's sequence id within its run.
+    pub sequence_id: u64,
+}
+
+/// Ways a receipt can contradict itself.
+///
+/// These are contract violations rather than runtime errors: each one means the receipt claims something its own
+/// other fields deny, which is exactly the dishonesty RFC 104 asks the runtime to avoid.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReceiptContractViolation {
+    /// The status says denied but the linked authority decision allowed the operation, or the reverse.
+    StatusContradictsAuthority {
+        /// The status the receipt claims.
+        status: ReceiptStatus,
+        /// Whether the linked decision actually allowed the operation.
+        authority_allowed: bool,
+    },
+    /// The receipt withheld attribute values yet claims replay from recorded local inputs.
+    DeterministicReplayOverRedactedAttributes {
+        /// The keys whose values were withheld.
+        redacted_keys: Vec<String>,
+    },
+}
+
+impl std::fmt::Display for ReceiptContractViolation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::StatusContradictsAuthority {
+                status,
+                authority_allowed,
+            } => write!(
+                f,
+                "receipt status `{}` contradicts an authority decision that {}",
+                status.as_str(),
+                if *authority_allowed { "allowed" } else { "denied" },
+            ),
+            Self::DeterministicReplayOverRedactedAttributes { redacted_keys } => write!(
+                f,
+                "receipt claims deterministic replay but withheld {}",
+                redacted_keys.join(", "),
+            ),
+        }
+    }
+}
+
+/// The durable record of one capability-aware operation.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct OperationReceipt {
+    /// Position within the emitting run, which is also this receipt's identity for references.
+    pub sequence_id: u64,
+    /// The capability whose authority the operation needed.
+    pub capability: CanonicalSymbolId,
+    /// The operation that ran, or would have run.
+    pub operation: CanonicalSymbolId,
+    /// The publisher's own name for what kind of operation this was, such as `http.request`.
+    pub operation_kind: String,
+    /// What happened.
+    pub status: ReceiptStatus,
+    /// The authority decision this receipt records the outcome of.
+    pub authority: AuthorityDecision,
+    /// Where the operation was written.
+    pub source_span: crate::HirSourceSpan,
+    /// The enclosing context's sequence id, when the operation ran inside one.
+    pub parent_context: Option<u64>,
+    /// Operation-specific attributes, redacted or not.
+    pub attributes: Vec<ReceiptAttribute>,
+    /// How replayable this operation is.
+    pub replay: ReplayClassification,
+}
+
+impl OperationReceipt {
+    /// Build the receipt for a governed denial.
+    ///
+    /// A denial produces a receipt without the provider ever being invoked, which is the point: RFC 104 treats a
+    /// refusal as a first-class outcome to be recorded, not as an absence of one. The status and replay
+    /// classification both follow from the decision, so a caller cannot accidentally record a denial as a success.
+    pub fn denied(
+        sequence_id: u64,
+        authority: AuthorityDecision,
+        operation_kind: impl Into<String>,
+        source_span: crate::HirSourceSpan,
+    ) -> Self {
+        Self {
+            sequence_id,
+            capability: authority.capability.clone(),
+            operation: authority.provenance.operation.clone(),
+            operation_kind: operation_kind.into(),
+            status: ReceiptStatus::Denied,
+            authority,
+            source_span,
+            parent_context: None,
+            attributes: Vec::new(),
+            // Nothing ran, so there are no recorded inputs to replay from.
+            replay: ReplayClassification::Unavailable,
+        }
+    }
+
+    /// A reference other receipts can hold instead of a copy.
+    pub const fn reference(&self) -> OperationReceiptRef {
+        OperationReceiptRef {
+            sequence_id: self.sequence_id,
+        }
+    }
+
+    /// The keys whose values were withheld.
+    pub fn redacted_keys(&self) -> Vec<String> {
+        self.attributes
+            .iter()
+            .filter(|attribute| attribute.is_redacted())
+            .map(|attribute| attribute.key.clone())
+            .collect()
+    }
+
+    /// Check that this receipt does not contradict itself.
+    ///
+    /// Both rules exist because a receipt is read long after the run that produced it, by a consumer with no way to
+    /// re-derive the truth: a status that disagrees with its own authority decision, or a deterministic replay claim
+    /// over inputs that were never persisted, would each be believed.
+    pub fn validate(&self) -> Result<(), ReceiptContractViolation> {
+        let authority_allowed = self.authority.is_allowed();
+        if (self.status == ReceiptStatus::Denied) == authority_allowed {
+            return Err(ReceiptContractViolation::StatusContradictsAuthority {
+                status: self.status,
+                authority_allowed,
+            });
+        }
+
+        if self.replay == ReplayClassification::Deterministic {
+            let redacted_keys = self.redacted_keys();
+            if !redacted_keys.is_empty() {
+                return Err(ReceiptContractViolation::DeterministicReplayOverRedactedAttributes { redacted_keys });
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl std::fmt::Display for OperationReceipt {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "#{} {} {} {} replay={}",
+            self.sequence_id,
+            self.operation_kind,
+            self.capability.declaration_name,
+            self.status.as_str(),
+            self.replay.as_str(),
+        )?;
+        let redacted = self.redacted_keys();
+        if !redacted.is_empty() {
+            write!(f, " redacted=[{}]", redacted.join(","))?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::facts::{
+        AuthorityDenialReason, AuthorityGrantContext, AuthorityMode, AuthorityProvenance, SemanticSourceTargetKind,
+    };
+
+    /// Build an authority decision for `host.http.request` requested by `app.billing.charge`.
+    fn authority(allowed: bool) -> AuthorityDecision {
+        let capability = CanonicalSymbolId::module_declaration(
+            vec!["host".to_string(), "http".to_string()],
+            "request",
+            SemanticSourceTargetKind::Capability,
+            crate::HirSourceSpan::new(10, 20),
+        );
+        let provenance = AuthorityProvenance {
+            operation: CanonicalSymbolId::module_declaration(
+                vec!["app".to_string(), "billing".to_string()],
+                "charge",
+                SemanticSourceTargetKind::Function,
+                crate::HirSourceSpan::new(80, 96),
+            ),
+            request_span: crate::HirSourceSpan::new(120, 140),
+            suggested_grant: "host.http.request".to_string(),
+        };
+        let grant = AuthorityGrantContext {
+            requested_scope: Vec::new(),
+            ceiling_applied: false,
+        };
+        if allowed {
+            AuthorityDecision::allowed(capability, AuthorityMode::Governed, grant, provenance)
+        } else {
+            AuthorityDecision::denied(
+                capability,
+                AuthorityMode::Governed,
+                AuthorityDenialReason::NotGranted,
+                grant,
+                provenance,
+            )
+        }
+    }
+
+    /// Build an allowed receipt with the given attributes and replay classification.
+    fn allowed_receipt(attributes: Vec<ReceiptAttribute>, replay: ReplayClassification) -> OperationReceipt {
+        let decision = authority(true);
+        OperationReceipt {
+            sequence_id: 7,
+            capability: decision.capability.clone(),
+            operation: decision.provenance.operation.clone(),
+            operation_kind: "http.request".to_string(),
+            status: ReceiptStatus::Allowed,
+            authority: decision,
+            source_span: crate::HirSourceSpan::new(120, 140),
+            parent_context: None,
+            attributes,
+            replay,
+        }
+    }
+
+    /// A governed denial must produce a receipt without the provider ever being invoked.
+    #[test]
+    fn a_governed_denial_produces_a_denied_receipt_with_nothing_executed() -> Result<(), String> {
+        let receipt =
+            OperationReceipt::denied(1, authority(false), "http.request", crate::HirSourceSpan::new(120, 140));
+
+        assert_eq!(receipt.status, ReceiptStatus::Denied);
+        assert!(receipt.attributes.is_empty(), "nothing ran, so nothing was recorded");
+        assert_eq!(
+            receipt.replay,
+            ReplayClassification::Unavailable,
+            "there are no recorded inputs to replay from",
+        );
+        assert_eq!(receipt.capability.declaration_name, "request");
+        assert_eq!(receipt.operation.declaration_name, "charge");
+        receipt.validate().map_err(|violation| violation.to_string())
+    }
+
+    /// An allowed receipt validates and carries its recorded attributes.
+    #[test]
+    fn an_allowed_receipt_records_its_attributes() -> Result<(), String> {
+        let receipt = allowed_receipt(
+            vec![ReceiptAttribute::public("http.method", "GET")],
+            ReplayClassification::External,
+        );
+
+        assert_eq!(receipt.status, ReceiptStatus::Allowed);
+        assert!(receipt.redacted_keys().is_empty());
+        receipt.validate().map_err(|violation| violation.to_string())
+    }
+
+    /// A failed operation is still an allowed one: authority was granted, the operation itself did not succeed.
+    #[test]
+    fn a_failed_operation_keeps_its_allowed_authority() -> Result<(), String> {
+        let mut receipt = allowed_receipt(Vec::new(), ReplayClassification::External);
+        receipt.status = ReceiptStatus::Failed;
+
+        receipt.validate().map_err(|violation| violation.to_string())
+    }
+
+    /// A redacted attribute keeps its key and sensitivity, and drops only the value.
+    #[test]
+    fn a_redacted_attribute_keeps_its_key_and_sensitivity() -> Result<(), String> {
+        let receipt = allowed_receipt(
+            vec![
+                ReceiptAttribute::public("http.method", "GET"),
+                ReceiptAttribute::redacted("http.url", AttributeSensitivity::Secret),
+            ],
+            ReplayClassification::Redacted,
+        );
+
+        assert_eq!(receipt.redacted_keys(), vec!["http.url".to_string()]);
+        let withheld = receipt
+            .attributes
+            .iter()
+            .find(|attribute| attribute.key == "http.url")
+            .ok_or("the redacted attribute is missing")?;
+        assert_eq!(withheld.value, None);
+        assert_eq!(
+            withheld.sensitivity,
+            AttributeSensitivity::Secret,
+            "sensitivity survives redaction, so a policy downstream still knows why the value is absent",
+        );
+        receipt.validate().map_err(|violation| violation.to_string())
+    }
+
+    /// A status that disagrees with its own authority decision is a contract violation.
+    #[test]
+    fn a_denied_status_over_an_allowing_decision_is_rejected() {
+        let mut receipt = allowed_receipt(Vec::new(), ReplayClassification::External);
+        receipt.status = ReceiptStatus::Denied;
+
+        assert_eq!(
+            receipt.validate(),
+            Err(ReceiptContractViolation::StatusContradictsAuthority {
+                status: ReceiptStatus::Denied,
+                authority_allowed: true,
+            }),
+        );
+    }
+
+    /// Claiming deterministic replay over withheld inputs is the dishonest claim RFC 104 forbids.
+    #[test]
+    fn deterministic_replay_over_redacted_attributes_is_rejected() {
+        let receipt = allowed_receipt(
+            vec![ReceiptAttribute::redacted("http.url", AttributeSensitivity::Secret)],
+            ReplayClassification::Deterministic,
+        );
+
+        assert_eq!(
+            receipt.validate(),
+            Err(ReceiptContractViolation::DeterministicReplayOverRedactedAttributes {
+                redacted_keys: vec!["http.url".to_string()],
+            }),
+        );
+    }
+
+    /// A backend receipt references this one rather than copying it.
+    #[test]
+    fn a_receipt_reference_carries_only_the_sequence_id() {
+        let receipt = allowed_receipt(Vec::new(), ReplayClassification::External);
+
+        assert_eq!(receipt.reference(), OperationReceiptRef { sequence_id: 7 });
+    }
+
+    /// Every status and replay classification needs a distinct snapshot spelling.
+    #[test]
+    fn statuses_and_replay_classifications_have_distinct_spellings() {
+        let statuses = [
+            ReceiptStatus::Observed,
+            ReceiptStatus::Allowed,
+            ReceiptStatus::Denied,
+            ReceiptStatus::Failed,
+            ReceiptStatus::Redacted,
+            ReceiptStatus::Skipped,
+            ReceiptStatus::Partial,
+        ];
+        let status_spellings: std::collections::HashSet<&str> = statuses.iter().map(|s| s.as_str()).collect();
+        assert_eq!(
+            status_spellings.len(),
+            statuses.len(),
+            "two statuses share one spelling"
+        );
+
+        let replays = [
+            ReplayClassification::Deterministic,
+            ReplayClassification::External,
+            ReplayClassification::FixtureRequired,
+            ReplayClassification::Redacted,
+            ReplayClassification::Unavailable,
+        ];
+        let replay_spellings: std::collections::HashSet<&str> = replays.iter().map(|r| r.as_str()).collect();
+        assert_eq!(
+            replay_spellings.len(),
+            replays.len(),
+            "two replay classifications share one spelling",
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Establishes RFC 104's shared, validated operation-receipt fact. It is a dependency-minimal semantic contract for future providers and reports; it does not add provider execution, a report producer, or a second backend-receipt schema.

Closes #1212. Contributes to #1028; does not close it.

## Type of change

- [x] New feature

## Area(s)

- [x] Runtime / Core crates (stdlib/core/derive)

## Key details

- `OperationReceipt` has a numeric schema version and a validated JSON representation. Invalid schema versions, authority links, status claims, and cleartext sensitive attributes are rejected before a consumer receives a receipt.
- A receipt carries the canonical invoked provider/callable operation separately from the `AuthorityDecision`'s requesting source operation and use-site provenance. Capability and source span are derived from, then validated against, that decision.
- The status matrix distinguishes governed denials from governed allowed outcomes and permissive/observe observations. A denied receipt cannot be constructed from an allowing or non-governed decision.
- Attributes retain key and sensitivity after redaction. Only public values may be persisted in cleartext until an explicit RFC 104 reveal policy exists.
- Run-report and backend correlation are intentionally not modeled here: #1028 owns that enclosing producer/report contract, rather than exporting an ambiguous sequence-only reference.

## Testing / verification

- [x] Manual verification described below

Manual verification notes:

- `cargo test -p incan_semantics_core --lib receipts` — 12 passed
- `cargo test -p incan_semantics_core --lib` — 64 passed
- `cargo check -p incan_semantics_core --all-targets`
- `cargo clippy -p incan_semantics_core --all-targets -- -D warnings`
- `make fmt-check`, `make rustdoc-gate`, and `git diff --check`
- Independent scope/architecture, invariant/test, and Rust-prose/maintainability re-reviews were clean after the fixes.

Slice-level gates (`make pre-commit`, full Oven suites, slice-wide CI) are deliberately deferred under the agreed shared-Oven cost policy.

## Docs impact

- [x] No docs changes needed

The public RFC remains the receipt-design authority. This change adds crate-level Rustdoc for the shared semantic contract; user-facing report documentation belongs with #1028's producer work.

## Checklist

- [x] I added/updated tests where it materially reduces regressions
