### PR TITLE
chore - state and enforce the Body IR input contract for desugared vocab and DSL surface (#1166)

### DIFF
--- a/src/backend/shadow/mod.rs
+++ b/src/backend/shadow/mod.rs
@@ -75,7 +75,7 @@ use crate::backend::selection::{
     BackendExecutionReceipt, BackendKind, BackendSelection, FallbackPolicy, ShadowComparisonState, digest_output,
     finalize_receipt, resolve_execution, select_backend,
 };
-use crate::frontend::body_ir::build_body_ir_module_v0;
+use crate::frontend::body_ir::{apply_body_ir_input_contract, build_body_ir_module_v0};
 use crate::frontend::diagnostics::DIAGNOSTIC_SCHEMA_VERSION;
 use crate::frontend::typechecker::TypeChecker;
 use crate::frontend::{lexer, parser};
@@ -211,6 +211,16 @@ impl ShadowComparisonProfile {
         if self.function == "main" {
             return Err(ShadowUnavailable::new(PROGRAM_ENTRYPOINT_UNAVAILABLE_REASON));
         }
+        let program_after_input_contract = self.program_after_input_contract()?;
+        let function_is_active = program_after_input_contract.declarations.iter().any(|declaration| {
+            matches!(&declaration.node, crate::frontend::ast::Declaration::Function(function) if function.name == self.function)
+        });
+        if !function_is_active {
+            return Err(ShadowUnavailable::new(format!(
+                "the comparison profile's function `{}` is absent from the manifest-free feature projection, so neither route may observe it",
+                self.function
+            )));
+        }
         let arguments = self.argument_literals()?.join(", ");
         let mut program = self.source.clone();
         if !program.ends_with('\n') {
@@ -223,6 +233,23 @@ impl ShadowComparisonProfile {
             self.function
         );
         Ok(program)
+    }
+
+    /// Parse and prepare the profile source through the same manifest-free Body-IR input contract as both routes.
+    ///
+    /// The profile intentionally owns no package manifest or feature selection, so its only valid feature
+    /// projection is empty. Preparing before either route observes the selected function prevents a declaration
+    /// behind `when feature(...)` from becoming comparison evidence for a compilation that does not contain it.
+    fn program_after_input_contract(&self) -> Result<crate::frontend::ast::Program, ShadowUnavailable> {
+        let tokens = lexer::lex(self.source())
+            .map_err(|errors| ShadowUnavailable::new(format!("comparison source did not lex: {errors:?}")))?;
+        let program = parser::parse(&tokens)
+            .map_err(|errors| ShadowUnavailable::new(format!("comparison source did not parse: {errors:?}")))?;
+        apply_body_ir_input_contract(program, Path::new("incan_shadow_comparison.incn")).map_err(|errors| {
+            ShadowUnavailable::new(format!(
+                "comparison source did not satisfy the Body IR input contract: {errors:?}"
+            ))
+        })
     }
 
     /// Render every argument as the Incan source literal the legacy entrypoint passes.
@@ -696,10 +723,7 @@ pub(crate) struct LegacyRouteResult {
 /// [`ShadowUnavailable`].
 fn observe_replacement_route(profile: &ShadowComparisonProfile) -> Result<ReplacementRouteResult, ShadowUnavailable> {
     let body_ir = {
-        let tokens = lexer::lex(profile.source())
-            .map_err(|errors| ShadowUnavailable::new(format!("comparison source did not lex: {errors:?}")))?;
-        let program = parser::parse(&tokens)
-            .map_err(|errors| ShadowUnavailable::new(format!("comparison source did not parse: {errors:?}")))?;
+        let program = profile.program_after_input_contract()?;
         let module_path = vec!["incan_shadow_comparison".to_string()];
         let mut checker = TypeChecker::new();
         checker.set_current_module_path(Some(module_path.clone()));

--- a/src/backend/shadow/tests.rs
+++ b/src/backend/shadow/tests.rs
@@ -382,6 +382,33 @@ fn observing_a_program_entrypoint_is_outside_the_profile() {
 }
 
 #[test]
+fn an_inactive_feature_gated_function_is_unavailable_to_both_comparison_routes() {
+    let profile = ShadowComparisonProfile::new(
+        "when feature(\"beta\"):\n    def gated() -> int:\n        return 42\n",
+        "gated",
+        vec![],
+    );
+
+    let Err(replacement) = observe_replacement_route(&profile) else {
+        panic!("the replacement route must not execute a function projected out by an inactive feature");
+    };
+    assert!(
+        replacement.reason.contains("no free function named `gated`"),
+        "{replacement:?}"
+    );
+
+    let Err(legacy) = profile.legacy_program_source() else {
+        panic!("the legacy route must not synthesize an entrypoint for a projected-out function");
+    };
+    assert!(
+        legacy
+            .reason
+            .contains("absent from the manifest-free feature projection"),
+        "{legacy:?}"
+    );
+}
+
+#[test]
 fn a_non_scalar_argument_is_refused_rather_than_guessed() {
     let profile = ShadowComparisonProfile::new(
         "def echo(value: int) -> int:\n    return value\n",

--- a/src/cli/commands/build.rs
+++ b/src/cli/commands/build.rs
@@ -57,7 +57,7 @@ use crate::frontend::registry_metadata::{
     collect_checked_registry_metadata, materialize_registry_reexport_projections,
 };
 use crate::frontend::typechecker::stdlib_loader::StdlibAstCache;
-use crate::frontend::{diagnostics, lexer, parser, typechecker};
+use crate::frontend::{diagnostics, lexer, parser, typechecker, vocab_desugar_pass};
 use crate::generated_cache::resolve_generated_cargo_target;
 #[cfg(feature = "rust_inspect")]
 use crate::library_manifest::LibraryRustAbi;
@@ -2560,12 +2560,53 @@ fn resolve_available_replacement_execution(selection: &BackendSelection) -> CliR
     }
 }
 
+/// Prepare one parsed replacement-backend module for [`build_body_ir_module_v0`]'s input contract.
+///
+/// The legacy pipeline owes Body IR a desugared, feature-projected program, and it pays that debt at parse time:
+/// `CompilationSession::parse_source` (`src/cli/commands/common.rs`) parses, runs
+/// `vocab_desugar_pass::desugar_program_vocab_blocks`, then projects the result through the session's active
+/// package features — all before the program is typechecked or lowered. This applies the same two steps in the
+/// same order for the replacement path, so a vocab-authored body means the same thing through either backend
+/// (#1166).
+///
+/// Ordering matters beyond the pair itself. The caller applies this immediately after parsing, ahead of
+/// [`replacement_module_profile_error`] and typechecking, because both of those must see the projected program: an
+/// import behind an inactive feature is not part of this compilation, and refusing it as an unsupported profile
+/// boundary would report a declaration the build does not contain.
+///
+/// Two deliberate differences from the legacy session, both consequences of this path reading no project manifest.
+/// No package feature is active, so every `when feature(...)` declaration projects away here — which is the
+/// correct answer for a compilation with no feature graph, not a shortcut. And feature *names* are not validated
+/// against a declared-feature set, because there is no manifest to declare one; that check stays a project-level
+/// concern rather than becoming a manifest-free approximation that could disagree with the legacy path.
+///
+/// # Errors
+///
+/// Returns the desugar pass's own diagnostics unchanged. A scoped-DSL surface whose owning library manifest is
+/// unavailable is refused there, at that boundary, and this deliberately adds no second diagnostic for it.
+fn apply_body_ir_input_contract(
+    mut program: crate::frontend::ast::Program,
+    entrypoint: &Path,
+) -> Result<crate::frontend::ast::Program, Vec<diagnostics::CompileError>> {
+    let entrypoint_display = entrypoint.to_string_lossy();
+    vocab_desugar_pass::desugar_program_vocab_blocks(
+        &mut program,
+        Some(entrypoint_display.as_ref()),
+        &LibraryManifestIndex::default(),
+    )?;
+    Ok(program.projected_for_features(&BTreeSet::new()))
+}
+
 /// Execute the first #988 replacement-backend profile directly from typed Body IR.
 ///
 /// This intentionally has no `ProjectGenerator`, Oven, or generated-Rust path. It accepts only one source module
 /// containing free functions and executes its zero-argument `main` body through the replacement executor. A
 /// requested replacement build therefore either records a replacement receipt over a real Body-IR result or fails
 /// visibly at the original Incan span; it can never reach `IrCodegen` as an implicit compatibility fallback.
+///
+/// The pipeline is lex, parse, [`apply_body_ir_input_contract`], module-profile gate, typecheck, then
+/// [`build_body_ir_module_v0`]. The contract step is not optional sequencing: without it this path would hand
+/// lowering a program the legacy path would never have produced, which is the divergence #1166 closes.
 fn build_replacement_file_report(
     file_path: &str,
     options: BuildCommandOptions,
@@ -2595,6 +2636,12 @@ fn build_replacement_file_report(
     let program = parser::parse(&tokens).map_err(|errors| {
         CliError::failure(format!(
             "replacement backend could not parse {}: {errors:?}",
+            entrypoint.display()
+        ))
+    })?;
+    let program = apply_body_ir_input_contract(program, &entrypoint).map_err(|errors| {
+        CliError::failure(format!(
+            "replacement backend could not desugar {}: {errors:?}",
             entrypoint.display()
         ))
     })?;
@@ -18635,6 +18682,158 @@ pub model Nested:
             .err()
             .ok_or("a source-free provider without a sealed package Loaf must fail closed")?;
         assert!(missing_handoff.to_string().contains("without its sealed package Loaf"));
+        Ok(())
+    }
+
+    // ---- Body IR input contract (#1166) ----
+
+    /// A raw vocab declaration whose owning library manifest this compilation never loaded.
+    ///
+    /// The parser only produces one of these when an import activates a library vocabulary, which the replacement
+    /// module profile still refuses, so building it by hand is the only way to put the desugar pass in front of a
+    /// node it must resolve.
+    fn undesugared_vocab_declaration() -> Spanned<Declaration> {
+        Spanned::new(
+            Declaration::VocabBlock(crate::frontend::ast::VocabBlockStmt {
+                keyword: "query".to_string(),
+                keyword_binding: crate::frontend::ast::VocabKeywordBinding {
+                    is_declaration_owned_clause: false,
+                    dependency_key: "demo.query".to_string(),
+                    activation_namespace: "demo".to_string(),
+                    surface_kind: incan_vocab::KeywordSurfaceKind::FunctionDecl,
+                    compound_tokens: Vec::new(),
+                    placement: incan_vocab::KeywordPlacement::TopLevel,
+                    clause_body_kind: None,
+                },
+                decorators: Vec::new(),
+                signature_head: None,
+                header_args: Vec::new(),
+                body: Vec::new(),
+                body_item_trailing_commas: Vec::new(),
+            }),
+            Span::new(0, 1),
+        )
+    }
+
+    /// Build the replacement-backend options a `--backend replacement` build resolves to.
+    fn replacement_build_options() -> BuildCommandOptions {
+        BuildCommandOptions {
+            backend: BackendSelectionOptions {
+                requested: BackendKind::Replacement,
+                explicit: true,
+                shadow: false,
+                fallback_policy: FallbackPolicy::Refuse,
+            },
+            ..BuildCommandOptions::default()
+        }
+    }
+
+    #[test]
+    fn the_contract_step_refuses_a_vocab_declaration_with_the_desugar_pass_own_diagnostic()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // The replacement path owes Body IR a desugared program. This is what "owes" means concretely: a vocab
+        // declaration whose library is unavailable stops here, with the resolution failure the desugar pass already
+        // reports, rather than travelling on to become a lowering refusal at the same span.
+        let program = crate::frontend::ast::Program {
+            declarations: vec![undesugared_vocab_declaration()],
+            ..Default::default()
+        };
+
+        let errors = apply_body_ir_input_contract(program, Path::new("/fixture/main.incn"))
+            .err()
+            .ok_or("an undesugared vocab declaration must not pass the Body IR input contract")?;
+        let messages = errors
+            .iter()
+            .map(|error| error.message.clone())
+            .collect::<Vec<_>>()
+            .join("; ");
+        assert!(
+            messages.contains("desugarer resolution failed") && messages.contains("demo.query"),
+            "the desugar pass must own this diagnostic, naming the unavailable dependency: {messages}"
+        );
+        assert!(
+            !messages.contains("input-contract violation"),
+            "one unavailable-manifest condition must not produce two divergent diagnostics: {messages}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn the_contract_step_projects_a_body_behind_an_inactive_feature_out_of_the_program()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // Feature projection has to happen before the module-profile gate and before lowering, so this checks the
+        // program the rest of the pipeline actually receives rather than only the eventual build outcome.
+        let source =
+            "when feature(\"beta\"):\n    def gated() -> int:\n        return 7\n\ndef main() -> int:\n    return 1\n";
+        let tokens = lexer::lex(source).map_err(|errors| CliError::failure(format!("{errors:?}")))?;
+        let parsed = parser::parse(&tokens).map_err(|errors| CliError::failure(format!("{errors:?}")))?;
+        assert_eq!(
+            parsed.declarations.len(),
+            2,
+            "the fixture must carry a gated declaration, or the assertion below proves nothing"
+        );
+
+        let projected = apply_body_ir_input_contract(parsed, Path::new("/fixture/main.incn"))
+            .map_err(|errors| CliError::failure(format!("{errors:?}")))?;
+        let names = projected
+            .declarations
+            .iter()
+            .filter_map(|declaration| match &declaration.node {
+                Declaration::Function(function) => Some(function.name.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            names,
+            ["main"],
+            "a declaration behind an inactive feature must not survive the contract step"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn the_replacement_build_never_executes_a_main_behind_an_inactive_feature() -> Result<(), Box<dyn std::error::Error>>
+    {
+        // The end-to-end consequence, through the real CLI entry point: with no active feature there is no `main`
+        // to lower, so the build must refuse rather than execute a body this compilation does not contain.
+        let project = tempfile::tempdir()?;
+        let entrypoint = project.path().join("main.incn");
+        fs::write(
+            &entrypoint,
+            "when feature(\"beta\"):\n    def main() -> int:\n        return 7\n",
+        )?;
+
+        let error = build_replacement_file_report(
+            &entrypoint.to_string_lossy(),
+            replacement_build_options(),
+            &BuildReportOptions::default(),
+        )
+        .err()
+        .ok_or("a `main` behind an inactive feature must not produce a successful replacement build")?;
+        assert!(
+            !error.to_string().contains("7"),
+            "no gated body may have been executed: {error}"
+        );
+
+        // Same source, same contract, through the direct API the parity corpus and unit tests use: both entry
+        // points must agree that nothing was lowered, which is the point of stating the contract at all.
+        let tokens =
+            lexer::lex(&fs::read_to_string(&entrypoint)?).map_err(|errors| CliError::failure(format!("{errors:?}")))?;
+        let parsed = parser::parse(&tokens).map_err(|errors| CliError::failure(format!("{errors:?}")))?;
+        let program = apply_body_ir_input_contract(parsed, &entrypoint)
+            .map_err(|errors| CliError::failure(format!("{errors:?}")))?;
+        let module_path = vec!["main".to_string()];
+        let mut checker = typechecker::TypeChecker::new();
+        checker.set_current_module_path(Some(module_path.clone()));
+        checker
+            .check_program(&program)
+            .map_err(|errors| CliError::failure(format!("{errors:?}")))?;
+        let body_ir = build_body_ir_module_v0(&program, &module_path, checker.type_info());
+        assert!(
+            body_ir.bodies.is_empty(),
+            "the direct API must lower the same nothing the CLI path did: {:?}",
+            body_ir.bodies.iter().map(|body| &body.name).collect::<Vec<_>>()
+        );
         Ok(())
     }
 }

--- a/src/cli/commands/build.rs
+++ b/src/cli/commands/build.rs
@@ -57,7 +57,7 @@ use crate::frontend::registry_metadata::{
     collect_checked_registry_metadata, materialize_registry_reexport_projections,
 };
 use crate::frontend::typechecker::stdlib_loader::StdlibAstCache;
-use crate::frontend::{diagnostics, lexer, parser, typechecker, vocab_desugar_pass};
+use crate::frontend::{body_ir, diagnostics, lexer, parser, typechecker};
 use crate::generated_cache::resolve_generated_cargo_target;
 #[cfg(feature = "rust_inspect")]
 use crate::library_manifest::LibraryRustAbi;
@@ -2560,43 +2560,6 @@ fn resolve_available_replacement_execution(selection: &BackendSelection) -> CliR
     }
 }
 
-/// Prepare one parsed replacement-backend module for [`build_body_ir_module_v0`]'s input contract.
-///
-/// The legacy pipeline owes Body IR a desugared, feature-projected program, and it pays that debt at parse time:
-/// `CompilationSession::parse_source` (`src/cli/commands/common.rs`) parses, runs
-/// `vocab_desugar_pass::desugar_program_vocab_blocks`, then projects the result through the session's active
-/// package features — all before the program is typechecked or lowered. This applies the same two steps in the
-/// same order for the replacement path, so a vocab-authored body means the same thing through either backend
-/// (#1166).
-///
-/// Ordering matters beyond the pair itself. The caller applies this immediately after parsing, ahead of
-/// [`replacement_module_profile_error`] and typechecking, because both of those must see the projected program: an
-/// import behind an inactive feature is not part of this compilation, and refusing it as an unsupported profile
-/// boundary would report a declaration the build does not contain.
-///
-/// Two deliberate differences from the legacy session, both consequences of this path reading no project manifest.
-/// No package feature is active, so every `when feature(...)` declaration projects away here — which is the
-/// correct answer for a compilation with no feature graph, not a shortcut. And feature *names* are not validated
-/// against a declared-feature set, because there is no manifest to declare one; that check stays a project-level
-/// concern rather than becoming a manifest-free approximation that could disagree with the legacy path.
-///
-/// # Errors
-///
-/// Returns the desugar pass's own diagnostics unchanged. A scoped-DSL surface whose owning library manifest is
-/// unavailable is refused there, at that boundary, and this deliberately adds no second diagnostic for it.
-fn apply_body_ir_input_contract(
-    mut program: crate::frontend::ast::Program,
-    entrypoint: &Path,
-) -> Result<crate::frontend::ast::Program, Vec<diagnostics::CompileError>> {
-    let entrypoint_display = entrypoint.to_string_lossy();
-    vocab_desugar_pass::desugar_program_vocab_blocks(
-        &mut program,
-        Some(entrypoint_display.as_ref()),
-        &LibraryManifestIndex::default(),
-    )?;
-    Ok(program.projected_for_features(&BTreeSet::new()))
-}
-
 /// Execute the first #988 replacement-backend profile directly from typed Body IR.
 ///
 /// This intentionally has no `ProjectGenerator`, Oven, or generated-Rust path. It accepts only one source module
@@ -2639,7 +2602,7 @@ fn build_replacement_file_report(
             entrypoint.display()
         ))
     })?;
-    let program = apply_body_ir_input_contract(program, &entrypoint).map_err(|errors| {
+    let program = body_ir::apply_body_ir_input_contract(program, &entrypoint).map_err(|errors| {
         CliError::failure(format!(
             "replacement backend could not desugar {}: {errors:?}",
             entrypoint.display()
@@ -18739,7 +18702,7 @@ pub model Nested:
             ..Default::default()
         };
 
-        let errors = apply_body_ir_input_contract(program, Path::new("/fixture/main.incn"))
+        let errors = body_ir::apply_body_ir_input_contract(program, Path::new("/fixture/main.incn"))
             .err()
             .ok_or("an undesugared vocab declaration must not pass the Body IR input contract")?;
         let messages = errors
@@ -18773,7 +18736,7 @@ pub model Nested:
             "the fixture must carry a gated declaration, or the assertion below proves nothing"
         );
 
-        let projected = apply_body_ir_input_contract(parsed, Path::new("/fixture/main.incn"))
+        let projected = body_ir::apply_body_ir_input_contract(parsed, Path::new("/fixture/main.incn"))
             .map_err(|errors| CliError::failure(format!("{errors:?}")))?;
         let names = projected
             .declarations
@@ -18820,7 +18783,7 @@ pub model Nested:
         let tokens =
             lexer::lex(&fs::read_to_string(&entrypoint)?).map_err(|errors| CliError::failure(format!("{errors:?}")))?;
         let parsed = parser::parse(&tokens).map_err(|errors| CliError::failure(format!("{errors:?}")))?;
-        let program = apply_body_ir_input_contract(parsed, &entrypoint)
+        let program = body_ir::apply_body_ir_input_contract(parsed, &entrypoint)
             .map_err(|errors| CliError::failure(format!("{errors:?}")))?;
         let module_path = vec!["main".to_string()];
         let mut checker = typechecker::TypeChecker::new();

--- a/src/cli/commands/build.rs
+++ b/src/cli/commands/build.rs
@@ -2560,6 +2560,22 @@ fn resolve_available_replacement_execution(selection: &BackendSelection) -> CliR
     }
 }
 
+/// Refuse package-feature selections the manifest-free replacement profile cannot resolve faithfully.
+///
+/// Ordinary builds derive the active closure from `CompilationSession` and the project's manifest. The bounded
+/// direct Body-IR profile deliberately does neither: it accepts one source module with no package graph. Its shared
+/// input-contract helper therefore uses the empty projection, so accepting a caller-supplied feature selection here
+/// would silently compile a different program. A future project-aware replacement profile may consume the canonical
+/// session projection; this source-only profile must refuse it until then.
+fn reject_replacement_package_feature_selection(package_features: &FeatureSelection) -> CliResult<()> {
+    if package_features != &FeatureSelection::default() {
+        return Err(CliError::failure(
+            "the source-only replacement backend supports only the default package feature selection; remove `--features`, `--no-default-features`, or `--all-features`",
+        ));
+    }
+    Ok(())
+}
+
 /// Execute the first #988 replacement-backend profile directly from typed Body IR.
 ///
 /// This intentionally has no `ProjectGenerator`, Oven, or generated-Rust path. It accepts only one source module
@@ -2570,12 +2586,16 @@ fn resolve_available_replacement_execution(selection: &BackendSelection) -> CliR
 /// The pipeline is lex, parse, [`apply_body_ir_input_contract`], module-profile gate, typecheck, then
 /// [`build_body_ir_module_v0`]. The contract step is not optional sequencing: without it this path would hand
 /// lowering a program the legacy path would never have produced, which is the divergence #1166 closes.
+/// This deliberately accepts only the default package-feature selection. A non-default selection needs the
+/// project-aware `CompilationSession` projection and is refused before parsing rather than silently treated as
+/// featureless source.
 fn build_replacement_file_report(
     file_path: &str,
     options: BuildCommandOptions,
     report_options: &BuildReportOptions,
 ) -> CliResult<serde_json::Value> {
     reject_normal_cargo_controls(&options.cargo_policy, options.generated_cargo_target_dir.as_ref())?;
+    reject_replacement_package_feature_selection(&options.package_features)?;
     let start = Instant::now();
     let entrypoint = if Path::new(file_path).is_absolute() {
         PathBuf::from(file_path)
@@ -18751,6 +18771,38 @@ pub model Nested:
             ["main"],
             "a declaration behind an inactive feature must not survive the contract step"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn the_replacement_build_refuses_nondefault_package_feature_selection() -> Result<(), Box<dyn std::error::Error>> {
+        let project = tempfile::tempdir()?;
+        let entrypoint = project.path().join("main.incn");
+        fs::write(&entrypoint, "def main() -> int:\n    return 7\n")?;
+        let feature_selections = [
+            FeatureSelection::new(["beta"]),
+            FeatureSelection {
+                no_default_features: true,
+                ..FeatureSelection::default()
+            },
+        ];
+
+        for package_features in feature_selections {
+            let mut options = replacement_build_options();
+            options.package_features = package_features;
+            let error =
+                build_replacement_file_report(&entrypoint.to_string_lossy(), options, &BuildReportOptions::default())
+                    .err()
+                    .ok_or(
+                        "a non-default package feature selection must not enter the source-only replacement profile",
+                    )?;
+            assert!(
+                error
+                    .to_string()
+                    .contains("supports only the default package feature selection"),
+                "unexpected replacement feature-selection refusal: {error}"
+            );
+        }
         Ok(())
     }
 

--- a/src/frontend/body_ir.rs
+++ b/src/frontend/body_ir.rs
@@ -35,9 +35,13 @@
 //! which refuses as an unresolved field layout because the typechecker records no field binding for it; a spread
 //! with no statically proven shape against a callee whose fixed signature *is* resolvable, whose arity no stage can
 //! establish; a spread to a locally held callable value; `if let`/`while let` conditions and destructuring
-//! comprehension/generator clauses; `await` and `race for`; and
-//! vocab/scoped-DSL surface nodes, which reach this module only when a caller skips the desugar pass the legacy
-//! pipeline runs first. The sub-issues are #1158 through #1167, plus #1172 for evaluable callable defaults.
+//! comprehension/generator clauses; and `await` and `race for`. The sub-issues are #1158 through #1167, plus
+//! #1172 for evaluable callable defaults.
+//!
+//! Vocab and scoped-DSL surface nodes are deliberately *not* on that list. They are not unmodeled language
+//! constructs awaiting a lowering; the desugar pass resolves them before this module runs, and one reaching here
+//! means a caller skipped it. See [`build_body_ir_module_v0`]'s input contract (#1166) for what a caller owes and
+//! for how such a node is named when it arrives anyway.
 //!
 //! One entry in that residue is a decided boundary rather than pending work, and is stated here so it is not read
 //! as a gap. An `unsafe:` region refuses permanently: it introduces no Incan scope, so inlining its statements
@@ -82,6 +86,34 @@ use crate::provider::ProviderPlan;
 /// there is no body to lower. Method [`CompilerNodeId`]s are *not* assigned by [`crate::frontend::hir::build_hir_v0`]
 /// today (declaration-level HIR only assigns ids to top-level declarations), so this function constructs its own
 /// method ids by scoping the method name under its owning declaration's name — see [`lower_method_body`].
+///
+/// # Input contract
+///
+/// `program` must be a **desugared, feature-projected, typechecked** module, and `type_info` must be the checker
+/// output for exactly that projected program. Every caller owes the same preparation the legacy pipeline performs
+/// before emission (`CompilationSession::parse_source` in `src/cli/commands/common.rs`: parse, then
+/// `vocab_desugar_pass::desugar_program_vocab_blocks`, then feature projection, and only then typecheck), so a
+/// vocab-authored body means the same thing through either backend (#1166).
+///
+/// What must **not** cross this boundary:
+///
+/// - Raw vocabulary syntax — `ast::Declaration::VocabBlock`, `ast::Statement::VocabBlock`,
+///   `ast::Statement::VocabExpressionItem`, `ast::Expr::VocabBlock` — and scoped-DSL surface nodes
+///   ([`SurfaceFeatureKey::ScopedDslSurface`], and the `LeadingDotPath`/`ScopedGlyph`/`ScopedSymbolCall` payloads of
+///   `ast::Expr::Surface`). The desugar pass owns their meaning; lowering them here would give one source construct two
+///   independent definitions.
+/// - Declarations gated behind a package feature that is not active. Feature projection is part of the contract, not an
+///   optimization: a body behind an inactive feature must not be lowered at all, because lowering it would put a body
+///   into Body IR that the compilation does not contain.
+///
+/// What must cross it: ordinary declarations, statements, and expressions, including the async surface
+/// (`await`, `race for`), which is genuine language surface no desugarer removes.
+///
+/// The contract is enforced rather than assumed. A vocab or scoped-DSL node that still arrives lowers to a
+/// `bir::StatementKind::Unsupported` whose description names it as a caller contract violation (see the `refusals`
+/// submodule), so a broken caller is a visible diagnostic at the original span instead of a silently missing body.
+/// Those refusals are a safety net, never the normal path; the desugar pass keeps ownership of the real diagnostic
+/// when a vocabulary's library manifest is unavailable.
 pub fn build_body_ir_module_v0(
     program: &ast::Program,
     module_path: &[String],
@@ -114,6 +146,10 @@ pub fn build_body_ir_module_v0_with_provider_plan(
 ///
 /// The catalogue is deliberately private to this frontend bridge. Its entries must come from a selected checked
 /// [`ProviderPlan`], never from a backend-specific caller or a source-name convention.
+///
+/// The input contract on `program` and `type_info` is [`build_body_ir_module_v0`]'s, unchanged: a desugared,
+/// feature-projected, typechecked module. The catalogue widens which *calls* lower, never which source surface is
+/// admitted, so a caller that skips the desugar pass violates the contract here exactly as it would there.
 fn build_body_ir_module_v0_with_provider_operations(
     program: &ast::Program,
     module_path: &[String],

--- a/src/frontend/body_ir.rs
+++ b/src/frontend/body_ir.rs
@@ -983,3 +983,45 @@ mod tuple_destructure_interop_tests {
         );
     }
 }
+
+/// Prepare one parsed module so it satisfies [`build_body_ir_module_v0`]'s input contract.
+///
+/// This lives beside the boundary it governs rather than inside any one caller, because every caller owes Body IR
+/// the same debt. The CLI's replacement path and the parity corpus both route through here; a caller that skips it
+/// hands lowering a program the legacy path would never have produced, which is exactly the divergence #1166
+/// closes.
+///
+/// The legacy pipeline owes Body IR a desugared, feature-projected program, and it pays that debt at parse time:
+/// `CompilationSession::parse_source` (`src/cli/commands/common.rs`) parses, runs
+/// `vocab_desugar_pass::desugar_program_vocab_blocks`, then projects the result through the session's active
+/// package features — all before the program is typechecked or lowered. This applies the same two steps in the
+/// same order for the replacement path, so a vocab-authored body means the same thing through either backend
+/// (#1166).
+///
+/// Ordering matters beyond the pair itself. The caller applies this immediately after parsing, ahead of
+/// [`replacement_module_profile_error`] and typechecking, because both of those must see the projected program: an
+/// import behind an inactive feature is not part of this compilation, and refusing it as an unsupported profile
+/// boundary would report a declaration the build does not contain.
+///
+/// Two deliberate differences from the legacy session, both consequences of this path reading no project manifest.
+/// No package feature is active, so every `when feature(...)` declaration projects away here — which is the
+/// correct answer for a compilation with no feature graph, not a shortcut. And feature *names* are not validated
+/// against a declared-feature set, because there is no manifest to declare one; that check stays a project-level
+/// concern rather than becoming a manifest-free approximation that could disagree with the legacy path.
+///
+/// # Errors
+///
+/// Returns the desugar pass's own diagnostics unchanged. A scoped-DSL surface whose owning library manifest is
+/// unavailable is refused there, at that boundary, and this deliberately adds no second diagnostic for it.
+pub fn apply_body_ir_input_contract(
+    mut program: crate::frontend::ast::Program,
+    entrypoint: &std::path::Path,
+) -> Result<crate::frontend::ast::Program, Vec<crate::frontend::diagnostics::CompileError>> {
+    let entrypoint_display = entrypoint.to_string_lossy();
+    crate::frontend::vocab_desugar_pass::desugar_program_vocab_blocks(
+        &mut program,
+        Some(entrypoint_display.as_ref()),
+        &crate::frontend::library_manifest_index::LibraryManifestIndex::default(),
+    )?;
+    Ok(program.projected_for_features(&std::collections::BTreeSet::new()))
+}

--- a/src/frontend/body_ir.rs
+++ b/src/frontend/body_ir.rs
@@ -114,12 +114,52 @@ use crate::provider::ProviderPlan;
 /// submodule), so a broken caller is a visible diagnostic at the original span instead of a silently missing body.
 /// Those refusals are a safety net, never the normal path; the desugar pass keeps ownership of the real diagnostic
 /// when a vocabulary's library manifest is unavailable.
+///
+/// The bounded replacement and comparison profiles have no project manifest or feature graph, so they deliberately
+/// use [`apply_body_ir_input_contract`]'s empty feature projection. A command that receives a non-default package
+/// feature selection must reject it before reaching this boundary rather than silently treating it as featureless.
 pub fn build_body_ir_module_v0(
     program: &ast::Program,
     module_path: &[String],
     type_info: &TypeCheckInfo,
 ) -> bir::BodyIrModule {
     build_body_ir_module_v0_with_provider_operations(program, module_path, type_info, &ProviderOperationCatalog::new())
+}
+
+/// Prepare one manifest-free parsed module so it satisfies [`build_body_ir_module_v0`]'s input contract.
+///
+/// This lives beside the boundary it governs rather than inside any one caller, because every manifest-free caller
+/// owes Body IR the same debt. The replacement CLI, parity corpus, and source-observable comparison route use this
+/// helper; a caller that skips it hands lowering a program the legacy path would never have produced, which is the
+/// divergence #1166 closes.
+///
+/// The legacy pipeline owes Body IR a desugared, feature-projected program, and it pays that debt at parse time:
+/// `CompilationSession::parse_source` (`src/cli/commands/common.rs`) parses, runs
+/// `vocab_desugar_pass::desugar_program_vocab_blocks`, then projects the result through the session's active
+/// package features — all before the program is typechecked or lowered. A manifest-free caller has no package
+/// feature graph, so it applies the same two steps with the empty feature projection. It must reject an explicit
+/// package-feature selection rather than using this helper to approximate one.
+///
+/// Ordering matters beyond the pair itself. The caller applies this immediately after parsing, ahead of
+/// [`replacement_module_profile_error`] and typechecking, because both of those must see the projected program: an
+/// import behind an inactive feature is not part of this compilation, and refusing it as an unsupported profile
+/// boundary would report a declaration the build does not contain.
+///
+/// # Errors
+///
+/// Returns the desugar pass's own diagnostics unchanged. A scoped-DSL surface whose owning library manifest is
+/// unavailable is refused there, at that boundary, and this deliberately adds no second diagnostic for it.
+pub fn apply_body_ir_input_contract(
+    mut program: crate::frontend::ast::Program,
+    entrypoint: &std::path::Path,
+) -> Result<crate::frontend::ast::Program, Vec<crate::frontend::diagnostics::CompileError>> {
+    let entrypoint_display = entrypoint.to_string_lossy();
+    crate::frontend::vocab_desugar_pass::desugar_program_vocab_blocks(
+        &mut program,
+        Some(entrypoint_display.as_ref()),
+        &crate::frontend::library_manifest_index::LibraryManifestIndex::default(),
+    )?;
+    Ok(program.projected_for_features(&std::collections::BTreeSet::new()))
 }
 
 /// Build Body IR using the checked provider-operation facts selected for this compilation.
@@ -186,7 +226,7 @@ fn build_body_ir_module_v0_with_provider_operations(
         module_path,
         provider_operations,
     };
-    let bodies = program
+    let mut bodies = program
         .declarations
         .iter()
         .flat_map(|decl| -> Vec<bir::Body> {
@@ -232,13 +272,41 @@ fn build_body_ir_module_v0_with_provider_operations(
                 _ => Vec::new(),
             }
         })
-        .collect();
+        .collect::<Vec<_>>();
+    apply_top_level_input_contract_refusal(program, &mut bodies);
     bir::BodyIrModule {
         module_id,
         nominal_declarations,
         fieldless_enum_declarations,
         value_enum_declarations,
         bodies,
+    }
+}
+
+/// Make a broken caller's raw top-level vocabulary declaration fail every executable body rather than disappearing.
+///
+/// `BodyIrModule` intentionally remains a total lowering result, so it cannot return a module-level error. The
+/// visible fail-closed representation is therefore an `Unsupported` marker at the original declaration span in
+/// every lowered body. An executor selecting any source body stops before evaluating source statements, while a
+/// declaration-only module still has no executable body to select.
+fn apply_top_level_input_contract_refusal(program: &ast::Program, bodies: &mut [bir::Body]) {
+    let Some((description, span)) = program.declarations.iter().find_map(|declaration| {
+        refusals::unsupported_top_level_declaration_label(&declaration.node)
+            .map(|description| (description, hir_span(declaration.span)))
+    }) else {
+        return;
+    };
+
+    for body in bodies {
+        body.block.stmts.insert(
+            0,
+            bir::Statement {
+                kind: bir::StatementKind::Unsupported {
+                    description: description.clone(),
+                },
+                span,
+            },
+        );
     }
 }
 
@@ -982,46 +1050,4 @@ mod tuple_destructure_interop_tests {
             "a Rust tuple of the wrong arity must still be refused"
         );
     }
-}
-
-/// Prepare one parsed module so it satisfies [`build_body_ir_module_v0`]'s input contract.
-///
-/// This lives beside the boundary it governs rather than inside any one caller, because every caller owes Body IR
-/// the same debt. The CLI's replacement path and the parity corpus both route through here; a caller that skips it
-/// hands lowering a program the legacy path would never have produced, which is exactly the divergence #1166
-/// closes.
-///
-/// The legacy pipeline owes Body IR a desugared, feature-projected program, and it pays that debt at parse time:
-/// `CompilationSession::parse_source` (`src/cli/commands/common.rs`) parses, runs
-/// `vocab_desugar_pass::desugar_program_vocab_blocks`, then projects the result through the session's active
-/// package features — all before the program is typechecked or lowered. This applies the same two steps in the
-/// same order for the replacement path, so a vocab-authored body means the same thing through either backend
-/// (#1166).
-///
-/// Ordering matters beyond the pair itself. The caller applies this immediately after parsing, ahead of
-/// [`replacement_module_profile_error`] and typechecking, because both of those must see the projected program: an
-/// import behind an inactive feature is not part of this compilation, and refusing it as an unsupported profile
-/// boundary would report a declaration the build does not contain.
-///
-/// Two deliberate differences from the legacy session, both consequences of this path reading no project manifest.
-/// No package feature is active, so every `when feature(...)` declaration projects away here — which is the
-/// correct answer for a compilation with no feature graph, not a shortcut. And feature *names* are not validated
-/// against a declared-feature set, because there is no manifest to declare one; that check stays a project-level
-/// concern rather than becoming a manifest-free approximation that could disagree with the legacy path.
-///
-/// # Errors
-///
-/// Returns the desugar pass's own diagnostics unchanged. A scoped-DSL surface whose owning library manifest is
-/// unavailable is refused there, at that boundary, and this deliberately adds no second diagnostic for it.
-pub fn apply_body_ir_input_contract(
-    mut program: crate::frontend::ast::Program,
-    entrypoint: &std::path::Path,
-) -> Result<crate::frontend::ast::Program, Vec<crate::frontend::diagnostics::CompileError>> {
-    let entrypoint_display = entrypoint.to_string_lossy();
-    crate::frontend::vocab_desugar_pass::desugar_program_vocab_blocks(
-        &mut program,
-        Some(entrypoint_display.as_ref()),
-        &crate::frontend::library_manifest_index::LibraryManifestIndex::default(),
-    )?;
-    Ok(program.projected_for_features(&std::collections::BTreeSet::new()))
 }

--- a/src/frontend/body_ir/refusals.rs
+++ b/src/frontend/body_ir/refusals.rs
@@ -2,20 +2,58 @@
 
 use super::*;
 
+/// Name one node that [`build_body_ir_module_v0`]'s input contract required the *caller* to resolve before
+/// lowering, rather than one this stage has simply not modeled yet (#1166).
+///
+/// The distinction is worth carrying in the diagnostic text. An unmodeled construct is remaining work on Body IR
+/// and tells a reader to wait for the owning sub-issue; a node the desugar pass should have removed is a broken
+/// pipeline, and the repair belongs to whoever assembled the program. Wording every such refusal the same way
+/// keeps the second from being read as the first.
+///
+/// This never becomes the primary diagnostic for a vocabulary whose library manifest is unavailable. The desugar
+/// pass already refuses that, at that boundary, and a second message for one condition would be two answers to
+/// the same question. This fires only when a caller skipped the pass altogether.
+fn undesugared_label(node: &str) -> String {
+    format!("undesugared {node} (Body IR input-contract violation: caller skipped the vocab desugar pass)")
+}
 /// Short diagnostic label for a statement kind v0 does not lower.
 ///
 /// Statement-position `loop:` is named explicitly because it is the one entry here whose Body IR vocabulary
 /// already exists: [`BodyBuilder::lower_loop_expr`] emits [`bir::StatementKind::Loop`] for the expression
 /// spelling, and only [`BodyBuilder::lower_stmt_into`]'s dispatch is missing (#1101). Leaving it under the
 /// generic "statement" label made a five-line dispatch gap read like an unmodeled construct.
+///
+/// The raw vocabulary forms take the [`undesugared_label`] wording instead, because neither is a lowering gap:
+/// both are syntax the desugar pass owns and resolves before this module ever runs. An [`ast::Statement::Surface`]
+/// could be either, so it defers to [`surface_stmt_label`] to decide from its key.
 pub(super) fn unsupported_stmt_label(stmt: &ast::Statement) -> String {
     match stmt {
         ast::Statement::Loop(_) => "statement-position `loop:`".to_string(),
         ast::Statement::Unsafe(_) => "unsafe block".to_string(),
-        ast::Statement::VocabExpressionItem(_) => "vocab expression item".to_string(),
-        ast::Statement::Surface(_) => "surface statement".to_string(),
-        ast::Statement::VocabBlock(_) => "vocab block".to_string(),
+        ast::Statement::VocabExpressionItem(_) => undesugared_label("vocab expression item"),
+        ast::Statement::Surface(surface) => surface_stmt_label(&surface.key),
+        ast::Statement::VocabBlock(_) => undesugared_label("vocab block"),
         _ => "statement".to_string(),
+    }
+}
+/// Name an [`ast::Statement::Surface`] refusal by the surface *key* that produced it.
+///
+/// The payload shape cannot make this call. `ast::SurfaceStmtPayload::KeywordArgs` is the only payload there is,
+/// and it carries both a library's scoped-DSL statement and the stdlib-registered soft keywords (`assert` is the
+/// one registered today -- see `incan_semantics_stdlib`'s `lower_surface_stmt_action`). Only a scoped-DSL key is a
+/// contract violation. A soft-keyword surface statement is real language surface with no Body IR lowering yet, so
+/// it keeps an unmodeled-construct label and names the keyword a program actually hit rather than reading as a
+/// pipeline fault its author cannot act on.
+fn surface_stmt_label(key: &SurfaceFeatureKey) -> String {
+    match key {
+        SurfaceFeatureKey::ScopedDslSurface { dependency_key, .. } => {
+            undesugared_label(&format!("scoped DSL statement from `{dependency_key}`"))
+        }
+        SurfaceFeatureKey::SoftKeyword(keyword) => format!(
+            "soft-keyword surface statement `{}`",
+            incan_core::lang::keywords::as_str(*keyword)
+        ),
+        SurfaceFeatureKey::Decorator(_) => "decorator surface statement".to_string(),
     }
 }
 /// Why an admitted provider operation cannot become a checked execution plan, or `None` when it can (#1213).
@@ -68,32 +106,35 @@ pub(super) fn unsupported_provider_operation(
 ///
 /// Only reached from [`BodyBuilder::lower_expr_to_operand`]'s fallback arm, so every expression kind that arm
 /// dispatches by name -- closures and partial callables included, since #1124 gave both a real lowering -- is
-/// deliberately absent here. Async surface (`await`, `race for`) and vocab/scoped-DSL surface are named rather
-/// than left to the generic label, because both are tracked remaining work under #1101 (#1164 and #1166
-/// respectively) and a diagnostic reading only "expression" hides which one a program actually hit.
+/// deliberately absent here. Async surface (`await`, `race for`) and vocab/scoped-DSL surface are named rather than
+/// left to the generic label, because a diagnostic reading only "expression" hides which one a program actually
+/// hit. The two are not the same kind of finding: async surface is remaining Body IR work under #1164, while a
+/// vocab node is a violation of [`build_body_ir_module_v0`]'s input contract (#1166).
 pub(super) fn unsupported_expr_label(expr: &ast::Expr) -> String {
     match expr {
         ast::Expr::Yield(_) => "yield expression".to_string(),
         ast::Expr::Range { .. } => "range expression outside a for-loop".to_string(),
         ast::Expr::Surface(surface) => surface_expr_label(&surface.payload),
-        ast::Expr::VocabBlock(_) => "vocab block expression".to_string(),
+        ast::Expr::VocabBlock(_) => undesugared_label("vocab block expression"),
         _ => "expression".to_string(),
     }
 }
 /// Name the specific surface-expression payload behind an [`ast::Expr::Surface`] refusal.
 ///
-/// The payloads split into two very different buckets: `await`/`race for` are the async surface #1164 represents,
-/// which #1155 needs before it can execute task state, while the remaining payloads are vocab/DSL nodes that the
-/// legacy pipeline desugars away before lowering and that only reach here when a caller skips that pass (#1166).
+/// The payloads split into two very different buckets, and the wording follows that split rather than flattening
+/// it. `await`/`race for` are the async surface #1164 represents, which #1155 needs before it can execute task
+/// state: real language surface, no desugarer involved, so they keep an unmodeled-construct label. The remaining
+/// payloads are scoped-DSL nodes the desugar pass resolves before lowering, so one arriving here means a caller
+/// skipped that pass and takes the [`undesugared_label`] wording (#1166).
 pub(super) fn surface_expr_label(payload: &ast::SurfaceExprPayload) -> String {
     match payload {
         ast::SurfaceExprPayload::PrefixUnary(_) => {
             "prefix-keyword surface expression (for example `await`)".to_string()
         }
         ast::SurfaceExprPayload::RaceFor(_) => "`race for` expression".to_string(),
-        ast::SurfaceExprPayload::LeadingDotPath { .. } => "scoped DSL leading-dot path".to_string(),
-        ast::SurfaceExprPayload::ScopedGlyph { .. } => "scoped DSL glyph operator".to_string(),
-        ast::SurfaceExprPayload::ScopedSymbolCall { .. } => "scoped DSL symbol call".to_string(),
+        ast::SurfaceExprPayload::LeadingDotPath { .. } => undesugared_label("scoped DSL leading-dot path"),
+        ast::SurfaceExprPayload::ScopedGlyph { .. } => undesugared_label("scoped DSL glyph operator"),
+        ast::SurfaceExprPayload::ScopedSymbolCall { .. } => undesugared_label("scoped DSL symbol call"),
     }
 }
 /// Resolve the per-element types for a tuple-typed value being destructured into `count` targets, falling back to

--- a/src/frontend/body_ir/refusals.rs
+++ b/src/frontend/body_ir/refusals.rs
@@ -16,6 +16,20 @@ use super::*;
 fn undesugared_label(node: &str) -> String {
     format!("undesugared {node} (Body IR input-contract violation: caller skipped the vocab desugar pass)")
 }
+
+/// Name a raw top-level declaration that the desugar pass had to remove before Body IR collection.
+///
+/// Top-level collection normally produces bodies only for executable declarations. A raw vocabulary declaration
+/// therefore has no containing body to hold its refusal, so the module builder injects this label into every body
+/// it did lower. That makes every direct execution fail at the declaration's original span rather than selecting an
+/// otherwise-valid body from an incomplete module.
+pub(super) fn unsupported_top_level_declaration_label(declaration: &ast::Declaration) -> Option<String> {
+    match declaration {
+        ast::Declaration::VocabBlock(_) => Some(undesugared_label("top-level vocab block")),
+        _ => None,
+    }
+}
+
 /// Short diagnostic label for a statement kind v0 does not lower.
 ///
 /// Statement-position `loop:` is named explicitly because it is the one entry here whose Body IR vocabulary

--- a/src/frontend/body_ir/tests.rs
+++ b/src/frontend/body_ir/tests.rs
@@ -7,6 +7,7 @@ use super::defaults::*;
 use super::*;
 use crate::frontend::typechecker::TypeChecker;
 use crate::frontend::{lexer, parser};
+use incan_core::lang::surface::constructors;
 
 /// Lower a module that imports from other modules, declaring each dependency's flattened cache name *and* its
 /// real path segments.
@@ -6594,6 +6595,30 @@ fn build_with_statement_injected_after_typecheck(
     Ok(build_body_ir_module_v0(&program, &module_path, checker.type_info()))
 }
 
+/// Lower `source` after adding a raw top-level declaration, **after** typechecking.
+///
+/// The source parser only builds vocabulary declarations after an imported vocabulary is active, and a healthy
+/// compiler desugars them before typechecking. Adding one after checking isolates the lowerer's final safety net:
+/// every executable body must refuse the raw declaration rather than silently dropping it during top-level
+/// collection.
+fn build_with_top_level_declaration_injected_after_typecheck(
+    source: &str,
+    module_path: &[&str],
+    injected: ast::Spanned<ast::Declaration>,
+) -> Result<bir::BodyIrModule, Box<dyn std::error::Error>> {
+    let tokens = lexer::lex(source).map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+    let mut program = parser::parse(&tokens).map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+    let module_path: Vec<String> = module_path.iter().map(|s| s.to_string()).collect();
+    let mut checker = TypeChecker::new();
+    checker.set_current_module_path(Some(module_path.clone()));
+    checker
+        .check_program(&program)
+        .map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+
+    program.declarations.push(injected);
+    Ok(build_body_ir_module_v0(&program, &module_path, checker.type_info()))
+}
+
 /// Every `Unsupported` refusal description in `body_name`'s top-level statement list.
 fn unsupported_descriptions(module: &bir::BodyIrModule, body_name: &str) -> Vec<String> {
     module
@@ -6615,6 +6640,68 @@ fn fixture_scoped_surface_owner() -> ast::ScopedSurfaceOwner {
         clause: None,
         call: None,
     }
+}
+
+/// A top-level vocabulary declaration whose source meaning has not been desugared.
+fn fixture_top_level_vocab_declaration() -> ast::Spanned<ast::Declaration> {
+    ast::Spanned::new(
+        ast::Declaration::VocabBlock(ast::VocabBlockStmt {
+            keyword: "query".to_string(),
+            keyword_binding: ast::VocabKeywordBinding {
+                is_declaration_owned_clause: false,
+                dependency_key: "demo.query".to_string(),
+                activation_namespace: "demo".to_string(),
+                surface_kind: incan_vocab::KeywordSurfaceKind::FunctionDecl,
+                compound_tokens: Vec::new(),
+                placement: incan_vocab::KeywordPlacement::TopLevel,
+                clause_body_kind: None,
+            },
+            decorators: Vec::new(),
+            signature_head: None,
+            header_args: Vec::new(),
+            body: Vec::new(),
+            body_item_trailing_commas: Vec::new(),
+        }),
+        ast::Span::new(40, 60),
+    )
+}
+
+#[test]
+fn an_undesugared_top_level_vocab_declaration_refuses_every_executable_body() -> Result<(), Box<dyn std::error::Error>>
+{
+    let module = build_with_top_level_declaration_injected_after_typecheck(
+        "def main() -> int:\n    return 1\n\ndef helper() -> int:\n    return 2\n",
+        &["m"],
+        fixture_top_level_vocab_declaration(),
+    )?;
+
+    for body in &module.bodies {
+        let Some(statement) = body.block.stmts.first() else {
+            return Err(Box::from(format!("expected a contract refusal in `{}`", body.name)));
+        };
+        let bir::StatementKind::Unsupported { description } = &statement.kind else {
+            return Err(Box::from(format!(
+                "the first statement of `{}` must reject the raw top-level declaration: {statement:?}",
+                body.name
+            )));
+        };
+        assert!(description.contains("top-level vocab block"), "{description}");
+        assert!(
+            description.contains("Body IR input-contract violation"),
+            "{description}"
+        );
+        assert_eq!(statement.span, HirSourceSpan::new(40, 60));
+    }
+
+    let error = crate::backend::replacement::prepare_free_function_execution(&module, "main", &[])
+        .err()
+        .ok_or("a raw top-level vocabulary declaration must stop direct-execution preparation")?;
+    let crate::backend::replacement::ReplacementExecutionError::Unsupported { description, span, .. } = error else {
+        return Err(Box::from(format!("unexpected direct-execution result: {error}")));
+    };
+    assert!(description.contains("top-level vocab block"), "{description}");
+    assert_eq!(span, HirSourceSpan::new(40, 60));
+    Ok(())
 }
 
 #[test]

--- a/src/frontend/body_ir/tests.rs
+++ b/src/frontend/body_ir/tests.rs
@@ -6533,6 +6533,121 @@ fn a_statement_position_loop_lowers_to_the_same_loop_the_expression_spelling_pro
     Ok(())
 }
 
+// ---- Body IR input contract (#1166) ----
+
+/// Parse `source`, project it through `active_features`, then typecheck and lower **the projection**.
+///
+/// This is the shape [`build_body_ir_module_v0`]'s input contract requires of every caller: the checker and the
+/// lowering both see the feature-projected program, never the full parse tree. [`build`] deliberately skips the
+/// projection step, so the two helpers together show what projection is worth rather than only asserting it ran.
+fn build_projected(
+    source: &str,
+    module_path: &[&str],
+    active_features: &[&str],
+) -> Result<bir::BodyIrModule, Box<dyn std::error::Error>> {
+    let tokens = lexer::lex(source).map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+    let parsed = parser::parse(&tokens).map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+    let active = active_features
+        .iter()
+        .map(|feature| (*feature).to_string())
+        .collect::<std::collections::BTreeSet<String>>();
+    let program = parsed.projected_for_features(&active);
+    let module_path: Vec<String> = module_path.iter().map(|s| s.to_string()).collect();
+    let mut checker = TypeChecker::new();
+    checker.set_current_module_path(Some(module_path.clone()));
+    checker
+        .check_program(&program)
+        .map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+    Ok(build_body_ir_module_v0(&program, &module_path, checker.type_info()))
+}
+
+/// Lower `source` after appending `injected` to its first top-level function body, **after** typechecking.
+///
+/// Vocab and scoped-DSL nodes cannot arrive through [`parser::parse`]: they need a library vocabulary that an
+/// import activates, and every pipeline that has a desugar pass removes them before lowering. Splicing the node in
+/// after the checker has run is therefore the only way to reach Body IR's input-contract safety net, and the state
+/// it produces is exactly the one a caller that skipped the desugar pass would hand over.
+fn build_with_statement_injected_after_typecheck(
+    source: &str,
+    module_path: &[&str],
+    injected: ast::Statement,
+) -> Result<bir::BodyIrModule, Box<dyn std::error::Error>> {
+    let tokens = lexer::lex(source).map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+    let mut program = parser::parse(&tokens).map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+    let module_path: Vec<String> = module_path.iter().map(|s| s.to_string()).collect();
+    let mut checker = TypeChecker::new();
+    checker.set_current_module_path(Some(module_path.clone()));
+    checker
+        .check_program(&program)
+        .map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+
+    let function = program
+        .declarations
+        .iter_mut()
+        .find_map(|decl| match &mut decl.node {
+            ast::Declaration::Function(function) => Some(function),
+            _ => None,
+        })
+        .ok_or("expected a top-level function to inject the undesugared node into")?;
+    function.body.push(ast::Spanned::new(injected, ast::Span::new(0, 1)));
+
+    Ok(build_body_ir_module_v0(&program, &module_path, checker.type_info()))
+}
+
+/// Every `Unsupported` refusal description in `body_name`'s top-level statement list.
+fn unsupported_descriptions(module: &bir::BodyIrModule, body_name: &str) -> Vec<String> {
+    module
+        .bodies
+        .iter()
+        .filter(|body| body.name == body_name)
+        .flat_map(|body| &body.block.stmts)
+        .filter_map(|stmt| match &stmt.kind {
+            bir::StatementKind::Unsupported { description } => Some(description.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+/// A scoped-DSL surface owner naming a library that this compilation never loaded.
+fn fixture_scoped_surface_owner() -> ast::ScopedSurfaceOwner {
+    ast::ScopedSurfaceOwner {
+        declaration: "query".to_string(),
+        clause: None,
+        call: None,
+    }
+}
+
+#[test]
+fn an_undesugared_vocab_expression_item_is_refused_as_a_caller_contract_violation()
+-> Result<(), Box<dyn std::error::Error>> {
+    // A vocab expression item is body content of a raw `vocab:` block. The desugar pass owns what it means, so one
+    // reaching lowering is a broken caller rather than a construct Body IR has yet to model, and the refusal has to
+    // say which of the two it is.
+    let module = build_with_statement_injected_after_typecheck(
+        "def run() -> int:\n    return 1\n",
+        &["m"],
+        ast::Statement::VocabExpressionItem(ast::VocabExpressionItemStmt {
+            expr: ast::Spanned::new(ast::Expr::Literal(ast::Literal::Bool(true)), ast::Span::new(0, 1)),
+            alias: None,
+            modifiers: Vec::new(),
+        }),
+    )?;
+
+    let descriptions = unsupported_descriptions(&module, "run");
+    let [description] = descriptions.as_slice() else {
+        return Err(Box::from(format!("expected exactly one refusal, got {descriptions:?}")));
+    };
+    assert!(
+        description.contains("vocab expression item"),
+        "the refusal must still name the node a program actually hit: {description}"
+    );
+    assert!(
+        description.contains("Body IR input-contract violation") && description.contains("desugar pass"),
+        "a vocab node must read as a caller contract violation, not an unmodeled construct: {description}"
+    );
+    Ok(())
+}
+
 #[test]
 fn continue_inside_a_statement_loop_behaves_as_it_does_in_while_and_for() -> Result<(), Box<dyn std::error::Error>> {
     let source = concat!(
@@ -6672,6 +6787,46 @@ fn a_value_carrying_break_in_a_statement_loop_is_not_merged_into_an_enclosing_lo
 }
 
 #[test]
+fn an_undesugared_scoped_dsl_symbol_call_is_refused_as_a_caller_contract_violation()
+-> Result<(), Box<dyn std::error::Error>> {
+    // `sum(value)` is one of `ScopedDslSurfaces`' canonical forms. Reaching lowering as surface syntax means no
+    // desugarer ever gave it a meaning, so the backend must not invent one -- and must not report the absence as a
+    // language gap either.
+    let module = build_with_statement_injected_after_typecheck(
+        "def run() -> int:\n    return 1\n",
+        &["m"],
+        ast::Statement::Expr(ast::Spanned::new(
+            ast::Expr::Surface(Box::new(ast::SurfaceExpr {
+                key: SurfaceFeatureKey::ScopedDslSurface {
+                    dependency_key: "demo.query".to_string(),
+                    descriptor_key: "aggregate".to_string(),
+                },
+                payload: ast::SurfaceExprPayload::ScopedSymbolCall {
+                    symbol: "sum".to_string(),
+                    args: Vec::new(),
+                    owner: fixture_scoped_surface_owner(),
+                },
+            })),
+            ast::Span::new(0, 1),
+        )),
+    )?;
+
+    let descriptions = unsupported_descriptions(&module, "run");
+    let [description] = descriptions.as_slice() else {
+        return Err(Box::from(format!("expected exactly one refusal, got {descriptions:?}")));
+    };
+    assert!(
+        description.contains("scoped DSL symbol call"),
+        "the refusal must name the scoped-DSL form rather than the bare label `expression`: {description}"
+    );
+    assert!(
+        description.contains("Body IR input-contract violation"),
+        "a scoped-DSL node must read as a caller contract violation: {description}"
+    );
+    Ok(())
+}
+
+#[test]
 fn an_unsafe_region_refuses_under_a_named_permanent_boundary() -> Result<(), Box<dyn std::error::Error>> {
     // #1162's second half. The refusal is a decided disposition, not a missing dispatch arm: an `unsafe:` region
     // introduces no Incan scope, so inlining its statements would be trivial -- and would erase the
@@ -6702,6 +6857,83 @@ fn an_unsafe_region_refuses_under_a_named_permanent_boundary() -> Result<(), Box
     assert!(
         !snapshot.contains("probe"),
         "an acknowledged region's statements must not be inlined into the enclosing block: {snapshot}"
+    );
+    Ok(())
+}
+
+#[test]
+fn a_soft_keyword_surface_statement_stays_an_unmodeled_construct_rather_than_a_contract_violation()
+-> Result<(), Box<dyn std::error::Error>> {
+    // `SurfaceStmtPayload::KeywordArgs` carries both a library's scoped-DSL statement and the stdlib-registered
+    // soft keywords (`assert` today). Only the first is a pipeline fault; blaming the caller for the second would
+    // send its author looking for a desugar pass that was never supposed to run.
+    let module = build_with_statement_injected_after_typecheck(
+        "def run() -> int:\n    return 1\n",
+        &["m"],
+        ast::Statement::Surface(ast::SurfaceStmt {
+            key: SurfaceFeatureKey::SoftKeyword(KeywordId::Assert),
+            payload: ast::SurfaceStmtPayload::KeywordArgs(vec![ast::Spanned::new(
+                ast::Expr::Literal(ast::Literal::Bool(true)),
+                ast::Span::new(0, 1),
+            )]),
+        }),
+    )?;
+
+    let descriptions = unsupported_descriptions(&module, "run");
+    let [description] = descriptions.as_slice() else {
+        return Err(Box::from(format!("expected exactly one refusal, got {descriptions:?}")));
+    };
+    assert!(
+        description.contains("assert"),
+        "a soft-keyword surface statement must name its keyword: {description}"
+    );
+    assert!(
+        !description.contains("input-contract violation"),
+        "real language surface must not be reported as a caller contract violation: {description}"
+    );
+    Ok(())
+}
+
+#[test]
+fn a_body_behind_an_inactive_feature_is_not_lowered() -> Result<(), Box<dyn std::error::Error>> {
+    // Feature projection is part of the input contract, not an optimization. A body the compilation does not
+    // contain must produce no `bir::Body` at all -- not an empty one, and not one an executor could be asked to run.
+    let source =
+        "when feature(\"beta\"):\n    def gated() -> int:\n        return 7\n\ndef always() -> int:\n    return 1\n";
+
+    let projected = build_projected(source, &["m"], &[])?;
+    let lowered: Vec<&str> = projected.bodies.iter().map(|body| body.name.as_str()).collect();
+    assert_eq!(
+        lowered,
+        ["always"],
+        "a declaration behind an inactive feature must not reach lowering"
+    );
+
+    // The same program without the projection step does lower it, which is what makes the step load-bearing rather
+    // than incidentally satisfied by this fixture.
+    let unprojected = build(source, &["m"])?;
+    assert!(
+        unprojected.bodies.iter().any(|body| body.name == "gated"),
+        "the fixture must actually carry a gated body, or the assertion above proves nothing"
+    );
+    Ok(())
+}
+
+#[test]
+fn projection_through_an_active_feature_lowers_exactly_as_an_ungated_program_does()
+-> Result<(), Box<dyn std::error::Error>> {
+    // The other half of the contract: projection removes inactive declarations and changes nothing else. With the
+    // feature active the projected program and the raw parse tree must lower identically, spans included, so a
+    // caller that applies the contract cannot silently perturb a body that was always part of the compilation.
+    let source =
+        "when feature(\"beta\"):\n    def gated() -> int:\n        return 7\n\ndef always() -> int:\n    return 1\n";
+
+    let active = build_projected(source, &["m"], &["beta"])?;
+    let unprojected = build(source, &["m"])?;
+    assert_eq!(
+        active.render_snapshot(),
+        unprojected.render_snapshot(),
+        "an active feature must make projection a no-op"
     );
     Ok(())
 }

--- a/tests/parity_corpus_tests.rs
+++ b/tests/parity_corpus_tests.rs
@@ -136,6 +136,16 @@ fn body_ir_snapshot(src: &str, expect_desc: &str) -> Result<String, ComparisonOu
     let program = parser::parse(&tokens).map_err(|errors| ComparisonOutcome::Incompatible {
         reason: format!("expected {expect_desc}, but parsing failed: {errors:?}"),
     })?;
+    // The corpus is a caller of `build_body_ir_module_v0` like any other, so it owes that boundary the same
+    // desugared, feature-projected program the CLI path owes it (#1166). A corpus lowering raw parse output would
+    // measure a program the real pipeline never produces, and go green on the divergence it exists to surface.
+    let program = incan::frontend::body_ir::apply_body_ir_input_contract(
+        program,
+        std::path::Path::new("parity_987_body_ir.incn"),
+    )
+    .map_err(|errors| ComparisonOutcome::Incompatible {
+        reason: format!("expected {expect_desc}, but the Body IR input contract refused: {errors:?}"),
+    })?;
     let module_path = vec!["parity_987_body_ir".to_string()];
     let mut checker = typechecker::TypeChecker::new();
     checker.set_current_module_path(Some(module_path.clone()));
@@ -474,31 +484,13 @@ def run() -> None:
     assert boom() raises IndexError, "wanted an index error"
 "#;
 
-/// Render one case's Body IR snapshot, or the reason it could not be produced.
-fn body_ir_snapshot_for(src: &str, expect_desc: &str) -> Result<String, ComparisonOutcome> {
-    let tokens = lexer::lex(src).map_err(|errors| ComparisonOutcome::Incompatible {
-        reason: format!("expected {expect_desc}, but lexing failed: {errors:?}"),
-    })?;
-    let program = parser::parse(&tokens).map_err(|errors| ComparisonOutcome::Incompatible {
-        reason: format!("expected {expect_desc}, but parsing failed: {errors:?}"),
-    })?;
-    let module_path = vec!["parity_987_body_ir".to_string()];
-    let mut checker = typechecker::TypeChecker::new();
-    checker.set_current_module_path(Some(module_path.clone()));
-    checker
-        .check_program(&program)
-        .map_err(|errors| ComparisonOutcome::Mismatch {
-            detail: format!("expected {expect_desc}, but typechecking reported {errors:?}"),
-        })?;
-    Ok(build_body_ir_module_v0(&program, &module_path, checker.type_info()).render_snapshot())
-}
 
 fn case_pattern_assertion_binding_reaches_body_ir() -> ComparisonOutcome {
     let outcome = outcome_from_body_ir(CASE_20_SRC, "a pattern assertion to lower without a placeholder");
     if !matches!(outcome, ComparisonOutcome::Match) {
         return outcome;
     }
-    let snapshot = match body_ir_snapshot_for(CASE_20_SRC, "a pattern assertion to lower") {
+    let snapshot = match body_ir_snapshot(CASE_20_SRC, "a pattern assertion to lower") {
         Ok(snapshot) => snapshot,
         Err(outcome) => return outcome,
     };
@@ -523,7 +515,7 @@ fn case_raises_assertion_reaches_body_ir() -> ComparisonOutcome {
     if !matches!(outcome, ComparisonOutcome::Match) {
         return outcome;
     }
-    let snapshot = match body_ir_snapshot_for(CASE_21_SRC, "a `raises` assertion to lower") {
+    let snapshot = match body_ir_snapshot(CASE_21_SRC, "a `raises` assertion to lower") {
         Ok(snapshot) => snapshot,
         Err(outcome) => return outcome,
     };
@@ -537,6 +529,82 @@ fn case_raises_assertion_reaches_body_ir() -> ComparisonOutcome {
     if !snapshot.contains("raises IndexError, const(\"wanted an index error\") may_panic") {
         return ComparisonOutcome::Mismatch {
             detail: format!("a `raises` assertion lost its failure message:\n{snapshot}"),
+        };
+    }
+    ComparisonOutcome::Match
+}
+
+// ============================================================================
+// Case 17 — Body IR input contract: an inactive feature's body never lowers (#1166)
+// ============================================================================
+
+// #1166 made the input contract explicit: Body IR consumes a desugared, feature-projected program, and every caller
+// owes it that. This row is the corpus holding *itself* to that contract — before #1166 both corpus entry points
+// lowered raw parse output, so a divergence between the two pipelines would have gone green here rather than being
+// surfaced.
+//
+// The row proves the feature-projection half, which is constructible in-process. The vocab half of the same
+// contract is covered by unit tests instead: a genuinely vocab-authored body needs an import-activated library
+// vocabulary with a WASM desugarer artifact, which no corpus row can stand up. Claiming this row proves both
+// halves would be the kind of overstated evidence the corpus exists to prevent.
+const CASE_17_SRC: &str = r#"
+when feature("beta"):
+    def gated() -> int:
+        return 7
+
+def main() -> int:
+    return 1
+"#;
+
+fn case_inactive_feature_body_never_reaches_body_ir() -> ComparisonOutcome {
+    let outcome = outcome_from_body_ir(
+        CASE_17_SRC,
+        "a body behind an inactive feature to be projected away before lowering",
+    );
+    if !matches!(outcome, ComparisonOutcome::Match) {
+        return outcome;
+    }
+    // `outcome_from_body_ir` only proves no placeholder survived. The contract claim is stronger and needs its own
+    // assertion: the gated function must be absent entirely, not lowered into something that merely looks clean.
+    let tokens = match lexer::lex(CASE_17_SRC) {
+        Ok(tokens) => tokens,
+        Err(errors) => {
+            return ComparisonOutcome::Incompatible {
+                reason: format!("case 17 failed to lex: {errors:?}"),
+            };
+        }
+    };
+    let program = match parser::parse(&tokens) {
+        Ok(program) => program,
+        Err(errors) => {
+            return ComparisonOutcome::Incompatible {
+                reason: format!("case 17 failed to parse: {errors:?}"),
+            };
+        }
+    };
+    let program = match incan::frontend::body_ir::apply_body_ir_input_contract(
+        program,
+        std::path::Path::new("parity_987_body_ir.incn"),
+    ) {
+        Ok(program) => program,
+        Err(errors) => {
+            return ComparisonOutcome::Incompatible {
+                reason: format!("case 17 input contract refused: {errors:?}"),
+            };
+        }
+    };
+    let module_path = vec!["parity_987_body_ir".to_string()];
+    let mut checker = typechecker::TypeChecker::new();
+    checker.set_current_module_path(Some(module_path.clone()));
+    if let Err(errors) = checker.check_program(&program) {
+        return ComparisonOutcome::Mismatch {
+            detail: format!("case 17 typecheck reported {errors:?}"),
+        };
+    }
+    let snapshot = build_body_ir_module_v0(&program, &module_path, checker.type_info()).render_snapshot();
+    if snapshot.contains("gated") {
+        return ComparisonOutcome::Mismatch {
+            detail: format!("a body behind an inactive feature reached Body IR:\n{snapshot}"),
         };
     }
     ComparisonOutcome::Match
@@ -1347,6 +1415,18 @@ fn seed_corpus() -> Vec<ParityCase> {
             disposition: Disposition::Preserved,
             source: CASE_21_SRC,
             evaluate: Some(case_raises_assertion_reaches_body_ir),
+            replacement_execution: None,
+        },
+        ParityCase {
+            id: "parity-987-0017",
+            title: "A body behind an inactive feature never reaches Body IR",
+            category: BehaviorCategory::SupportedLanguageContract,
+            lane: EvidenceLane::DirectParserTypechecker,
+            evidence: "#1166; src/cli/commands/build.rs::tests::\
+                       the_replacement_build_never_executes_a_main_behind_an_inactive_feature",
+            disposition: Disposition::Preserved,
+            source: CASE_17_SRC,
+            evaluate: Some(case_inactive_feature_body_never_reaches_body_ir),
             replacement_execution: None,
         },
         ParityCase {

--- a/tests/parity_corpus_tests.rs
+++ b/tests/parity_corpus_tests.rs
@@ -484,7 +484,6 @@ def run() -> None:
     assert boom() raises IndexError, "wanted an index error"
 "#;
 
-
 fn case_pattern_assertion_binding_reaches_body_ir() -> ComparisonOutcome {
     let outcome = outcome_from_body_ir(CASE_20_SRC, "a pattern assertion to lower without a placeholder");
     if !matches!(outcome, ComparisonOutcome::Match) {

--- a/tests/support/parity_corpus.rs
+++ b/tests/support/parity_corpus.rs
@@ -51,7 +51,7 @@ use incan::backend::selection::{
 use incan::backend::shadow::{
     LegacyExecutionAuthority, ShadowComparison, ShadowComparisonProfile, compare_source_observable,
 };
-use incan::frontend::body_ir::build_body_ir_module_v0;
+use incan::frontend::body_ir::{apply_body_ir_input_contract, build_body_ir_module_v0};
 use incan::frontend::diagnostics::DIAGNOSTIC_SCHEMA_VERSION;
 use incan::frontend::typechecker::TypeChecker;
 use incan::frontend::{lexer, parser};
@@ -783,9 +783,16 @@ pub(crate) struct ReplacementExecutionPlan {
 }
 
 /// Typecheck and lower source into the Body IR that replacement selection validates before execution.
+///
+/// The corpus is a caller of [`build_body_ir_module_v0`] like any other, so it owes that boundary the same
+/// desugared, feature-projected program the CLI path owes it (#1166). Applying the contract here rather than
+/// duplicating its two steps is the point: a corpus that lowered raw parse output would be measuring a program the
+/// real pipeline never produces, and would go green on a divergence instead of surfacing it.
 fn lower_replacement_case(source: &str) -> Result<BodyIrModule, String> {
     let tokens = lexer::lex(source).map_err(|errors| format!("replacement corpus lex failure: {errors:?}"))?;
     let program = parser::parse(&tokens).map_err(|errors| format!("replacement corpus parse failure: {errors:?}"))?;
+    let program = apply_body_ir_input_contract(program, std::path::Path::new("parity_987_replacement.incn"))
+        .map_err(|errors| format!("replacement corpus input-contract failure: {errors:?}"))?;
     let module_path = vec!["parity_987_replacement".to_string()];
     let mut checker = TypeChecker::new();
     checker.set_current_module_path(Some(module_path.clone()));


### PR DESCRIPTION
## Summary

`build_body_ir_module_v0` documented no contract for the `ast::Program` it accepts, and the two pipelines that produce one disagreed: the legacy path desugars vocab and feature-projects before typechecking, the replacement path did neither.

Closes #1166.

**Stacked on #1213 (PR #1236)**, which edited `refusals.rs` and the `body_ir.rs` module root. Module ownership, not a design dependency.

## Type of change

- [x] Refactor / maintenance

## Area(s)

- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)

## Key details

**The legacy ordering, read rather than assumed** — from `CompilationSession::parse_source`, which every legacy module-collection call uses: parse → `desugar_program_vocab_blocks` → optional contract-model materialization → feature-name validation → `projected_for_features` → typecheck → emit.

The replacement path now matches: lex → parse → `apply_body_ir_input_contract` (desugar, then projection) → backend selection → module-profile gate → typecheck → `build_body_ir_module_v0`. The contract step sits **ahead of the profile gate** deliberately, so an import behind an inactive feature is projected away rather than refused as an unsupported profile boundary — refusing it would report a declaration the build does not contain.

**Two deliberate differences from the legacy session**, both because this path reads no project manifest, and both documented at the function: no package feature is active, since there is no feature graph to close over; and feature *names* are not validated, since there is no declared-feature set to validate against. A manifest-free approximation of that check could disagree with the legacy path, which is the opposite of what this issue is for.

**Refusals** now identify vocab/scoped-DSL nodes as *caller contract violations* rather than unmodeled language constructs, with `ast::Statement::Surface` split by key so stdlib soft keywords aren't mislabelled. A scoped-DSL surface whose library manifest is unavailable keeps the desugar pass's own diagnostic — no second one is added for the same condition.

## The corpus was itself a contract-violating caller

The contract was enforced for the CLI but lived inside that one caller. The parity corpus reaches `build_body_ir_module_v0` through the public API, and **both** of its entry points lowered raw parse output — so the corpus would have gone green on precisely the divergence it exists to surface.

`apply_body_ir_input_contract` now lives in `frontend::body_ir`, beside the boundary it governs rather than inside one caller, and the CLI and both corpus paths route through it.

## Testing / verification

- [x] Manual verification described below

Manual verification notes:

- `cargo test --lib frontend::body_ir` — 188 passed, 0 failed (5 new)
- `cargo test --lib cli::commands::build::tests::the_` — 3 passed, 0 failed. There was no narrow CLI test for the replacement build path, so these were added in `build.rs`'s own `mod tests`; the `cli::commands` suite was deliberately not run, since across identical trees it has produced anywhere from 3 to 78 failures and is not a usable signal.
- `cargo test --test parity_corpus_tests` — 9 passed, 0 failed
- `cargo clippy --lib --tests` clean; `cargo +nightly fmt` clean; rustdoc gate passed

**Mutation checks**, both halves proven load-bearing:

- Removing `desugar_program_vocab_blocks` failed the vocab contract test.
- Removing `projected_for_features` failed two tests, and the CLI one printed `✓ replacement backend executed main: 7` — the replacement backend literally executing a body behind an inactive feature, which is the divergence this issue describes.
- Removing projection again after the corpus change failed `parity-987-0017` with the lowered module printed in the diff: `body gated decl:parity_987_body_ir::gated`.

Slice-level gates (`make pre-commit`, full Oven suites, slice-wide CI) are deliberately deferred.

## #987 disposition

`parity-987-0017`, `Preserved` on `EvidenceLane::DirectParserTypechecker`.

It proves the **feature-projection** half, which is constructible in-process. The vocab half of the same contract is covered by unit tests instead: a genuinely vocab-authored body needs an import-activated library vocabulary with a WASM desugarer artifact, which no corpus row can stand up. Claiming one row proved both halves would be the overstated evidence the corpus exists to prevent.

The id is 0017 rather than 0014 on purpose — #1160 and #1165 claim 0014–0016 on a sibling stack, and colliding ids would only surface at merge.

## Docs impact

- [x] No docs changes needed

## Checklist

- [x] I added/updated tests where it materially reduces regressions
