### PR TITLE
feature - represent bytes literals and range values in Body IR (#1165)

### DIFF
--- a/crates/incan_core/src/lang/surface/types.rs
+++ b/crates/incan_core/src/lang/surface/types.rs
@@ -360,6 +360,17 @@ pub const SURFACE_TYPES: &[SurfaceTypeInfo] = &[
 /// literal string.
 pub const TASK_JOIN_ERROR_TYPE_NAME: &str = "TaskJoinError";
 
+/// Canonical Incan name of the checked range type (`"Range"`).
+///
+/// This name is compiler-synthesized rather than source-spellable: `TypeChecker::check_range_expr` is its only
+/// producer, and writing `Range` in source resolves nothing. Because no declaration can introduce it, the producer
+/// and every consumer agree only by spelling the same string -- so they share this constant rather than three
+/// literals that drift silently.
+///
+/// Distinct from the `range()` builtin's iterator return type, which is a plain `Named("Range")` and deliberately
+/// keeps its own iteration path.
+pub const RANGE_TYPE_NAME: &str = "Range";
+
 /// Canonical Incan name of the semaphore acquire error type (`"SemaphoreAcquireError"`).
 pub const SEMAPHORE_ACQUIRE_ERROR_TYPE_NAME: &str = "SemaphoreAcquireError";
 

--- a/crates/incan_semantics_core/src/body_ir.rs
+++ b/crates/incan_semantics_core/src/body_ir.rs
@@ -1758,7 +1758,7 @@ pub enum AggregateKind {
 }
 
 impl AggregateKind {
-    /// Declared name of an [`Self::Range`] aggregate's inclusive lower bound.
+    /// Declared name of an [`Self::Range`] aggregate's lower bound.
     pub const RANGE_FIELD_START: &'static str = "start";
     /// Declared name of an [`Self::Range`] aggregate's upper bound, whose own inclusivity is
     /// [`Self::RANGE_FIELD_INCLUSIVE`].

--- a/crates/incan_semantics_core/src/body_ir.rs
+++ b/crates/incan_semantics_core/src/body_ir.rs
@@ -662,18 +662,46 @@ pub enum Constant {
     Float(String),
     Bool(bool),
     Str(String),
+    /// A `b"..."` byte-string literal, represented as an **owned buffer** rather than a borrowed slice.
+    ///
+    /// This is deliberately its own variant instead of a reuse of [`Self::Str`]. `bytes` and `str` are distinct
+    /// source types with distinct equality, and the compiler-owned string helpers ([`HelperOp::StrConcat`] and its
+    /// siblings) assume their operands are text; a byte string arriving as a string constant would be handed to
+    /// them silently.
+    ///
+    /// The owned-versus-borrowed choice is stated rather than left implicit because it decides the
+    /// [`OwnershipFact`] every later read of a `bytes` value gets. `IncanType::Primitive(IncanPrimitiveType::Bytes)`
+    /// reports [`crate::AbiV0Ownership::Owned`], so re-reading a `bytes` local must select
+    /// [`OwnershipFact::Clone`] or [`OwnershipFact::Move`] — exactly what [`Self::Str`] already gets, and the
+    /// opposite of what a borrowed-slice representation would have claimed. Holding the literal as an owned buffer
+    /// keeps the constant and its type's own ownership fact agreeing.
+    ///
+    /// Like [`Self::Str`], this records no runtime requirement of its own: it is an immutable literal buffer, not a
+    /// helper-constructed value. Operations *on* bytes keep whatever refusal they already had.
+    Bytes(Vec<u8>),
     Unit,
     None,
 }
 
 impl Constant {
     /// Render a deterministic maintainer-facing spelling for this constant.
+    ///
+    /// A byte string renders every byte as a `\xNN` escape rather than as text, so a snapshot can never read a
+    /// `bytes` constant as the `str` constant it is not.
     fn render_snapshot(&self) -> String {
         match self {
             Self::Int(v) => format!("const({v})"),
             Self::Float(v) => format!("const({v})"),
             Self::Bool(v) => format!("const({v})"),
             Self::Str(v) => format!("const({v:?})"),
+            Self::Bytes(bytes) => {
+                let mut rendered = String::from("const(b\"");
+                for byte in bytes {
+                    let _ = write!(&mut rendered, "\\x{byte:02x}");
+                }
+                rendered.push_str("\")");
+                rendered
+            }
             Self::Unit => "const(())".to_string(),
             Self::None => "const(none)".to_string(),
         }
@@ -1710,16 +1738,56 @@ pub enum AggregateKind {
     /// `{v, ...}` set literal. Operands are the set's elements, one per entry -- the same flat shape as
     /// [`AggregateKind::List`].
     Set,
+    /// A `start..end` / `start..=end` **range value**: the same value a `for` header consumes, but usable in any
+    /// operand position.
+    ///
+    /// A range is an aggregate rather than a [`Constant`] form or a helper-constructed value, for two reasons.
+    /// Its bounds are arbitrary expressions (`lo..hi` is as legal as `0..10`), which a constant cannot hold; and
+    /// it needs no runtime service to exist -- four scalars laid out side by side, allocating nothing and calling
+    /// nothing -- so modelling it as a [`Callee::Helper`] call would invent a runtime dependency that the `for`
+    /// header's own normalization proves is not there. That is also why range construction records no
+    /// [`crate::AbiV0RuntimeRequirement`], the same as [`Self::Tuple`] and unlike [`Self::List`]/[`Self::Set`].
+    ///
+    /// Operands appear in exactly [`Self::RANGE_FIELDS`] order, and a consumer reading one back projects it by
+    /// that name (`PlaceElem::Field("start")`). Inclusivity is an *operand*, not a static property of this
+    /// variant: `..` versus `..=` is fixed per construction site, but the site that constructs a range and the
+    /// loop that later iterates it need not be the same statement, so a consumer holding only the value must be
+    /// able to read which one it is instead of having to prove where it came from.
+    Range,
     Constructor(ConstructorTarget),
 }
 
 impl AggregateKind {
+    /// Declared name of an [`Self::Range`] aggregate's inclusive lower bound.
+    pub const RANGE_FIELD_START: &'static str = "start";
+    /// Declared name of an [`Self::Range`] aggregate's upper bound, whose own inclusivity is
+    /// [`Self::RANGE_FIELD_INCLUSIVE`].
+    pub const RANGE_FIELD_END: &'static str = "end";
+    /// Declared name of an [`Self::Range`] aggregate's per-iteration increment.
+    ///
+    /// The surface has no step spelling -- `start..end` and `start..=end` are the only two forms the parser
+    /// produces -- so this is always the unit step today. It is carried as a real operand rather than left
+    /// implicit because a consumer otherwise has to *assume* the increment, and because it is the same `1` the
+    /// `for` header's normalization already adds to its index each iteration.
+    pub const RANGE_FIELD_STEP: &'static str = "step";
+    /// Declared name of an [`Self::Range`] aggregate's inclusivity flag: `true` for `start..=end`, `false` for
+    /// `start..end`.
+    pub const RANGE_FIELD_INCLUSIVE: &'static str = "inclusive";
+    /// Every [`Self::Range`] field name, in the order its operands appear in the aggregate.
+    pub const RANGE_FIELDS: [&'static str; 4] = [
+        Self::RANGE_FIELD_START,
+        Self::RANGE_FIELD_END,
+        Self::RANGE_FIELD_STEP,
+        Self::RANGE_FIELD_INCLUSIVE,
+    ];
+
     /// Compact snapshot spelling for this aggregate kind.
     fn as_str(&self) -> String {
         match self {
             Self::Tuple => "tuple".to_string(),
             Self::List => "list".to_string(),
             Self::Set => "set".to_string(),
+            Self::Range => "range".to_string(),
             Self::Constructor(target) => format!("constructor({}){}", target.name, target.binding.render_snapshot()),
         }
     }
@@ -3780,5 +3848,56 @@ mod tests {
             },
         );
         assert_eq!(body.render_snapshot(), body.render_snapshot());
+    }
+
+    #[test]
+    fn bytes_constants_and_range_aggregates_render_distinctly() {
+        let mut body = sample_body();
+        body.block.stmts.insert(
+            0,
+            Statement {
+                kind: StatementKind::Assign {
+                    place: Place::from_local(LocalId(2)),
+                    rvalue: Rvalue::Use(Operand::Constant(Constant::Bytes(b"hi".to_vec()))),
+                },
+                span: HirSourceSpan::new(0, 1),
+            },
+        );
+        body.block.stmts.insert(
+            1,
+            Statement {
+                kind: StatementKind::Assign {
+                    place: Place::from_local(LocalId(2)),
+                    rvalue: Rvalue::Aggregate(
+                        AggregateKind::Range,
+                        vec![
+                            ArgumentElement::One(Operand::Constant(Constant::Int(0))),
+                            ArgumentElement::One(Operand::Constant(Constant::Int(10))),
+                            ArgumentElement::One(Operand::Constant(Constant::Int(1))),
+                            ArgumentElement::One(Operand::Constant(Constant::Bool(true))),
+                        ],
+                    ),
+                },
+                span: HirSourceSpan::new(0, 1),
+            },
+        );
+        let snapshot = body.render_snapshot();
+
+        // A byte string escapes every byte, so it can never be mistaken for the `str` constant with the same
+        // contents -- which is exactly the conflation `Constant::Bytes` exists to prevent.
+        assert!(
+            snapshot.contains("const(b\"\\x68\\x69\")"),
+            "bytes constant: {snapshot}"
+        );
+        assert_ne!(
+            Constant::Bytes(b"hi".to_vec()).render_snapshot(),
+            Constant::Str("hi".to_string()).render_snapshot(),
+            "a bytes constant and a string constant with the same contents must not render alike"
+        );
+        assert!(
+            snapshot.contains("range[const(0), const(10), const(1), const(true)]"),
+            "range aggregate in RANGE_FIELDS order: {snapshot}"
+        );
+        assert_eq!(AggregateKind::RANGE_FIELDS.len(), 4);
     }
 }

--- a/src/backend/replacement/mod.rs
+++ b/src/backend/replacement/mod.rs
@@ -4314,7 +4314,7 @@ impl BodyExecutor {
         span: HirSourceSpan,
     ) -> Result<ReplacementValue, ReplacementExecutionError> {
         match operand {
-            Operand::Constant(constant) => Ok(constant_value(constant)),
+            Operand::Constant(constant) => constant_value(constant, span),
             Operand::Place(place_operand) => {
                 let local = place_operand.place.local;
                 self.ownership_reads.push(OwnershipRead {
@@ -4811,6 +4811,7 @@ fn aggregate_label(kind: &incan_semantics_core::body_ir::AggregateKind) -> &'sta
         incan_semantics_core::body_ir::AggregateKind::Tuple => "tuple",
         incan_semantics_core::body_ir::AggregateKind::List => "list",
         incan_semantics_core::body_ir::AggregateKind::Set => "set",
+        incan_semantics_core::body_ir::AggregateKind::Range => "range",
         incan_semantics_core::body_ir::AggregateKind::Constructor(_) => "constructor",
     }
 }
@@ -4968,13 +4969,18 @@ const fn value_kind(value: &ReplacementValue) -> &'static str {
 }
 
 /// Convert one Body-IR literal into a first-profile replacement value.
-fn constant_value(constant: &Constant) -> ReplacementValue {
+///
+/// This is fallible because not every constant the frontend can now represent has a direct runtime value. A
+/// byte-string literal is representable in Body IR (#1165) but carries no `bytes` value in this profile, so it
+/// refuses at the read rather than being coerced into the `str` it is not.
+fn constant_value(constant: &Constant, span: HirSourceSpan) -> Result<ReplacementValue, ReplacementExecutionError> {
     match constant {
-        Constant::Int(value) => ReplacementValue::Int(*value),
-        Constant::Bool(value) => ReplacementValue::Bool(*value),
-        Constant::Str(value) => ReplacementValue::Str(value.clone()),
-        Constant::Unit | Constant::None => ReplacementValue::Unit,
-        Constant::Float(value) => ReplacementValue::Float(value.clone()),
+        Constant::Int(value) => Ok(ReplacementValue::Int(*value)),
+        Constant::Bool(value) => Ok(ReplacementValue::Bool(*value)),
+        Constant::Str(value) => Ok(ReplacementValue::Str(value.clone())),
+        Constant::Unit | Constant::None => Ok(ReplacementValue::Unit),
+        Constant::Float(value) => Ok(ReplacementValue::Float(value.clone())),
+        Constant::Bytes(_) => Err(unsupported("byte-string literal", span)),
     }
 }
 
@@ -4985,9 +4991,10 @@ fn direct_pattern_constant(
 ) -> Result<ReplacementValue, ReplacementExecutionError> {
     match constant {
         Constant::Int(_) | Constant::Bool(_) | Constant::Str(_) | Constant::Unit | Constant::None => {
-            Ok(constant_value(constant))
+            constant_value(constant, span)
         }
         Constant::Float(_) => Err(unsupported("floating-point match literal", span)),
+        Constant::Bytes(_) => Err(unsupported("byte-string match literal", span)),
     }
 }
 

--- a/src/frontend/body_ir.rs
+++ b/src/frontend/body_ir.rs
@@ -17,11 +17,11 @@
 //! and [`bir::Body::is_generator`]), all three RFC 018 `assert` forms -- plain condition, `assert value is P`
 //! (whose bindings stay live for the rest of the enclosing block), and `assert call() raises E` (see
 //! [`BodyBuilder::lower_assert`]) -- `pass`, `break` (including a value-producing `break` inside a `loop`
-//! expression), `continue`. Expressions fully lowered: identifiers, literals (int/float/decimal/bool/string),
+//! expression), `continue`. Expressions fully lowered: identifiers, literals (int/float/decimal/bool/string/bytes),
 //! arithmetic/comparison/boolean binary operators and all three unary operators, calls and method calls (including
 //! named, out-of-order, defaulted, and explicitly generic argument spellings -- see [`BodyBuilder::lower_call`]),
-//! field access, indexing, slicing, parenthesization, tuples, list/dict/set literals (list and dict spread entries
-//! included; set literals have no spread spelling), `model`/`class`
+//! field access, indexing, slicing, parenthesization, range values, tuples, list/dict/set literals (list and dict
+//! spread entries included; set literals have no spread spelling), `model`/`class`
 //! construction (named-only at the source level, bound to declared field order -- see
 //! [`BodyBuilder::lower_nominal_construction`]), expression-position `if`/`loop`, `try` (`?`), f-strings,
 //! list/dict comprehensions, lazy generator expressions, closure literals, partial callables (see
@@ -36,8 +36,7 @@
 //! with no statically proven shape against a callee whose fixed signature *is* resolvable, whose arity no stage can
 //! establish; a spread to a locally held callable value; the `**`, bitwise, shift, `in`/`not
 //! in`, and `is`/`is not` operators and their compound forms; `if let`/`while let` conditions and destructuring
-//! comprehension/generator clauses; statement-position `loop:`; `unsafe:` regions; `await` and `race for`; bytes
-//! literals and a `Range` used as a value outside a `for` header; and
+//! comprehension/generator clauses; statement-position `loop:`; `unsafe:` regions; `await` and `race for`; and
 //! vocab/scoped-DSL surface nodes, which reach this module only when a caller skips the desugar pass the legacy
 //! pipeline runs first. The sub-issues are #1158 through #1167, plus #1172 for evaluable callable defaults.
 //!
@@ -367,6 +366,11 @@ struct BodyBuilder<'type_info, 'source> {
     /// Locals whose value has been moved out via a full-value (non-projected) read, so scope-exit drop insertion
     /// skips them.
     moved_out: HashSet<bir::LocalId>,
+    /// Locals whose current value was built by `lower_range_value` or copied from another such local. A checked
+    /// `Range[T]` spelling alone is not a layout contract: parameters, call results, imports, and user
+    /// declarations can use it without the four-field `AggregateKind::Range` representation. Only this
+    /// source-local provenance permits a later `for` loop to project range fields.
+    materialized_range_locals: HashSet<bir::LocalId>,
     /// Stack of the innermost-to-outermost enclosing loop's `break`-value target, pushed/popped by every loop-
     /// lowering path (`while`, `for`, and value-producing `loop` expressions) around its own body. `Some(local)`
     /// means the innermost loop is a value-producing `loop:` expression (see [`Self::lower_loop_expr`]) whose
@@ -401,6 +405,7 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
             external_locals: HashMap::new(),
             remaining_reads: HashMap::new(),
             moved_out: HashSet::new(),
+            materialized_range_locals: HashSet::new(),
             loop_break_targets: Vec::new(),
             runtime_requirements: Vec::new(),
             panic_facts: Vec::new(),

--- a/src/frontend/body_ir/async_.rs
+++ b/src/frontend/body_ir/async_.rs
@@ -1,5 +1,6 @@
 //! Lowering for `await` and `race` suspension points.
 
+use super::control_flow::intersect_range_layouts;
 use super::reads::*;
 use super::*;
 
@@ -60,8 +61,14 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
         }
         self.record_runtime_requirement(AbiV0RuntimeRequirement::AsyncRuntime);
 
+        let range_layouts_before_arms = self.materialized_range_locals.clone();
+        let mut range_layouts_after_arms = Vec::with_capacity(race.arms.len());
         let mut arms = Vec::with_capacity(race.arms.len());
         for (arm, awaitable) in race.arms.iter().zip(awaitables) {
+            // A race resumes exactly one arm. Each arm therefore begins from the same predecessor provenance;
+            // otherwise a source-local range constructed in a prior textual arm could authorize a projection in
+            // a later arm that can execute instead.
+            self.materialized_range_locals = range_layouts_before_arms.clone();
             let arm_scope = self.new_scope(Some(scope), hir_span_value);
             // The arm binds the *awaited output* type, which only the typechecker computes: `Awaitable[T]` binds
             // `T`, `JoinHandle[T]` binds `Result[T, TaskJoinError]`. The awaitable's own type would be wrong.
@@ -98,6 +105,7 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
             // that arm, exactly like a closure body's. Code after the race, and each later arm, must keep resolving
             // every name to whatever it meant outside.
             self.bindings = enclosing_bindings;
+            range_layouts_after_arms.push(self.materialized_range_locals.clone());
 
             arms.push(bir::RaceArm {
                 awaitable,
@@ -109,6 +117,9 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
                 result,
             });
         }
+        // Code after the race follows exactly one selected arm. A range layout is usable only if it survives
+        // every possible winner; an empty arm set conservatively carries no constructed-layout fact.
+        self.materialized_range_locals = intersect_range_layouts(range_layouts_after_arms);
 
         let ty = self.resolve_ty(span);
         let destination = self.new_temp(ty.clone(), scope, hir_span_value);

--- a/src/frontend/body_ir/closures.rs
+++ b/src/frontend/body_ir/closures.rs
@@ -88,6 +88,10 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
         }
 
         // ---- Lower the body under the closure's own bindings, then restore the enclosing scope's ----
+        // The closure body is deferred. Its assignments must not update the enclosing body's proof that a local
+        // currently has the source-local range aggregate layout; its captured/writeable locals are a distinct
+        // invocation frame.
+        let saved_materialized_range_locals = self.materialized_range_locals.clone();
         let mut body_stmts = Vec::new();
         let result = self.lower_expr_to_operand(body_expr, closure_scope, &mut body_stmts);
         for (name, previous) in saved_bindings {
@@ -100,6 +104,7 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
                 }
             }
         }
+        self.materialized_range_locals = saved_materialized_range_locals;
 
         let closure_body = bir::ClosureBody {
             capture_locals,

--- a/src/frontend/body_ir/comprehensions.rs
+++ b/src/frontend/body_ir/comprehensions.rs
@@ -1,6 +1,7 @@
 //! Lowering for list and dict comprehensions and generator expressions, and the clause/terminal machinery they share.
 
 use super::args::*;
+use super::control_flow::intersect_range_layouts;
 use super::free_vars::*;
 use super::reads::*;
 use super::*;
@@ -159,6 +160,9 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
         // enclosing place directly after this point, and restoring the full binding map below prevents generator
         // clause/capture names from leaking into the following enclosing statement.
         let enclosing_bindings = self.bindings.clone();
+        // Only the first source is evaluated at construction. The rest is deferred until polling, so range-layout
+        // facts it creates belong to the generator frame rather than the enclosing straight-line body.
+        let saved_materialized_range_locals = self.materialized_range_locals.clone();
         let free_names = free_vars_in_generator_deferred_body(generator);
         let mut captured_operands = Vec::with_capacity(free_names.len());
         let mut capture_locals = Vec::with_capacity(free_names.len());
@@ -265,6 +269,7 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
             span: hir_span_value,
         });
         self.bindings = enclosing_bindings;
+        self.materialized_range_locals = saved_materialized_range_locals;
 
         // `Generator::new` owns a boxed iterator in the legacy runtime, even when every captured source value is
         // Copy-shaped. Record that allocation fact directly rather than relying on incidental temporary locals.
@@ -302,8 +307,13 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
         out: &mut Vec<bir::Statement>,
     ) {
         let enclosing_bindings = self.bindings.clone();
+        let range_layouts_before = self.materialized_range_locals.clone();
         self.lower_comprehension_clauses(clauses, terminal, scope, span, out);
         self.bindings = enclosing_bindings;
+        // A comprehension clause may execute zero times, so a source-local range layout constructed only inside
+        // its body cannot become a fact about the following enclosing statement.
+        self.materialized_range_locals =
+            intersect_range_layouts(vec![range_layouts_before, self.materialized_range_locals.clone()]);
     }
 
     /// Recursively desugar a comprehension/generator clause chain into nested `Loop`/`If` statements, terminating

--- a/src/frontend/body_ir/control_flow.rs
+++ b/src/frontend/body_ir/control_flow.rs
@@ -31,6 +31,31 @@ fn index_read(idx_local: bir::LocalId) -> bir::Operand {
     bir::Operand::place(bir::Place::from_local(idx_local), bir::OwnershipFact::Copy, false)
 }
 
+/// Retain a local range-layout fact only when every control-flow successor retains it.
+pub(super) fn intersect_range_layouts(
+    states: Vec<std::collections::HashSet<bir::LocalId>>,
+) -> std::collections::HashSet<bir::LocalId> {
+    let mut states = states.into_iter();
+    let Some(mut common) = states.next() else {
+        return std::collections::HashSet::new();
+    };
+    for state in states {
+        common.retain(|local| state.contains(local));
+    }
+    common
+}
+
+/// Return the immediate inline range parts through redundant source parentheses.
+fn inline_range_parts(
+    expr: &ast::Spanned<ast::Expr>,
+) -> Option<(&ast::Spanned<ast::Expr>, &ast::Spanned<ast::Expr>, bool)> {
+    match &expr.node {
+        ast::Expr::Range { start, end, inclusive } => Some((start, end, *inclusive)),
+        ast::Expr::Paren(inner) => inline_range_parts(inner),
+        _ => None,
+    }
+}
+
 impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
     /// Lower `if`/`elif`/`else` into a [`bir::StatementKind::If`] chain. `elif` branches are folded into nested
     /// `else { if ... }` wrappers from the last branch inward (see the inline comment above the fold loop), and an
@@ -49,15 +74,21 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
         };
         let cond = self.lower_expr_to_operand(cond_expr, scope, out);
 
+        let range_layouts_before = self.materialized_range_locals.clone();
         let then_block = self.lower_branch_block(&if_stmt.then_body, scope, span);
+        let mut range_layouts_after_branches = vec![self.materialized_range_locals.clone()];
+
+        self.materialized_range_locals = range_layouts_before.clone();
         let mut else_block = if_stmt
             .else_body
             .as_ref()
             .map(|else_body| self.lower_branch_block(else_body, scope, span));
+        range_layouts_after_branches.push(self.materialized_range_locals.clone());
 
         // Fold `elif` branches into nested `else { if ... }` wrappers, innermost (last elif) first, so the earlier
         // conditions end up evaluated first at the top of the chain once wrapped by the outer `if` pushed below.
         for (elif_cond, elif_body) in if_stmt.elif_branches.iter().rev() {
+            self.materialized_range_locals = range_layouts_before.clone();
             let mut wrapper = Vec::new();
             let cond_operand = self.lower_expr_to_operand(elif_cond, scope, &mut wrapper);
             let then_block = self.lower_branch_block(elif_body, scope, span);
@@ -70,7 +101,10 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
                 span,
             });
             else_block = Some(bir::Block { scope, stmts: wrapper });
+            range_layouts_after_branches.push(self.materialized_range_locals.clone());
         }
+
+        self.materialized_range_locals = intersect_range_layouts(range_layouts_after_branches);
 
         out.push(bir::Statement {
             kind: bir::StatementKind::If {
@@ -116,11 +150,16 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
     ) -> bir::Operand {
         let hir_span_value = hir_span(span);
         let cond = self.lower_expr_to_operand(&if_expr.condition, scope, out);
+        let range_layouts_before = self.materialized_range_locals.clone();
         let then_block = self.lower_branch_block(&if_expr.then_body, scope, hir_span_value);
+        let then_range_layouts = self.materialized_range_locals.clone();
+        self.materialized_range_locals = range_layouts_before;
         let else_block = if_expr
             .else_body
             .as_ref()
             .map(|body| self.lower_branch_block(body, scope, hir_span_value));
+        self.materialized_range_locals =
+            intersect_range_layouts(vec![then_range_layouts, self.materialized_range_locals.clone()]);
         out.push(bir::Statement {
             kind: bir::StatementKind::If {
                 cond,
@@ -149,6 +188,7 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
         let hir_span_value = hir_span(span);
         let ty = self.resolve_ty(span);
         let loop_scope = self.new_scope(Some(scope), hir_span_value);
+        let range_layouts_before = self.materialized_range_locals.clone();
         let result_local = self.new_temp(ty.clone(), loop_scope, hir_span_value);
 
         self.loop_break_targets.push(Some(result_local));
@@ -156,6 +196,8 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
         self.lower_block_into(&loop_expr.body, loop_scope, &mut body_stmts);
         self.insert_scope_drops(&mut body_stmts, loop_scope);
         self.loop_break_targets.pop();
+        self.materialized_range_locals =
+            intersect_range_layouts(vec![range_layouts_before, self.materialized_range_locals.clone()]);
 
         out.push(bir::Statement {
             kind: bir::StatementKind::Loop {
@@ -185,6 +227,7 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
         };
 
         let loop_scope = self.new_scope(Some(scope), span);
+        let range_layouts_before = self.materialized_range_locals.clone();
         // `while` never produces a value from `break`, so push `None`: a `break` inside this loop's body must
         // resolve to a plain valueless exit even if this `while` is lexically nested inside a value-producing
         // `loop:` expression (see `Self::loop_break_targets`'s docs for why the stack exists).
@@ -212,6 +255,8 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
         self.lower_block_into(&while_stmt.body, loop_scope, &mut body_stmts);
         self.insert_scope_drops(&mut body_stmts, loop_scope);
         self.loop_break_targets.pop();
+        self.materialized_range_locals =
+            intersect_range_layouts(vec![range_layouts_before, self.materialized_range_locals.clone()]);
 
         out.push(bir::Statement {
             kind: bir::StatementKind::Loop {
@@ -267,7 +312,17 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
         // pattern must disappear after the statement. Keep the active lookup map for restoration while leaving the
         // loop locals themselves in Body IR for the loop's statements to reference.
         let enclosing_bindings = self.bindings.clone();
-        let Some(range) = self.range_loop_source(&for_stmt.iter, &iter_ty, scope, out) else {
+        let range_layouts_before = self.materialized_range_locals.clone();
+        let range = match self.range_loop_source(&for_stmt.iter, &iter_ty) {
+            Ok(range) => range,
+            Err(reason) => {
+                self.push_unsupported_stmt(reason, span, out);
+                self.bindings = enclosing_bindings;
+                self.materialized_range_locals = range_layouts_before;
+                return;
+            }
+        };
+        let Some(range) = range else {
             let loop_scope = self.new_scope(Some(scope), span);
             let item_local = self.declare_for_item_local(&for_stmt.pattern, &item_ty, loop_scope, span, &for_stmt.body);
             self.lower_general_iteration(
@@ -291,21 +346,22 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
                 },
             );
             self.bindings = enclosing_bindings;
+            self.materialized_range_locals =
+                intersect_range_layouts(vec![range_layouts_before, self.materialized_range_locals.clone()]);
             return;
         };
         self.lower_range_counting_loop(for_stmt, &item_ty, &range, scope, span, out);
         self.bindings = enclosing_bindings;
+        self.materialized_range_locals =
+            intersect_range_layouts(vec![range_layouts_before, self.materialized_range_locals.clone()]);
     }
 
     /// The item type a `for` loop's pattern binds, falling back to a range value's own element type.
     ///
-    /// Normally this is just the typechecker's recorded type for the pattern span. A range value is the one case
-    /// that needs help: `TypeChecker::infer_iterator_element_type` has no `Range` arm, so `for i in some_range`
-    /// records `i` as [`IncanType::Unknown`] even though the range's own type argument says exactly what it
-    /// yields. Taking the element type from there is not lowering inventing a type -- it is reading the one the
-    /// typechecker already resolved for the range -- and without it the item local would declare as `?` and every
-    /// read of it would carry [`bir::OwnershipFact::Unknown`] rather than the `copy` an `int` gets, which would
-    /// leave a bound range iterating with visibly different facts from the inline header form.
+    /// Normally this is just the typechecker's recorded type for the pattern span. The generic `Range[T]` spelling
+    /// carries its item type, so it supplies the recovery fallback only when the checker has no fact. That type
+    /// fallback never grants aggregate-layout authority; [`Self::range_loop_source`] separately requires local
+    /// materialization provenance before field projection.
     fn for_item_type(&self, pattern: &ast::Spanned<ast::Pattern>, iter_ty: &IncanType) -> IncanType {
         let checked = self.resolve_ty(pattern.span);
         if !matches!(checked, IncanType::Unknown) {
@@ -318,29 +374,55 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
     /// is a range *value*, or `None` when the loop belongs on the general-iteration path.
     ///
     /// An inline `start..end` header keeps its AST sub-expressions, because its bounds are still lowered directly
-    /// (and its `end` deliberately re-lowered per iteration -- see [`Self::lower_range_counting_loop`]). Anything
-    /// else is a range only if the typechecker says so, and reading its fields back afterwards is sound because
-    /// the checked range type has exactly one producer: `TypeChecker::check_range_expr` (see [`RANGE_TYPE_BASE`]).
-    /// Every value of that type therefore came from a range expression, which [`Self::lower_range_value`] is the
-    /// only lowering for -- so the [`bir::AggregateKind::Range`] field layout this returns a place into is
-    /// guaranteed to be the layout that value actually has. The `range()` builtin resolves to a different type and
-    /// keeps its existing iterator path.
+    /// (and its `end` deliberately re-lowered per iteration -- see [`Self::lower_range_counting_loop`]). A bound
+    /// range needs an independently proven local [`bir::AggregateKind::Range`] producer. A `Range[T]` type spelling
+    /// alone cannot prove the aggregate layout: parameters, call results, imported values, and user declarations
+    /// may carry it without `start`/`end`/`step`/`inclusive` fields. Those cases refuse visibly rather than inventing
+    /// a private range ABI. The `range()` builtin resolves to a different type and keeps its existing iteration path.
     fn range_loop_source<'ast>(
-        &mut self,
+        &self,
         iter_expr: &'ast ast::Spanned<ast::Expr>,
         iter_ty: &IncanType,
-        scope: bir::ScopeId,
-        out: &mut Vec<bir::Statement>,
-    ) -> Option<RangeLoopSource<'ast>> {
-        if let ast::Expr::Range { start, end, inclusive } = &iter_expr.node {
-            return Some(RangeLoopSource::Header {
-                start,
-                end,
-                inclusive: *inclusive,
-            });
+    ) -> Result<Option<RangeLoopSource<'ast>>, String> {
+        if let Some((start, end, inclusive)) = inline_range_parts(iter_expr) {
+            return Ok(Some(RangeLoopSource::Header { start, end, inclusive }));
         }
-        range_value_element_type(iter_ty)?;
-        Some(RangeLoopSource::Value(self.lower_expr_to_place(iter_expr, scope, out)))
+        if range_value_element_type(iter_ty).is_none() {
+            return Ok(None);
+        }
+        let Some(place) = self.materialized_range_place(iter_expr) else {
+            return Err("range value without a source-local Body IR range aggregate".to_string());
+        };
+        Ok(Some(RangeLoopSource::Value(place)))
+    }
+
+    /// Whether `expr` is a source-local value whose current Body-IR representation has the declared range layout.
+    /// This follows only direct range literals, parentheses, and copies of another proven local; calls, imports,
+    /// parameters, fields, and arbitrary type spellings remain unproven.
+    pub(super) fn expr_has_materialized_range_layout(&self, expr: &ast::Spanned<ast::Expr>) -> bool {
+        match &expr.node {
+            ast::Expr::Range { .. } => true,
+            ast::Expr::Paren(inner) => self.expr_has_materialized_range_layout(inner),
+            ast::Expr::Ident(name) => self
+                .bindings
+                .get(name)
+                .is_some_and(|local| self.materialized_range_locals.contains(local)),
+            _ => false,
+        }
+    }
+
+    /// Return the plain local place for a range value whose layout provenance is still live.
+    fn materialized_range_place(&self, expr: &ast::Spanned<ast::Expr>) -> Option<bir::Place> {
+        match &expr.node {
+            ast::Expr::Paren(inner) => self.materialized_range_place(inner),
+            ast::Expr::Ident(name) => self
+                .bindings
+                .get(name)
+                .copied()
+                .filter(|local| self.materialized_range_locals.contains(local))
+                .map(bir::Place::from_local),
+            _ => None,
+        }
     }
 
     /// Read one declared field off a materialized [`bir::AggregateKind::Range`] value.

--- a/src/frontend/body_ir/control_flow.rs
+++ b/src/frontend/body_ir/control_flow.rs
@@ -1,9 +1,35 @@
 //! Lowering for conditional and looping control flow, and the iteration protocol behind `for`.
 
 use super::args::*;
+use super::primitives::*;
 use super::reads::*;
 use super::refusals::*;
 use super::*;
+
+/// Where one range-shaped `for` loop takes its bounds, step, and inclusivity from.
+///
+/// The two variants are the two ways the surface can spell a range in iterable position, and they differ only in
+/// where those facts live: written into the header, or carried by an already-built range value. Both drive the
+/// same normalized counting loop -- see [`BodyBuilder::lower_range_counting_loop`].
+enum RangeLoopSource<'ast> {
+    /// An inline `start..end` / `start..=end` loop header, still holding its un-lowered bound expressions.
+    Header {
+        start: &'ast ast::Spanned<ast::Expr>,
+        end: &'ast ast::Spanned<ast::Expr>,
+        inclusive: bool,
+    },
+    /// A materialized [`bir::AggregateKind::Range`] value, read back through its own declared fields.
+    Value(bir::Place),
+}
+
+/// Read a counting loop's index local.
+///
+/// The index is a compiler-owned `int` temporary that the loop itself both writes and re-reads several times per
+/// iteration, so its reads are always plain [`bir::OwnershipFact::Copy`] and never a last use. Going through
+/// [`BodyBuilder::ownership_fact_for_place`] would consult a read countdown that was never seeded for a temporary.
+fn index_read(idx_local: bir::LocalId) -> bir::Operand {
+    bir::Operand::place(bir::Place::from_local(idx_local), bir::OwnershipFact::Copy, false)
+}
 
 impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
     /// Lower `if`/`elif`/`else` into a [`bir::StatementKind::If`] chain. `elif` branches are folded into nested
@@ -198,12 +224,20 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
         });
     }
 
-    /// Lower a `for` statement. `for x in start..end: body` (range-shaped iterables) lowers into a normalized
-    /// counting `Loop`, preserving #1103's original range-loop shape unchanged. Every other iterable -- builtin
-    /// collections (`List`/`Dict`/`String`) and user-defined iterables implementing the RFC 068 `__iter__`/
-    /// `__next__` protocol, including the fallible `for item in iterable?:` form (RFC 115) -- lowers through
-    /// [`Self::lower_general_iteration`], sharing its per-clause iteration primitive with comprehensions and
-    /// generator expressions (see [`Self::lower_comprehension_clauses`]).
+    /// Lower a `for` statement. Range-shaped iterables lower into a normalized counting `Loop`, preserving
+    /// #1103's original range-loop shape for the inline `for x in start..end:` header unchanged. Every other
+    /// iterable -- builtin collections (`List`/`Dict`/`String`) and user-defined iterables implementing the RFC
+    /// 068 `__iter__`/`__next__` protocol, including the fallible `for item in iterable?:` form (RFC 115) --
+    /// lowers through [`Self::lower_general_iteration`], sharing its per-clause iteration primitive with
+    /// comprehensions and generator expressions (see [`Self::lower_comprehension_clauses`]).
+    ///
+    /// "Range-shaped" covers two spellings, and both reach the same counting loop (#1165). One is the inline
+    /// header, whose bounds are still lowered straight out of the AST. The other is a range *value* -- `r = 0..10`
+    /// then `for i in r:` -- which reaches this point as an ordinary expression of the checked range type; it is
+    /// materialized as a place and the loop reads its declared [`bir::AggregateKind::RANGE_FIELDS`] back, so a
+    /// bound range iterates with the same facts as the range it was bound from instead of degrading to an opaque
+    /// [`bir::StatementKind::IterNext`] poll. See [`Self::range_loop_source`] for why reading those fields back is
+    /// sound, and [`Self::range_value_stop_condition`] for the one place the two spellings genuinely differ.
     ///
     /// Both paths accept the same loop-pattern subset the typechecker accepts -- a plain binding, `_`, and
     /// (recursively) a tuple of those, per `TypeChecker::define_for_pattern_bindings` in
@@ -223,7 +257,8 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
         span: HirSourceSpan,
         out: &mut Vec<bir::Statement>,
     ) {
-        let item_ty = self.resolve_ty(for_stmt.pattern.span);
+        let iter_ty = self.resolve_ty(for_stmt.iter.span);
+        let item_ty = self.for_item_type(&for_stmt.pattern, &iter_ty);
         if let Some(reason) = unsupported_for_pattern(&for_stmt.pattern.node, &item_ty) {
             self.push_unsupported_stmt(reason, span, out);
             return;
@@ -232,7 +267,7 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
         // pattern must disappear after the statement. Keep the active lookup map for restoration while leaving the
         // loop locals themselves in Body IR for the loop's statements to reference.
         let enclosing_bindings = self.bindings.clone();
-        let ast::Expr::Range { start, end, inclusive } = &for_stmt.iter.node else {
+        let Some(range) = self.range_loop_source(&for_stmt.iter, &iter_ty, scope, out) else {
             let loop_scope = self.new_scope(Some(scope), span);
             let item_local = self.declare_for_item_local(&for_stmt.pattern, &item_ty, loop_scope, span, &for_stmt.body);
             self.lower_general_iteration(
@@ -258,9 +293,164 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
             self.bindings = enclosing_bindings;
             return;
         };
+        self.lower_range_counting_loop(for_stmt, &item_ty, &range, scope, span, out);
+        self.bindings = enclosing_bindings;
+    }
 
+    /// The item type a `for` loop's pattern binds, falling back to a range value's own element type.
+    ///
+    /// Normally this is just the typechecker's recorded type for the pattern span. A range value is the one case
+    /// that needs help: `TypeChecker::infer_iterator_element_type` has no `Range` arm, so `for i in some_range`
+    /// records `i` as [`IncanType::Unknown`] even though the range's own type argument says exactly what it
+    /// yields. Taking the element type from there is not lowering inventing a type -- it is reading the one the
+    /// typechecker already resolved for the range -- and without it the item local would declare as `?` and every
+    /// read of it would carry [`bir::OwnershipFact::Unknown`] rather than the `copy` an `int` gets, which would
+    /// leave a bound range iterating with visibly different facts from the inline header form.
+    fn for_item_type(&self, pattern: &ast::Spanned<ast::Pattern>, iter_ty: &IncanType) -> IncanType {
+        let checked = self.resolve_ty(pattern.span);
+        if !matches!(checked, IncanType::Unknown) {
+            return checked;
+        }
+        range_value_element_type(iter_ty).cloned().unwrap_or(checked)
+    }
+
+    /// Classify a `for` header's iterable as a range the counting loop can drive, lowering it to a place when it
+    /// is a range *value*, or `None` when the loop belongs on the general-iteration path.
+    ///
+    /// An inline `start..end` header keeps its AST sub-expressions, because its bounds are still lowered directly
+    /// (and its `end` deliberately re-lowered per iteration -- see [`Self::lower_range_counting_loop`]). Anything
+    /// else is a range only if the typechecker says so, and reading its fields back afterwards is sound because
+    /// the checked range type has exactly one producer: `TypeChecker::check_range_expr` (see [`RANGE_TYPE_BASE`]).
+    /// Every value of that type therefore came from a range expression, which [`Self::lower_range_value`] is the
+    /// only lowering for -- so the [`bir::AggregateKind::Range`] field layout this returns a place into is
+    /// guaranteed to be the layout that value actually has. The `range()` builtin resolves to a different type and
+    /// keeps its existing iterator path.
+    fn range_loop_source<'ast>(
+        &mut self,
+        iter_expr: &'ast ast::Spanned<ast::Expr>,
+        iter_ty: &IncanType,
+        scope: bir::ScopeId,
+        out: &mut Vec<bir::Statement>,
+    ) -> Option<RangeLoopSource<'ast>> {
+        if let ast::Expr::Range { start, end, inclusive } = &iter_expr.node {
+            return Some(RangeLoopSource::Header {
+                start,
+                end,
+                inclusive: *inclusive,
+            });
+        }
+        range_value_element_type(iter_ty)?;
+        Some(RangeLoopSource::Value(self.lower_expr_to_place(iter_expr, scope, out)))
+    }
+
+    /// Read one declared field off a materialized [`bir::AggregateKind::Range`] value.
+    ///
+    /// Every range field is a scalar read through a non-empty projection, so this always resolves to
+    /// [`bir::OwnershipFact::Copy`] and never consumes the range local's last use -- a loop may read the same
+    /// field on every iteration without the range appearing to be moved out from under itself.
+    fn read_range_field(&mut self, range: &bir::Place, field: &str, field_ty: &IncanType) -> bir::Operand {
+        let mut place = range.clone();
+        place.projection.push(bir::PlaceElem::Field(field.to_string()));
+        let (fact, last_use) = self.ownership_fact_for_place(&place, field_ty);
+        bir::Operand::place(place, fact, last_use)
+    }
+
+    /// Build the break condition for a loop over a range *value*: stop once the index has passed the range's end,
+    /// or has reached an end the range does not include.
+    ///
+    /// This is the one place the two range spellings differ, and the reason is that inclusivity is a property of
+    /// the value rather than of the loop. An inline header knows which of `>` and `>=` it wants at lowering time,
+    /// because `..` versus `..=` is written right there. A bound range does not: the statement that built the
+    /// value and the loop that consumes it are different statements, and nothing stops a program from binding one
+    /// range on one branch and another on the other. Choosing the comparison here from whichever construction
+    /// lowering happened to see first would be a guess that a reassignment silently invalidates. So this computes
+    /// *both* of the comparisons the inline form picks between, and lets the range's own
+    /// [`bir::AggregateKind::RANGE_FIELD_INCLUSIVE`] operand select between them -- the same decision, made from
+    /// the value instead of from the syntax.
+    ///
+    /// Every field is re-read per iteration, matching the inline form, which also re-lowers its `end` expression
+    /// each time around rather than snapshotting it before the loop.
+    fn range_value_stop_condition(
+        &mut self,
+        range: &bir::Place,
+        idx_local: bir::LocalId,
+        loop_scope: bir::ScopeId,
+        span: HirSourceSpan,
+        body_stmts: &mut Vec<bir::Statement>,
+    ) -> bir::Operand {
         let int_ty = IncanType::Primitive(IncanPrimitiveType::Int);
-        let start_operand = self.lower_expr_to_operand(start, scope, out);
+        let bool_ty = IncanType::Primitive(IncanPrimitiveType::Bool);
+        let past_end = {
+            let end = self.read_range_field(range, bir::AggregateKind::RANGE_FIELD_END, &int_ty);
+            let idx = index_read(idx_local);
+            self.push_assign_temp(
+                bir::Rvalue::BinaryOp(bir::BinOp::Gt, idx, end),
+                bool_ty.clone(),
+                loop_scope,
+                span,
+                body_stmts,
+            )
+        };
+        let at_or_past_end = {
+            let end = self.read_range_field(range, bir::AggregateKind::RANGE_FIELD_END, &int_ty);
+            let idx = index_read(idx_local);
+            self.push_assign_temp(
+                bir::Rvalue::BinaryOp(bir::BinOp::Ge, idx, end),
+                bool_ty.clone(),
+                loop_scope,
+                span,
+                body_stmts,
+            )
+        };
+        let inclusive = self.read_range_field(range, bir::AggregateKind::RANGE_FIELD_INCLUSIVE, &bool_ty);
+        let exclusive = self.push_assign_temp(
+            bir::Rvalue::UnaryOp(bir::UnOp::Not, inclusive),
+            bool_ty.clone(),
+            loop_scope,
+            span,
+            body_stmts,
+        );
+        let stops_at_end = self.push_assign_temp(
+            bir::Rvalue::BinaryOp(bir::BinOp::And, at_or_past_end, exclusive),
+            bool_ty.clone(),
+            loop_scope,
+            span,
+            body_stmts,
+        );
+        self.push_assign_temp(
+            bir::Rvalue::BinaryOp(bir::BinOp::Or, past_end, stops_at_end),
+            bool_ty,
+            loop_scope,
+            span,
+            body_stmts,
+        )
+    }
+
+    /// Lower one range-shaped `for` loop into the normalized counting `Loop` both range spellings share: seed an
+    /// index from the range's start, break once it reaches the end, bind the loop pattern from the index, run the
+    /// body, then advance the index by the range's step.
+    ///
+    /// Where the two spellings get those three pieces from is the only difference, and each is taken from
+    /// `source`: an inline header lowers its own AST sub-expressions and knows its step and inclusivity
+    /// statically, while a range value reads them back off the place it was materialized into. The `end` bound is
+    /// evaluated *inside* the loop body in both cases, preserving the inline form's established re-evaluation
+    /// timing rather than hoisting it.
+    fn lower_range_counting_loop(
+        &mut self,
+        for_stmt: &ast::ForStmt,
+        item_ty: &IncanType,
+        source: &RangeLoopSource<'_>,
+        scope: bir::ScopeId,
+        span: HirSourceSpan,
+        out: &mut Vec<bir::Statement>,
+    ) {
+        let int_ty = IncanType::Primitive(IncanPrimitiveType::Int);
+        let start_operand = match source {
+            RangeLoopSource::Header { start, .. } => self.lower_expr_to_operand(start, scope, out),
+            RangeLoopSource::Value(range) => {
+                self.read_range_field(range, bir::AggregateKind::RANGE_FIELD_START, &int_ty)
+            }
+        };
         let idx_local = self.new_temp(int_ty.clone(), scope, span);
         out.push(bir::Statement {
             kind: bir::StatementKind::Assign {
@@ -275,16 +465,22 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
         self.loop_break_targets.push(None);
         let mut body_stmts = Vec::new();
 
-        let end_operand = self.lower_expr_to_operand(end, loop_scope, &mut body_stmts);
-        let idx_read = bir::Operand::place(bir::Place::from_local(idx_local), bir::OwnershipFact::Copy, false);
-        let cmp_op = if *inclusive { bir::BinOp::Gt } else { bir::BinOp::Ge };
-        let cond = self.push_assign_temp(
-            bir::Rvalue::BinaryOp(cmp_op, idx_read, end_operand),
-            IncanType::Primitive(IncanPrimitiveType::Bool),
-            loop_scope,
-            span,
-            &mut body_stmts,
-        );
+        let cond = match source {
+            RangeLoopSource::Header { end, inclusive, .. } => {
+                let end_operand = self.lower_expr_to_operand(end, loop_scope, &mut body_stmts);
+                let cmp_op = if *inclusive { bir::BinOp::Gt } else { bir::BinOp::Ge };
+                self.push_assign_temp(
+                    bir::Rvalue::BinaryOp(cmp_op, index_read(idx_local), end_operand),
+                    IncanType::Primitive(IncanPrimitiveType::Bool),
+                    loop_scope,
+                    span,
+                    &mut body_stmts,
+                )
+            }
+            RangeLoopSource::Value(range) => {
+                self.range_value_stop_condition(range, idx_local, loop_scope, span, &mut body_stmts)
+            }
+        };
         let break_scope = self.new_scope(Some(loop_scope), span);
         body_stmts.push(bir::Statement {
             kind: bir::StatementKind::If {
@@ -305,21 +501,17 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
         // per-iteration item local at all -- unlike the general path, where `IterNext` must still write the polled
         // item somewhere for the poll itself to happen.
         if !matches!(for_stmt.pattern.node, ast::Pattern::Wildcard) {
-            let item_local = self.declare_for_item_local(&for_stmt.pattern, &item_ty, loop_scope, span, &for_stmt.body);
+            let item_local = self.declare_for_item_local(&for_stmt.pattern, item_ty, loop_scope, span, &for_stmt.body);
             body_stmts.push(bir::Statement {
                 kind: bir::StatementKind::Assign {
                     place: bir::Place::from_local(item_local),
-                    rvalue: bir::Rvalue::Use(bir::Operand::place(
-                        bir::Place::from_local(idx_local),
-                        bir::OwnershipFact::Copy,
-                        false,
-                    )),
+                    rvalue: bir::Rvalue::Use(index_read(idx_local)),
                 },
                 span,
             });
             self.bind_for_pattern(
                 &for_stmt.pattern,
-                &item_ty,
+                item_ty,
                 item_local,
                 loop_scope,
                 &for_stmt.body,
@@ -330,10 +522,14 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
         self.lower_block_into(&for_stmt.body, loop_scope, &mut body_stmts);
         self.insert_scope_drops(&mut body_stmts, loop_scope);
 
-        let one = bir::Operand::Constant(bir::Constant::Int(1));
-        let idx_read_for_incr = bir::Operand::place(bir::Place::from_local(idx_local), bir::OwnershipFact::Copy, false);
+        let step = match source {
+            RangeLoopSource::Header { .. } => bir::Operand::Constant(bir::Constant::Int(RANGE_UNIT_STEP)),
+            RangeLoopSource::Value(range) => {
+                self.read_range_field(range, bir::AggregateKind::RANGE_FIELD_STEP, &int_ty)
+            }
+        };
         let incremented = self.push_assign_temp(
-            bir::Rvalue::BinaryOp(bir::BinOp::Add, idx_read_for_incr, one),
+            bir::Rvalue::BinaryOp(bir::BinOp::Add, index_read(idx_local), step),
             int_ty,
             loop_scope,
             span,
@@ -357,7 +553,6 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
             },
             span,
         });
-        self.bindings = enclosing_bindings;
     }
 
     /// Declare the local each produced item of a `for` loop is written into.

--- a/src/frontend/body_ir/defaults.rs
+++ b/src/frontend/body_ir/defaults.rs
@@ -30,6 +30,7 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
         let next_scope = self.next_scope;
         let saved_remaining_reads = self.remaining_reads.clone();
         let saved_moved_out = self.moved_out.clone();
+        let saved_materialized_range_locals = self.materialized_range_locals.clone();
         let saved_bindings = std::mem::take(&mut self.bindings);
         let saved_external_locals = std::mem::take(&mut self.external_locals);
         let mut stmts = Vec::new();
@@ -83,9 +84,11 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
             self.next_scope = next_scope;
             self.remaining_reads = saved_remaining_reads;
             self.moved_out = saved_moved_out;
+            self.materialized_range_locals = saved_materialized_range_locals;
             return bir::CallableParamDefault::Unsupported { span, description };
         }
 
+        self.materialized_range_locals = saved_materialized_range_locals;
         bir::CallableParamDefault::Source(bir::DefaultComputation {
             span: hir_span(default_expr.span),
             stmts,

--- a/src/frontend/body_ir/expr.rs
+++ b/src/frontend/body_ir/expr.rs
@@ -33,10 +33,7 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
                 let (fact, last_use) = self.ownership_fact_for_place(&place, &ty);
                 bir::Operand::place(place, fact, last_use)
             }
-            ast::Expr::Literal(lit) => match lower_literal(lit) {
-                Some(constant) => bir::Operand::Constant(constant),
-                None => self.unsupported_operand("bytes literal".to_string(), scope, span, out),
-            },
+            ast::Expr::Literal(lit) => bir::Operand::Constant(lower_literal(lit)),
             ast::Expr::Paren(inner) => self.lower_expr_to_operand(inner, scope, out),
             ast::Expr::Field(base, name) => {
                 if let Some(target) = self.local_fieldless_enum_variant_target(base, name) {

--- a/src/frontend/body_ir/expr.rs
+++ b/src/frontend/body_ir/expr.rs
@@ -99,6 +99,9 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
             ast::Expr::Partial(partial) => self.lower_partial(partial, expr.span, scope, out),
             ast::Expr::Match(subject, arms) => self.lower_match(subject, arms, expr.span, scope, out),
             ast::Expr::Surface(surface) => self.lower_surface_expr(surface, expr.span, scope, out),
+            ast::Expr::Range { start, end, inclusive } => {
+                self.lower_range_value(start, end, *inclusive, expr.span, scope, out)
+            }
             other => self.unsupported_operand(unsupported_expr_label(other), scope, span, out),
         }
     }

--- a/src/frontend/body_ir/literals.rs
+++ b/src/frontend/body_ir/literals.rs
@@ -87,6 +87,46 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
         )
     }
 
+    /// Lower `start..end` / `start..=end` used as a **value** into a [`bir::AggregateKind::Range`] aggregate.
+    ///
+    /// A range is a value, not only a loop header: `r = 0..10` typechecks, so Body IR has to be able to hold one
+    /// wherever an operand goes. The four operands are laid down in [`bir::AggregateKind::RANGE_FIELDS`] order --
+    /// the two bounds first, in written source order because both are arbitrary expressions whose evaluation is
+    /// observable, then the step and the inclusivity flag, neither of which the surface can spell as an
+    /// expression. See that variant's own docs for why a range is an aggregate rather than a constant form or a
+    /// helper-constructed value, and for why inclusivity rides as an operand instead of as a static property of
+    /// the kind.
+    ///
+    /// No runtime requirement is recorded: four scalars side by side allocate nothing and call nothing, which is
+    /// [`bir::AggregateKind::Tuple`]'s treatment rather than [`Self::lower_list_literal`]'s.
+    pub(super) fn lower_range_value(
+        &mut self,
+        start: &ast::Spanned<ast::Expr>,
+        end: &ast::Spanned<ast::Expr>,
+        inclusive: bool,
+        span: ast::Span,
+        scope: bir::ScopeId,
+        out: &mut Vec<bir::Statement>,
+    ) -> bir::Operand {
+        let hir_span_value = hir_span(span);
+        let start_operand = self.lower_expr_to_operand(start, scope, out);
+        let end_operand = self.lower_expr_to_operand(end, scope, out);
+        let elements = fixed_elements(vec![
+            start_operand,
+            end_operand,
+            bir::Operand::Constant(bir::Constant::Int(RANGE_UNIT_STEP)),
+            bir::Operand::Constant(bir::Constant::Bool(inclusive)),
+        ]);
+        let ty = self.resolve_ty(span);
+        self.push_assign_temp(
+            bir::Rvalue::Aggregate(bir::AggregateKind::Range, elements),
+            ty,
+            scope,
+            hir_span_value,
+            out,
+        )
+    }
+
     /// Lower a dict literal `{k: v, ...}` to a [`bir::Rvalue::Dict`], one entry per source entry, in written order.
     ///
     /// Keys and values are lowered in written order, key before value, because both are arbitrary expressions

--- a/src/frontend/body_ir/match_.rs
+++ b/src/frontend/body_ir/match_.rs
@@ -1,5 +1,6 @@
 //! Lowering for `match` expressions and their patterns.
 
+use super::control_flow::intersect_range_layouts;
 use super::primitives::*;
 use super::reads::*;
 use super::refusals::*;
@@ -38,9 +39,10 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
     /// union-type pattern narrowing, no RFC 021 field-alias resolution).
     ///
     /// Bails the whole expression to an explicit unsupported placeholder *before* lowering the scrutinee when any
-    /// arm's pattern contains a byte-string literal (the one pattern shape [`bir::Constant`] cannot represent --
-    /// see [`match_pattern_is_supported`]), mirroring [`Self::lower_binary`]'s "check before partially lowering"
-    /// precedent so an unrepresentable pattern never produces a partially-lowered `Rvalue::Match`.
+    /// arm's pattern contains a byte-string literal (a pattern form outside Body IR's current closed matching
+    /// vocabulary -- see [`match_pattern_is_supported`]), mirroring [`Self::lower_binary`]'s "check before
+    /// partially lowering" precedent so an unrepresentable pattern never produces a partially-lowered
+    /// `Rvalue::Match`.
     pub(super) fn lower_match(
         &mut self,
         subject: &ast::Spanned<ast::Expr>,
@@ -69,8 +71,13 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
         // more precise facts against projected places rooted at this same scrutinee.
         let scrutinee_operand = bir::Operand::place(scrutinee_place.clone(), bir::OwnershipFact::Borrow, false);
 
+        let range_layouts_before = self.materialized_range_locals.clone();
+        let mut range_layouts_after_arms = Vec::with_capacity(arms.len());
         let mut lowered_arms = Vec::with_capacity(arms.len());
         for arm in arms {
+            // At runtime exactly one arm executes. Lower every arm from the predecessor fact set so a range
+            // constructed only in an earlier textual arm cannot authorize field projections in a later one.
+            self.materialized_range_locals = range_layouts_before.clone();
             let arm_span = hir_span(arm.span);
             let arm_scope = self.new_scope(Some(scope), arm_span);
 
@@ -121,6 +128,7 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
                     }
                 }
             }
+            range_layouts_after_arms.push(self.materialized_range_locals.clone());
 
             lowered_arms.push(bir::MatchArm {
                 pattern,
@@ -130,6 +138,9 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
                 result,
             });
         }
+        // Code after a match must be valid for whichever arm matched. Preserve a layout fact only when every
+        // arm leaves it true; no-arm matches conservatively retain no constructed-layout fact.
+        self.materialized_range_locals = intersect_range_layouts(range_layouts_after_arms);
 
         let ty = self.resolve_ty(expr_span);
         self.push_assign_temp(
@@ -209,11 +220,10 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
                 let (fact, last_use) = self.ownership_fact_for_place(place, expected_ty);
                 bir::Pattern::Var(bir::PatternBinding { local, fact, last_use })
             }
-            // `match_pattern_is_supported` has already ruled out the one shape `lower_literal` cannot represent
-            // (a byte-string literal) for every arm in this match before `Self::lower_match` calls this method at
-            // all, so the `None` case here is unreachable in practice; `Constant::Unit` is a harmless, structurally
-            // valid fallback rather than a panic if that invariant is ever violated.
-            ast::Pattern::Literal(lit) => bir::Pattern::Literal(lower_literal(lit).unwrap_or(bir::Constant::Unit)),
+            // `match_pattern_is_supported` has already ruled out byte-string patterns before
+            // `Self::lower_match` calls this method. Literal expression lowering is total; this is a separate
+            // pattern-vocabulary boundary, retained until Body IR models byte-pattern matching semantics.
+            ast::Pattern::Literal(lit) => bir::Pattern::Literal(lower_literal(lit)),
             ast::Pattern::Tuple(items) => {
                 let element_types = tuple_element_types(expected_ty, items.len());
                 let fields = items

--- a/src/frontend/body_ir/primitives.rs
+++ b/src/frontend/body_ir/primitives.rs
@@ -144,7 +144,7 @@ pub(super) fn lower_literal(lit: &ast::Literal) -> bir::Constant {
 /// helper with a local provenance check before reading [`bir::AggregateKind::Range`] fields. The `range()` builtin
 /// is deliberately *not* this type: it resolves to a plain `Named("Range")` iterator
 /// (`src/frontend/symbols.rs`) and keeps its existing iteration path.
-pub(super) const RANGE_TYPE_BASE: &str = "Range";
+pub(super) const RANGE_TYPE_BASE: &str = incan_core::lang::surface::types::RANGE_TYPE_NAME;
 /// The per-iteration increment of every range the surface can spell.
 ///
 /// There is no step spelling in the language (`start..end` and `start..=end` are the only forms the parser

--- a/src/frontend/body_ir/primitives.rs
+++ b/src/frontend/body_ir/primitives.rs
@@ -122,30 +122,28 @@ pub(super) fn lower_binary_op(op: ast::BinaryOp) -> Option<bir::BinOp> {
 ///
 /// Every literal kind the AST can hold now maps to a [`bir::Constant`], byte strings included -- a `b"..."`
 /// becomes [`bir::Constant::Bytes`] and never a [`bir::Constant::Str`], because the two are distinct source types
-/// whose ownership and equality differ (see that variant's own docs for the owned-buffer rationale). The `Option`
-/// return therefore has no `None` case left; it is kept because [`BodyBuilder::lower_match_pattern`] consumes this
-/// through the same signature, and byte-string *patterns* are still refused up front by
-/// [`match_pattern_is_supported`] rather than lowered here.
-pub(super) fn lower_literal(lit: &ast::Literal) -> Option<bir::Constant> {
+/// whose ownership and equality differ (see that variant's own docs for the owned-buffer rationale). Byte-string
+/// *patterns* remain a separate, deliberately unsupported pattern-admission boundary; they do not make literal
+/// expression lowering partial.
+pub(super) fn lower_literal(lit: &ast::Literal) -> bir::Constant {
     match lit {
-        ast::Literal::Int(int_lit) => Some(bir::Constant::Int(int_lit.value)),
-        ast::Literal::Float(float_lit) => Some(bir::Constant::Float(float_lit.repr.clone())),
-        ast::Literal::Decimal(decimal_lit) => Some(bir::Constant::Float(decimal_lit.repr.clone())),
-        ast::Literal::String(s) => Some(bir::Constant::Str(s.clone())),
-        ast::Literal::Bool(b) => Some(bir::Constant::Bool(*b)),
-        ast::Literal::None => Some(bir::Constant::None),
-        ast::Literal::Bytes(bytes) => Some(bir::Constant::Bytes(bytes.clone())),
+        ast::Literal::Int(int_lit) => bir::Constant::Int(int_lit.value),
+        ast::Literal::Float(float_lit) => bir::Constant::Float(float_lit.repr.clone()),
+        ast::Literal::Decimal(decimal_lit) => bir::Constant::Float(decimal_lit.repr.clone()),
+        ast::Literal::String(s) => bir::Constant::Str(s.clone()),
+        ast::Literal::Bool(b) => bir::Constant::Bool(*b),
+        ast::Literal::None => bir::Constant::None,
+        ast::Literal::Bytes(bytes) => bir::Constant::Bytes(bytes.clone()),
     }
 }
 /// Canonical base name of the checked range-value type, as the typechecker spells it (`Range[int]`).
 ///
-/// `TypeChecker::check_range_expr` (`src/frontend/typechecker/check_expr/control_flow.rs`) is the only place that
-/// mints this generic, and the collection-type registry carries no entry for it, so lowering matches the base name
-/// that one producer writes rather than a [`CollectionTypeId`] that does not exist. Because that producer is
-/// unique, every value of this type in a well-typed program came from a `start..end` / `start..=end` expression --
-/// which is what lets [`BodyBuilder::lower_for`] read a range value's declared fields back without first proving
-/// where the value was built. The `range()` builtin is deliberately *not* this type: it resolves to a plain
-/// `Named("Range")` iterator (`src/frontend/symbols.rs`) and keeps its existing iteration path.
+/// `TypeChecker::check_range_expr` (`src/frontend/typechecker/check_expr/control_flow.rs`) produces this spelling,
+/// but a type spelling is not evidence of a Body-IR aggregate layout: parameters, returns, and user declarations
+/// can cross the frontend boundary with the same generic base. [`BodyBuilder::lower_for`] therefore combines this
+/// helper with a local provenance check before reading [`bir::AggregateKind::Range`] fields. The `range()` builtin
+/// is deliberately *not* this type: it resolves to a plain `Named("Range")` iterator
+/// (`src/frontend/symbols.rs`) and keeps its existing iteration path.
 pub(super) const RANGE_TYPE_BASE: &str = "Range";
 /// The per-iteration increment of every range the surface can spell.
 ///
@@ -156,9 +154,8 @@ pub(super) const RANGE_TYPE_BASE: &str = "Range";
 pub(super) const RANGE_UNIT_STEP: i64 = 1;
 /// The element type a checked range value yields per iteration, or `None` when `ty` is not a range value.
 ///
-/// Used both to recognise a range in iterable position and to recover the loop item type: the typechecker's
-/// `infer_iterator_element_type` has no `Range` arm, so `for i in some_range` resolves its pattern to
-/// [`IncanType::Unknown`], while the range's own single type argument says exactly what it produces.
+/// Used to recognise a range-shaped type and recover a checked loop item type. A caller must not use this
+/// type-level fact alone as permission to project a range aggregate's fields; see [`RANGE_TYPE_BASE`].
 pub(super) fn range_value_element_type(ty: &IncanType) -> Option<&IncanType> {
     match ty {
         IncanType::Generic { base, args } if base == RANGE_TYPE_BASE => args.first(),

--- a/src/frontend/body_ir/primitives.rs
+++ b/src/frontend/body_ir/primitives.rs
@@ -118,7 +118,14 @@ pub(super) fn lower_binary_op(op: ast::BinaryOp) -> Option<bir::BinOp> {
         | ast::BinaryOp::PipeBackward => None,
     }
 }
-/// Lower a literal to a Body IR constant, or `None` for literal kinds v0 does not model distinctly (`bytes`).
+/// Lower a literal to a Body IR constant.
+///
+/// Every literal kind the AST can hold now maps to a [`bir::Constant`], byte strings included -- a `b"..."`
+/// becomes [`bir::Constant::Bytes`] and never a [`bir::Constant::Str`], because the two are distinct source types
+/// whose ownership and equality differ (see that variant's own docs for the owned-buffer rationale). The `Option`
+/// return therefore has no `None` case left; it is kept because [`BodyBuilder::lower_match_pattern`] consumes this
+/// through the same signature, and byte-string *patterns* are still refused up front by
+/// [`match_pattern_is_supported`] rather than lowered here.
 pub(super) fn lower_literal(lit: &ast::Literal) -> Option<bir::Constant> {
     match lit {
         ast::Literal::Int(int_lit) => Some(bir::Constant::Int(int_lit.value)),
@@ -127,6 +134,34 @@ pub(super) fn lower_literal(lit: &ast::Literal) -> Option<bir::Constant> {
         ast::Literal::String(s) => Some(bir::Constant::Str(s.clone())),
         ast::Literal::Bool(b) => Some(bir::Constant::Bool(*b)),
         ast::Literal::None => Some(bir::Constant::None),
-        ast::Literal::Bytes(_) => None,
+        ast::Literal::Bytes(bytes) => Some(bir::Constant::Bytes(bytes.clone())),
+    }
+}
+/// Canonical base name of the checked range-value type, as the typechecker spells it (`Range[int]`).
+///
+/// `TypeChecker::check_range_expr` (`src/frontend/typechecker/check_expr/control_flow.rs`) is the only place that
+/// mints this generic, and the collection-type registry carries no entry for it, so lowering matches the base name
+/// that one producer writes rather than a [`CollectionTypeId`] that does not exist. Because that producer is
+/// unique, every value of this type in a well-typed program came from a `start..end` / `start..=end` expression --
+/// which is what lets [`BodyBuilder::lower_for`] read a range value's declared fields back without first proving
+/// where the value was built. The `range()` builtin is deliberately *not* this type: it resolves to a plain
+/// `Named("Range")` iterator (`src/frontend/symbols.rs`) and keeps its existing iteration path.
+pub(super) const RANGE_TYPE_BASE: &str = "Range";
+/// The per-iteration increment of every range the surface can spell.
+///
+/// There is no step spelling in the language (`start..end` and `start..=end` are the only forms the parser
+/// produces), so this is a single shared constant rather than a lowered operand: it is both the
+/// [`bir::AggregateKind::RANGE_FIELD_STEP`] operand a range value carries and the increment
+/// [`BodyBuilder::lower_for`]'s normalized counting loop adds to its index, which keeps the two from drifting.
+pub(super) const RANGE_UNIT_STEP: i64 = 1;
+/// The element type a checked range value yields per iteration, or `None` when `ty` is not a range value.
+///
+/// Used both to recognise a range in iterable position and to recover the loop item type: the typechecker's
+/// `infer_iterator_element_type` has no `Range` arm, so `for i in some_range` resolves its pattern to
+/// [`IncanType::Unknown`], while the range's own single type argument says exactly what it produces.
+pub(super) fn range_value_element_type(ty: &IncanType) -> Option<&IncanType> {
+    match ty {
+        IncanType::Generic { base, args } if base == RANGE_TYPE_BASE => args.first(),
+        _ => None,
     }
 }

--- a/src/frontend/body_ir/refusals.rs
+++ b/src/frontend/body_ir/refusals.rs
@@ -164,9 +164,9 @@ pub(super) fn tuple_type_elements(ty: &IncanType) -> Option<&[IncanType]> {
     }
 }
 /// Whether `pattern` is representable by [`bir::Pattern`]'s closed vocabulary. The only unrepresentable shape is a
-/// byte-string literal pattern ([`bir::Constant`] has no byte-string variant -- see [`lower_literal`]'s own `None`
-/// case for the identical gap in plain literal *expressions*); every other pattern shape lowers structurally, with
-/// [`IncanType::Unknown`] field-type fallbacks where needed rather than an outright failure (see
+/// byte-string literal pattern: [`bir::Constant::Bytes`] represents byte *values*, but Body IR does not yet model
+/// byte-pattern matching semantics. Every other pattern shape lowers structurally, with [`IncanType::Unknown`]
+/// field-type fallbacks where needed rather than an outright failure (see
 /// [`BodyBuilder::lower_match_pattern`]'s own docs). Checked for every arm before [`BodyBuilder::lower_match`]
 /// lowers any of them, mirroring [`BodyBuilder::binary_op_is_supported`]'s "check before partially lowering"
 /// precedent.

--- a/src/frontend/body_ir/stmt.rs
+++ b/src/frontend/body_ir/stmt.rs
@@ -107,6 +107,7 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
         let ty = self
             .callable_value_ty(&assignment.value)
             .unwrap_or_else(|| self.resolve_ty(assignment.value.span));
+        let materializes_range = self.expr_has_materialized_range_layout(&assignment.value);
         let value = self.lower_expr_to_operand(&assignment.value, scope, out);
         let local = match assignment.binding {
             ast::BindingKind::Reassign => self
@@ -125,6 +126,11 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
             },
             span,
         });
+        if materializes_range {
+            self.materialized_range_locals.insert(local);
+        } else {
+            self.materialized_range_locals.remove(&local);
+        }
     }
 
     /// Lower `obj.field = value` (including the compound `obj.field <op>= value` form). The parser already

--- a/src/frontend/body_ir/tests.rs
+++ b/src/frontend/body_ir/tests.rs
@@ -5971,6 +5971,238 @@ fn an_unresolved_raises_error_type_refuses_by_naming_the_assert_form() -> Result
     Ok(())
 }
 
+// ---- Bytes literals and range values (#1165) ----
+
+#[test]
+fn bytes_literals_lower_to_their_own_constant_rather_than_a_string() -> Result<(), Box<dyn std::error::Error>> {
+    let source = concat!(
+        "def send(payload: bytes) -> int:\n",
+        "  return 1\n",
+        "\n",
+        "def keep() -> bytes:\n",
+        "  greeting = b\"hi\"\n",
+        "  return greeting\n",
+        "\n",
+        "def run() -> int:\n",
+        "  return send(b\"\\x00\\xff\")\n",
+    );
+    let module = build(source, &["m", "bytes_literal"])?;
+    let snapshot = module.render_snapshot();
+
+    assert!(
+        !snapshot.contains("unsupported("),
+        "a byte-string literal must lower to a real constant: {snapshot}"
+    );
+    assert!(
+        snapshot.contains("const(b\"\\x68\\x69\")"),
+        "a bound byte-string literal must render as its own bytes constant: {snapshot}"
+    );
+    assert!(
+        !snapshot.contains("const(\"hi\")"),
+        "a byte-string literal must never be represented as the string constant it is not: {snapshot}"
+    );
+    assert!(
+        snapshot.contains("call fn:send(const(b\"\\x00\\xff\"))"),
+        "a byte-string literal must survive as a constant in argument position: {snapshot}"
+    );
+    assert!(
+        snapshot.contains(" greeting : bytes [binding]"),
+        "the bound local must keep its checked `bytes` type: {snapshot}"
+    );
+
+    // The owned-buffer representation is what makes this read a move rather than a copy: `bytes` reports
+    // `AbiV0Ownership::Owned`, so its last read transfers ownership exactly as a `str` local's would.
+    let greeting = local_for_binding(&snapshot, "greeting").ok_or("expected a local for `greeting`")?;
+    assert!(
+        snapshot.contains(&format!("return move({greeting}, last_use)")),
+        "the last read of an owned bytes local must be a move: {snapshot}"
+    );
+    Ok(())
+}
+
+#[test]
+fn a_range_bound_to_a_local_lowers_to_a_range_value() -> Result<(), Box<dyn std::error::Error>> {
+    let source = concat!(
+        "def build_ranges() -> int:\n",
+        "  half_open = 0..10\n",
+        "  closed = 1..=5\n",
+        "  return 0\n",
+    );
+    let module = build(source, &["m", "range_value"])?;
+    let snapshot = module.render_snapshot();
+
+    assert!(
+        !snapshot.contains("unsupported("),
+        "a range in value position must lower to a real operand: {snapshot}"
+    );
+    assert!(
+        snapshot.contains("range[const(0), const(10), const(1), const(false)]"),
+        "an exclusive range must carry its bounds, unit step, and `false` inclusivity: {snapshot}"
+    );
+    assert!(
+        snapshot.contains("range[const(1), const(5), const(1), const(true)]"),
+        "an inclusive range must differ from the exclusive one only in its inclusivity operand: {snapshot}"
+    );
+    assert!(
+        snapshot.contains(" half_open : Range[int] [binding]"),
+        "the bound local must keep the checked range type: {snapshot}"
+    );
+    Ok(())
+}
+
+/// The facts two range spellings must agree on, read out of a lowered body's single `Loop` statement.
+///
+/// Deliberately not a snapshot comparison: a bound range reads its bounds off a value while an inline header
+/// lowers them from the AST, so the two bodies cannot be textually identical. What must match is how iteration
+/// proceeds -- counting rather than polling, one conditional exit, an item bound from the index by copy, and one
+/// arithmetic advance per iteration.
+#[derive(Debug, PartialEq)]
+struct RangeIterationFacts {
+    /// Whether any iteration in the body is an iterator poll rather than a counting step.
+    polls_an_iterator: bool,
+    /// How many `if <cond>: break` exits guard the loop.
+    conditional_breaks: usize,
+    /// Declared type of the local the loop pattern binds.
+    item_binding_ty: String,
+    /// Ownership fact the per-iteration item write reads the index with.
+    item_read_fact: String,
+    /// Operator the index is advanced with at the end of each iteration.
+    advance_op: String,
+}
+
+/// Extract [`RangeIterationFacts`] from the named body's single loop, over the binding `item_name`.
+fn range_iteration_facts(
+    module: &bir::BodyIrModule,
+    body_name: &str,
+    item_name: &str,
+) -> Result<RangeIterationFacts, Box<dyn std::error::Error>> {
+    let body = module
+        .bodies
+        .iter()
+        .find(|body| body.name == body_name)
+        .ok_or("expected the loop body")?;
+    let item_local = body
+        .locals
+        .iter()
+        .find(|local| local.name.as_deref() == Some(item_name))
+        .ok_or("expected a local for the loop binding")?;
+    let loop_stmts = body
+        .block
+        .stmts
+        .iter()
+        .find_map(|stmt| match &stmt.kind {
+            bir::StatementKind::Loop { body } => Some(&body.stmts),
+            _ => None,
+        })
+        .ok_or("expected a normalized loop")?;
+
+    let polls_an_iterator = loop_stmts
+        .iter()
+        .any(|stmt| matches!(&stmt.kind, bir::StatementKind::IterNext { .. }));
+    let conditional_breaks = loop_stmts
+        .iter()
+        .filter(|stmt| match &stmt.kind {
+            bir::StatementKind::If { then_block, .. } => {
+                matches!(then_block.stmts.as_slice(), [only] if matches!(&only.kind, bir::StatementKind::Break { .. }))
+            }
+            _ => false,
+        })
+        .count();
+    let item_read_fact = loop_stmts
+        .iter()
+        .find_map(|stmt| match &stmt.kind {
+            bir::StatementKind::Assign {
+                place,
+                rvalue: bir::Rvalue::Use(bir::Operand::Place(read)),
+            } if place.local == item_local.id && place.projection.is_empty() => Some(format!("{:?}", read.fact)),
+            _ => None,
+        })
+        .ok_or("expected the per-iteration item write")?;
+    let advance = loop_stmts
+        .get(loop_stmts.len().wrapping_sub(2))
+        .ok_or("expected an index advance before the loop ends")?;
+    let bir::StatementKind::Assign {
+        rvalue: bir::Rvalue::BinaryOp(advance_op, _, _),
+        ..
+    } = &advance.kind
+    else {
+        return Err("the statement before the index write must compute the advanced index".into());
+    };
+
+    Ok(RangeIterationFacts {
+        polls_an_iterator,
+        conditional_breaks,
+        item_binding_ty: item_local.ty.to_string(),
+        item_read_fact,
+        advance_op: format!("{advance_op:?}"),
+    })
+}
+
+#[test]
+fn a_bound_range_iterates_with_the_same_facts_as_the_inline_range() -> Result<(), Box<dyn std::error::Error>> {
+    let bound_source = concat!(
+        "def total() -> int:\n",
+        "  r = 0..10\n",
+        "  mut acc = 0\n",
+        "  for i in r:\n",
+        "    acc = acc + i\n",
+        "  return acc\n",
+    );
+    let inline_source = concat!(
+        "def total() -> int:\n",
+        "  mut acc = 0\n",
+        "  for i in 0..10:\n",
+        "    acc = acc + i\n",
+        "  return acc\n",
+    );
+    let bound = build(bound_source, &["m", "bound_range_for"])?;
+    let inline = build(inline_source, &["m", "inline_range_for"])?;
+
+    assert!(
+        !bound.render_snapshot().contains("unsupported("),
+        "iterating a bound range must not fall back to a placeholder: {}",
+        bound.render_snapshot()
+    );
+    let bound_facts = range_iteration_facts(&bound, "total", "i")?;
+    assert!(
+        !bound_facts.polls_an_iterator,
+        "a bound range must keep the counting-loop shape rather than degrading to an iterator poll: {bound_facts:?}"
+    );
+    assert_eq!(
+        bound_facts,
+        range_iteration_facts(&inline, "total", "i")?,
+        "a bound range must iterate with the same facts as the inline range it was bound from"
+    );
+    Ok(())
+}
+
+#[test]
+fn a_bound_range_loop_drives_itself_from_the_range_value_fields() -> Result<(), Box<dyn std::error::Error>> {
+    let source = concat!(
+        "def total() -> int:\n",
+        "  r = 1..=5\n",
+        "  mut acc = 0\n",
+        "  for i in r:\n",
+        "    acc = acc + i\n",
+        "  return acc\n",
+    );
+    let module = build(source, &["m", "bound_range_fields"])?;
+    let snapshot = module.render_snapshot();
+    let range = local_for_binding(&snapshot, "r").ok_or("expected a local for `r`")?;
+
+    for field in bir::AggregateKind::RANGE_FIELDS {
+        assert!(
+            snapshot.contains(&format!("copy({range}.{field})")),
+            "the loop must read the range's own `{field}` field rather than re-deriving it: {snapshot}"
+        );
+    }
+    assert!(
+        !snapshot.contains("iter_next("),
+        "a bound range must not be polled as a general iterable: {snapshot}"
+    );
+    Ok(())
+}
+
 /// Corrupt provider metadata whose authority is not a capability is rejected before lowering can mint a plan.
 #[test]
 fn corrupt_provider_metadata_with_a_non_capability_authority_is_rejected() -> Result<(), Box<dyn std::error::Error>> {

--- a/src/frontend/body_ir/tests.rs
+++ b/src/frontend/body_ir/tests.rs
@@ -5464,7 +5464,11 @@ fn a_pattern_assertion_binding_is_a_declared_local_read_by_the_statements_after_
     let bir::Pattern::Enum { variant, fields, .. } = pattern else {
         return Err(format!("expected `Some(..)` to lower to a constructor pattern: {pattern:?}").into());
     };
-    assert_eq!(variant, "Some");
+    assert_eq!(
+        variant,
+        constructors::as_str(constructors::ConstructorId::Some),
+        "the assertion must lower `Some(..)` to the registry's own constructor spelling",
+    );
     let [bir::Pattern::Var(binding)] = fields.as_slice() else {
         return Err(format!("expected one `PatternBinding` payload: {fields:?}").into());
     };

--- a/src/frontend/body_ir/tests.rs
+++ b/src/frontend/body_ir/tests.rs
@@ -1274,26 +1274,30 @@ fn trait_method_default_uses_a_deferred_source_computation() -> Result<(), Box<d
 }
 
 #[test]
-fn unrepresentable_default_is_a_parameter_refusal_at_its_own_span() -> Result<(), Box<dyn std::error::Error>> {
+fn byte_string_default_is_a_deferred_body_ir_constant_at_its_own_span() -> Result<(), Box<dyn std::error::Error>> {
     let source = "def keep(payload: bytes = b\"x\") -> bytes:\n  return payload\n";
     let module = build(source, &["m", "unsupported_default"])?;
     let keep = module.bodies.first().ok_or("expected the keep function Body IR")?;
     let payload = keep.params.first().ok_or("expected the payload parameter")?;
 
-    let bir::CallableParamDefault::Unsupported { span, description } = &payload.default else {
-        return Err("bytes defaults must refuse instead of pretending to be executable".into());
+    let bir::CallableParamDefault::Source(default) = &payload.default else {
+        return Err("bytes defaults must retain their representable Body-IR constant".into());
     };
-    assert_eq!(description, "bytes literal");
     let default_start = source.find("b\"x\"").ok_or("missing bytes default spelling")?;
     assert_eq!(
-        *span,
+        default.span,
         HirSourceSpan::new(default_start, default_start + "b\"x\"".len()),
-        "the refusal must retain the unsupported default expression's exact source span"
+        "the deferred computation must retain the default expression's exact source span"
+    );
+    assert!(default.stmts.is_empty());
+    assert_eq!(
+        default.result,
+        bir::Operand::Constant(bir::Constant::Bytes(b"x".to_vec()))
     );
     assert_eq!(
         keep.locals.len(),
         1,
-        "refused speculative lowering must not leak a default temporary or external local: {keep:?}"
+        "a literal default must not allocate a speculative temporary or external local: {keep:?}"
     );
     assert!(
         !keep
@@ -1301,7 +1305,7 @@ fn unrepresentable_default_is_a_parameter_refusal_at_its_own_span() -> Result<()
             .stmts
             .iter()
             .any(|statement| matches!(&statement.kind, bir::StatementKind::Unsupported { .. })),
-        "the refusal belongs to the parameter contract, not the normal function body: {keep:?}"
+        "the deferred default belongs to parameter metadata, not the normal function body: {keep:?}"
     );
 
     Ok(())
@@ -1446,10 +1450,10 @@ fn invalid_default_is_rejected_before_body_ir_is_built() -> Result<(), Box<dyn s
 
 #[test]
 fn refused_default_restores_ownership_state_before_local_ids_are_reused() -> Result<(), Box<dyn std::error::Error>> {
-    // Lowering the partial moves one of its synthesized forwarding locals before the bytes literal refuses.
+    // Lowering the partial moves one of its synthesized forwarding locals before the unsupported binary refuses.
     // The transaction must discard that move before `second` reuses the local id in the normal body, or the
     // required root-scope drop would silently disappear.
-    let source = "def route(method: str) -> str:\n  return method\n\ndef choose(value: str = (partial route(method=\"GET\")) + b\"x\") -> str:\n  first = \"first\"\n  second = \"second\"\n  return first\n";
+    let source = "def route(method: str) -> str:\n  return method\n\ndef choose(value: str = (partial route(method=\"GET\")) + missing) -> str:\n  first = \"first\"\n  second = \"second\"\n  return first\n";
     let (module, _diagnostics) = build_after_expected_typecheck_errors(source, &["m", "default_ownership_rollback"])?;
     let choose = module
         .bodies
@@ -1457,10 +1461,13 @@ fn refused_default_restores_ownership_state_before_local_ids_are_reused() -> Res
         .find(|body| body.name == "choose")
         .ok_or("expected the choose Body IR")?;
     let value = choose.params.first().ok_or("expected choose's value parameter")?;
-    assert!(matches!(
-        &value.default,
-        bir::CallableParamDefault::Unsupported { description, .. } if description == "bytes literal"
-    ));
+    let bir::CallableParamDefault::Unsupported { description, .. } = &value.default else {
+        return Err(format!("the unsupported default must remain a refusal: {:?}", value.default).into());
+    };
+    assert!(
+        description.contains("binary operator Add"),
+        "the refusal must name the unsupported default operation: {description}"
+    );
     let second = choose
         .locals
         .iter()
@@ -2546,10 +2553,9 @@ fn lowers_a_nested_tuple_pattern_with_field_projected_bindings() -> Result<(), B
 
 #[test]
 fn byte_string_literal_pattern_lowers_to_an_explicit_placeholder() -> Result<(), Box<dyn std::error::Error>> {
-    // `bir::Constant` has no byte-string variant (mirrors `lower_literal`'s own gap for a plain literal
-    // *expression*), so a match with an unrepresentable arm bails the whole expression to `Unsupported` before
-    // lowering the scrutinee, rather than silently mis-rendering the pattern as a catch-all wildcard the way
-    // the existing Rust-emission backend's own `lower_pattern` does.
+    // `bir::Constant::Bytes` represents a byte value, but the closed `bir::Pattern` vocabulary does not yet model
+    // byte-pattern matching semantics. Refuse before lowering the scrutinee rather than silently mis-rendering
+    // the pattern as a catch-all wildcard the existing Rust-emission backend's own `lower_pattern` would emit.
     let source = concat!(
         "def check(data: bytes) -> str:\n",
         "  match data:\n",
@@ -2610,6 +2616,17 @@ fn local_for_binding(snapshot: &str, name: &str) -> Option<String> {
         let (id, tail) = line.trim().strip_prefix("local ")?.split_once(' ')?;
         tail.starts_with(&format!("{name} : ")).then(|| format!("_{id}"))
     })
+}
+
+/// Find the last binding with `name`, used where a later same-name assignment shadows the earlier value.
+fn last_local_for_binding(snapshot: &str, name: &str) -> Option<String> {
+    snapshot
+        .lines()
+        .filter_map(|line| {
+            let (id, tail) = line.trim().strip_prefix("local ")?.split_once(' ')?;
+            tail.starts_with(&format!("{name} : ")).then(|| format!("_{id}"))
+        })
+        .next_back()
 }
 
 #[test]
@@ -6180,6 +6197,7 @@ fn a_bound_range_iterates_with_the_same_facts_as_the_inline_range() -> Result<()
 fn a_bound_range_loop_drives_itself_from_the_range_value_fields() -> Result<(), Box<dyn std::error::Error>> {
     let source = concat!(
         "def total() -> int:\n",
+        "  mut r = 0..5\n",
         "  r = 1..=5\n",
         "  mut acc = 0\n",
         "  for i in r:\n",
@@ -6188,7 +6206,7 @@ fn a_bound_range_loop_drives_itself_from_the_range_value_fields() -> Result<(), 
     );
     let module = build(source, &["m", "bound_range_fields"])?;
     let snapshot = module.render_snapshot();
-    let range = local_for_binding(&snapshot, "r").ok_or("expected a local for `r`")?;
+    let range = last_local_for_binding(&snapshot, "r").ok_or("expected a local for `r`")?;
 
     for field in bir::AggregateKind::RANGE_FIELDS {
         assert!(
@@ -6200,6 +6218,79 @@ fn a_bound_range_loop_drives_itself_from_the_range_value_fields() -> Result<(), 
         !snapshot.contains("iter_next("),
         "a bound range must not be polled as a general iterable: {snapshot}"
     );
+    for operator in [">", ">=", "not", " and ", " or "] {
+        assert!(
+            snapshot.contains(operator),
+            "the loop must derive its stop condition from the bound value's dynamic inclusivity: {snapshot}"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn a_range_returned_by_a_local_callable_refuses_before_field_projection() -> Result<(), Box<dyn std::error::Error>> {
+    let source = concat!(
+        "def identity[T](value: T) -> T:\n",
+        "  return value\n",
+        "\n",
+        "def total() -> int:\n",
+        "  values = identity(0..4)\n",
+        "  for value in values:\n",
+        "    return value\n",
+        "  return 0\n",
+    );
+    let module = build(source, &["m", "opaque_range_parameter"])?;
+    let snapshot = module.render_snapshot();
+
+    assert!(
+        snapshot.contains("unsupported(range value without a source-local Body IR range aggregate)"),
+        "a type spelling alone must not invent a Range aggregate layout: {snapshot}"
+    );
+    for field in bir::AggregateKind::RANGE_FIELDS {
+        assert!(
+            !snapshot.contains(&format!("values.{field}")),
+            "a callable result with no local range aggregate must never acquire a synthetic `{field}` projection: {snapshot}"
+        );
+    }
+    Ok(())
+}
+
+/// Deferred or zero-or-more expression scopes cannot make an enclosing call result into a source-local range
+/// aggregate. Closures and comprehension elements are expression-only in the current grammar, so assignments cannot
+/// occur in those bodies; these source fixtures instead pin the reachable boundary: capturing or yielding the opaque
+/// `Range[int]` value does not authorize later range-field projections from the enclosing binding.
+#[test]
+fn nested_or_deferred_range_uses_do_not_authorize_an_outer_range_projection() -> Result<(), Box<dyn std::error::Error>>
+{
+    let prefix = concat!(
+        "def identity[T](value: T) -> T:\n",
+        "  return value\n",
+        "\n",
+        "def total() -> int:\n",
+        "  mut r = identity(0..4)\n",
+    );
+    let suffix = concat!("  for value in r:\n", "    return value\n", "  return 0\n",);
+    let nested_bodies = [
+        "  unused = () => r\n",
+        "  unused = (r for ignored in [])\n",
+        "  unused = [r for ignored in []]\n",
+    ];
+
+    for (index, nested_body) in nested_bodies.iter().enumerate() {
+        let source = format!("{prefix}{nested_body}{suffix}");
+        let module = build(&source, &["m", "nested_range_provenance"])?;
+        let snapshot = module.render_snapshot();
+        assert!(
+            snapshot.contains("unsupported(range value without a source-local Body IR range aggregate)"),
+            "nested fixture {index} must leave the outer call result unproven: {snapshot}"
+        );
+        for field in bir::AggregateKind::RANGE_FIELDS {
+            assert!(
+                !snapshot.contains(&format!("r.{field}")),
+                "nested fixture {index} must not project a range field from the outer call result: {snapshot}"
+            );
+        }
+    }
     Ok(())
 }
 

--- a/src/frontend/typechecker/check_expr/control_flow.rs
+++ b/src/frontend/typechecker/check_expr/control_flow.rs
@@ -416,6 +416,6 @@ impl TypeChecker {
                 .push(errors::type_mismatch("int", &end_ty.to_string(), end.span));
         }
 
-        ResolvedType::Generic("Range".to_string(), vec![ResolvedType::Int])
+        ResolvedType::Generic(surface_types::RANGE_TYPE_NAME.to_string(), vec![ResolvedType::Int])
     }
 }

--- a/src/frontend/typechecker/check_stmt.rs
+++ b/src/frontend/typechecker/check_stmt.rs
@@ -1649,6 +1649,14 @@ impl TypeChecker {
                 if let Some(elem) = iter_ty.iterator_item_type() {
                     return elem.clone();
                 }
+                // A range is not a collection, so it has no `collection_type_id`, but iterating one still yields its
+                // element type. The inline `for i in 0..10` header never reaches here because `check_for_stmt`
+                // resolves that expression directly; only a range *bound to a local* arrives as a `Range[T]` value.
+                // Without this arm that binding iterates with an unknown item type, which stays invisible until
+                // something downstream needs the type -- `acc + i` refusing to lower, for instance.
+                if name == "Range" && !args.is_empty() {
+                    return args[0].clone();
+                }
                 match collection_type_id(name.as_str()) {
                     Some(CollectionTypeId::List) | Some(CollectionTypeId::Set) if !args.is_empty() => args[0].clone(),
                     Some(CollectionTypeId::Dict) if args.len() >= 2 => {

--- a/src/frontend/typechecker/check_stmt.rs
+++ b/src/frontend/typechecker/check_stmt.rs
@@ -1654,7 +1654,7 @@ impl TypeChecker {
                 // resolves that expression directly; only a range *bound to a local* arrives as a `Range[T]` value.
                 // Without this arm that binding iterates with an unknown item type, which stays invisible until
                 // something downstream needs the type -- `acc + i` refusing to lower, for instance.
-                if name == "Range" && !args.is_empty() {
+                if name == incan_core::lang::surface::types::RANGE_TYPE_NAME && !args.is_empty() {
                     return args[0].clone();
                 }
                 match collection_type_id(name.as_str()) {

--- a/tests/parity_corpus_tests.rs
+++ b/tests/parity_corpus_tests.rs
@@ -527,6 +527,47 @@ fn case_supported_call_spreads_reach_body_ir() -> ComparisonOutcome {
 }
 
 // ============================================================================
+// Cases 15 and 16 — Supported language contract: bytes literals and range values reach Body IR (#1165)
+// ============================================================================
+
+// A byte-string literal is ordinary accepted source with its own type, but `lower_literal` had no `bir::Constant`
+// for it, so every `b"..."` reached a placeholder. The row is about representation, not bytes operations: those
+// keep whatever refusal they already had.
+const CASE_15_SRC: &str = r#"
+def send(payload: bytes) -> int:
+    return 1
+
+def main() -> None:
+    greeting = b"hi"
+    println(send(greeting))
+"#;
+
+fn case_supported_bytes_literal_reaches_body_ir() -> ComparisonOutcome {
+    outcome_from_body_ir(
+        CASE_15_SRC,
+        "a byte-string literal to lower to its own bytes constant rather than a placeholder",
+    )
+}
+
+// A range is a value, not only a `for` header. `r = 0..10` has always typechecked, so refusing it in lowering left
+// Body IR non-total over accepted programs; binding one and then iterating it exercises both halves.
+const CASE_16_SRC: &str = r#"
+def main() -> None:
+    r = 0..10
+    mut total = 0
+    for i in r:
+        total = total + i
+    println(total)
+"#;
+
+fn case_supported_range_value_reaches_body_ir() -> ComparisonOutcome {
+    outcome_from_body_ir(
+        CASE_16_SRC,
+        "a range bound to a local to lower to a real range value that the loop then iterates",
+    )
+}
+
+// ============================================================================
 // Case 6 — Diagnostic behavior: dead code after `return` warns (migrated from a silent accept)
 // ============================================================================
 
@@ -1139,6 +1180,28 @@ fn seed_corpus() -> Vec<ParityCase> {
             disposition: Disposition::Preserved,
             source: CASE_3_SRC,
             evaluate: Some(case_supported_string_membership_reaches_body_ir),
+            replacement_execution: None,
+        },
+        ParityCase {
+            id: "parity-987-0015",
+            title: "Byte-string literals are representable in Body IR",
+            category: BehaviorCategory::SupportedLanguageContract,
+            lane: EvidenceLane::DirectParserTypechecker,
+            evidence: "#1165; src/frontend/body_ir/tests.rs::bytes_literals_lower_to_their_own_constant_rather_than_a_string",
+            disposition: Disposition::Preserved,
+            source: CASE_15_SRC,
+            evaluate: Some(case_supported_bytes_literal_reaches_body_ir),
+            replacement_execution: None,
+        },
+        ParityCase {
+            id: "parity-987-0016",
+            title: "A range bound to a local is representable in Body IR and iterates from that value",
+            category: BehaviorCategory::SupportedLanguageContract,
+            lane: EvidenceLane::DirectParserTypechecker,
+            evidence: "#1165; src/frontend/body_ir/tests.rs::a_bound_range_iterates_with_the_same_facts_as_the_inline_range",
+            disposition: Disposition::Preserved,
+            source: CASE_16_SRC,
+            evaluate: Some(case_supported_range_value_reaches_body_ir),
             replacement_execution: None,
         },
         ParityCase {

--- a/tests/replacement_backend_execution_tests.rs
+++ b/tests/replacement_backend_execution_tests.rs
@@ -1473,11 +1473,15 @@ def main() -> int:
     };
     let default_start = source
         .find("b\"x\"")
-        .ok_or("default fixture must contain bytes literal")?;
+        .ok_or("default fixture must contain a byte-string literal")?;
     let span = error.primary_span().ok_or("default refusal must retain source span")?;
     assert_eq!(span.start, default_start);
     assert_eq!(span.end, default_start + "b\"x\"".len());
-    assert!(error.to_string().contains("bytes literal"));
+    // The refusal moved but did not weaken. Before #1165 a byte-string literal had no `bir::Constant`, so
+    // *lowering* refused it; now it lowers and the executor refuses the value, because this profile carries no
+    // `bytes` runtime representation. The property under test is unchanged -- refused at the default's own span,
+    // with no receipt -- so only the construct's name in the message moves.
+    assert!(error.to_string().contains("byte-string literal"));
     Ok(())
 }
 
@@ -2632,7 +2636,7 @@ def main() -> int:
     let default_start = source.find("b\"x\"").ok_or("fixture must contain bytes default")?;
     let default_end = default_start + "b\"x\"".len();
     assert!(
-        combined.contains("bytes literal"),
+        combined.contains("byte-string literal"),
         "refusal must name the unsupported default: {combined}"
     );
     assert!(

--- a/tests/replacement_backend_execution_tests.rs
+++ b/tests/replacement_backend_execution_tests.rs
@@ -1485,6 +1485,40 @@ def main() -> int:
     Ok(())
 }
 
+/// A materialized range aggregate remains outside the direct runtime profile. Preflight must reject the aggregate
+/// before evaluating either bound, so an observable bound cannot turn a refusal into a partial execution.
+#[test]
+fn replacement_refuses_a_range_aggregate_before_evaluating_its_bounds() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+def bound() -> int:
+  assert false
+  return 4
+
+def main() -> int:
+  values = 0..bound()
+  return 1
+"#;
+    let module = lower_typed_body_ir(source)?;
+    let error = execute_free_function(&module, "main", &[])
+        .err()
+        .ok_or("a range aggregate must refuse before replacement execution")?;
+    let range_start = source
+        .find("0..bound()")
+        .ok_or("fixture must contain a range aggregate")?;
+    let span = error
+        .primary_span()
+        .ok_or("range aggregate refusal must retain its source span")?;
+
+    assert!(error.to_string().contains("range aggregate"));
+    assert_eq!(span.start, range_start);
+    assert_eq!(span.end, range_start + "0..bound()".len());
+    assert!(
+        !error.to_string().contains("assertion failed"),
+        "the range boundary must reject before it can execute the bound call: {error}"
+    );
+    Ok(())
+}
+
 /// A missing direct-entry argument refuses at the original declaration body, whose call is the selected entrypoint.
 #[test]
 fn replacement_refuses_a_missing_required_callable_argument_at_the_declaration_body_span()
@@ -2651,6 +2685,63 @@ def main() -> int:
             && !temporary.path().join("target/incan").exists()
             && !temporary.path().join(".incan/backend/receipt.json").exists(),
         "an unsupported default must not generate legacy output or publish a replacement receipt"
+    );
+    Ok(())
+}
+
+/// A source-selected range value is rejected at the aggregate before replacement can execute its bound call,
+/// generate a legacy artifact, or publish a receipt.
+#[test]
+fn replacement_cli_refuses_a_range_aggregate_without_a_receipt() -> Result<(), Box<dyn std::error::Error>> {
+    let temporary = tempfile::tempdir()?;
+    let entrypoint = temporary.path().join("main.incn");
+    let source = r#"def bound() -> int:
+  assert false
+  return 4
+
+def main() -> int:
+  values = 0..bound()
+  return 1
+"#;
+    fs::write(&entrypoint, source)?;
+
+    let output = Command::new(incan_binary())
+        .args([
+            "build",
+            entrypoint.to_string_lossy().as_ref(),
+            "--backend",
+            "replacement",
+            "--backend-fallback",
+            "refuse",
+        ])
+        .output()?;
+    assert!(!output.status.success(), "a range aggregate must visibly refuse");
+    let combined = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let range_start = source
+        .find("0..bound()")
+        .ok_or("fixture must contain a range aggregate")?;
+    let range_end = range_start + "0..bound()".len();
+    assert!(
+        combined.contains("range aggregate"),
+        "refusal must name the unsupported aggregate: {combined}"
+    );
+    assert!(
+        combined.contains(&format!(
+            "primary Incan source location: {}:{range_start}..{range_end}",
+            entrypoint.display()
+        )),
+        "refusal must retain the aggregate span: {combined}"
+    );
+    assert!(
+        !combined.contains("assertion failed")
+            && !combined.contains("Generated Rust project")
+            && !temporary.path().join("target/incan").exists()
+            && !temporary.path().join(".incan/backend/receipt.json").exists(),
+        "a range aggregate must not execute its bounds, fall back, or publish a receipt"
     );
     Ok(())
 }

--- a/workspaces/docs-site/docs/language/reference/language.md
+++ b/workspaces/docs-site/docs/language/reference/language.md
@@ -49,6 +49,7 @@ Reservation describes how a spelling is reserved: `Hard` keywords are always res
 | Def | `def` | `fn` | Hard | - | Definition | Statement | RFC 000 | 0.1 | Stable |
 | Async | `async` |  | Soft | `std.async` | Definition | Modifier | RFC 000 | 0.1 | Stable |
 | Await | `await` |  | Soft | `std.async` | Definition | Expression | RFC 000 | 0.1 | Stable |
+| Capability | `capability` |  | Contextual | - | Definition | Statement | RFC 104 | 0.6 | Draft |
 | Class | `class` |  | Hard | - | Definition | Statement | RFC 000 | 0.1 | Stable |
 | Model | `model` |  | Hard | - | Definition | Statement | RFC 000 | 0.1 | Stable |
 | Trait | `trait` |  | Hard | - | Definition | Statement | RFC 000 | 0.1 | Stable |
@@ -368,6 +369,7 @@ Class, model, trait, enum, newtype, field, alias, and module decorators remain l
 | ClassMethod | `@classmethod` |  | Mark a method as a class method (no implicit self receiver). | RFC 000 | 0.2 | Stable |
 | Requires | `@requires` |  | Declare required fields for trait default methods. | RFC 000 | 0.1 | Stable |
 | Describe | `@std.registry.describe` |  | Attach a compiler-checked typed registry descriptor to a declaration. | RFC 113 | 0.5 | Stable |
+| ProviderOperation | `@provider_operation` |  | Attach one checked RFC 104 capability requirement to a provider function. | RFC 104 | 0.6 | Stable |
 
 ## Derives
 

--- a/workspaces/ide/vscode/incan.tmLanguage.json
+++ b/workspaces/ide/vscode/incan.tmLanguage.json
@@ -628,7 +628,7 @@
           "name": "keyword.control.async.incan"
         },
         {
-          "match": "\\b(alias|class|def|enum|fn|model|newtype|trait|type)\\b",
+          "match": "\\b(alias|capability|class|def|enum|fn|model|newtype|trait|type)\\b",
           "name": "keyword.declaration.incan"
         },
         {


### PR DESCRIPTION
## Summary

Adds the Slice 1 Body-IR vocabulary for byte literals and source-local range values, while keeping unsupported runtime profiles visibly fail-closed.

Closes #1165.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [x] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: byte literals now retain a distinct Body-IR `bytes` value; source-local ranges can be bound and iterated using their recorded fields.
- **Internals**: a bound range is projected only when Body IR can prove its current local was constructed as `AggregateKind::Range` (or copied from one). A parameter, call result, import, or same-spelled type without that proof refuses before synthetic field projection. Provenance is joined conservatively across control flow and does not escape deferred or zero-or-more nested bodies.
- **Risks**: the replacement executor continues to refuse byte runtime values and materialized range aggregates before evaluating their bounds. That produces no generated-Rust fallback, artifact, or receipt. Inline counting-range execution is unchanged and is not evidence that range values execute.

## Testing / verification

- [x] `cargo test`
- [ ] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `cargo test -p incan --lib body_ir` — 208 passed
- `cargo test -p incan_semantics_core --lib body_ir` — 30 passed
- `cargo test -p incan --test replacement_backend_execution_tests` — 75 passed
- `cargo test -p incan --test parity_corpus_tests` — 9 passed
- `cargo clippy -p incan -p incan_semantics_core --all-targets -- -D warnings`, `make fmt`, `make fmt-check`, `make rustdoc-gate`, and `git diff --check` passed.
- The shared Oven/full `make pre-commit` gate remains deliberately deferred to Slice 1 integration.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions
