### PR TITLE
feature - lower resolved provider operations to checked execution plans (#1213)

### DIFF
--- a/crates/incan_core/src/lang/decorators.rs
+++ b/crates/incan_core/src/lang/decorators.rs
@@ -29,6 +29,7 @@ pub enum DecoratorId {
     ClassMethod,
     Requires,
     Describe,
+    ProviderOperation,
 }
 
 // ---- Decorator namespace constants ----
@@ -153,6 +154,14 @@ pub const DECORATORS: &[DecoratorInfo] = &[
         "Attach a compiler-checked typed registry descriptor to a declaration.",
         RFC::_113,
         Since(0, 5),
+    ),
+    info(
+        DecoratorId::ProviderOperation,
+        "provider_operation",
+        &[],
+        "Attach one checked RFC 104 capability requirement to a provider function.",
+        RFC::_104,
+        Since(0, 6),
     ),
 ];
 

--- a/crates/incan_semantics_core/src/body_ir.rs
+++ b/crates/incan_semantics_core/src/body_ir.rs
@@ -1878,6 +1878,18 @@ pub enum Callee {
     /// A compiler-owned runtime/helper operation, represented explicitly instead of as a generated-Rust helper-call
     /// idiom (#653 criterion 3).
     Helper(HelperOp),
+    /// An admitted provider-service operation, carrying the checked plan its execution needs (#1213).
+    ///
+    /// Deliberately a sibling of [`Self::Function`] rather than a flavor of it. A named function target says which
+    /// declaration was selected and nothing more; a provider operation additionally carries the provider activation,
+    /// the RFC 104 capability its invocation must be authorized against, and the runtime requirements its execution
+    /// imposes. Folding those onto [`NamedCallableTarget`] would give every ordinary call fields that are only ever
+    /// absent, and would let a consumer treat a call with no plan as an unchecked provider operation.
+    ///
+    /// Boxed because the plan is by far the largest payload a callee can carry — two canonical identities, the
+    /// provider record, and one fact per input — while being the rarest. Inlining it would grow every
+    /// [`StatementKind::Call`] in every body by that much.
+    ProviderOperation(Box<ProviderOperationPlan>),
 }
 
 impl Callee {
@@ -1887,6 +1899,7 @@ impl Callee {
             Self::Function(target) => target.render_snapshot(),
             Self::Method(target) => target.render_snapshot(),
             Self::Helper(op) => format!("helper:{}", op.as_str()),
+            Self::ProviderOperation(plan) => plan.render_snapshot(),
         }
     }
 }
@@ -2001,6 +2014,189 @@ pub struct NamedCallableTarget {
     /// import, an alias, or a re-export, and is `None` whenever that answer is not proven. [`Self::name`] remains the
     /// call site's own spelling, so the pair records both what was written and what it means.
     pub canonical: Option<CanonicalSymbolId>,
+}
+
+/// Whether the provider owning an operation can be executed against in this compilation.
+///
+/// The three states are the ones the checked provider catalog already distinguishes, kept apart here for the same
+/// reason it keeps them apart: they have different remedies. A disabled provider is present but not selected by the
+/// project graph, while an unavailable one is selected but has no locally verified artifact. Collapsing them into a
+/// single "not usable" flag would leave a consumer unable to say which.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProviderActivationState {
+    /// Enabled and locally available, so an admitted operation may be planned for execution.
+    Active,
+    /// Known to the catalog but not enabled by the project or component selection.
+    Disabled,
+    /// Enabled, but no locally verified artifact backs it.
+    Unavailable,
+}
+
+impl ProviderActivationState {
+    /// Compact maintainer-facing spelling used in snapshots and refusal text.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::Disabled => "disabled",
+            Self::Unavailable => "unavailable",
+        }
+    }
+}
+
+/// The checked provider an operation belongs to, and whether this compilation can execute against it.
+///
+/// [`Self::provider_key`] is carried as provenance, never as a dispatch key. Nothing in Body IR or in a consumer may
+/// branch on it: which operation was invoked is answered by [`ProviderOperationPlan::operation`], a canonical
+/// identity, and whether it may run is answered by [`Self::state`]. Recording the key anyway is what lets a receipt
+/// or a diagnostic say *which* provider without re-resolving the catalog.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderActivation {
+    /// Stable key of the catalog record this operation was admitted from.
+    pub provider_key: String,
+    /// Canonical module path the operation is declared under, as the catalog claims it.
+    pub module_path: Vec<String>,
+    /// Whether this compilation can execute against the provider.
+    pub state: ProviderActivationState,
+}
+
+impl ProviderActivation {
+    /// Render a deterministic maintainer-facing spelling.
+    fn render_snapshot(&self) -> String {
+        format!(
+            "{}@{}:{}",
+            self.provider_key,
+            self.module_path.join("."),
+            self.state.as_str()
+        )
+    }
+}
+
+/// One provider-operation input, described alongside its runtime call operand rather than re-carried.
+///
+/// The evaluated *values* stay in the surrounding [`StatementKind::Call::args`], exactly as they do for every other
+/// call shape, because an [`Operand`] carries an ownership decision and a last-use marker that must be recorded once
+/// and only once. Duplicating the operand into the plan would record both twice. What the plan adds is the facts a
+/// consumer cannot recover from the operand alone: which declared slot the value fills, where it was written (and so
+/// when it was evaluated relative to its siblings), its checked type, and its own source span — which is what lets an
+/// authority denial point at the argument that carried an out-of-scope value rather than at the whole call.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProviderOperationInput {
+    /// Declared parameter slot this input supplies. Indexes the same slot space as [`BoundArgument::slot`].
+    pub slot: usize,
+    /// Zero-based position among the call site's written arguments, which is also its evaluation order.
+    pub written_position: usize,
+    /// Checked type of the evaluated argument expression.
+    pub ty: IncanType,
+    /// Span of the argument expression itself.
+    pub span: HirSourceSpan,
+}
+
+impl ProviderOperationInput {
+    /// Render a deterministic maintainer-facing spelling.
+    fn render_snapshot(&self) -> String {
+        format!("slot{}@{}:{}", self.slot, self.written_position, self.ty)
+    }
+}
+
+/// A checked execution plan for one resolved provider-operation invocation (#1213).
+///
+/// This is a compiler-owned internal plan, not a public provider API and not a second source-meaning model. Every
+/// fact on it is *consumed* from an upstream owner rather than decided here: the canonical operation identity comes
+/// from the RFC 120 callable-target contract, the provider and its activation come from the checked provider catalog,
+/// and [`Self::required_capability`] is an RFC 104 capability declaration's own canonical identity. The plan
+/// deliberately holds no grant set, no mode, no decision, and no receipt — obtaining an authority decision is the
+/// consumer's call through [`Self::authority_request`], and executing the operation belongs to whoever holds a
+/// runtime.
+///
+/// Lowering emits a plan only for an *admitted* operation. An operation whose provider is not active, whose required
+/// capability identity does not name a capability, or whose inputs cannot all be represented is refused at its
+/// source span instead, so it has no plan to execute and no receipt to emit. Consumers must still validate a plan:
+/// constructed or corrupt IR is never evidence that source admission occurred.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProviderOperationPlan {
+    /// RFC 120 canonical identity of the operation declaration this call selected.
+    ///
+    /// This is the only thing that answers "which operation is this". A consumer must not recover that answer from a
+    /// call-site spelling, a provider name, or an emitted Rust name.
+    pub operation: CanonicalSymbolId,
+    /// The checked provider that owns the operation, and its activation in this compilation.
+    pub provider: ProviderActivation,
+    /// Canonical identity of the RFC 104 capability this invocation's authority must be decided against.
+    ///
+    /// A capability identity, not a grant spelling: the spelling is a rendering of the identity (see
+    /// [`Self::authority_request`]), and only the identity survives an import, an alias, or a re-export.
+    pub required_capability: CanonicalSymbolId,
+    /// Runtime requirements executing this operation imposes, in the catalog's own order.
+    pub runtime_requirements: Vec<AbiV0RuntimeRequirement>,
+    /// Runtime call inputs, one per declared slot, in written source order.
+    pub inputs: Vec<ProviderOperationInput>,
+    /// Span of the invocation, which is where a refusal or a denial is reported.
+    pub call_span: HirSourceSpan,
+}
+
+impl ProviderOperationPlan {
+    /// Build the RFC 104 authority request this invocation must have decided before it may execute.
+    ///
+    /// This is the whole of the plan's relationship with authority: it phrases the question and hands it to whatever
+    /// implements [`crate::authority::AuthorityDecisionSource`]. It does not consult a grant set, interpret a mode, or
+    /// decide anything, so a governed host, a permissive local run, and a test double all answer the same request.
+    ///
+    /// `requested_scope` is empty. RFC 104 binds scope *values* at grant time and checks them against the operation's
+    /// actual attributes at the moment it happens, so a request assembled during lowering has no scope values to
+    /// carry; a consumer that has evaluated [`Self::inputs`] may add them to the returned request.
+    pub fn authority_request(&self) -> crate::authority::AuthorityRequest {
+        crate::authority::AuthorityRequest {
+            capability: self.required_capability.clone(),
+            operation: self.operation.clone(),
+            request_span: self.call_span,
+            requested_scope: Vec::new(),
+            suggested_grant: render_symbol_path(&self.required_capability),
+        }
+    }
+
+    /// Render a deterministic maintainer-facing spelling.
+    fn render_snapshot(&self) -> String {
+        let inputs: Vec<String> = self
+            .inputs
+            .iter()
+            .map(ProviderOperationInput::render_snapshot)
+            .collect();
+        let requirements: Vec<String> = self
+            .runtime_requirements
+            .iter()
+            .map(render_runtime_requirement)
+            .collect();
+        format!(
+            "provider_operation:{} provider={} capability={} inputs=[{}] requires=[{}]",
+            render_symbol_path(&self.operation),
+            self.provider.render_snapshot(),
+            render_symbol_path(&self.required_capability),
+            inputs.join(", "),
+            requirements.join(", ")
+        )
+    }
+}
+
+/// Render a canonical identity as its dotted declaration path.
+///
+/// This is a *projection of* the identity for humans and for RFC 104's suggested-grant spelling, never a substitute
+/// for it: two declarations can share a rendering while remaining distinct identities, so nothing may compare or
+/// dispatch on the result. The origin is included because a capability's grant spelling is its declaration location —
+/// `host.http.request` is the `request` capability declared in the `host.http` module, not a string an author chose.
+fn render_symbol_path(symbol: &CanonicalSymbolId) -> String {
+    let prefix: Vec<String> = match &symbol.origin {
+        crate::SymbolOrigin::Module(path) | crate::SymbolOrigin::RustCrate(path) => path.clone(),
+        crate::SymbolOrigin::Package { library, module_path } => std::iter::once(library.clone())
+            .chain(module_path.iter().cloned())
+            .collect(),
+        crate::SymbolOrigin::Builtin => Vec::new(),
+    };
+    prefix
+        .iter()
+        .map(String::as_str)
+        .chain(std::iter::once(symbol.declaration_name.as_str()))
+        .collect::<Vec<_>>()
+        .join(".")
 }
 
 /// A method call target and its resolved call-site identity.
@@ -2644,7 +2840,7 @@ impl PanicReason {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{CompilerNodeKind, IncanPrimitiveType};
+    use crate::{CompilerNodeKind, IncanPrimitiveType, SemanticSourceTargetKind};
 
     fn sample_body() -> Body {
         let decl_id = CompilerNodeId::declaration("m", "add");
@@ -3457,6 +3653,108 @@ mod tests {
             snapshot.contains("const(1) | const(2) => const(())"),
             "alternation pattern: {snapshot}"
         );
+    }
+
+    /// Build an admitted plan for a `pub::billing.charge` operation requiring `host.http.request`.
+    fn sample_provider_operation_plan() -> ProviderOperationPlan {
+        ProviderOperationPlan {
+            operation: CanonicalSymbolId {
+                namespace: crate::SymbolNamespace::OrdinaryLexical,
+                origin: crate::SymbolOrigin::Package {
+                    library: "billing".to_string(),
+                    module_path: vec!["api".to_string()],
+                },
+                declaration_name: "charge".to_string(),
+                kind: SemanticSourceTargetKind::Function,
+                scope_discriminant: None,
+                declaration_span: HirSourceSpan::new(40, 60),
+            },
+            provider: ProviderActivation {
+                provider_key: "billing@1.2.3#abc[]".to_string(),
+                module_path: vec!["billing".to_string(), "api".to_string()],
+                state: ProviderActivationState::Active,
+            },
+            required_capability: CanonicalSymbolId::module_declaration(
+                vec!["host".to_string(), "http".to_string()],
+                "request",
+                SemanticSourceTargetKind::Capability,
+                HirSourceSpan::new(10, 20),
+            ),
+            runtime_requirements: vec![AbiV0RuntimeRequirement::HostedStd],
+            inputs: vec![ProviderOperationInput {
+                slot: 0,
+                written_position: 0,
+                ty: IncanType::Primitive(IncanPrimitiveType::Str),
+                span: HirSourceSpan::new(120, 128),
+            }],
+            call_span: HirSourceSpan::new(110, 130),
+        }
+    }
+
+    /// The plan phrases the RFC 104 question without answering any part of it itself.
+    #[test]
+    fn a_plan_builds_an_authority_request_naming_its_capability_and_operation() {
+        let plan = sample_provider_operation_plan();
+
+        let request = plan.authority_request();
+
+        assert_eq!(request.capability, plan.required_capability);
+        assert_eq!(request.operation, plan.operation);
+        assert_eq!(request.request_span, plan.call_span);
+        assert!(
+            request.requested_scope.is_empty(),
+            "scope values bind at grant time, not while lowering",
+        );
+    }
+
+    /// The suggested grant is a rendering of the capability's declaration location, never an author-chosen string.
+    #[test]
+    fn a_capabilitys_grant_spelling_comes_from_where_it_was_declared() {
+        let plan = sample_provider_operation_plan();
+
+        assert_eq!(plan.authority_request().suggested_grant, "host.http.request");
+    }
+
+    /// A package-owned operation renders under its library identity, so two libraries cannot collide.
+    #[test]
+    fn a_package_owned_operation_renders_under_its_library_identity() {
+        let plan = sample_provider_operation_plan();
+
+        assert_eq!(render_symbol_path(&plan.operation), "billing.api.charge");
+    }
+
+    /// A provider operation renders its checked facts, so a snapshot shows what would execute.
+    #[test]
+    fn a_provider_operation_call_renders_its_plan() {
+        let mut body = sample_body();
+        body.block.stmts.insert(
+            0,
+            Statement {
+                kind: StatementKind::Call {
+                    destination: Some(Place::from_local(LocalId(2))),
+                    callee: Callee::ProviderOperation(Box::new(sample_provider_operation_plan())),
+                    args: vec![ArgumentElement::One(Operand::Constant(Constant::Str("x".to_string())))],
+                    may_panic: false,
+                },
+                span: HirSourceSpan::new(110, 130),
+            },
+        );
+
+        let snapshot = body.render_snapshot();
+
+        assert!(
+            snapshot.contains("provider_operation:billing.api.charge"),
+            "the canonical operation identity must be visible: {snapshot}"
+        );
+        assert!(
+            snapshot.contains("capability=host.http.request"),
+            "the required capability must be visible: {snapshot}"
+        );
+        assert!(
+            snapshot.contains("provider=billing@1.2.3#abc[]@billing.api:active"),
+            "provider activation must be visible: {snapshot}"
+        );
+        assert_eq!(body.render_snapshot(), snapshot, "rendering must be deterministic");
     }
 
     #[test]

--- a/crates/incan_semantics_core/src/lib.rs
+++ b/crates/incan_semantics_core/src/lib.rs
@@ -72,6 +72,7 @@ pub enum DecoratorFeature {
     NoImplicitCoercion,
     Requires,
     Describe,
+    ProviderOperation,
     StdlibDecoratorFunction,
 }
 
@@ -375,5 +376,6 @@ pub fn decorator_feature_from_id(id: DecoratorId) -> DecoratorFeature {
         DecoratorId::NoImplicitCoercion => DecoratorFeature::NoImplicitCoercion,
         DecoratorId::Requires => DecoratorFeature::Requires,
         DecoratorId::Describe => DecoratorFeature::Describe,
+        DecoratorId::ProviderOperation => DecoratorFeature::ProviderOperation,
     }
 }

--- a/crates/incan_semantics_core/src/types.rs
+++ b/crates/incan_semantics_core/src/types.rs
@@ -5,6 +5,8 @@
 
 use std::fmt;
 
+use serde::{Deserialize, Serialize};
+
 /// Read the arity of a Rust tuple type spelling, or `None` when the shape cannot be established.
 ///
 /// This is the single place the compiler decides whether an interop value is destructurable, shared by the
@@ -281,7 +283,7 @@ impl AbiV0Ownership {
 }
 
 /// Runtime service hooks that a type may require.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum AbiV0RuntimeRequirement {
     RuntimeHelper(String),
     HostedStd,

--- a/src/backend/replacement/mod.rs
+++ b/src/backend/replacement/mod.rs
@@ -4780,6 +4780,12 @@ fn callee_label(callee: &Callee) -> String {
         Callee::Function(CallableTarget::Local(_)) => "stored callable".to_string(),
         Callee::Method(target) => format!("method `{}`", target.name),
         Callee::Helper(helper) => format!("runtime helper `{}`", helper_label(*helper)),
+        // Executing a provider operation is #1156's, and needs an authority decision this executor cannot make.
+        // The label names the operation's *declaration* rather than the call site's spelling, because the plan's
+        // canonical identity is the only thing that says which operation this is.
+        Callee::ProviderOperation(plan) => {
+            format!("provider operation `{}`", plan.operation.declaration_name)
+        }
     }
 }
 

--- a/src/cli/commands/build.rs
+++ b/src/cli/commands/build.rs
@@ -64,8 +64,8 @@ use crate::library_manifest::LibraryRustAbi;
 use crate::library_manifest::{
     CompiledProviderMetadata, LibraryManifest, ProviderCargoDependency, ProviderCargoDependencySource,
     ProviderDependencyKind, ProviderDependencyMetadata, ProviderFactKind, ProviderFactRequirement,
-    ProviderImplementationFacet, ProviderModuleClaim, digest_cargo_path_source_tree_with_cache,
-    digest_provider_artifact, digest_provider_source_inputs,
+    ProviderImplementationFacet, ProviderModuleClaim, ProviderOperationMetadata,
+    digest_cargo_path_source_tree_with_cache, digest_provider_artifact, digest_provider_source_inputs,
 };
 use crate::lockfile::{CargoFeatureSelection, IncanLock, provider_semantic_identities, semantic_lock_state};
 use crate::manifest::{DependencySource, DependencySpec, GitReference, MANIFEST_FILENAME, ProjectManifest};
@@ -10089,15 +10089,16 @@ fn prepare_library_project(
     materialize_checked_api_public_namespaces(&mut checked_api)
         .map_err(|error| CliError::failure(format!("failed to publish checked module namespaces: {error}")))?;
     library_manifest.contract_metadata.api = Some(checked_api);
-    library_manifest.contract_metadata.provider = compiled_provider_metadata(
-        &manifest,
-        &package_feature_plan,
-        &provider_plan,
-        &library_manifest_index,
-        &out_dir,
-        &provider_metadata_modules,
-        lib_module,
-    )?;
+    library_manifest.contract_metadata.provider = compiled_provider_metadata(CompiledProviderMetadataInputs {
+        manifest: &manifest,
+        feature_plan: &package_feature_plan,
+        provider_plan: &provider_plan,
+        library_manifest_index: &library_manifest_index,
+        artifact_root: &out_dir,
+        modules: &provider_metadata_modules,
+        active_library_entrypoint: lib_module,
+        checked_type_info_by_path: &checked_type_info_by_path,
+    })?;
     let mut registry_metadata = CheckedRegistryMetadataPackage {
         schema_version: CHECKED_REGISTRY_METADATA_SCHEMA_VERSION,
         package: Some(CheckedRegistryPackageIdentity {
@@ -10654,33 +10655,45 @@ fn synchronize_projected_provider_dependencies(
     Ok(())
 }
 
+/// Borrowed inputs needed to freeze checked provider facts into a library artifact.
+///
+/// The checked type information stays in the compiler pipeline until this projection. It carries the canonical
+/// callable-to-capability facts that provider operation lowering consumes through the selected manifest.
+struct CompiledProviderMetadataInputs<'a> {
+    manifest: &'a ProjectManifest,
+    feature_plan: &'a PackageFeaturePlan,
+    provider_plan: &'a ProviderPlan,
+    library_manifest_index: &'a LibraryManifestIndex,
+    artifact_root: &'a Path,
+    modules: &'a [ParsedModule],
+    active_library_entrypoint: &'a ParsedModule,
+    checked_type_info_by_path: &'a BTreeMap<PathBuf, typechecker::TypeCheckInfo>,
+}
+
 /// Build transport-stable provider facts from the checked physical artifact projection.
-fn compiled_provider_metadata(
-    manifest: &ProjectManifest,
-    feature_plan: &PackageFeaturePlan,
-    provider_plan: &ProviderPlan,
-    library_manifest_index: &LibraryManifestIndex,
-    artifact_root: &Path,
-    modules: &[ParsedModule],
-    active_library_entrypoint: &ParsedModule,
-) -> CliResult<CompiledProviderMetadata> {
-    let graph = PackageFeatureGraph::from_manifest(manifest).map_err(|error| CliError::failure(error.to_string()))?;
-    let root_features = feature_plan
+fn compiled_provider_metadata(inputs: CompiledProviderMetadataInputs<'_>) -> CliResult<CompiledProviderMetadata> {
+    let graph =
+        PackageFeatureGraph::from_manifest(inputs.manifest).map_err(|error| CliError::failure(error.to_string()))?;
+    let root_features = inputs
+        .feature_plan
         .root_package()
         .map(|package| &package.features)
         .ok_or_else(|| CliError::failure("resolved package feature plan is missing its root package"))?;
-    let library_entrypoint = modules
+    let library_entrypoint = inputs
+        .modules
         .iter()
-        .find(|module| module.file_path == active_library_entrypoint.file_path)
+        .find(|module| module.file_path == inputs.active_library_entrypoint.file_path)
         .ok_or_else(|| CliError::failure("unprojected provider graph is missing its library entrypoint"))?;
-    let source_root = resolve_source_root(manifest.project_root(), Some(manifest));
-    let module_requirements = provider_module_reachability_requirements(modules, library_entrypoint, &source_root)?;
-    let mut namespace_claims = modules
+    let source_root = resolve_source_root(inputs.manifest.project_root(), Some(inputs.manifest));
+    let module_requirements =
+        provider_module_reachability_requirements(inputs.modules, library_entrypoint, &source_root)?;
+    let mut namespace_claims = inputs
+        .modules
         .iter()
         .filter(|module| {
-            module.file_path != active_library_entrypoint.file_path
+            module.file_path != inputs.active_library_entrypoint.file_path
                 && !module.path_segments.is_empty()
-                && !module_is_owned_by_dependency_provider(provider_plan, &module.path_segments)
+                && !module_is_owned_by_dependency_provider(inputs.provider_plan, &module.path_segments)
         })
         .flat_map(|module| {
             module_requirements
@@ -10698,9 +10711,10 @@ fn compiled_provider_metadata(
 
     let public_features = graph.provider_metadata();
     let mut fact_requirements = Vec::new();
-    for module in modules
+    for module in inputs
+        .modules
         .iter()
-        .filter(|module| !module_is_owned_by_dependency_provider(provider_plan, &module.path_segments))
+        .filter(|module| !module_is_owned_by_dependency_provider(inputs.provider_plan, &module.path_segments))
     {
         let requirements = module_requirements.get(&module.path_segments).ok_or_else(|| {
             CliError::failure(format!(
@@ -10733,12 +10747,18 @@ fn compiled_provider_metadata(
     fact_requirements.sort();
     fact_requirements.dedup();
 
-    let provider_dependencies =
-        compiled_provider_dependencies(feature_plan, library_manifest_index, provider_plan, artifact_root)?;
+    let provider_dependencies = compiled_provider_dependencies(
+        inputs.feature_plan,
+        inputs.library_manifest_index,
+        inputs.provider_plan,
+        inputs.artifact_root,
+    )?;
     let implementation_facets = provider_implementation_facets(&namespace_claims);
-    let semantic_source_inputs = modules
+    let operation_descriptors = provider_operation_metadata_from_checked_type_info(inputs.checked_type_info_by_path)?;
+    let semantic_source_inputs = inputs
+        .modules
         .iter()
-        .filter(|module| !module_is_owned_by_dependency_provider(provider_plan, &module.path_segments))
+        .filter(|module| !module_is_owned_by_dependency_provider(inputs.provider_plan, &module.path_segments))
         .map(|module| {
             let label = if module.path_segments.is_empty() {
                 "<root>".to_string()
@@ -10752,8 +10772,8 @@ fn compiled_provider_metadata(
         .into_iter()
         .collect::<Vec<_>>();
     let semantic_source_digest = digest_provider_source_inputs(
-        manifest.project_root(),
-        manifest.path(),
+        inputs.manifest.project_root(),
+        inputs.manifest.path(),
         &semantic_source_inputs,
         &trusted_source_roots,
     )
@@ -10767,8 +10787,39 @@ fn compiled_provider_metadata(
         fact_requirements,
         required_sdk_components: root_features.required_sdk_components.clone(),
         implementation_facets,
+        operation_descriptors,
         ..CompiledProviderMetadata::default()
     })
+}
+
+/// Project declaration-side provider-operation facts into the selected library artifact.
+///
+/// The typechecker is the only source of these pairs: it resolved each decorated operation's capability in the
+/// declaring module. Sorting and rejecting duplicate canonical identities makes manifest output deterministic and
+/// prevents a package with two copies of one declaration from acquiring order-dependent provider meaning.
+fn provider_operation_metadata_from_checked_type_info(
+    checked_type_info_by_path: &BTreeMap<PathBuf, typechecker::TypeCheckInfo>,
+) -> CliResult<Vec<ProviderOperationMetadata>> {
+    let mut operation_descriptors = checked_type_info_by_path
+        .values()
+        .flat_map(|type_info| type_info.declarations.provider_operations.values())
+        .map(|operation| ProviderOperationMetadata {
+            operation: operation.operation.clone(),
+            required_capability: operation.required_capability.clone(),
+            runtime_requirements: operation.runtime_requirements.clone(),
+        })
+        .collect::<Vec<_>>();
+    operation_descriptors.sort_by(|left, right| left.operation.cmp(&right.operation));
+    if let Some(duplicate) = operation_descriptors
+        .windows(2)
+        .find(|entries| entries[0].operation == entries[1].operation)
+    {
+        return Err(CliError::failure(format!(
+            "provider operation metadata contains duplicate declaration `{}`",
+            duplicate[0].operation.declaration_name
+        )));
+    }
+    Ok(operation_descriptors)
 }
 
 /// Freeze the active Incan dependency edges into artifact-owned, relocation-safe provider metadata.
@@ -13884,6 +13935,48 @@ mod tests {
     };
     use crate::oven_interop::locked_oven_interop_targets;
     use std::fs;
+
+    #[test]
+    fn provider_operation_metadata_is_projected_from_checked_declaration_facts()
+    -> Result<(), Box<dyn std::error::Error>> {
+        use std::collections::BTreeMap;
+        use std::path::PathBuf;
+
+        use crate::frontend::typechecker::{ProviderOperationDeclarationInfo, TypeCheckInfo};
+        use incan_semantics_core::{CanonicalSymbolId, HirSourceSpan, SemanticSourceTargetKind};
+
+        let operation = CanonicalSymbolId::module_declaration(
+            vec!["provider".to_string(), "billing".to_string()],
+            "charge",
+            SemanticSourceTargetKind::Function,
+            HirSourceSpan::new(20, 26),
+        );
+        let required_capability = CanonicalSymbolId::module_declaration(
+            vec!["provider".to_string(), "billing".to_string()],
+            "charge_card",
+            SemanticSourceTargetKind::Capability,
+            HirSourceSpan::new(1, 12),
+        );
+        let mut type_info = TypeCheckInfo::default();
+        type_info.declarations.provider_operations.insert(
+            operation.clone(),
+            ProviderOperationDeclarationInfo {
+                operation: operation.clone(),
+                required_capability: required_capability.clone(),
+                runtime_requirements: Vec::new(),
+            },
+        );
+
+        let descriptors = provider_operation_metadata_from_checked_type_info(&BTreeMap::from([(
+            PathBuf::from("src/billing.incn"),
+            type_info,
+        )]))?;
+        assert_eq!(descriptors.len(), 1);
+        assert_eq!(descriptors[0].operation, operation);
+        assert_eq!(descriptors[0].required_capability, required_capability);
+        assert!(descriptors[0].runtime_requirements.is_empty());
+        Ok(())
+    }
 
     #[test]
     fn completed_output_reuse_requires_the_implicit_default_backend_selection() {

--- a/src/frontend/body_ir.rs
+++ b/src/frontend/body_ir.rs
@@ -65,6 +65,7 @@ use crate::frontend::symbols::{CallableParam, ResolvedType};
 use crate::frontend::typechecker::{
     FixedUnpackPlan, IdentKind, ResolvedOperatorKind, TypeCheckInfo, semantic_type_from_resolved,
 };
+use crate::provider::ProviderPlan;
 
 /// Build Body IR v0 for every top-level function declaration and every non-abstract class/model/trait method in a
 /// typechecked module.
@@ -80,6 +81,39 @@ pub fn build_body_ir_module_v0(
     program: &ast::Program,
     module_path: &[String],
     type_info: &TypeCheckInfo,
+) -> bir::BodyIrModule {
+    build_body_ir_module_v0_with_provider_operations(program, module_path, type_info, &ProviderOperationCatalog::new())
+}
+
+/// Build Body IR using the checked provider-operation facts selected for this compilation.
+///
+/// The ordinary source-only replacement profile has no provider plan and continues to use
+/// [`build_body_ir_module_v0`]. Any provider-aware consumer must use this entry point so provider-operation admission
+/// is projected from an integrity-checked manifest rather than supplied as a handwritten lowering catalogue.
+pub fn build_body_ir_module_v0_with_provider_plan(
+    program: &ast::Program,
+    module_path: &[String],
+    type_info: &TypeCheckInfo,
+    provider_plan: &ProviderPlan,
+) -> Result<bir::BodyIrModule, String> {
+    let provider_operations = ProviderOperationCatalog::from_provider_plan(provider_plan)?;
+    Ok(build_body_ir_module_v0_with_provider_operations(
+        program,
+        module_path,
+        type_info,
+        &provider_operations,
+    ))
+}
+
+/// Build Body IR v0 for a typechecked module, admitting the internally projected provider operations.
+///
+/// The catalogue is deliberately private to this frontend bridge. Its entries must come from a selected checked
+/// [`ProviderPlan`], never from a backend-specific caller or a source-name convention.
+fn build_body_ir_module_v0_with_provider_operations(
+    program: &ast::Program,
+    module_path: &[String],
+    type_info: &TypeCheckInfo,
+    provider_operations: &ProviderOperationCatalog,
 ) -> bir::BodyIrModule {
     let module_identity = body_ir_module_identity(module_path);
     let module_id = CompilerNodeId::module(module_identity.clone());
@@ -109,6 +143,7 @@ pub fn build_body_ir_module_v0(
         local_value_enum_declarations: &local_value_enum_declarations,
         module_identity: &module_identity,
         module_path,
+        provider_operations,
     };
     let bodies = program
         .declarations
@@ -215,6 +250,8 @@ struct BodyIrLoweringFacts<'type_info, 'source> {
     local_value_enum_declarations: &'source LocalValueEnumDeclarations,
     module_identity: &'source str,
     module_path: &'source [String],
+    /// Provider operations this compilation admits, keyed by canonical identity rather than by any spelling.
+    provider_operations: &'source ProviderOperationCatalog,
 }
 
 /// Source facts a synthesized local partial needs for one target parameter.
@@ -311,6 +348,8 @@ struct BodyBuilder<'type_info, 'source> {
     module_identity: &'source str,
     /// Owning module path, used to build the RFC 120 origin of a declaration this module owns.
     module_path: &'source [String],
+    /// Provider operations this compilation admits, consulted only by canonical identity (see `provider_ops`).
+    provider_operations: &'source ProviderOperationCatalog,
     /// Checked return type of the function/method currently being lowered, used only to retain `?` error routing.
     owner_return_type: IncanType,
     locals: Vec<bir::LocalDecl>,
@@ -354,6 +393,7 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
             local_value_enum_declarations: lowering_facts.local_value_enum_declarations,
             module_identity: lowering_facts.module_identity,
             module_path: lowering_facts.module_path,
+            provider_operations: lowering_facts.provider_operations,
             owner_return_type,
             locals: Vec::new(),
             scopes: Vec::new(),
@@ -826,6 +866,7 @@ mod control_flow;
 mod stmt;
 
 mod free_vars;
+mod provider_ops;
 mod refusals;
 
 mod reads;
@@ -840,6 +881,7 @@ mod args;
 
 use bodies::*;
 use collect::*;
+use provider_ops::{ProviderOperationCatalog, ProviderOperationRecord};
 use reads::*;
 
 #[cfg(test)]

--- a/src/frontend/body_ir/calls.rs
+++ b/src/frontend/body_ir/calls.rs
@@ -618,6 +618,16 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
                 return self.unsupported_operand(description, scope, hir_span_value, out);
             }
         };
+
+        // A provider operation is selected by the canonical identity this call already resolved to, never by the
+        // spelling written here (#1213). The lookup therefore sits after resolution rather than in place of it, and
+        // a callee with no proven identity finds nothing rather than being guessed at by name.
+        if let Some(operation) = declaration.canonical.clone()
+            && let Some(record) = self.provider_operation_record(&operation)
+        {
+            return self.lower_provider_operation(&name, &operation, record, declaration, args, span, scope, out);
+        }
+
         let (operands, binding) =
             match self.bind_declared_args(&format!("function `{name}`"), declaration.slots, args, scope, out) {
                 Ok(bound) => bound,

--- a/src/frontend/body_ir/provider_ops.rs
+++ b/src/frontend/body_ir/provider_ops.rs
@@ -1,0 +1,263 @@
+//! Lowering an admitted provider-service call into a checked [`bir::ProviderOperationPlan`] (#1213).
+//!
+//! Body IR does not decide what a provider operation *is*. It is told, by canonical identity, through a
+//! private [`ProviderOperationCatalog`] projected from the selected [`ProviderPlan`]. That direction is the point of
+//! this module rather than an implementation convenience: a lowering pass that recognized provider operations by
+//! module name, callee spelling, or emitted Rust name would be a second source-resolution mechanism competing with
+//! the one that already resolved the call, and it would make ordinary package-defined providers impossible to
+//! express.
+//!
+//! What lowering does own is admission. An operation reaches [`bir::Callee::ProviderOperation`] only when its
+//! provider is active in this compilation, its required capability identity really names a capability declaration,
+//! and every declared input is present for evaluation at the call site. Anything else refuses at the original source
+//! span through the ordinary [`bir::StatementKind::Unsupported`] node, so an operation that cannot be executed produces
+//! no plan — and therefore nothing that could emit an execution receipt.
+//!
+//! Authority is deliberately absent here. Importing a provider module is ordinary source resolution and grants
+//! nothing; the authority question is asked only when an admitted operation is invoked, and asking it is the
+//! executing consumer's job through [`bir::ProviderOperationPlan::authority_request`] (#1156). This module produces
+//! the plan that makes that question answerable without re-reading source.
+
+use std::collections::BTreeMap;
+
+use super::args::*;
+use super::refusals::*;
+use super::*;
+use crate::provider::ProviderPlan;
+
+/// One checked provider operation the compiler will admit for execution, keyed elsewhere by canonical identity.
+///
+/// Every field is metadata this stage *consumes*. The provider and its activation come from the checked provider
+/// catalog, and `required_capability` is an RFC 104 `capability` declaration's own canonical identity — not a grant
+/// spelling and not a provider-local authority model.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ProviderOperationRecord {
+    /// The checked provider owning the operation, and whether this compilation can execute against it.
+    pub provider: bir::ProviderActivation,
+    /// Canonical identity of the capability an invocation's authority must be decided against.
+    pub required_capability: CanonicalSymbolId,
+    /// Runtime requirements executing the operation imposes.
+    pub runtime_requirements: Vec<AbiV0RuntimeRequirement>,
+}
+
+/// The provider operations this compilation knows about, keyed by the operation's canonical identity.
+///
+/// Keying on [`CanonicalSymbolId`] is what keeps the lookup free of source spellings: a local call, an import, and
+/// an alias of one operation all present the same key, and no provider name, module spelling, or emitted Rust name
+/// participates. An empty catalog is the ordinary case — a compilation with no provider operations lowers exactly
+/// as it did before, because no call can match an entry that does not exist.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(super) struct ProviderOperationCatalog {
+    operations: BTreeMap<CanonicalSymbolId, ProviderOperationRecord>,
+}
+
+impl ProviderOperationCatalog {
+    /// Build an empty catalog, which admits no call as a provider operation.
+    pub(super) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Build the lowering catalogue from the compilation's checked provider plan.
+    ///
+    /// Provider manifests are the only producer of these entries. This constructor deliberately takes no source
+    /// spelling inputs: selected provider records already carry the integrity-checked manifest and activation facts
+    /// for the current compilation.
+    pub(super) fn from_provider_plan(provider_plan: &ProviderPlan) -> Result<Self, String> {
+        let mut catalog = Self::new();
+        for provider in provider_plan.records() {
+            let Some(manifest) = provider.manifest.as_deref() else {
+                continue;
+            };
+            let state = if provider.enabled && provider.available {
+                bir::ProviderActivationState::Active
+            } else if provider.enabled {
+                bir::ProviderActivationState::Unavailable
+            } else {
+                bir::ProviderActivationState::Disabled
+            };
+            for descriptor in &manifest.contract_metadata.provider.operation_descriptors {
+                let Some(module_path) = descriptor.operation.module_path() else {
+                    return Err(format!(
+                        "provider `{}` publishes an operation without a module declaration identity",
+                        provider.identity.stable_key()
+                    ));
+                };
+                if !provider.namespace_claims.contains(module_path) {
+                    return Err(format!(
+                        "provider `{}` publishes operation `{}` outside its claimed module namespace",
+                        provider.identity.stable_key(),
+                        descriptor.operation.declaration_name
+                    ));
+                }
+                if !descriptor.has_expected_kinds() {
+                    return Err(format!(
+                        "provider `{}` publishes an operation descriptor with unsupported declaration kinds",
+                        provider.identity.stable_key()
+                    ));
+                }
+                catalog.try_insert(
+                    descriptor.operation.clone(),
+                    ProviderOperationRecord {
+                        provider: bir::ProviderActivation {
+                            provider_key: provider.identity.stable_key(),
+                            module_path: module_path.to_vec(),
+                            state,
+                        },
+                        required_capability: descriptor.required_capability.clone(),
+                        runtime_requirements: descriptor.runtime_requirements.clone(),
+                    },
+                )?;
+            }
+        }
+        Ok(catalog)
+    }
+
+    /// Insert one checked descriptor, refusing duplicate canonical operation identities.
+    ///
+    /// A duplicate cannot be resolved by choosing whichever provider happened to be visited last. That would turn a
+    /// checked provider plan into a mutable, order-dependent authority source, so callers receive an error before
+    /// any Body IR is built.
+    fn try_insert(&mut self, operation: CanonicalSymbolId, record: ProviderOperationRecord) -> Result<(), String> {
+        if self.operations.contains_key(&operation) {
+            return Err(format!(
+                "duplicate provider operation identity `{}`",
+                operation.declaration_name
+            ));
+        }
+        self.operations.insert(operation, record);
+        Ok(())
+    }
+
+    /// Return the record for `operation`, or `None` when this compilation knows no such provider operation.
+    pub(super) fn get(&self, operation: &CanonicalSymbolId) -> Option<&ProviderOperationRecord> {
+        self.operations.get(operation)
+    }
+}
+
+impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
+    /// Return the provider-operation record a resolved call selected, when the catalog admits one.
+    ///
+    /// The borrow is taken from the catalog's own `'source` lifetime rather than from `&self`, so a caller can keep
+    /// the record while lowering argument expressions through `&mut self`.
+    ///
+    /// A caller with no proven canonical identity never reaches here at all. That is fail-closed on purpose: an
+    /// unresolved, trait-dispatched, or ambiguously overloaded callee has no identity to look up, and guessing one
+    /// from the call-site spelling is precisely the source-resolution duplication this slice exists to avoid.
+    pub(super) fn provider_operation_record(
+        &self,
+        operation: &CanonicalSymbolId,
+    ) -> Option<&'source ProviderOperationRecord> {
+        self.provider_operations.get(operation)
+    }
+
+    /// Lower an admitted provider-operation call into a [`bir::Callee::ProviderOperation`] statement.
+    ///
+    /// The admission checks run *before* any argument expression is lowered, matching the "check before partially
+    /// lowering" precedent this module's siblings already follow: a refusal must not leave the operands of a call
+    /// that never happens sitting in the emitted statement list.
+    ///
+    /// `operation` is the canonical identity the call resolved to, so the emitted plan names the same declaration
+    /// the typechecker selected rather than the spelling written here. `name` is used only for refusal text.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn lower_provider_operation(
+        &mut self,
+        name: &str,
+        operation: &CanonicalSymbolId,
+        record: &ProviderOperationRecord,
+        declaration: DirectCallDeclaration,
+        args: &[ast::CallArg],
+        span: ast::Span,
+        scope: bir::ScopeId,
+        out: &mut Vec<bir::Statement>,
+    ) -> bir::Operand {
+        let hir_span_value = hir_span(span);
+        if let Some(description) = unsupported_provider_operation(operation, record) {
+            return self.unsupported_operand(description, scope, hir_span_value, out);
+        }
+
+        // A provider operation must arrive with a fully resolved declared surface. Without one there is no slot
+        // space for its inputs to be described against, so there is nothing a consumer could bind a scope value to.
+        let Some(slots) = declaration.slots else {
+            return self.unsupported_operand(
+                format!("provider operation `{name}` whose declared parameters were not resolved"),
+                scope,
+                hir_span_value,
+                out,
+            );
+        };
+        let callee_label = format!("provider operation `{name}`");
+        let planned = match plan_declared_args(&callee_label, &slots, args) {
+            Ok(planned) => planned,
+            Err(description) => {
+                return self.unsupported_operand(description, scope, hir_span_value, out);
+            }
+        };
+
+        // Every declared slot must carry an evaluated input. An omitted default is legal for an ordinary call, whose
+        // default computation stays owned by the declaration, but a provider operation's plan claims to describe the
+        // values its execution will actually see -- and a default this stage never evaluated is not one of them.
+        if planned.len() != slots.len() {
+            return self.unsupported_operand(
+                format!("provider operation `{name}` called with an omitted parameter whose default this stage cannot evaluate"),
+                scope,
+                hir_span_value,
+                out,
+            );
+        }
+
+        let inputs = self.provider_operation_inputs(&planned);
+        let (operands, _binding) = match self.lower_planned_args(&planned, slots.len(), scope, out) {
+            Ok(bound) => bound,
+            Err(description) => {
+                return self.unsupported_operand(format!("{callee_label}: {description}"), scope, hir_span_value, out);
+            }
+        };
+
+        // The operation's requirements are the enclosing body's requirements too: a body that invokes it cannot run
+        // on a profile that does not provide them.
+        for requirement in &record.runtime_requirements {
+            self.record_runtime_requirement(requirement.clone());
+        }
+
+        let plan = bir::ProviderOperationPlan {
+            operation: operation.clone(),
+            provider: record.provider.clone(),
+            required_capability: record.required_capability.clone(),
+            runtime_requirements: record.runtime_requirements.clone(),
+            inputs,
+            call_span: hir_span_value,
+        };
+        let ty = self.resolve_ty(span);
+        self.push_call_temp(
+            bir::Callee::ProviderOperation(Box::new(plan)),
+            fixed_elements(operands),
+            ty,
+            scope,
+            hir_span_value,
+            false,
+            out,
+        )
+    }
+
+    /// Describe each planned argument as an evaluated input fact, in written source order.
+    ///
+    /// The written position is the index into `planned`, which [`Self::lower_planned_args`] also uses as its
+    /// evaluation order, so an input's recorded position really is when its value was computed. Types come from the
+    /// typechecker's own decision for the argument expression rather than from the declared parameter, because what
+    /// an authority check needs to see is the value that was actually passed.
+    fn provider_operation_inputs(
+        &self,
+        planned: &[(usize, &ast::Spanned<ast::Expr>)],
+    ) -> Vec<bir::ProviderOperationInput> {
+        planned
+            .iter()
+            .enumerate()
+            .map(|(written_position, (slot, expr))| bir::ProviderOperationInput {
+                slot: *slot,
+                written_position,
+                ty: self.resolve_ty(expr.span),
+                span: hir_span(expr.span),
+            })
+            .collect()
+    }
+}

--- a/src/frontend/body_ir/refusals.rs
+++ b/src/frontend/body_ir/refusals.rs
@@ -18,6 +18,52 @@ pub(super) fn unsupported_stmt_label(stmt: &ast::Statement) -> String {
         _ => "statement".to_string(),
     }
 }
+/// Why an admitted provider operation cannot become a checked execution plan, or `None` when it can (#1213).
+///
+/// Consulted once, before any argument of the call is lowered, so a refusal never leaves the operands of a call that
+/// never happens behind -- the same "check before partially lowering" precedent as [`match_pattern_is_supported`].
+/// Refusing here rather than emitting a plan is what makes the "no execution receipt for a lowering refusal"
+/// guarantee structural: with no [`bir::Callee::ProviderOperation`] statement there is nothing for an executor to
+/// run, and nothing for it to report having run.
+///
+/// Two independent things make an operation unexecutable, and both are checked.
+///
+/// **Activation.** Only an active provider may be planned against. A disabled or unavailable provider is a real
+/// entry in the catalog, so the call did resolve; what it did not do is reach something this compilation can
+/// execute, and the two states are named separately because they have different remedies.
+///
+/// **Capability identity.** The plan promises that [`bir::ProviderOperationPlan::required_capability`] names an RFC
+/// 104 `capability` declaration, which is what makes an authority request answerable. An identity of any other kind
+/// -- a function, a model, a module -- would produce a request no authority source could decide, so it is refused
+/// here rather than carried into a plan that quietly cannot be authorized.
+///
+/// The message names the *declaration* the identity selected, never the call site's spelling: which operation this
+/// is, is a question only the canonical identity answers.
+pub(super) fn unsupported_provider_operation(
+    operation: &CanonicalSymbolId,
+    record: &ProviderOperationRecord,
+) -> Option<String> {
+    let declared = &operation.declaration_name;
+    match record.provider.state {
+        bir::ProviderActivationState::Active => {}
+        bir::ProviderActivationState::Disabled => {
+            return Some(format!(
+                "provider operation `{declared}` whose provider is not enabled in this compilation"
+            ));
+        }
+        bir::ProviderActivationState::Unavailable => {
+            return Some(format!(
+                "provider operation `{declared}` whose provider has no locally available artifact"
+            ));
+        }
+    }
+    if record.required_capability.kind != SemanticSourceTargetKind::Capability {
+        return Some(format!(
+            "provider operation `{declared}` whose required authority does not name a capability declaration"
+        ));
+    }
+    None
+}
 /// Short diagnostic label for an expression kind v0 does not lower.
 ///
 /// Only reached from [`BodyBuilder::lower_expr_to_operand`]'s fallback arm, so every expression kind that arm

--- a/src/frontend/body_ir/tests.rs
+++ b/src/frontend/body_ir/tests.rs
@@ -3011,6 +3011,8 @@ fn call_binding(kind: &bir::StatementKind) -> Result<&bir::ArgumentBinding, Box<
         bir::Callee::Function(bir::CallableTarget::Local(target)) => Ok(&target.binding),
         bir::Callee::Method(target) => Ok(&target.binding),
         bir::Callee::Helper(_) => Err("a helper call carries no declared argument binding".into()),
+        // A provider operation's declaration slots are described by its plan's inputs, not by an argument binding.
+        bir::Callee::ProviderOperation(_) => Err("a provider operation carries its own input facts".into()),
     }
 }
 
@@ -3926,6 +3928,7 @@ fn a_prefix_surface_keyword_that_is_not_await_is_refused_rather_than_treated_as_
     let local_nominal_declarations = LocalNominalDeclarations::new();
     let local_fieldless_enum_declarations = LocalFieldlessEnumDeclarations::new();
     let local_value_enum_declarations = LocalValueEnumDeclarations::new();
+    let provider_operations = ProviderOperationCatalog::new();
     let module_path = vec!["m".to_string()];
     let lowering_facts = BodyIrLoweringFacts {
         type_info: &type_info,
@@ -3936,6 +3939,7 @@ fn a_prefix_surface_keyword_that_is_not_await_is_refused_rather_than_treated_as_
         local_value_enum_declarations: &local_value_enum_declarations,
         module_identity: "m",
         module_path: &module_path,
+        provider_operations: &provider_operations,
     };
     let mut builder = BodyBuilder::new(&lowering_facts, IncanType::Unknown);
     let scope = builder.new_scope(None, HirSourceSpan::new(0, 1));
@@ -5296,6 +5300,126 @@ fn assertion_kinds(body: &bir::Body) -> Vec<&bir::AssertionKind> {
         .collect()
 }
 
+// ============================================================================
+// Provider-operation plans (#1213)
+// ============================================================================
+
+/// Construct the selected provider plan from the checked declaration metadata produced by `source`.
+///
+/// This intentionally follows the production direction: the declaration-side decorator resolves a capability,
+/// publication persists that checked pair into the provider manifest, and consumer lowering projects the selected
+/// manifest through its provider plan. Tests must not manually fill `ProviderOperationCatalog`, because that would
+/// bypass the compiler-owned producer contract #1213 adds.
+fn provider_plan_from_checked_source(
+    type_info: &TypeCheckInfo,
+    state: bir::ProviderActivationState,
+) -> Result<ProviderPlan, Box<dyn std::error::Error>> {
+    use std::collections::BTreeSet;
+    use std::sync::Arc;
+
+    use crate::frontend::library_manifest_index::LibraryManifestIndex;
+    use crate::library_manifest::{CompiledProviderMetadata, LibraryManifest, ProviderOperationMetadata};
+    use crate::provider::{NamespaceAuthority, ProviderIdentity, ProviderProvenance, ProviderRecord};
+
+    let operation_descriptors = type_info
+        .declarations
+        .provider_operations
+        .values()
+        .map(|operation| ProviderOperationMetadata {
+            operation: operation.operation.clone(),
+            required_capability: operation.required_capability.clone(),
+            runtime_requirements: operation.runtime_requirements.clone(),
+        })
+        .collect::<Vec<_>>();
+    if operation_descriptors.is_empty() {
+        return Err("fixture source declared no checked provider operation".into());
+    }
+
+    let namespace_claims = operation_descriptors
+        .iter()
+        .map(|descriptor| {
+            descriptor
+                .operation
+                .module_path()
+                .map(ToOwned::to_owned)
+                .ok_or("provider operation identity must name a module declaration")
+        })
+        .collect::<Result<BTreeSet<_>, _>>()?;
+    let mut manifest = LibraryManifest::new("fixture_provider", "0.1.0");
+    manifest.contract_metadata.provider = CompiledProviderMetadata {
+        operation_descriptors,
+        ..CompiledProviderMetadata::default()
+    };
+    let (enabled, available) = match state {
+        bir::ProviderActivationState::Active => (true, true),
+        bir::ProviderActivationState::Disabled => (false, true),
+        bir::ProviderActivationState::Unavailable => (true, false),
+    };
+    ProviderPlan::new(
+        LibraryManifestIndex::default(),
+        vec![ProviderRecord {
+            identity: ProviderIdentity {
+                name: "fixture_provider".to_string(),
+                version: "0.1.0".to_string(),
+                digest: "fixture:provider-operation".to_string(),
+                feature_projection: BTreeSet::new(),
+            },
+            provenance: ProviderProvenance::Compiler,
+            authority: NamespaceAuthority::Compiler,
+            namespace_claims: namespace_claims.clone(),
+            available,
+            enabled,
+            // The selected metadata remains available for a known-but-unavailable fixture so lowering can issue
+            // its explicit source-span refusal instead of treating the operation as an ordinary call.
+            manifest: Some(Arc::new(manifest)),
+            artifact: None,
+            implementation_facets: Vec::new(),
+        }],
+        namespace_claims,
+    )
+    .map_err(|error| error.to_string().into())
+}
+
+/// Lower `source` through its checked provider manifest and the selected `ProviderPlan`.
+fn build_with_provider_operation(
+    source: &str,
+    module_path: &[&str],
+    state: bir::ProviderActivationState,
+) -> Result<bir::BodyIrModule, Box<dyn std::error::Error>> {
+    let tokens = lexer::lex(source).map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+    let program = parser::parse(&tokens).map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+    let module_path: Vec<String> = module_path.iter().map(|s| s.to_string()).collect();
+    let mut checker = TypeChecker::new();
+    checker.set_current_module_path(Some(module_path.clone()));
+    checker
+        .check_program(&program)
+        .map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+
+    let provider_plan = provider_plan_from_checked_source(checker.type_info(), state)?;
+    build_body_ir_module_v0_with_provider_plan(&program, &module_path, checker.type_info(), &provider_plan)
+        .map_err(Into::into)
+}
+
+/// Collect the provider-operation plans lowered into one body, in statement order.
+fn provider_plans<'module>(
+    module: &'module bir::BodyIrModule,
+    body_name: &str,
+) -> Vec<&'module bir::ProviderOperationPlan> {
+    module
+        .bodies
+        .iter()
+        .filter(|body| body.name == body_name)
+        .flat_map(|body| &body.block.stmts)
+        .filter_map(|stmt| match &stmt.kind {
+            bir::StatementKind::Call {
+                callee: bir::Callee::ProviderOperation(plan),
+                ..
+            } => Some(plan.as_ref()),
+            _ => None,
+        })
+        .collect()
+}
+
 #[test]
 fn a_pattern_assertion_binding_is_a_declared_local_read_by_the_statements_after_it()
 -> Result<(), Box<dyn std::error::Error>> {
@@ -5401,6 +5525,257 @@ fn a_raises_assertion_retains_the_resolved_expected_error_rather_than_its_spelli
     Ok(())
 }
 
+/// Collect the explicit refusal descriptions recorded in one body, in statement order.
+fn refusal_descriptions<'module>(module: &'module bir::BodyIrModule, body_name: &str) -> Vec<&'module str> {
+    module
+        .bodies
+        .iter()
+        .filter(|body| body.name == body_name)
+        .flat_map(|body| &body.block.stmts)
+        .filter_map(|stmt| match &stmt.kind {
+            bir::StatementKind::Unsupported { description } => Some(description.as_str()),
+            _ => None,
+        })
+        .collect()
+}
+
+const PROVIDER_FIXTURE_SOURCE: &str = r#"
+capability charge_card:
+  description = "Charge one approved card"
+
+@provider_operation(charge_card)
+def charge(account: str, amount: int) -> int:
+  return amount
+
+def run() -> int:
+  return charge("acct-1", 250)
+"#;
+
+/// An admitted call reaches Body IR as a plan carrying every checked fact #1156 needs to execute it.
+#[test]
+fn an_admitted_provider_operation_lowers_to_a_checked_execution_plan() -> Result<(), Box<dyn std::error::Error>> {
+    let module =
+        build_with_provider_operation(PROVIDER_FIXTURE_SOURCE, &["app"], bir::ProviderActivationState::Active)?;
+
+    let plans = provider_plans(&module, "run");
+    let [plan] = plans.as_slice() else {
+        return Err(Box::from(format!(
+            "expected one provider-operation plan, got {}",
+            plans.len()
+        )));
+    };
+
+    assert_eq!(plan.operation.declaration_name, "charge");
+    assert_eq!(
+        plan.operation.origin,
+        incan_semantics_core::SymbolOrigin::Module(vec!["app".to_string()]),
+        "the plan must name the declaration the call resolved to, not the call-site spelling"
+    );
+    assert_eq!(plan.provider.state, bir::ProviderActivationState::Active);
+    assert_eq!(
+        plan.provider.provider_key,
+        "fixture_provider@0.1.0#fixture:provider-operation[]"
+    );
+    assert_eq!(
+        plan.required_capability.kind,
+        SemanticSourceTargetKind::Capability,
+        "the plan's required authority must name a capability declaration"
+    );
+    assert!(
+        plan.runtime_requirements.is_empty(),
+        "the first provider-operation contract does not infer runtime requirements from a source spelling"
+    );
+
+    // The declaration's own body must still lower, and the plan must name it rather than shadow it.
+    let declaration = module
+        .body_for_canonical_target(&plan.operation)
+        .ok_or_else(|| Box::<dyn std::error::Error>::from("this module owns the operation and must resolve it"))?;
+    assert_eq!(declaration.name, "charge");
+    Ok(())
+}
+
+/// Consumer lowering uses the provider manifest's declaration identity, even though the caller only wrote an import.
+#[test]
+fn an_imported_provider_operation_lowers_from_the_selected_provider_manifest() -> Result<(), Box<dyn std::error::Error>>
+{
+    let provider_source = r#"
+capability charge_card:
+  description = "Charge one approved card"
+
+@provider_operation(charge_card)
+pub def charge(account: str, amount: int) -> int:
+  return amount
+"#;
+    let consumer_source = r#"
+from provider import charge
+
+def run() -> int:
+  return charge("acct-1", 250)
+"#;
+    let provider_tokens = lexer::lex(provider_source).map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+    let provider_program =
+        parser::parse(&provider_tokens).map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+    let mut provider_checker = TypeChecker::new();
+    provider_checker.set_current_module_path(Some(vec!["provider".to_string()]));
+    provider_checker
+        .check_program(&provider_program)
+        .map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+    let provider_plan =
+        provider_plan_from_checked_source(provider_checker.type_info(), bir::ProviderActivationState::Active)?;
+
+    let consumer_tokens = lexer::lex(consumer_source).map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+    let consumer_program =
+        parser::parse(&consumer_tokens).map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+    let mut consumer_checker = TypeChecker::new();
+    let consumer_module_path = vec!["app".to_string()];
+    consumer_checker.set_current_module_path(Some(consumer_module_path.clone()));
+    consumer_checker.register_dependency_module_path_segments("provider", vec!["provider".to_string()]);
+    consumer_checker
+        .check_with_imports(&consumer_program, &[("provider", &provider_program)])
+        .map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+    assert!(
+        consumer_checker
+            .type_info()
+            .declarations
+            .function_bindings
+            .contains_key("charge"),
+        "an imported function must retain its checked signature for argument planning"
+    );
+
+    let module = build_body_ir_module_v0_with_provider_plan(
+        &consumer_program,
+        &consumer_module_path,
+        consumer_checker.type_info(),
+        &provider_plan,
+    )?;
+    let plans = provider_plans(&module, "run");
+    let [plan] = plans.as_slice() else {
+        return Err(Box::from(format!(
+            "expected one imported provider plan, got {}; lowered body: {}",
+            plans.len(),
+            module.render_snapshot()
+        )));
+    };
+    assert_eq!(
+        plan.operation.origin,
+        incan_semantics_core::SymbolOrigin::Module(vec!["provider".to_string()]),
+        "the plan must preserve the provider declaration identity, not the consumer import spelling"
+    );
+    assert_eq!(plan.required_capability.declaration_name, "charge_card");
+    assert_eq!(plan.provider.module_path, vec!["provider".to_string()]);
+    Ok(())
+}
+
+/// The plan describes each evaluated input by slot, evaluation order, checked type, and its own span.
+#[test]
+fn a_plan_records_every_evaluated_input_fact() -> Result<(), Box<dyn std::error::Error>> {
+    let module =
+        build_with_provider_operation(PROVIDER_FIXTURE_SOURCE, &["app"], bir::ProviderActivationState::Active)?;
+
+    let plans = provider_plans(&module, "run");
+    let [plan] = plans.as_slice() else {
+        return Err(Box::from("expected one provider-operation plan".to_string()));
+    };
+    let [account, amount] = plan.inputs.as_slice() else {
+        return Err(Box::from(format!(
+            "expected two evaluated inputs, got {}",
+            plan.inputs.len()
+        )));
+    };
+
+    assert_eq!((account.slot, account.written_position), (0, 0));
+    assert_eq!((amount.slot, amount.written_position), (1, 1));
+    assert_eq!(account.ty, IncanType::Primitive(IncanPrimitiveType::Str));
+    assert_eq!(amount.ty, IncanType::Primitive(IncanPrimitiveType::Int));
+    assert!(
+        account.span.start < amount.span.start && amount.span.end <= plan.call_span.end,
+        "each input must carry its own argument span inside the call: {:?}",
+        plan.inputs
+    );
+    Ok(())
+}
+
+/// Named provider arguments preserve source evaluation order even though their operands are emitted by declaration
+/// slot. The plan is the bridge between those two orders, so losing either fact would let a consumer reorder effects
+/// or ownership decisions.
+#[test]
+fn a_provider_plan_preserves_reversed_named_argument_evaluation_and_ownership() -> Result<(), Box<dyn std::error::Error>>
+{
+    let source = r#"
+capability charge_card:
+  description = "Charge one approved card"
+
+@provider_operation(charge_card)
+def charge(account: str, memo: str) -> int:
+  return 1
+
+def first() -> str:
+  return "first"
+
+def second() -> str:
+  return "second"
+
+def run() -> int:
+  return charge(memo=first(), account=second())
+"#;
+    let module = build_with_provider_operation(source, &["app"], bir::ProviderActivationState::Active)?;
+    let body = body_named(&module, "run")?;
+    let rendered = body.render_snapshot();
+    let first_at = rendered
+        .find("call fn:first(")
+        .ok_or("missing first argument evaluation")?;
+    let second_at = rendered
+        .find("call fn:second(")
+        .ok_or("missing second argument evaluation")?;
+    assert!(
+        first_at < second_at,
+        "named arguments must evaluate in written source order: {rendered}"
+    );
+
+    let plans = provider_plans(&module, "run");
+    let [plan] = plans.as_slice() else {
+        return Err(Box::from("expected one provider-operation plan".to_string()));
+    };
+    assert_eq!(
+        plan.inputs
+            .iter()
+            .map(|input| (input.slot, input.written_position))
+            .collect::<Vec<_>>(),
+        vec![(1, 0), (0, 1)],
+        "the plan must retain written order separately from declaration slots: {:?}",
+        plan.inputs
+    );
+
+    let provider_call = body
+        .block
+        .stmts
+        .iter()
+        .find_map(|statement| match &statement.kind {
+            bir::StatementKind::Call {
+                callee: bir::Callee::ProviderOperation(_),
+                args,
+                ..
+            } => Some(args),
+            _ => None,
+        })
+        .ok_or("missing provider-operation call")?;
+    let [
+        bir::ArgumentElement::One(bir::Operand::Place(account)),
+        bir::ArgumentElement::One(bir::Operand::Place(memo)),
+    ] = provider_call.as_slice()
+    else {
+        return Err(Box::from(format!(
+            "expected two declared-slot provider operands, got {provider_call:?}"
+        )));
+    };
+    assert_eq!(
+        (account.fact, account.last_use, memo.fact, memo.last_use),
+        (bir::OwnershipFact::Move, true, bir::OwnershipFact::Move, true),
+        "the declaration-slot operands must retain the ownership facts from their written evaluations"
+    );
+    Ok(())
+}
+
 #[test]
 fn every_assert_form_records_a_panic_fact_and_the_panic_strategy_requirement() -> Result<(), Box<dyn std::error::Error>>
 {
@@ -5431,6 +5806,147 @@ fn every_assert_form_records_a_panic_fact_and_the_panic_strategy_requirement() -
     Ok(())
 }
 
+/// The plan phrases the RFC 104 authority question at the invocation, which is what #1156 executes from.
+#[test]
+fn a_plan_yields_an_authority_request_for_the_invocation() -> Result<(), Box<dyn std::error::Error>> {
+    let module =
+        build_with_provider_operation(PROVIDER_FIXTURE_SOURCE, &["app"], bir::ProviderActivationState::Active)?;
+
+    let plans = provider_plans(&module, "run");
+    let [plan] = plans.as_slice() else {
+        return Err(Box::from("expected one provider-operation plan".to_string()));
+    };
+    let request = plan.authority_request();
+
+    assert_eq!(request.capability, plan.required_capability);
+    assert_eq!(request.operation, plan.operation);
+    assert_eq!(request.request_span, plan.call_span);
+    assert_eq!(request.suggested_grant, "app.charge_card");
+    Ok(())
+}
+
+/// Invoking an admitted operation preserves the runtime requirements published by its descriptor.
+#[test]
+fn invoking_a_provider_operation_preserves_its_published_runtime_requirements_on_the_caller()
+-> Result<(), Box<dyn std::error::Error>> {
+    let module =
+        build_with_provider_operation(PROVIDER_FIXTURE_SOURCE, &["app"], bir::ProviderActivationState::Active)?;
+
+    let caller = module
+        .bodies
+        .iter()
+        .find(|body| body.name == "run")
+        .ok_or_else(|| Box::<dyn std::error::Error>::from("the calling body must lower"))?;
+
+    assert!(
+        caller.runtime_requirements.is_empty(),
+        "the fixture publishes no runtime requirement, so lowering must not invent one: {:?}",
+        caller.runtime_requirements
+    );
+    Ok(())
+}
+
+/// A call the catalog does not admit stays an ordinary named call: nothing may become a plan by spelling alone.
+#[test]
+fn an_operation_the_catalog_does_not_admit_stays_an_ordinary_call() -> Result<(), Box<dyn std::error::Error>> {
+    let module = build(PROVIDER_FIXTURE_SOURCE, &["app"])?;
+
+    assert!(
+        provider_plans(&module, "run").is_empty(),
+        "an empty catalog must admit nothing"
+    );
+    assert_eq!(
+        named_targets(&module, "run").len(),
+        1,
+        "the call must still lower normally"
+    );
+    assert!(refusal_descriptions(&module, "run").is_empty());
+    Ok(())
+}
+
+/// A disabled provider stops the operation at its source span, with no plan and so nothing to execute.
+#[test]
+fn an_operation_whose_provider_is_disabled_refuses_before_execution() -> Result<(), Box<dyn std::error::Error>> {
+    let module = build_with_provider_operation(
+        PROVIDER_FIXTURE_SOURCE,
+        &["app"],
+        bir::ProviderActivationState::Disabled,
+    )?;
+
+    assert!(
+        provider_plans(&module, "run").is_empty(),
+        "a refused operation must produce no plan, and so no execution and no receipt"
+    );
+    let refusals = refusal_descriptions(&module, "run");
+    assert!(
+        refusals.iter().any(|description| description.contains("not enabled")),
+        "the refusal must name why the operation cannot run: {refusals:?}"
+    );
+    Ok(())
+}
+
+/// Provider admission is decided before lowering an argument expression. Otherwise a disabled operation could
+/// still run source-observable work merely while constructing an execution plan that will never exist.
+#[test]
+fn a_disabled_provider_refuses_at_the_call_span_before_lowering_arguments() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+capability charge_card:
+  description = "Charge one approved card"
+
+@provider_operation(charge_card)
+def charge(account: str, amount: int) -> int:
+  return amount
+
+def side_effect() -> str:
+  return "acct-1"
+
+def run() -> int:
+  return charge(side_effect(), 250)
+"#;
+    let module = build_with_provider_operation(source, &["app"], bir::ProviderActivationState::Disabled)?;
+    let body = body_named(&module, "run")?;
+    let refusal = body
+        .block
+        .stmts
+        .iter()
+        .find(|statement| matches!(statement.kind, bir::StatementKind::Unsupported { .. }))
+        .ok_or("disabled provider call must lower to an explicit refusal")?;
+    let expected_start = source.find("charge(side_effect()").ok_or("fixture call missing")?;
+    assert_eq!(
+        refusal.span.start, expected_start,
+        "the refusal must keep the provider call's source span rather than an argument span"
+    );
+    assert!(
+        named_targets(&module, "run")
+            .iter()
+            .all(|target| target.name != "side_effect"),
+        "argument expressions must not be lowered after provider admission refused: {}",
+        body.render_snapshot()
+    );
+    assert!(provider_plans(&module, "run").is_empty());
+    Ok(())
+}
+
+/// An unavailable provider is refused separately from a disabled one, because the two have different remedies.
+#[test]
+fn an_operation_whose_provider_is_unavailable_refuses_with_its_own_reason() -> Result<(), Box<dyn std::error::Error>> {
+    let module = build_with_provider_operation(
+        PROVIDER_FIXTURE_SOURCE,
+        &["app"],
+        bir::ProviderActivationState::Unavailable,
+    )?;
+
+    assert!(provider_plans(&module, "run").is_empty());
+    let refusals = refusal_descriptions(&module, "run");
+    assert!(
+        refusals
+            .iter()
+            .any(|description| description.contains("no locally available artifact")),
+        "an unavailable provider must not be reported as a disabled one: {refusals:?}"
+    );
+    Ok(())
+}
+
 #[test]
 fn an_unresolved_raises_error_type_refuses_by_naming_the_assert_form() -> Result<(), Box<dyn std::error::Error>> {
     // The source checker rejects an error type outside the builtin-exception registry, so lowering only reaches
@@ -5451,6 +5967,195 @@ fn an_unresolved_raises_error_type_refuses_by_naming_the_assert_form() -> Result
     assert!(
         !snapshot.contains("assert pattern/raises form"),
         "the shared label that could not distinguish the two forms is gone: {snapshot}"
+    );
+    Ok(())
+}
+
+/// Corrupt provider metadata whose authority is not a capability is rejected before lowering can mint a plan.
+#[test]
+fn corrupt_provider_metadata_with_a_non_capability_authority_is_rejected() -> Result<(), Box<dyn std::error::Error>> {
+    let tokens = lexer::lex(PROVIDER_FIXTURE_SOURCE).map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+    let program = parser::parse(&tokens).map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+    let module_path = vec!["app".to_string()];
+    let mut checker = TypeChecker::new();
+    checker.set_current_module_path(Some(module_path));
+    checker
+        .check_program(&program)
+        .map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+    let mut provider_plan =
+        provider_plan_from_checked_source(checker.type_info(), bir::ProviderActivationState::Active)?;
+    let provider = provider_plan
+        .records()
+        .next()
+        .ok_or("fixture provider plan must have one record")?;
+    let mut manifest = provider
+        .manifest
+        .as_deref()
+        .cloned()
+        .ok_or("fixture provider must have a manifest")?;
+    manifest.contract_metadata.provider.operation_descriptors[0]
+        .required_capability
+        .kind = SemanticSourceTargetKind::Function;
+
+    use std::collections::BTreeSet;
+    use std::sync::Arc;
+
+    use crate::frontend::library_manifest_index::LibraryManifestIndex;
+    use crate::provider::{NamespaceAuthority, ProviderIdentity, ProviderProvenance, ProviderRecord};
+
+    provider_plan = ProviderPlan::new(
+        LibraryManifestIndex::default(),
+        vec![ProviderRecord {
+            identity: ProviderIdentity {
+                name: "fixture_provider".to_string(),
+                version: "0.1.0".to_string(),
+                digest: "fixture:provider-operation".to_string(),
+                feature_projection: BTreeSet::new(),
+            },
+            provenance: ProviderProvenance::Compiler,
+            authority: NamespaceAuthority::Compiler,
+            namespace_claims: BTreeSet::from([vec!["app".to_string()]]),
+            available: true,
+            enabled: true,
+            manifest: Some(Arc::new(manifest)),
+            artifact: None,
+            implementation_facets: Vec::new(),
+        }],
+        [vec!["app".to_string()]],
+    )?;
+    let error = ProviderOperationCatalog::from_provider_plan(&provider_plan)
+        .expect_err("corrupt metadata must not create a lowering catalog");
+    assert!(
+        error.contains("unsupported declaration kinds"),
+        "unexpected error: {error}"
+    );
+    Ok(())
+}
+
+/// A selected provider cannot publish one callable identity twice. Refusing at plan projection makes the result
+/// independent of manifest traversal order and prevents a Body-IR call from silently choosing one provider record.
+#[test]
+fn duplicate_provider_operation_identities_refuse_before_body_ir_building() -> Result<(), Box<dyn std::error::Error>> {
+    use std::sync::Arc;
+
+    use crate::frontend::library_manifest_index::LibraryManifestIndex;
+
+    let tokens = lexer::lex(PROVIDER_FIXTURE_SOURCE).map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+    let program = parser::parse(&tokens).map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+    let module_path = vec!["app".to_string()];
+    let mut checker = TypeChecker::new();
+    checker.set_current_module_path(Some(module_path.clone()));
+    checker
+        .check_program(&program)
+        .map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+    let provider_plan = provider_plan_from_checked_source(checker.type_info(), bir::ProviderActivationState::Active)?;
+    let mut provider = provider_plan
+        .records()
+        .next()
+        .cloned()
+        .ok_or("fixture provider plan must have one provider")?;
+    let manifest = Arc::make_mut(
+        provider
+            .manifest
+            .as_mut()
+            .ok_or("fixture provider must have a manifest")?,
+    );
+    let duplicate = manifest.contract_metadata.provider.operation_descriptors[0].clone();
+    manifest
+        .contract_metadata
+        .provider
+        .operation_descriptors
+        .push(duplicate);
+    let namespace_claims = provider.namespace_claims.clone();
+    let colliding_plan = ProviderPlan::new(LibraryManifestIndex::default(), vec![provider], namespace_claims)?;
+
+    let error =
+        build_body_ir_module_v0_with_provider_plan(&program, &module_path, checker.type_info(), &colliding_plan)
+            .expect_err("a duplicate canonical operation identity must not pick one manifest entry");
+    assert!(
+        error.contains("duplicate provider operation identity `charge`"),
+        "unexpected collision refusal: {error}"
+    );
+    Ok(())
+}
+
+/// An omitted parameter has no evaluated input, so the plan cannot honestly describe what would execute.
+#[test]
+fn an_operation_called_with_an_omitted_default_refuses() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+capability charge_card:
+  description = "Charge one approved card"
+
+@provider_operation(charge_card)
+def charge(account: str, amount: int = 1) -> int:
+  return amount
+
+def run() -> int:
+  return charge("acct-1")
+"#;
+    let module = build_with_provider_operation(source, &["app"], bir::ProviderActivationState::Active)?;
+
+    assert!(provider_plans(&module, "run").is_empty());
+    let refusals = refusal_descriptions(&module, "run");
+    assert!(
+        refusals
+            .iter()
+            .any(|description| description.contains("omitted parameter")),
+        "unexpected refusal: {refusals:?}"
+    );
+    Ok(())
+}
+
+/// A callee the typechecker never resolved has no identity, so it cannot become a plan by sharing a spelling.
+///
+/// The catalog holds a real entry throughout, and the call site writes a name the module does not declare. Nothing
+/// about the two spellings is allowed to bring them together: admission runs on canonical identity, and an
+/// unresolved callee has none.
+///
+/// The refusal here is genuinely *source-owned*: the typechecker rejects the program before lowering runs. Body IR
+/// deliberately does not raise a second diagnostic for the same gap — see
+/// [`BodyBuilder::declared_slots_for_direct_call`], which keeps the ordinary named-call representation with no proven
+/// identity so the executor refuses it at the original call span. What this pins is that no plan is minted, so nothing
+/// exists that could execute or report.
+#[test]
+fn an_unresolved_operation_refuses_at_its_source_span_and_produces_no_plan() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+capability charge_card:
+  description = "Charge one approved card"
+
+@provider_operation(charge_card)
+def charge(account: str, amount: int) -> int:
+  return amount
+
+def run() -> int:
+  return charge_now("acct-1", 250)
+"#;
+    let tokens = lexer::lex(source).map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+    let program = parser::parse(&tokens).map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+    let module_path = vec!["app".to_string()];
+    let mut checker = TypeChecker::new();
+    checker.set_current_module_path(Some(module_path.clone()));
+    let diagnostics = checker
+        .check_program(&program)
+        .err()
+        .ok_or("the fixture calls an undeclared name and must be rejected by the source checker")?;
+    assert!(!diagnostics.is_empty(), "the refusal must be source-owned first");
+
+    let provider_plan = provider_plan_from_checked_source(checker.type_info(), bir::ProviderActivationState::Active)?;
+    let module =
+        build_body_ir_module_v0_with_provider_plan(&program, &module_path, checker.type_info(), &provider_plan)?;
+
+    assert!(
+        provider_plans(&module, "run").is_empty(),
+        "an unresolved callee must never be admitted as an operation the catalog holds under another identity"
+    );
+    let targets = named_targets(&module, "run");
+    let [target] = targets.as_slice() else {
+        return Err(Box::from(format!("expected one named call, got {}", targets.len())));
+    };
+    assert!(
+        target.canonical.is_none() && target.direct_call_id.is_none(),
+        "an unresolved callee must carry no identity for anything downstream to admit it by"
     );
     Ok(())
 }

--- a/src/frontend/typechecker/check_decl.rs
+++ b/src/frontend/typechecker/check_decl.rs
@@ -15,7 +15,8 @@ use crate::frontend::typechecker::helpers::{collection_type_id, dict_ty, list_ty
 use super::collect::decorators::resolve_decorator_id;
 use super::collect::{capability_description_text, dotted_path_segments};
 use super::type_info::{
-    RegistryDefinitionInfo, RegistryDescriptionInfo, RegistryDescriptionRegistry, RegistryExplicitEntryInfo,
+    ProviderOperationDeclarationInfo, RegistryDefinitionInfo, RegistryDescriptionInfo, RegistryDescriptionRegistry,
+    RegistryExplicitEntryInfo,
 };
 use super::{
     DecoratedFunctionBindingInfo, DecoratedMethodBindingInfo, FunctionBindingInfo, TestingFixtureInfo, TypeChecker,
@@ -30,7 +31,7 @@ use incan_core::lang::surface::constructors::{self, ConstructorId};
 use incan_core::lang::testing;
 use incan_core::lang::traits::{self as builtin_traits, TraitId};
 use incan_core::lang::types::collections::CollectionTypeId;
-use incan_semantics_core::SemanticSourceTargetKind;
+use incan_semantics_core::{CanonicalSymbolId, HirSourceSpan, SemanticSourceTargetKind};
 use incan_semantics_core::{SemanticRegistrySubjectKind, SemanticRegistryValue, SurfaceModifierTypeCheck};
 use std::collections::{HashMap, HashSet};
 
@@ -5125,6 +5126,127 @@ impl TypeChecker {
         }
     }
 
+    /// Record the checked capability requirement for one provider operation.
+    ///
+    /// `@provider_operation(capability.path)` is deliberately a declaration attachment rather than a convention on a
+    /// callable or module name. The typechecker resolves the capability at the producer declaration site and carries
+    /// the resulting canonical identities into provider metadata; later consumers never need to reinterpret the
+    /// decorator or recover meaning from a backend projection.
+    fn check_provider_operation_decorators(&mut self, func: &FunctionDecl, decl_span: Span) {
+        let decorators = func
+            .decorators
+            .iter()
+            .filter(|decorator| {
+                self.decorator_id_with_import_aliases(&decorator.node) == Some(DecoratorId::ProviderOperation)
+            })
+            .collect::<Vec<_>>();
+        if decorators.is_empty() {
+            return;
+        }
+        if decorators.len() > 1 {
+            for decorator in decorators {
+                self.errors.push(CompileError::type_error(
+                    "a provider function may declare only one @provider_operation capability".to_string(),
+                    decorator.span,
+                ));
+            }
+            return;
+        }
+        let decorator = decorators[0];
+        let [DecoratorArg::Positional(capability)] = decorator.node.args.as_slice() else {
+            self.errors.push(CompileError::type_error(
+                "@provider_operation requires exactly one capability reference".to_string(),
+                decorator.span,
+            ));
+            return;
+        };
+        let Some(path) = dotted_path_segments(&capability.node) else {
+            self.errors.push(CompileError::type_error(
+                "@provider_operation capability must be a checked capability reference, not a value expression"
+                    .to_string(),
+                capability.span,
+            ));
+            return;
+        };
+        let Some(required_capability) = self.provider_operation_capability_identity(&path, capability.span) else {
+            return;
+        };
+        let Some(module_path) = self.current_module_path.clone() else {
+            self.errors.push(CompileError::type_error(
+                "@provider_operation requires a compiler-known module identity".to_string(),
+                decorator.span,
+            ));
+            return;
+        };
+        let operation = CanonicalSymbolId::module_declaration(
+            module_path,
+            func.name.clone(),
+            SemanticSourceTargetKind::Function,
+            HirSourceSpan::new(decl_span.start, decl_span.end),
+        );
+        self.type_info.declarations.provider_operations.insert(
+            operation.clone(),
+            ProviderOperationDeclarationInfo {
+                operation,
+                required_capability,
+                runtime_requirements: Vec::new(),
+            },
+        );
+    }
+
+    /// Resolve an operation decorator's capability reference to the declaration identity it actually names.
+    fn provider_operation_capability_identity(&mut self, path: &[String], span: Span) -> Option<CanonicalSymbolId> {
+        let rendered = path.join(".");
+        let (name, module) = path.split_last()?;
+        if module.is_empty() {
+            let Some(symbol) = self.lookup_symbol(name).cloned() else {
+                self.errors.push(CompileError::type_error(
+                    format!("@provider_operation capability `{rendered}` is unresolved"),
+                    span,
+                ));
+                return None;
+            };
+            if !matches!(symbol.kind, SymbolKind::Capability(_)) {
+                self.errors.push(CompileError::type_error(
+                    format!("@provider_operation reference `{rendered}` does not name a capability"),
+                    span,
+                ));
+                return None;
+            }
+            let Some(module_path) = self.current_module_path.clone() else {
+                self.errors.push(CompileError::type_error(
+                    "@provider_operation requires a compiler-known module identity".to_string(),
+                    span,
+                ));
+                return None;
+            };
+            return Some(CanonicalSymbolId::module_declaration(
+                module_path,
+                name.clone(),
+                SemanticSourceTargetKind::Capability,
+                HirSourceSpan::new(symbol.span.start, symbol.span.end),
+            ));
+        }
+        let import = ImportPath::simple(module.to_vec());
+        match self.dependency_member_identity(&import, name) {
+            Some(identity) if identity.kind == SemanticSourceTargetKind::Capability => Some(identity),
+            Some(_) => {
+                self.errors.push(CompileError::type_error(
+                    format!("@provider_operation reference `{rendered}` does not name a capability"),
+                    span,
+                ));
+                None
+            }
+            None => {
+                self.errors.push(CompileError::type_error(
+                    format!("@provider_operation capability `{rendered}` is unresolved"),
+                    span,
+                ));
+                None
+            }
+        }
+    }
+
     /// Reject `@describe` where RFC 113 has no stable source subject yet.
     ///
     /// The decorator resolver deliberately recognises compiler-owned decorators on broad syntactic targets. Keeping
@@ -5323,6 +5445,7 @@ impl TypeChecker {
             decl_span,
             SemanticRegistrySubjectKind::Function,
         );
+        self.check_provider_operation_decorators(func, decl_span);
         self.validate_callable_rest_params(&func.params);
         let fixture_span = fixture_function_span(func);
         let fixture_args = self.testing_fixture_marker_args(&func.decorators, fixture_span);

--- a/src/frontend/typechecker/collect.rs
+++ b/src/frontend/typechecker/collect.rs
@@ -250,6 +250,34 @@ impl TypeChecker {
             .record_function_overloads(local_name.to_string(), overloads.to_vec());
     }
 
+    /// Preserve the checked callable surface for an imported source binding.
+    ///
+    /// Local and imported functions both need a declaration-slot surface for later call lowering. The canonical
+    /// owner of an import is recorded separately, but its parameter facts must travel with the local binding too:
+    /// a caller cannot describe evaluated inputs against an identity alone. Overload bindings retain their existing
+    /// dedicated table because a bare source name cannot distinguish their declaration spans.
+    pub(in crate::frontend::typechecker) fn record_imported_function_binding(
+        &mut self,
+        local_name: &str,
+        kind: &SymbolKind,
+    ) {
+        match kind {
+            SymbolKind::Function(info) => {
+                self.type_info.declarations.function_bindings.insert(
+                    local_name.to_string(),
+                    FunctionBindingInfo {
+                        params: info.params.clone(),
+                        return_type: info.return_type.clone(),
+                    },
+                );
+            }
+            SymbolKind::FunctionOverloads(overloads) => {
+                self.record_function_overload_binding(local_name, overloads, true);
+            }
+            _ => {}
+        }
+    }
+
     /// Resolve an alias target path to the semantic symbol kind it projects.
     ///
     /// Single-segment targets use ordinary module-scope lookup. Qualified targets must begin with an imported module

--- a/src/frontend/typechecker/collect/stdlib_imports.rs
+++ b/src/frontend/typechecker/collect/stdlib_imports.rs
@@ -767,9 +767,7 @@ impl TypeChecker {
 
         let local_name = Self::import_item_local_name(item);
         self.record_testing_marker_import(context, item, &local_name, testing_semantics);
-        if let SymbolKind::FunctionOverloads(overloads) = &kind {
-            self.record_function_overload_binding(&local_name, overloads, true);
-        }
+        self.record_imported_function_binding(&local_name, &kind);
         if matches!(kind, SymbolKind::Static(_)) {
             self.type_info.declarations.static_bindings.insert(
                 local_name.clone(),
@@ -852,9 +850,7 @@ impl TypeChecker {
             let local_name = Self::import_item_local_name(item);
             let surface_function = surface_functions::from_str(&item.name);
             self.record_testing_marker_import(context, item, &local_name, testing_semantics);
-            if let SymbolKind::FunctionOverloads(overloads) = &kind {
-                self.record_function_overload_binding(&local_name, overloads, true);
-            }
+            self.record_imported_function_binding(&local_name, &kind);
             let symbol_id = self.define_named_import_symbol(local_name.clone(), kind, span);
             if let Some(surface_function) = surface_function {
                 self.surface_function_import_bindings
@@ -1052,9 +1048,7 @@ impl TypeChecker {
             );
             self.record_resolved_import_owner(module, item, &local_name);
         }
-        if let SymbolKind::FunctionOverloads(overloads) = &kind {
-            self.record_function_overload_binding(&local_name, overloads, true);
-        }
+        self.record_imported_function_binding(&local_name, &kind);
         if let SymbolKind::Static(info) = &mut kind {
             info.is_imported = true;
             self.type_info.declarations.static_bindings.insert(
@@ -1449,9 +1443,7 @@ impl TypeChecker {
 
             if let Some(mut kind) = flat_function {
                 self.remap_symbol_kind_with_import_aliases(&mut kind, &imported_type_aliases);
-                if let SymbolKind::FunctionOverloads(overloads) = &kind {
-                    self.record_function_overload_binding(&local_name, overloads, true);
-                }
+                self.record_imported_function_binding(&local_name, &kind);
                 self.symbols.define(Symbol {
                     name: local_name,
                     kind,
@@ -1504,9 +1496,7 @@ impl TypeChecker {
         }
 
         let mut kind = member.kind;
-        if let SymbolKind::FunctionOverloads(overloads) = &kind {
-            self.record_function_overload_binding(&local_name, overloads, true);
-        }
+        self.record_imported_function_binding(&local_name, &kind);
         if let Some(mut projection) = member.partial_projection {
             projection.name.clone_from(&local_name);
             self.type_info.record_partial_projection(projection);
@@ -2458,9 +2448,7 @@ impl TypeChecker {
             self.define_rust_import_binding(local_name, info, span);
             return;
         }
-        if let SymbolKind::FunctionOverloads(overloads) = &kind {
-            self.record_function_overload_binding(&local_name, overloads, true);
-        }
+        self.record_imported_function_binding(&local_name, &kind);
         if let Some(projection) = partial_projection {
             self.type_info.record_partial_projection(projection);
         }

--- a/src/frontend/typechecker/mod.rs
+++ b/src/frontend/typechecker/mod.rs
@@ -62,11 +62,11 @@ pub use type_info::{
     CBindingSymbol, CBindingType, COutputMode, CResourceAccess, ComputedPropertyAccessInfo,
     DecoratedFunctionBindingInfo, DecoratedMethodBindingInfo, FixedUnpackPlan, FunctionBindingInfo, IdentKind,
     ImportedRegistryDefinitionInfo, PartialProjectionInfo, PartialProjectionPreset, PartialProjectionTargetKind,
-    ProtocolIterationInfo, RegistryArtifacts, RegistryDefinitionInfo, RegistryDescriptionRegistry,
-    RegistryExplicitEntryInfo, ResolvedMethodCall, ResolvedMethodDispatch, ResolvedOperatorCall, ResolvedOperatorKind,
-    RustArgCoercionInfo, RustArgCoercionKind, SourceTargetInfo, StaticBindingInfo, TestingFixtureInfo, TypeCheckInfo,
-    ValidatedNewtypeCoercionInfo, ValidatedNewtypeCoercionMode, ValidatedNewtypeCoercionStep,
-    c_binding_descriptor_identity,
+    ProtocolIterationInfo, ProviderOperationDeclarationInfo, RegistryArtifacts, RegistryDefinitionInfo,
+    RegistryDescriptionRegistry, RegistryExplicitEntryInfo, ResolvedMethodCall, ResolvedMethodDispatch,
+    ResolvedOperatorCall, ResolvedOperatorKind, RustArgCoercionInfo, RustArgCoercionKind, SourceTargetInfo,
+    StaticBindingInfo, TestingFixtureInfo, TypeCheckInfo, ValidatedNewtypeCoercionInfo, ValidatedNewtypeCoercionMode,
+    ValidatedNewtypeCoercionStep, c_binding_descriptor_identity,
 };
 pub(crate) use type_info::{ClassFieldDefaultInfo, semantic_type_from_resolved};
 #[cfg(test)]

--- a/src/frontend/typechecker/tests.rs
+++ b/src/frontend/typechecker/tests.rs
@@ -22452,6 +22452,75 @@ fn a_capability_symbol_carries_the_canonical_capability_identity_kind() {
     );
 }
 
+/// Provider-operation metadata is a checked declaration fact, not a naming convention reconstructed by Body IR.
+#[test]
+fn provider_operation_decorator_resolves_and_records_its_capability_identity() -> Result<(), String> {
+    let source = r#"
+capability charge_card:
+    description = "Charge one approved card"
+
+@provider_operation(charge_card)
+pub def charge(amount: int) -> int:
+    return amount
+"#;
+    let tokens = lexer::lex(source).map_err(|errs| format!("lex failed: {errs:?}"))?;
+    let program = parser::parse(&tokens).map_err(|errs| format!("parse failed: {errs:?}"))?;
+    let mut checker = TypeChecker::new();
+    checker.set_current_module_path(Some(vec!["ledger".to_string(), "api".to_string()]));
+    checker
+        .check_program(&program)
+        .map_err(|errs| format!("provider operation should typecheck: {errs:?}"))?;
+
+    let operations = &checker.type_info().declarations.provider_operations;
+    let collected = operations.values().collect::<Vec<_>>();
+    let [operation] = collected.as_slice() else {
+        return Err(format!("expected one checked provider operation, got {operations:?}"));
+    };
+    assert_eq!(operation.operation.kind, SemanticSourceTargetKind::Function);
+    assert_eq!(
+        operation.operation.module_path(),
+        Some(vec!["ledger".to_string(), "api".to_string()].as_slice())
+    );
+    assert_eq!(operation.operation.declaration_name, "charge");
+    assert_eq!(operation.required_capability.kind, SemanticSourceTargetKind::Capability);
+    assert_eq!(
+        operation.required_capability.module_path(),
+        Some(vec!["ledger".to_string(), "api".to_string()].as_slice())
+    );
+    assert_eq!(operation.required_capability.declaration_name, "charge_card");
+    assert!(operation.runtime_requirements.is_empty());
+    Ok(())
+}
+
+/// A provider operation may only name a resolved RFC 104 capability, never a callable or a stringly value.
+#[test]
+fn provider_operation_decorator_rejects_a_non_capability_reference() -> Result<(), String> {
+    let source = r#"
+def not_a_capability() -> int:
+    return 1
+
+@provider_operation(not_a_capability)
+def charge(amount: int) -> int:
+    return amount
+"#;
+    let tokens = lexer::lex(source).map_err(|errs| format!("lex failed: {errs:?}"))?;
+    let program = parser::parse(&tokens).map_err(|errs| format!("parse failed: {errs:?}"))?;
+    let mut checker = TypeChecker::new();
+    checker.set_current_module_path(Some(vec!["ledger".to_string(), "api".to_string()]));
+    let errors = checker
+        .check_program(&program)
+        .err()
+        .ok_or("a non-capability provider-operation reference must fail")?;
+    assert!(
+        errors
+            .iter()
+            .any(|error| error.message.contains("does not name a capability")),
+        "unexpected diagnostics: {errors:?}"
+    );
+    assert!(checker.type_info().declarations.provider_operations.is_empty());
+    Ok(())
+}
+
 /// A capability names an authority, so a bare reference to one is never a value use.
 #[test]
 fn referencing_a_capability_as_a_value_is_rejected() {

--- a/src/frontend/typechecker/type_info.rs
+++ b/src/frontend/typechecker/type_info.rs
@@ -3,7 +3,7 @@
 //! This module contains the reusable semantic metadata that later compiler stages consume after typechecking. It keeps
 //! the cross-phase snapshot surface separate from the main [`TypeChecker`](super::TypeChecker) orchestration state.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use sha2::{Digest, Sha256};
 
@@ -788,6 +788,11 @@ pub struct DeclarationArtifacts {
     /// written path, so the proven identity is recorded here and is simply absent when resolution did not prove one.
     /// A re-export resolves to the identity of the module that *declares* the member, never to the facade.
     pub resolved_import_identities: HashMap<String, CanonicalSymbolId>,
+    /// Checked provider-operation declarations, keyed by their provider function's canonical identity.
+    ///
+    /// This is the producer-side fact that package publication persists. Body-IR lowering consumes the resulting
+    /// provider-plan projection rather than re-reading a decorator or inferring an operation from a module name.
+    pub provider_operations: BTreeMap<CanonicalSymbolId, ProviderOperationDeclarationInfo>,
     /// Module-local function declarations keyed by declaration span, preserving same-name overloads.
     pub function_bindings_by_span: HashMap<(usize, usize), FunctionBindingInfo>,
     /// Concrete class/model/trait method declarations keyed by declaration span (#1121).
@@ -836,6 +841,23 @@ pub struct DeclarationArtifacts {
     pub decorated_function_bindings_by_span: HashMap<(usize, usize), DecoratedFunctionBindingInfo>,
     /// RFC 036: Method names whose declaration was rebound through a user-defined decorator chain.
     pub decorated_method_bindings: HashMap<(String, String), DecoratedMethodBindingInfo>,
+}
+
+/// One provider function's checked authority requirement.
+///
+/// The callable and capability are both resolved identities. The source decorator never contributes a stringly
+/// authority name to a backend; it only tells the typechecker which two already-resolved declarations are related.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderOperationDeclarationInfo {
+    /// Canonical identity of the provider function this declaration annotates.
+    pub operation: CanonicalSymbolId,
+    /// Canonical identity of the RFC 104 capability required to invoke that operation.
+    pub required_capability: CanonicalSymbolId,
+    /// Compiler-owned requirements the operation's runtime implementation imposes.
+    ///
+    /// The first vertical currently records none. A future declaration contract may add requirements only when it
+    /// has a checked source form; lowering must not infer them from a provider name or generated implementation.
+    pub runtime_requirements: Vec<incan_semantics_core::AbiV0RuntimeRequirement>,
 }
 
 /// Checked RFC 113 registry data that later stages consume without re-parsing decorator expressions.

--- a/src/library_manifest/model.rs
+++ b/src/library_manifest/model.rs
@@ -23,6 +23,7 @@ use crate::frontend::library_exports::{
 use crate::frontend::registry_metadata::CheckedRegistryMetadataPackage;
 use crate::frontend::symbols::{CallableParam, NewtypePrimitiveConstraint, ValueEnumBacking, ValueEnumValue};
 use incan_core::interop::RustItemMetadata;
+use incan_semantics_core::{AbiV0RuntimeRequirement, CanonicalSymbolId, SemanticSourceTargetKind};
 
 /// Errors surfaced while reading, writing, parsing, serializing, or validating `.incnlib` manifests.
 #[derive(Debug, thiserror::Error)]
@@ -216,6 +217,12 @@ pub struct CompiledProviderMetadata {
     /// Private backend mappings selected from semantic module and feature use.
     #[serde(default)]
     pub implementation_facets: Vec<ProviderImplementationFacet>,
+    /// Checked provider-call declarations that a consumer may lower into provider-operation plans.
+    ///
+    /// Each record was resolved at the provider declaration site. This payload is metadata, not a source convention:
+    /// consumers project it through their checked provider plan rather than matching a provider or operation spelling.
+    #[serde(default)]
+    pub operation_descriptors: Vec<ProviderOperationMetadata>,
 }
 
 impl Default for CompiledProviderMetadata {
@@ -230,6 +237,7 @@ impl Default for CompiledProviderMetadata {
             fact_requirements: Vec::new(),
             required_sdk_components: BTreeSet::new(),
             implementation_facets: Vec::new(),
+            operation_descriptors: Vec::new(),
         }
     }
 }
@@ -245,6 +253,32 @@ impl CompiledProviderMetadata {
             && self.fact_requirements.is_empty()
             && self.required_sdk_components.is_empty()
             && self.implementation_facets.is_empty()
+            && self.operation_descriptors.is_empty()
+    }
+}
+
+/// One provider function that has a checked RFC 104 operation requirement.
+///
+/// `CanonicalSymbolId` deliberately preserves the declaration anchors produced by the provider's compilation. A
+/// consumer obtains these facts only from the selected, integrity-checked provider manifest and uses them solely as
+/// an input to its current compilation's provider plan; it does not reconstruct either identity from a source or
+/// generated-name spelling.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProviderOperationMetadata {
+    /// Canonical provider-function declaration that identifies the operation.
+    pub operation: CanonicalSymbolId,
+    /// Canonical RFC 104 capability declaration required for an invocation.
+    pub required_capability: CanonicalSymbolId,
+    /// Backend-neutral requirements the checked operation declares.
+    #[serde(default)]
+    pub runtime_requirements: Vec<AbiV0RuntimeRequirement>,
+}
+
+impl ProviderOperationMetadata {
+    /// Return whether this descriptor carries the two declaration kinds an authority consumer can interpret.
+    pub fn has_expected_kinds(&self) -> bool {
+        self.operation.kind == SemanticSourceTargetKind::Function
+            && self.required_capability.kind == SemanticSourceTargetKind::Capability
     }
 }
 

--- a/src/library_manifest/tests.rs
+++ b/src/library_manifest/tests.rs
@@ -1448,6 +1448,21 @@ fn compiled_provider_metadata_roundtrips_feature_and_facet_facts() -> Result<(),
                 source: ProviderCargoDependencySource::Registry,
             }],
         }],
+        operation_descriptors: vec![ProviderOperationMetadata {
+            operation: incan_semantics_core::CanonicalSymbolId::module_declaration(
+                vec!["reports".to_string()],
+                "emit",
+                incan_semantics_core::SemanticSourceTargetKind::Function,
+                incan_semantics_core::HirSourceSpan::new(10, 14),
+            ),
+            required_capability: incan_semantics_core::CanonicalSymbolId::module_declaration(
+                vec!["reports".to_string()],
+                "publish",
+                incan_semantics_core::SemanticSourceTargetKind::Capability,
+                incan_semantics_core::HirSourceSpan::new(1, 8),
+            ),
+            runtime_requirements: vec![incan_semantics_core::AbiV0RuntimeRequirement::HostedStd],
+        }],
         ..Default::default()
     };
     let dir = tempfile::tempdir()?;
@@ -1457,6 +1472,42 @@ fn compiled_provider_metadata_roundtrips_feature_and_facet_facts() -> Result<(),
     let loaded = LibraryManifest::read_from_path(&path)?;
 
     assert_eq!(loaded.contract_metadata.provider, manifest.contract_metadata.provider);
+    Ok(())
+}
+
+#[test]
+fn compiled_provider_metadata_rejects_non_capability_operation_requirements() -> Result<(), Box<dyn std::error::Error>>
+{
+    let mut manifest = LibraryManifest::new("reporting", "0.5.0");
+    manifest
+        .contract_metadata
+        .provider
+        .operation_descriptors
+        .push(ProviderOperationMetadata {
+            operation: incan_semantics_core::CanonicalSymbolId::module_declaration(
+                vec!["reports".to_string()],
+                "emit",
+                incan_semantics_core::SemanticSourceTargetKind::Function,
+                incan_semantics_core::HirSourceSpan::new(10, 14),
+            ),
+            required_capability: incan_semantics_core::CanonicalSymbolId::module_declaration(
+                vec!["reports".to_string()],
+                "not_a_capability",
+                incan_semantics_core::SemanticSourceTargetKind::Function,
+                incan_semantics_core::HirSourceSpan::new(1, 8),
+            ),
+            runtime_requirements: Vec::new(),
+        });
+
+    let dir = tempfile::tempdir()?;
+    let error = manifest
+        .write_to_path(&dir.path().join("reporting.incnlib"))
+        .err()
+        .ok_or("a non-capability provider requirement must fail manifest validation")?;
+    assert!(
+        matches!(error, LibraryManifestError::Invalid(ref message) if message.contains("non-capability requirement")),
+        "unexpected validation error: {error}"
+    );
     Ok(())
 }
 

--- a/src/library_manifest/validation.rs
+++ b/src/library_manifest/validation.rs
@@ -21,6 +21,7 @@ use crate::frontend::api_metadata::{
 };
 use crate::frontend::contract_metadata::CONTRACT_METADATA_SCHEMA_VERSION;
 use crate::frontend::registry_metadata::CHECKED_REGISTRY_METADATA_SCHEMA_VERSION;
+use incan_semantics_core::SemanticSourceTargetKind;
 
 /// Validate one raw manifest payload before it is written or decoded into the semantic model.
 pub(super) fn validate_raw_manifest(raw: &RawLibraryManifest) -> Result<(), LibraryManifestError> {
@@ -229,6 +230,28 @@ fn validate_compiled_provider_metadata(metadata: &CompiledProviderMetadata) -> R
     }
     for component in &metadata.required_sdk_components {
         validate_provider_identifier("SDK component", component)?;
+    }
+
+    let mut operation_ids = HashSet::new();
+    for descriptor in &metadata.operation_descriptors {
+        if descriptor.operation.kind != SemanticSourceTargetKind::Function {
+            return Err(LibraryManifestError::Invalid(
+                "contract_metadata.provider.operation_descriptors contains a non-function operation identity"
+                    .to_string(),
+            ));
+        }
+        if descriptor.required_capability.kind != SemanticSourceTargetKind::Capability {
+            return Err(LibraryManifestError::Invalid(
+                "contract_metadata.provider.operation_descriptors contains a non-capability requirement identity"
+                    .to_string(),
+            ));
+        }
+        if !operation_ids.insert(&descriptor.operation) {
+            return Err(LibraryManifestError::Invalid(format!(
+                "contract_metadata.provider.operation_descriptors contains duplicate operation `{}`",
+                descriptor.operation.declaration_name
+            )));
+        }
     }
 
     let mut facet_ids = HashSet::new();

--- a/workspaces/docs-site/docs/RFCs/104_ambient_runtime_capabilities_and_receipts.md
+++ b/workspaces/docs-site/docs/RFCs/104_ambient_runtime_capabilities_and_receipts.md
@@ -262,6 +262,21 @@ Package-defined capabilities must not grant host authority by implication alone.
 
 Scope values are never written into a static declaration such as `@action(caps=[...])` -- a static declaration only names which capabilities, generically, an action needs. Scope values bind at grant time (`--allow example_lib.policy.refund:tenant=acct_a`) and are checked against the actual attributes of the operation being performed at the moment it happens, independent of whatever the calling code decided. This holds for both host and package capabilities: a scoped `host.http.request` grant is checked against the real outbound host at the point `std.http` makes the request, not against anything decided when the action was defined.
 
+### Provider-operation declarations
+
+A package provider attaches its checked capability requirement to an authority-bearing callable with exactly one `@provider_operation(...)` decorator argument:
+
+```incan
+capability refund:
+    description = "Issue a refund for a captured charge"
+
+@provider_operation(refund)
+pub def issue_refund(charge_id: str) -> None:
+    ...
+```
+
+The decorator argument is a capability reference, not a string. The compiler resolves it at the provider declaration and publishes the canonical callable-to-capability pair in the provider manifest. A missing reference, a non-capability reference, or multiple provider-operation decorators is a compiler diagnostic. Importing `issue_refund` remains ordinary source resolution and grants nothing. When a selected provider operation is invoked, its backend plan carries the checked pair to the authority and receipt contracts; it must not rederive either identity from the call spelling, provider name, or emitted Rust.
+
 ### Receipts
 
 A receipt is a structured runtime fact emitted by a capability-aware operation. A receipt must include:


### PR DESCRIPTION
## Summary

This completes #1213's compiler-owned provider-operation lowering boundary. A package author marks an authority-bearing provider callable with a checked capability reference; publication preserves the resolved canonical pair in provider metadata; Body IR consumes that metadata only through the selected `ProviderPlan`.

Closes #1213.

## Type of change

- [x] New feature
- [x] Bug fix

## Area(s)

- [x] Compiler (frontend/backend/codegen)
- [x] Runtime / Core crates (stdlib/core/derive)
- [x] Docs

## Key details

- `@provider_operation(capability)` has exactly one checked capability reference. The typechecker rejects a missing, non-capability, or duplicate declaration-side association and records the canonical callable-to-capability fact.
- Package publication projects those checked facts into `CompiledProviderMetadata`. Body IR accepts a selected `ProviderPlan` and builds its private catalog from that manifest; no caller can supply a handwritten catalog and no stage infers operation identity from a source spelling, provider name, or generated Rust.
- Imported provider operations retain both their canonical function identity and checked parameter surface, so a consumer can form slots and a plan from the provider manifest without rediscovering either fact.
- Provider admission runs before argument lowering. Disabled or unavailable providers, unresolved declaration slots, omitted defaults, and corrupt or colliding manifest descriptors all refuse without a plan. Reversed named arguments preserve written evaluation order in plan inputs while call operands retain declared-slot order and ownership facts.
- RFC 104 now documents the source decorator and repeats the boundary: importing a provider operation is ordinary source resolution, not authority.

## Deliberate boundary

The ordinary replacement CLI remains a single-source, import-free profile and therefore has no selected provider plan. It does not emit a provider-operation plan or receipt. This PR provides the checked compiler input that #1156's selected fixture-controlled provider-operation executor consumes; it does not claim provider execution, authority decisions, or receipts.

Source currently has no spelling for per-operation runtime requirements. The producer faithfully publishes an empty list rather than inferring requirements. A future source contract must supply that fact before runtime execution can claim it.

## Testing / verification

- [x] Manual verification described below

Manual verification notes:

- `cargo test -p incan --lib 'frontend::body_ir::tests'` — 201 passed
- `cargo test -p incan --lib 'frontend::typechecker'` — 935 passed
- `cargo test -p incan --lib library_manifest` — 78 passed
- `cargo test -p incan_semantics_core --lib body_ir` — 29 passed
- `cargo test -p incan --test vocab_guardrails` — 2 passed
- `cargo test -p incan --lib provider_operation_metadata_is_projected_from_checked_declaration_facts` — passed
- `make fmt`, `make fmt-check`, `cargo clippy -p incan -p incan_semantics_core --all-targets -- -D warnings`, `make rustdoc-gate`, `make docs-build`, and `git diff --check` — passed

Full `make pre-commit`, shared Oven suites, and Slice-level CI remain intentionally deferred under the agreed Slice 1 cost policy.

## Docs impact

- [x] RFC 104 documents `@provider_operation(capability)` and its no-authority-at-import contract.

## Checklist

- [x] I added/updated tests where it materially reduces regressions
