### PR TITLE
feature - lower statement-position loop and name the residual statement refusals in Body IR (#1162)

### DIFF
--- a/src/frontend/body_ir.rs
+++ b/src/frontend/body_ir.rs
@@ -11,8 +11,8 @@
 //! [`incan_semantics_core::body_ir`] module docs for the full rationale). Statements fully lowered: assignment
 //! (inferred/let/mutable/reassignment), field/index assignment (including their pre-desugared compound `<op>=`
 //! forms), compound assignment (`x <op>= y`), tuple unpacking, multi-target (lvalue) tuple assignment, chained
-//! assignment, `return`, `if`/`elif`/`else`, `while`, `for` (both a `start..end` range and a general iterable --
-//! builtin collections or a resolved `__iter__`/`__next__` protocol, including the fallible `for item in
+//! assignment, `return`, `if`/`elif`/`else`, `loop:`, `while`, `for` (both a `start..end` range and a general
+//! iterable -- builtin collections or a resolved `__iter__`/`__next__` protocol, including the fallible `for item in
 //! iterable?:` form), expression statements, statement-position `yield value` (see [`BodyBuilder::lower_stmt_into`]
 //! and [`bir::Body::is_generator`]), all three RFC 018 `assert` forms -- plain condition, `assert value is P`
 //! (whose bindings stay live for the rest of the enclosing block), and `assert call() raises E` (see
@@ -34,11 +34,17 @@
 //! remaining work rather than as an implied "almost everything" claim: a spread in a `model`/`class` construction,
 //! which refuses as an unresolved field layout because the typechecker records no field binding for it; a spread
 //! with no statically proven shape against a callee whose fixed signature *is* resolvable, whose arity no stage can
-//! establish; a spread to a locally held callable value; the `**`, bitwise, shift, `in`/`not
-//! in`, and `is`/`is not` operators and their compound forms; `if let`/`while let` conditions and destructuring
-//! comprehension/generator clauses; statement-position `loop:`; `unsafe:` regions; `await` and `race for`; and
+//! establish; a spread to a locally held callable value; `if let`/`while let` conditions and destructuring
+//! comprehension/generator clauses; `await` and `race for`; and
 //! vocab/scoped-DSL surface nodes, which reach this module only when a caller skips the desugar pass the legacy
 //! pipeline runs first. The sub-issues are #1158 through #1167, plus #1172 for evaluable callable defaults.
+//!
+//! One entry in that residue is a decided boundary rather than pending work, and is stated here so it is not read
+//! as a gap. An `unsafe:` region refuses permanently: it introduces no Incan scope, so inlining its statements
+//! would be trivial, and that is precisely the problem — it would erase the acknowledgement the region exists to
+//! record and let a direct replacement execution profile run an explicitly authorized region without ever being
+//! told. Body IR v0 carries no acknowledgement fact a consumer could weigh, so the honest answer is a named
+//! refusal owned by #1162 rather than a silent inline. See [`BodyBuilder::refuse_unsafe_region`].
 //!
 //! Two coverage limits are silent rather than marked, and both are deliberate. Expression-position `yield` (the
 //! two-way send/receive protocol) is a stub in the existing Rust-emission backend too, so there is no behavior to

--- a/src/frontend/body_ir/control_flow.rs
+++ b/src/frontend/body_ir/control_flow.rs
@@ -171,6 +171,56 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
         bir::Operand::Constant(bir::Constant::Unit)
     }
 
+    /// Push one [`bir::StatementKind::Loop`] whose body `lower_body` fills in, owning the two pieces of loop state
+    /// every unconditional-loop spelling needs: the `break` target inner `break` statements resolve against, and
+    /// the end-of-iteration drops for locals the body declared in `loop_scope`.
+    ///
+    /// `break_target` is the only thing that separates the spellings routed through here. `Some(result_local)` is
+    /// the value-producing `loop:` expression, whose `break value` statements assign into that place before exiting
+    /// (see [`Self::lower_break`]). `None` is every statement-position loop, where `break` is a plain valueless
+    /// exit. Pushing `None` is not a formality: it is what stops a `break` inside a statement-position loop that is
+    /// lexically nested in a `loop:` expression from being rewritten into an assignment to the *outer* loop's
+    /// result place (see [`Self::loop_break_targets`] for why the stack exists).
+    ///
+    /// `loop_scope` is the caller's to create rather than this helper's, because the `loop:` expression must
+    /// declare its result temporary in that scope before any body statement is lowered.
+    ///
+    /// The two `for` paths deliberately do not route through here. [`Self::lower_range_counting_loop`] drops its
+    /// scope mid-body, before the index advance it appends afterwards, and [`Self::lower_general_iteration`] leaves
+    /// the drops to its caller's body closure; both would need this helper's fixed "body, then drops" order relaxed
+    /// into a per-caller choice, which would buy nothing but an extra parameter.
+    fn push_loop(
+        &mut self,
+        loop_scope: bir::ScopeId,
+        break_target: Option<bir::LocalId>,
+        span: HirSourceSpan,
+        out: &mut Vec<bir::Statement>,
+        lower_body: impl FnOnce(&mut Self, bir::ScopeId, &mut Vec<bir::Statement>),
+    ) {
+        // A loop body runs zero or more times, so a range-layout fact established inside it holds on entry only if
+        // it also held before. Intersecting entry state with exit state is what keeps that conservative -- and
+        // doing it here rather than at each caller is why every loop spelling gets it, including the statement
+        // `loop:` this helper was extracted to serve (#1165 established the fact, #1162 extracted the tail).
+        let range_layouts_before = self.materialized_range_locals.clone();
+        self.loop_break_targets.push(break_target);
+        let mut body_stmts = Vec::new();
+        lower_body(self, loop_scope, &mut body_stmts);
+        self.insert_scope_drops(&mut body_stmts, loop_scope);
+        self.loop_break_targets.pop();
+        self.materialized_range_locals =
+            intersect_range_layouts(vec![range_layouts_before, self.materialized_range_locals.clone()]);
+
+        out.push(bir::Statement {
+            kind: bir::StatementKind::Loop {
+                body: bir::Block {
+                    scope: loop_scope,
+                    stmts: body_stmts,
+                },
+            },
+            span,
+        });
+    }
+
     /// Lower a value-producing `loop:` expression (`ast::Expr::Loop`) into a [`bir::StatementKind::Loop`] plus a
     /// dedicated result local that every `break value` inside the loop's *own* body (not a nested loop's --
     /// enforced by [`Self::loop_break_targets`]) assigns into before exiting. The typechecker resolves this
@@ -188,32 +238,52 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
         let hir_span_value = hir_span(span);
         let ty = self.resolve_ty(span);
         let loop_scope = self.new_scope(Some(scope), hir_span_value);
-        let range_layouts_before = self.materialized_range_locals.clone();
         let result_local = self.new_temp(ty.clone(), loop_scope, hir_span_value);
 
-        self.loop_break_targets.push(Some(result_local));
-        let mut body_stmts = Vec::new();
-        self.lower_block_into(&loop_expr.body, loop_scope, &mut body_stmts);
-        self.insert_scope_drops(&mut body_stmts, loop_scope);
-        self.loop_break_targets.pop();
-        self.materialized_range_locals =
-            intersect_range_layouts(vec![range_layouts_before, self.materialized_range_locals.clone()]);
-
-        out.push(bir::Statement {
-            kind: bir::StatementKind::Loop {
-                body: bir::Block {
-                    scope: loop_scope,
-                    stmts: body_stmts,
-                },
-            },
-            span: hir_span_value,
-        });
+        self.push_loop(
+            loop_scope,
+            Some(result_local),
+            hir_span_value,
+            out,
+            |builder, loop_scope, body_stmts| builder.lower_block_into(&loop_expr.body, loop_scope, body_stmts),
+        );
         self.temp_operand(result_local, &ty)
+    }
+
+    /// Lower a statement-position `loop: body` into the same [`bir::StatementKind::Loop`] the expression spelling
+    /// produces, minus the result place: the loop runs its body until a `break` exits it and yields nothing.
+    ///
+    /// The two spellings differ in exactly one fact and it is the break target. The typechecker already draws the
+    /// same line — `check_loop_stmt` pushes a `LoopContextKind::Statement` context and rejects `break value` inside
+    /// it with `break_value_requires_loop_expression`, while `check_loop_expr` pushes an `Expression` context and
+    /// unifies the break types (both in `src/frontend/typechecker/check_stmt.rs`). Passing `None` here is that same
+    /// rule read off the typechecker rather than a second one invented in lowering: a well-typed program has no
+    /// value-carrying `break` to route anywhere, and a hand-built AST that has one keeps its value on the `Break`
+    /// statement per [`bir::StatementKind::Break`]'s documented default instead of being silently merged into some
+    /// enclosing loop's result.
+    ///
+    /// Scoping mirrors [`Self::lower_while`], which the typechecker treats identically (`check_while_stmt` opens
+    /// the same `ScopeKind::Block` and pushes the same statement loop context). `continue` needs nothing here at
+    /// all: it lowers to [`bir::StatementKind::Continue`] in [`Self::lower_stmt_into`] and means the innermost
+    /// enclosing loop wherever it appears.
+    pub(super) fn lower_loop_stmt(
+        &mut self,
+        loop_stmt: &ast::LoopStmt,
+        scope: bir::ScopeId,
+        span: HirSourceSpan,
+        out: &mut Vec<bir::Statement>,
+    ) {
+        let loop_scope = self.new_scope(Some(scope), span);
+        self.push_loop(loop_scope, None, span, out, |builder, loop_scope, body_stmts| {
+            builder.lower_block_into(&loop_stmt.body, loop_scope, body_stmts)
+        });
     }
 
     /// Lower `while cond: body` into Body IR's single normalized loop shape: a [`bir::StatementKind::Loop`] whose
     /// body opens with `if not cond: break`, followed by the lowered loop body. A `while let` pattern condition —
     /// not yet modeled by v0 — lowers to an explicit unsupported placeholder instead of the real loop.
+    ///
+    /// The condition is lowered *inside* the loop body, in `loop_scope`, so it is re-evaluated every iteration.
     pub(super) fn lower_while(
         &mut self,
         while_stmt: &ast::WhileStmt,
@@ -227,45 +297,28 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
         };
 
         let loop_scope = self.new_scope(Some(scope), span);
-        let range_layouts_before = self.materialized_range_locals.clone();
-        // `while` never produces a value from `break`, so push `None`: a `break` inside this loop's body must
-        // resolve to a plain valueless exit even if this `while` is lexically nested inside a value-producing
-        // `loop:` expression (see `Self::loop_break_targets`'s docs for why the stack exists).
-        self.loop_break_targets.push(None);
-        let mut body_stmts = Vec::new();
-        let cond_operand = self.lower_expr_to_operand(cond_expr, loop_scope, &mut body_stmts);
-        let negated = self.negate_operand(cond_operand, loop_scope, span, &mut body_stmts);
-        let break_scope = self.new_scope(Some(loop_scope), span);
-        let break_block = bir::Block {
-            scope: break_scope,
-            stmts: vec![bir::Statement {
-                kind: bir::StatementKind::Break { value: None },
-                span,
-            }],
-        };
-        body_stmts.push(bir::Statement {
-            kind: bir::StatementKind::If {
-                cond: negated,
-                then_block: break_block,
-                else_block: None,
-            },
-            span,
-        });
-
-        self.lower_block_into(&while_stmt.body, loop_scope, &mut body_stmts);
-        self.insert_scope_drops(&mut body_stmts, loop_scope);
-        self.loop_break_targets.pop();
-        self.materialized_range_locals =
-            intersect_range_layouts(vec![range_layouts_before, self.materialized_range_locals.clone()]);
-
-        out.push(bir::Statement {
-            kind: bir::StatementKind::Loop {
-                body: bir::Block {
-                    scope: loop_scope,
-                    stmts: body_stmts,
+        // `while` never produces a value from `break`, so the break target is `None` -- see `Self::push_loop`.
+        self.push_loop(loop_scope, None, span, out, |builder, loop_scope, body_stmts| {
+            let cond_operand = builder.lower_expr_to_operand(cond_expr, loop_scope, body_stmts);
+            let negated = builder.negate_operand(cond_operand, loop_scope, span, body_stmts);
+            let break_scope = builder.new_scope(Some(loop_scope), span);
+            let break_block = bir::Block {
+                scope: break_scope,
+                stmts: vec![bir::Statement {
+                    kind: bir::StatementKind::Break { value: None },
+                    span,
+                }],
+            };
+            body_stmts.push(bir::Statement {
+                kind: bir::StatementKind::If {
+                    cond: negated,
+                    then_block: break_block,
+                    else_block: None,
                 },
-            },
-            span,
+                span,
+            });
+
+            builder.lower_block_into(&while_stmt.body, loop_scope, body_stmts);
         });
     }
 

--- a/src/frontend/body_ir/stmt.rs
+++ b/src/frontend/body_ir/stmt.rs
@@ -22,6 +22,14 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
     /// `stmt` in its enclosing block, threaded through to [`Self::lower_assignment`] for last-use seeding. Statement
     /// kinds outside v0's covered subset fall through to an explicit [`Self::push_unsupported_stmt`] rather than
     /// panicking (see this module's module-level docs for the exact covered/uncovered split).
+    ///
+    /// Two kinds are dispatched here despite refusing, rather than being left to the trailing catch-all, and both
+    /// are deliberate. `ast::Statement::Unsafe` is a stated permanent boundary that has to name its own reason —
+    /// see [`Self::refuse_unsafe_region`]. Everything the catch-all still reaches is vocab/surface residue
+    /// (`Surface`, `VocabBlock`, `VocabExpressionItem`), whose disposition belongs to the Body IR input-contract
+    /// work rather than to any single construct: those nodes reach this module only when a caller skips the
+    /// desugar pass the legacy pipeline runs first (#1166). No statement kind lowers under the bare `"statement"`
+    /// label any more (#1162).
     pub(super) fn lower_stmt_into(
         &mut self,
         stmt: &ast::Spanned<ast::Statement>,
@@ -58,8 +66,10 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
                 });
             }
             ast::Statement::If(if_stmt) => self.lower_if(if_stmt, scope, span, out),
+            ast::Statement::Loop(loop_stmt) => self.lower_loop_stmt(loop_stmt, scope, span, out),
             ast::Statement::While(while_stmt) => self.lower_while(while_stmt, scope, span, out),
             ast::Statement::For(for_stmt) => self.lower_for(for_stmt, scope, span, out),
+            ast::Statement::Unsafe(_) => self.refuse_unsafe_region(span, out),
             ast::Statement::Expr(expr) => {
                 // `yield value` parses as an ordinary expression statement wrapping `ast::Expr::Yield(Some(_))`
                 // (there is no separate `ast::Statement::Yield` AST node) -- mirror the existing Rust-emission
@@ -86,6 +96,30 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
             }),
             other => self.push_unsupported_stmt(unsupported_stmt_label(other), span, out),
         }
+    }
+
+    /// Refuse an `unsafe:` region, permanently and by design, naming the boundary rather than leaving a placeholder
+    /// that reads like an unmodeled construct.
+    ///
+    /// This is a stated disposition, not a gap waiting on lowering work. `ast::UnsafeStmt` is documented as a
+    /// scoped acknowledgement region for operations requiring explicit authorization, and it introduces no separate
+    /// Incan scope — its statements are ordinary statements of the enclosing block, so lowering them inline would
+    /// be *easy*. That is exactly why the refusal has to be explicit: inlining them would erase the acknowledgement
+    /// and leave a direct replacement execution profile silently running an authorized region it was never told
+    /// about. A consumer that wants to admit such a region must do so deliberately, against a representation that
+    /// carries the acknowledgement, and Body IR v0 has no such representation.
+    ///
+    /// The refusal therefore says why rather than only what, and is the corpus's one `Disposition::Unsupported`
+    /// row (`parity-987-0018` in `tests/parity_corpus_tests.rs`), owned by #1162. Reversing it means designing the
+    /// acknowledgement fact first, not adding a dispatch arm.
+    fn refuse_unsafe_region(&self, span: HirSourceSpan, out: &mut Vec<bir::Statement>) {
+        self.push_unsupported_stmt(
+            "`unsafe:` acknowledgement region: refused by design, because Body IR v0 cannot carry the \
+             acknowledgement a consumer would need to admit it deliberately (#1162)"
+                .to_string(),
+            span,
+            out,
+        );
     }
 
     /// Lower an inferred/`let`/`mutable`/reassignment statement. A `Reassign` binding reuses the existing local for

--- a/src/frontend/body_ir/tests.rs
+++ b/src/frontend/body_ir/tests.rs
@@ -6486,3 +6486,222 @@ def run() -> int:
     );
     Ok(())
 }
+
+// ============================================================================
+// Statement-position `loop:` and the `unsafe:` boundary (#1162)
+// ============================================================================
+
+/// The indentation `render_block` gives a statement nested one block below a body's top-level statements.
+///
+/// A body renders its own block at depth 1, so a top-level statement carries two spaces and anything inside that
+/// statement's nested block carries four. Tests that care about *where* a statement landed compare against this
+/// rather than merely finding the text somewhere in the body, which would also pass if the statement had escaped
+/// into the enclosing block.
+const NESTED_BLOCK_INDENT: &str = "    ";
+
+#[test]
+fn a_statement_position_loop_lowers_to_the_same_loop_the_expression_spelling_produces()
+-> Result<(), Box<dyn std::error::Error>> {
+    // `bir::StatementKind::Loop` already existed and the expression spelling already emitted it; only
+    // `lower_stmt_into`'s dispatch was missing, so the plain statement form -- the more common one -- refused.
+    let source = concat!(
+        "def count_to(limit: int) -> int:\n",
+        "  mut i = 0\n",
+        "  loop:\n",
+        "    if i >= limit:\n",
+        "      break\n",
+        "    i = i + 1\n",
+        "  return i\n",
+    );
+    let module = build(source, &["m", "loop_stmt"])?;
+    let snapshot = body_named(&module, "count_to")?.render_snapshot();
+
+    assert!(
+        !snapshot.contains("unsupported("),
+        "a statement-position `loop:` must lower rather than refuse: {snapshot}"
+    );
+    assert!(
+        snapshot.lines().any(|line| line.trim() == "loop:"),
+        "it must lower to Body IR's one normalized loop shape: {snapshot}"
+    );
+    // The statement spelling produces no value, so its `break` stays a plain valueless exit rather than acquiring
+    // the result place a `loop:` expression's `break value` is rewritten into.
+    assert!(
+        snapshot.lines().any(|line| line.trim() == "break"),
+        "the loop must be exited by a valueless break: {snapshot}"
+    );
+    Ok(())
+}
+
+#[test]
+fn continue_inside_a_statement_loop_behaves_as_it_does_in_while_and_for() -> Result<(), Box<dyn std::error::Error>> {
+    let source = concat!(
+        "def odd_count(limit: int) -> int:\n",
+        "  mut i = 0\n",
+        "  mut odds = 0\n",
+        "  loop:\n",
+        "    if i >= limit:\n",
+        "      break\n",
+        "    i = i + 1\n",
+        "    if i % 2 == 0:\n",
+        "      continue\n",
+        "    odds = odds + 1\n",
+        "  return odds\n",
+    );
+    let module = build(source, &["m", "loop_stmt_continue"])?;
+    let snapshot = body_named(&module, "odd_count")?.render_snapshot();
+
+    assert!(
+        !snapshot.contains("unsupported("),
+        "a statement `loop:` carrying a `continue` must lower whole: {snapshot}"
+    );
+    assert!(
+        snapshot.lines().any(|line| line.trim() == "continue"),
+        "`continue` must lower to the shared continue statement: {snapshot}"
+    );
+    Ok(())
+}
+
+#[test]
+fn nested_statement_loops_each_get_their_own_loop_block() -> Result<(), Box<dyn std::error::Error>> {
+    let source = concat!(
+        "def grid(rows: int, cols: int) -> int:\n",
+        "  mut cells = 0\n",
+        "  mut r = 0\n",
+        "  loop:\n",
+        "    if r >= rows:\n",
+        "      break\n",
+        "    mut c = 0\n",
+        "    loop:\n",
+        "      if c >= cols:\n",
+        "        break\n",
+        "      c = c + 1\n",
+        "      cells = cells + 1\n",
+        "    r = r + 1\n",
+        "  return cells\n",
+    );
+    let module = build(source, &["m", "nested_loop_stmt"])?;
+    let snapshot = body_named(&module, "grid")?.render_snapshot();
+
+    assert!(
+        !snapshot.contains("unsupported("),
+        "nested statement loops must lower whole: {snapshot}"
+    );
+    let loop_indents: Vec<&str> = snapshot
+        .lines()
+        .filter(|line| line.trim() == "loop:")
+        .map(|line| &line[..line.len() - line.trim_start().len()])
+        .collect();
+    // Asserting only that two loops exist would also pass if the inner one had been hoisted out of the outer
+    // one's body, so require the second to be nested inside the first.
+    assert_eq!(loop_indents.len(), 2, "both loops must be represented: {snapshot}");
+    assert!(
+        loop_indents[1].len() > loop_indents[0].len(),
+        "the inner loop must stay nested inside the outer loop's body: {snapshot}"
+    );
+    Ok(())
+}
+
+#[test]
+fn an_unsupported_statement_inside_a_statement_loop_keeps_its_own_refusal() -> Result<(), Box<dyn std::error::Error>> {
+    // The loop must not swallow a construct it happens to contain: a consumer loses only that statement, not the
+    // whole loop. The stand-in is collection membership, which #1160 deliberately left refused while giving every
+    // other operator in that position a representation -- the same stand-in
+    // `an_unsupported_construct_in_a_race_arm_does_not_collapse_the_whole_race` uses, and chosen for the same
+    // reason: a stand-in that later becomes representable turns its test vacuous.
+    let source = concat!(
+        "def scan(values: list[int]) -> int:\n",
+        "  mut i = 0\n",
+        "  loop:\n",
+        "    if i >= 3:\n",
+        "      break\n",
+        "    hit = i in values\n",
+        "    i = i + 1\n",
+        "  return i\n",
+    );
+    let module = build(source, &["m", "loop_stmt_partial"])?;
+    let snapshot = body_named(&module, "scan")?.render_snapshot();
+
+    assert!(
+        snapshot.lines().any(|line| line.trim() == "loop:"),
+        "the loop itself must still be represented: {snapshot}"
+    );
+    let refusal = snapshot
+        .lines()
+        .find(|line| line.contains("unsupported(binary operator In)"))
+        .ok_or("missing the refusal for the unrepresentable loop-body statement")?;
+    assert!(
+        refusal.starts_with(NESTED_BLOCK_INDENT),
+        "the refusal must stay inside the loop body rather than collapsing or escaping the loop: {snapshot}"
+    );
+    Ok(())
+}
+
+#[test]
+fn a_value_carrying_break_in_a_statement_loop_is_not_merged_into_an_enclosing_loop_expression()
+-> Result<(), Box<dyn std::error::Error>> {
+    // The typechecker owns this rule and already rejects the program (`break_value_requires_loop_expression`), so
+    // lowering's job is only to not invent a second rule. A statement `loop:` pushes no break target, which is
+    // what stops the value from being rewritten into the *enclosing* `loop:` expression's result place -- an
+    // assignment the source never wrote.
+    let source = concat!(
+        "def find(limit: int) -> int:\n",
+        "  return loop:\n",
+        "    mut i = 0\n",
+        "    loop:\n",
+        "      if i >= limit:\n",
+        "        break 1\n",
+        "      i = i + 1\n",
+        "    break i\n",
+    );
+    let (module, diagnostics) = build_after_expected_typecheck_errors(source, &["m", "loop_stmt_break_value"])?;
+    assert!(
+        diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.contains("`break <value>` is only valid inside `loop:` expressions")),
+        "the source checker must reject a value-carrying break in a statement loop: {diagnostics:?}"
+    );
+
+    let snapshot = body_named(&module, "find")?.render_snapshot();
+    assert!(
+        snapshot.lines().any(|line| line.trim() == "break const(1)"),
+        "the rejected value must stay on the `break` statement rather than being assigned into the outer loop's \
+         result place: {snapshot}"
+    );
+    Ok(())
+}
+
+#[test]
+fn an_unsafe_region_refuses_under_a_named_permanent_boundary() -> Result<(), Box<dyn std::error::Error>> {
+    // #1162's second half. The refusal is a decided disposition, not a missing dispatch arm: an `unsafe:` region
+    // introduces no Incan scope, so inlining its statements would be trivial -- and would erase the
+    // acknowledgement the region exists to record.
+    let source = concat!(
+        "def probe(x: int) -> int:\n",
+        "  return x\n",
+        "\n",
+        "def touch(value: int) -> int:\n",
+        "  mut total = 0\n",
+        "  unsafe:\n",
+        "    total = probe(value)\n",
+        "  return total\n",
+    );
+    let module = build(source, &["m", "unsafe_region"])?;
+    let snapshot = body_named(&module, "touch")?.render_snapshot();
+
+    assert!(
+        snapshot.contains("unsupported(`unsafe:` acknowledgement region:"),
+        "the refusal must name the construct rather than reading as a generic placeholder: {snapshot}"
+    );
+    assert!(
+        snapshot.contains("refused by design") && snapshot.contains("#1162"),
+        "the refusal must state that it is a decided boundary and name its owner: {snapshot}"
+    );
+    // The region's own statements must not quietly become statements of the enclosing block, which is the
+    // silent-execution outcome the refusal exists to prevent.
+    assert!(
+        !snapshot.contains("probe"),
+        "an acknowledged region's statements must not be inlined into the enclosing block: {snapshot}"
+    );
+    Ok(())
+}

--- a/tests/parity_corpus_tests.rs
+++ b/tests/parity_corpus_tests.rs
@@ -91,37 +91,60 @@ fn messages(errors: Vec<CompileError>) -> Vec<String> {
 /// about execution — a `DirectReplacementBodyIr` row owns that, and neither lane establishes a receipt-aware
 /// comparison, which #1146 owns.
 fn outcome_from_body_ir(src: &str, expect_desc: &str) -> ComparisonOutcome {
-    let tokens = match lexer::lex(src) {
-        Ok(tokens) => tokens,
-        Err(errors) => {
-            return ComparisonOutcome::Incompatible {
-                reason: format!("expected {expect_desc}, but lexing failed: {errors:?}"),
-            };
-        }
+    let snapshot = match body_ir_snapshot(src, expect_desc) {
+        Ok(snapshot) => snapshot,
+        Err(outcome) => return outcome,
     };
-    let program = match parser::parse(&tokens) {
-        Ok(program) => program,
-        Err(errors) => {
-            return ComparisonOutcome::Incompatible {
-                reason: format!("expected {expect_desc}, but parsing failed: {errors:?}"),
-            };
-        }
-    };
-    let module_path = vec!["parity_987_body_ir".to_string()];
-    let mut checker = typechecker::TypeChecker::new();
-    checker.set_current_module_path(Some(module_path.clone()));
-    if let Err(errors) = checker.check_program(&program) {
-        return ComparisonOutcome::Mismatch {
-            detail: format!("expected {expect_desc}, but typechecking reported {errors:?}"),
-        };
-    }
-    let snapshot = build_body_ir_module_v0(&program, &module_path, checker.type_info()).render_snapshot();
     if snapshot.contains("unsupported(") {
         return ComparisonOutcome::Mismatch {
             detail: format!("expected {expect_desc}, but Body IR still contains a placeholder:\n{snapshot}"),
         };
     }
     ComparisonOutcome::Match
+}
+
+/// Lower `src` to Body IR and report whether it refuses under the exact label `expected_refusal` names.
+///
+/// The sibling of [`outcome_from_body_ir`] for a row whose disposition is `Disposition::Unsupported`: the case's
+/// documented behavior is a *stated refusal*, so proving it means the placeholder is present and says which
+/// construct it is, not merely that some placeholder exists. Matching on the label rather than on the bare
+/// `unsupported(` prefix is what stops this row from staying green if the construct were later inlined and some
+/// unrelated statement in the same source started refusing instead.
+fn outcome_from_body_ir_refusal(src: &str, expected_refusal: &str, expect_desc: &str) -> ComparisonOutcome {
+    let snapshot = match body_ir_snapshot(src, expect_desc) {
+        Ok(snapshot) => snapshot,
+        Err(outcome) => return outcome,
+    };
+    if !snapshot.contains(expected_refusal) {
+        return ComparisonOutcome::Mismatch {
+            detail: format!("expected {expect_desc}, but Body IR did not carry that refusal:\n{snapshot}"),
+        };
+    }
+    ComparisonOutcome::Match
+}
+
+/// Lex, parse, typecheck, and lower `src`, returning the rendered Body IR snapshot.
+///
+/// The shared front half of [`outcome_from_body_ir`] and [`outcome_from_body_ir_refusal`]. A failure before
+/// lowering is returned as the `ComparisonOutcome` the caller should report rather than as an error the caller
+/// must re-describe: lex/parse failures are `Incompatible` (the probe could not run at all), while a typecheck
+/// failure is a real `Mismatch` (the source is supposed to be accepted).
+fn body_ir_snapshot(src: &str, expect_desc: &str) -> Result<String, ComparisonOutcome> {
+    let tokens = lexer::lex(src).map_err(|errors| ComparisonOutcome::Incompatible {
+        reason: format!("expected {expect_desc}, but lexing failed: {errors:?}"),
+    })?;
+    let program = parser::parse(&tokens).map_err(|errors| ComparisonOutcome::Incompatible {
+        reason: format!("expected {expect_desc}, but parsing failed: {errors:?}"),
+    })?;
+    let module_path = vec!["parity_987_body_ir".to_string()];
+    let mut checker = typechecker::TypeChecker::new();
+    checker.set_current_module_path(Some(module_path.clone()));
+    checker
+        .check_program(&program)
+        .map_err(|errors| ComparisonOutcome::Mismatch {
+            detail: format!("expected {expect_desc}, but typechecking reported {errors:?}"),
+        })?;
+    Ok(build_body_ir_module_v0(&program, &module_path, checker.type_info()).render_snapshot())
 }
 
 fn outcome_from_typecheck(src: &str, expect: impl FnOnce(&[String]) -> bool, expect_desc: &str) -> ComparisonOutcome {
@@ -564,6 +587,64 @@ fn case_supported_range_value_reaches_body_ir() -> ComparisonOutcome {
     outcome_from_body_ir(
         CASE_16_SRC,
         "a range bound to a local to lower to a real range value that the loop then iterates",
+    )
+}
+
+// ============================================================================
+// Cases 17 and 18 — Statement-position `loop:` reaches Body IR; `unsafe:` is a stated boundary (#1162)
+// ============================================================================
+
+// `bir::StatementKind::Loop` already existed and the expression spelling already emitted it, so the plain
+// statement spelling -- the more common one -- was refused by a missing dispatch arm rather than by a missing
+// representation. Included with `continue` and a nested loop, because the loop's break/continue vocabulary is
+// what makes the row about the construct rather than about one keyword.
+const CASE_18_SRC: &str = r#"
+def grid(rows: int, cols: int) -> int:
+    mut cells = 0
+    mut r = 0
+    loop:
+        if r >= rows:
+            break
+        mut c = 0
+        loop:
+            if c >= cols:
+                break
+            c = c + 1
+            if c % 2 == 0:
+                continue
+            cells = cells + 1
+        r = r + 1
+    return cells
+"#;
+
+fn case_supported_statement_loop_reaches_body_ir() -> ComparisonOutcome {
+    outcome_from_body_ir(
+        CASE_18_SRC,
+        "a statement-position `loop:` to lower to a real Body IR loop, nesting and `continue` included",
+    )
+}
+
+// The corpus's first `Disposition::Unsupported` row. This is a decided boundary, not pending lowering work: an
+// `unsafe:` region introduces no Incan scope, so inlining its statements would be trivial -- and would erase the
+// acknowledgement the region exists to record, letting a direct replacement execution profile run an explicitly
+// authorized region without ever being told. The row asserts the refusal is present *and named*, so inlining the
+// region later cannot leave it silently green.
+const CASE_19_SRC: &str = r#"
+def probe(x: int) -> int:
+    return x
+
+def touch(value: int) -> int:
+    mut total = 0
+    unsafe:
+        total = probe(value)
+    return total
+"#;
+
+fn case_unsafe_region_is_a_stated_refusal() -> ComparisonOutcome {
+    outcome_from_body_ir_refusal(
+        CASE_19_SRC,
+        "unsupported(`unsafe:` acknowledgement region:",
+        "an `unsafe:` region to refuse under a named, reasoned boundary rather than lower silently",
     )
 }
 
@@ -1202,6 +1283,46 @@ fn seed_corpus() -> Vec<ParityCase> {
             disposition: Disposition::Preserved,
             source: CASE_16_SRC,
             evaluate: Some(case_supported_range_value_reaches_body_ir),
+            replacement_execution: None,
+        },
+        ParityCase {
+            id: "parity-987-0018",
+            title: "Statement-position `loop:` is representable in Body IR, not only the expression spelling",
+            category: BehaviorCategory::SupportedLanguageContract,
+            lane: EvidenceLane::DirectParserTypechecker,
+            evidence: "#1162; src/frontend/body_ir/tests.rs::a_statement_position_loop_lowers_to_the_same_loop_the_expression_spelling_produces",
+            disposition: Disposition::Preserved,
+            source: CASE_18_SRC,
+            evaluate: Some(case_supported_statement_loop_reaches_body_ir),
+            replacement_execution: None,
+        },
+        ParityCase {
+            id: "parity-987-0019",
+            title: "An `unsafe:` acknowledgement region refuses in Body IR under a named, stated boundary",
+            category: BehaviorCategory::SupportedLanguageContract,
+            lane: EvidenceLane::DirectParserTypechecker,
+            evidence: "#1162; src/frontend/body_ir/tests.rs::an_unsafe_region_refuses_under_a_named_permanent_boundary",
+            // The corpus's first real `Unsupported` row, so it carries the full migration note the schema asks
+            // for rather than a pointer to one.
+            disposition: Disposition::Unsupported {
+                owning_issue: 1162,
+                migration_note: "An `unsafe:` region records an explicit acknowledgement that the operations \
+                                 inside it require authorization. It introduces no separate Incan scope, so \
+                                 lowering its statements into the enclosing block would be a two-line change — \
+                                 and would erase exactly the fact the region exists to carry, leaving a direct \
+                                 replacement execution profile running an authorized region it was never told \
+                                 about. Body IR v0 has no acknowledgement fact a consumer could weigh, so the \
+                                 region refuses under a named label stating that it is refused by design \
+                                 (`BodyBuilder::refuse_unsafe_region` in src/frontend/body_ir/stmt.rs). \
+                                 Cutover impact: a program whose `unsafe:` region must execute cannot use the \
+                                 replacement backend; the legacy Rust-emission backend keeps compiling it \
+                                 unchanged, so no accepted program regresses. Reversing this disposition means \
+                                 designing the acknowledgement representation first and deciding who may admit \
+                                 it — adding a dispatch arm alone would be the silent execution this row \
+                                 exists to prevent. Owned by #1162 until that design lands.",
+            },
+            source: CASE_19_SRC,
+            evaluate: Some(case_unsafe_region_is_a_stated_refusal),
             replacement_execution: None,
         },
         ParityCase {


### PR DESCRIPTION
## Summary

`bir::StatementKind::Loop` existed and `lower_loop_expr` already emitted it — only `lower_stmt_into`'s dispatch was missing, so a statement-position `loop:` fell through to a refusal. This wires it up and settles the disposition of the remaining statement residue.

Closes #1162.

**Stacked on #1165 (PR #1237)**, which reshaped `lower_for` in the same file; #1165 is itself stacked on #1160 (PR #1234).

## Type of change

- [x] New feature

## Area(s)

- [x] Compiler (frontend/backend/codegen)

## Key details

- **No third loop path.** `lower_loop_expr` and `lower_while` already shared a byte-for-byte identical tail; that tail is now a `push_loop` helper with the statement form as its third caller. The break target is the only fact separating the three spellings.
- **The break target was read off the typechecker, not invented.** `check_loop_stmt` pushes `LoopContextKind::Statement` and rejects `break value` through `break_value_requires_loop_expression`, exactly as `check_while_stmt` does. Passing `None` restates that existing rule rather than adding a second one in lowering.
- The generic `"statement"` catch-all was already gone before this work — the #1101 module split named all five residual kinds. What remained of the refusals half was the `unsafe:` disposition.

## `unsafe:` is refused permanently, and says why

```
unsupported(`unsafe:` acknowledgement region: refused by design, because Body IR v0 cannot carry the
acknowledgement a consumer would need to admit it deliberately (#1162))
```

An `unsafe:` region introduces no Incan scope, so inlining its statements would be a two-line change — and that is exactly the problem. It would erase the acknowledgement and leave a direct replacement execution profile running an authorized region it was never told about. The reasoning is recorded at the refusal, in the module docs, and in the corpus migration note, so the next reader doesn't re-derive it and reach the opposite conclusion.

## Testing / verification

- [x] Manual verification described below

Manual verification notes:

- `cargo test --lib frontend::body_ir` — 193 passed, 0 failed (6 new)
- `cargo test -p incan_semantics_core --lib body_ir` — 26 passed, 0 failed
- `cargo test --test parity_corpus_tests` — 9 passed, 0 failed, with `parity-987-0018` (Preserved) and `parity-987-0019` (Unsupported)
- `cargo test --test replacement_backend_execution_tests` — 72 passed, 0 failed
- `cargo clippy --lib --tests` clean; `cargo +nightly fmt` clean; rustdoc gate passed

**Mutation checks**, three:

- Dropping the loop body's lowering failed 5 tests.
- Passing `Some(temp)` as the break target failed exactly 1 — the test that pins the statement/expression distinction. A plain valueless `break` cannot detect that, so the test deliberately routes through a program the typechecker rejects.
- Renaming the `unsafe:` refusal failed the unit test *and* both corpus tests, confirming the `Unsupported` row is load-bearing rather than decorative.

Slice-level gates (`make pre-commit`, full Oven suites, slice-wide CI) are deliberately deferred.

## Row ids are 0018/0019, not 0017/0018

`parity-987-0017` is claimed by #1166 on a sibling stack. These were renumbered before opening, since colliding ids would only have surfaced at merge.

## Follow-ups left in a file this branch does not own

This change makes three things in `refusals.rs` unreachable — the `Statement::Loop` arm, the `Statement::Unsafe` arm, and the `_ => "statement"` fallback, which no longer matches any variant that exists today. Its rustdoc is also stale: it explains that `loop:` is named *because* only the dispatch is missing, describing the gap this PR closes. The fallback is worth keeping as a defensive default for a future variant; the two dead arms and the paragraph are not.

Nothing is red because of it — no compile error, no clippy warning. It is grouped with the other post-merge `refusals.rs` cleanup that spans this stack and #1166's.

`refuse_unsafe_region` living in `stmt.rs` rather than as a label in `refusals.rs` is a consequence of that same ownership boundary, not a design preference — the reason has to travel with the emitted description.

## Docs impact

- [x] No docs changes needed

`src/frontend/body_ir.rs`'s module docs are the canonical covered/uncovered split and named statement `loop:` and `unsafe:` as pending residue, which this makes false. Updated (docs only, no code lines).

## Checklist

- [x] I added/updated tests where it materially reduces regressions
