### PR TITLE
feature - execute one checked provider-service operation from Body IR (#1156)

### DIFF
--- a/src/backend/replacement/mod.rs
+++ b/src/backend/replacement/mod.rs
@@ -15,6 +15,14 @@
 //! callable/default forms, general destructuring, and other projections remain visible refusals. Its enclosing
 //! declaration snapshot retains a deferred generator's shape, but the frame executes and adds execution-frame
 //! evidence only when collection polls it; no path falls back to generated Rust.
+//!
+//! One checked provider-service operation also executes directly, from the already-lowered
+//! [`ProviderOperationPlan`] rather than from source or generated Rust (#1156). That vertical is owned by
+//! [`provider`], which consumes the RFC 104 authority and operation-receipt contracts instead of restating them;
+//! this module supplies it with evaluated operands and refuses an unresolved, inactive, or unauthorized operation
+//! at the original source span.
+
+pub mod provider;
 
 use std::{
     cell::RefCell,
@@ -33,14 +41,17 @@ use incan_semantics_core::body_ir::{
     FieldlessEnumDeclaration, FieldlessEnumVariantDeclaration, FieldlessEnumVariantTarget, GeneratorBody, HelperOp,
     IterProtocol, LocalCallableTarget, LocalId, LocalOrigin, MatchArm, NamedCallableBuiltin, NamedCallableTarget,
     NominalDeclaration, NominalPatternTarget, Operand, OwnershipFact, Pattern, PatternBinding, Place, PlaceElem,
-    ResultVariant, ResultVariantKind, Rvalue, ScopeId, Statement, StatementKind, TryErrorRouting, UnOp,
-    ValueEnumBacking, ValueEnumDeclaration, ValueEnumVariantDeclaration, ValueEnumVariantTarget,
+    ProviderActivationState, ProviderOperationPlan, ResultVariant, ResultVariantKind, Rvalue, ScopeId, Statement,
+    StatementKind, TryErrorRouting, UnOp, ValueEnumBacking, ValueEnumDeclaration, ValueEnumVariantDeclaration,
+    ValueEnumVariantTarget,
 };
 use incan_semantics_core::{
     AbiV0RuntimeRequirement, CompilerNodeId, CompilerNodeKind, HirSourceSpan, IncanPrimitiveType, IncanType,
+    SemanticSourceTargetKind,
 };
 
 use crate::backend::selection::digest_output;
+use provider::{ProviderExecutionRecord, ProviderInputValue, ProviderRuntime, canonical_provider_execution_summary};
 
 /// Bounded instruction count for one replacement execution.
 ///
@@ -452,7 +463,14 @@ pub struct ReplacementExecution {
     pub runtime_requirements: Vec<AbiV0RuntimeRequirement>,
     /// Every direct task-frame transition observed during this successful execution, in source execution order.
     task_lifecycle: Vec<TaskLifecycleEvent>,
-    /// Content identity of the actual Body-IR snapshot, ownership facts, requirements, and observed result.
+    /// Every provider operation this execution ran, each referencing its own RFC 104 operation receipt.
+    ///
+    /// Empty for a run that executed no provider operation. A run that was *refused* by a governed denial or a
+    /// provider failure never produces a [`ReplacementExecution`] at all, so its receipts are read from the
+    /// [`provider::ProviderRuntime`] the caller supplied rather than from here.
+    provider_executions: Vec<ProviderExecutionRecord>,
+    /// Content identity of the actual Body-IR snapshot, ownership facts, requirements, provider executions, and
+    /// observed result.
     pub output_identity: String,
 }
 
@@ -465,6 +483,11 @@ pub struct ValidatedFreeFunctionExecution<'module, 'args> {
     module: &'module BodyIrModule,
     name: String,
     args: &'args [ReplacementValue],
+    /// The provider runtime this execution's admitted provider operations were validated against.
+    ///
+    /// Retained on the capability rather than passed again at execution time so the runtime that answered
+    /// "does any host execute this operation" is necessarily the one that later invokes it.
+    providers: Option<Rc<ProviderRuntime>>,
 }
 
 impl ReplacementExecution {
@@ -484,6 +507,18 @@ impl ReplacementExecution {
     #[must_use]
     pub fn task_lifecycle_evidence(&self) -> Vec<TaskLifecycleProjection> {
         task_lifecycle_projection(&self.task_lifecycle)
+    }
+
+    /// Return the backend provider-execution receipts bound into this execution's output identity.
+    ///
+    /// Each entry references its RFC 104 operation receipt by sequence id rather than restating it, so a consumer
+    /// that needs the authority decision or the recorded attributes reads the operation receipt itself.
+    #[must_use]
+    pub fn provider_execution_evidence(&self) -> Vec<provider::ProviderExecutionProjection> {
+        self.provider_executions
+            .iter()
+            .map(ProviderExecutionRecord::projection)
+            .collect()
     }
 }
 
@@ -532,6 +567,51 @@ pub enum ReplacementExecutionError {
         /// End byte offset duplicated for typed error formatting.
         span_end: usize,
     },
+    /// An RFC 104 authority decision refused an admitted provider operation, so it never ran.
+    ///
+    /// Deliberately distinct from [`Self::RuntimeFailure`]: nothing executed, and the remedy is a grant rather than
+    /// a change to the program. The referenced receipt is the denial's own record — a denied operation still emits
+    /// one, which is why this error names it rather than reporting a bare refusal.
+    #[error(
+        "replacement backend refused provider operation `{operation}` at original Incan source span \
+         {span_start}..{span_end}: {reason}"
+    )]
+    ProviderAuthorityDenied {
+        /// Declaration name of the refused operation, from its canonical identity.
+        operation: String,
+        /// Why authority was refused, and which grant would permit it.
+        reason: String,
+        /// Sequence id of the denied RFC 104 operation receipt this refusal produced.
+        receipt_sequence_id: u64,
+        /// Original Incan source span carried by the operation's plan.
+        span: HirSourceSpan,
+        /// Start byte offset duplicated for typed error formatting.
+        span_start: usize,
+        /// End byte offset duplicated for typed error formatting.
+        span_end: usize,
+    },
+    /// Authority was granted and the provider operation itself failed.
+    ///
+    /// Separate from a denial because the two have nothing in common but their visibility: here the operation ran,
+    /// its receipt records `failed` over an *allowing* decision, and any resource it acquired was released.
+    #[error(
+        "replacement backend provider operation `{operation}` failed at original Incan source span \
+         {span_start}..{span_end}: {detail}"
+    )]
+    ProviderOperationFailed {
+        /// Declaration name of the failed operation, from its canonical identity.
+        operation: String,
+        /// Source-observable description of the provider's own failure.
+        detail: String,
+        /// Sequence id of the failed RFC 104 operation receipt this invocation produced.
+        receipt_sequence_id: u64,
+        /// Original Incan source span carried by the operation's plan.
+        span: HirSourceSpan,
+        /// Start byte offset duplicated for typed error formatting.
+        span_start: usize,
+        /// End byte offset duplicated for typed error formatting.
+        span_end: usize,
+    },
 }
 
 impl ReplacementExecutionError {
@@ -547,14 +627,41 @@ impl ReplacementExecutionError {
             Self::MissingFunction { .. } | Self::ArgumentCount { .. } => "INCAN-R988-ENTRYPOINT",
             Self::Unsupported { .. } => "INCAN-R988-UNSUPPORTED",
             Self::RuntimeFailure { .. } => "INCAN-R988-RUNTIME",
+            Self::ProviderAuthorityDenied { .. } => "INCAN-R1156-DENIED",
+            Self::ProviderOperationFailed { .. } => "INCAN-R1156-PROVIDER",
         }
     }
 
     /// Return the original Incan source location when this outcome arose from Body IR.
     pub const fn primary_span(&self) -> Option<HirSourceSpan> {
         match self {
-            Self::Unsupported { span, .. } | Self::RuntimeFailure { span, .. } => Some(*span),
+            Self::Unsupported { span, .. }
+            | Self::RuntimeFailure { span, .. }
+            | Self::ProviderAuthorityDenied { span, .. }
+            | Self::ProviderOperationFailed { span, .. } => Some(*span),
             Self::MissingFunction { .. } | Self::ArgumentCount { .. } => None,
+        }
+    }
+
+    /// Return the RFC 104 operation receipt this outcome emitted, when it emitted one.
+    ///
+    /// Only the two provider outcomes do. A refusal that happened before the operation was invoked — an unsupported
+    /// construct, an inactive provider, an unresolved operation — deliberately has no receipt to name, which is the
+    /// structural form of "nothing ran, so nothing was recorded".
+    pub const fn operation_receipt(&self) -> Option<super::replacement::provider::ProviderReceiptLink> {
+        match self {
+            Self::ProviderAuthorityDenied {
+                receipt_sequence_id, ..
+            }
+            | Self::ProviderOperationFailed {
+                receipt_sequence_id, ..
+            } => Some(super::replacement::provider::ProviderReceiptLink {
+                sequence_id: *receipt_sequence_id,
+            }),
+            Self::MissingFunction { .. }
+            | Self::ArgumentCount { .. }
+            | Self::Unsupported { .. }
+            | Self::RuntimeFailure { .. } => None,
         }
     }
 }
@@ -568,6 +675,21 @@ pub fn prepare_free_function_execution<'module, 'args>(
     name: &str,
     args: &'args [ReplacementValue],
 ) -> Result<ValidatedFreeFunctionExecution<'module, 'args>, ReplacementExecutionError> {
+    prepare_free_function_execution_with_providers(module, name, args, None)
+}
+
+/// Validate and prepare one Body-IR free function that may invoke admitted provider operations.
+///
+/// A `None` runtime is not a permissive default: it means no host executes any provider operation in this run, so
+/// every admitted provider call refuses at its own source span during this pre-execution gate rather than part-way
+/// through the body. That is what keeps [`prepare_free_function_execution`]'s existing contract — refuse before
+/// executing, and emit no receipt for a refusal — true for the provider vocabulary too.
+pub fn prepare_free_function_execution_with_providers<'module, 'args>(
+    module: &'module BodyIrModule,
+    name: &str,
+    args: &'args [ReplacementValue],
+    providers: Option<&Rc<ProviderRuntime>>,
+) -> Result<ValidatedFreeFunctionExecution<'module, 'args>, ReplacementExecutionError> {
     let body = named_free_function(module, name)?;
     if body.is_generator() {
         return Err(unsupported("generator body", body.span));
@@ -580,11 +702,12 @@ pub fn prepare_free_function_execution<'module, 'args>(
         });
     }
     validate_scalar_arguments(args, body.span)?;
-    validate_direct_body_profile(body)?;
+    validate_direct_body_profile(body, providers.map(Rc::as_ref))?;
     Ok(ValidatedFreeFunctionExecution {
         module,
         name: name.to_string(),
         args,
+        providers: providers.cloned(),
     })
 }
 
@@ -593,7 +716,11 @@ pub fn prepare_free_function_execution<'module, 'args>(
 /// The selected entrypoint and every same-module named callee use this one gate. Applying it only at the entrypoint
 /// would let an otherwise admitted call dispatch an unvalidated sibling body and publish a receipt for a profile the
 /// runtime promises to refuse.
-fn validate_direct_body_profile(body: &Body) -> Result<(), ReplacementExecutionError> {
+fn validate_direct_body_profile(
+    body: &Body,
+    providers: Option<&ProviderRuntime>,
+) -> Result<(), ReplacementExecutionError> {
+    validate_provider_operation_hosts(&body.block.stmts, providers)?;
     // An `async def` produces an awaitable even when its body has no explicit `await`. Executing its statements as
     // an ordinary scalar body would erase task construction, suspension, wake, cancellation, and receipt semantics
     // that belong to #1155. The stored declaration fact is therefore a direct profile boundary, not something this
@@ -617,6 +744,64 @@ fn validate_direct_body_profile(body: &Body) -> Result<(), ReplacementExecutionE
     } else {
         validate_block_profile(&body.block, &tuple_iteration_locals, &scalar_tuple_collection_locals)
     }
+}
+
+/// Refuse every admitted provider operation this body invokes that no host in this run executes.
+///
+/// This is a separate pass rather than another clause of the structural profile validator because it asks a
+/// different question. The structural gate asks whether the *plan* is executable at all — an active provider, a
+/// capability-kinded authority, one input per argument — and needs nothing but the plan to answer. This asks
+/// whether *this run* has a host for the operation, which only the supplied runtime knows. Splitting them keeps the
+/// structural refusal identical whether or not a runtime was supplied, and keeps both refusals before execution, so
+/// an unresolved operation never leaves a partially executed body or an execution receipt behind.
+fn validate_provider_operation_hosts(
+    statements: &[Statement],
+    providers: Option<&ProviderRuntime>,
+) -> Result<(), ReplacementExecutionError> {
+    for statement in statements {
+        match &statement.kind {
+            StatementKind::Call {
+                callee: Callee::ProviderOperation(plan),
+                ..
+            } => {
+                let resolved = providers.is_some_and(|runtime| runtime.resolves(&plan.operation));
+                if !resolved {
+                    return Err(unsupported(
+                        format!(
+                            "provider operation `{}` that no provider host in this run executes",
+                            plan.operation.declaration_name
+                        ),
+                        plan.call_span,
+                    ));
+                }
+            }
+            StatementKind::If {
+                then_block, else_block, ..
+            } => {
+                validate_provider_operation_hosts(&then_block.stmts, providers)?;
+                if let Some(else_block) = else_block {
+                    validate_provider_operation_hosts(&else_block.stmts, providers)?;
+                }
+            }
+            StatementKind::Loop { body } => validate_provider_operation_hosts(&body.stmts, providers)?,
+            StatementKind::Race { arms, .. } => {
+                for arm in arms {
+                    validate_provider_operation_hosts(&arm.body.stmts, providers)?;
+                }
+            }
+            StatementKind::Assign {
+                rvalue: Rvalue::Match { arms, .. },
+                ..
+            } => {
+                for arm in arms {
+                    validate_provider_operation_hosts(&arm.guard_stmts, providers)?;
+                    validate_provider_operation_hosts(&arm.body_stmts, providers)?;
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(())
 }
 
 /// Validate the deliberately source-local async subset without treating a task frame as a synchronous body.
@@ -721,6 +906,21 @@ pub fn execute_free_function(
     execute_prevalidated_free_function(execution)
 }
 
+/// Execute one named free function that may invoke admitted provider operations against `providers`.
+///
+/// The runtime is the caller's, and stays the caller's: a governed denial and a provider failure both stop this
+/// execution with an error, and their RFC 104 receipts are read from `providers` afterwards. Returning receipts
+/// only on success would make the two outcomes RFC 104 most wants recorded the two it could not report.
+pub fn execute_free_function_with_providers(
+    module: &BodyIrModule,
+    name: &str,
+    args: &[ReplacementValue],
+    providers: &Rc<ProviderRuntime>,
+) -> Result<ReplacementExecution, ReplacementExecutionError> {
+    let execution = prepare_free_function_execution_with_providers(module, name, args, Some(providers))?;
+    execute_prevalidated_free_function(execution)
+}
+
 /// Execute one free function that has already passed [`prepare_free_function_execution`].
 ///
 /// This consumes the validated capability, preserving the rule that callers select the source profile before the
@@ -730,7 +930,7 @@ pub fn execute_prevalidated_free_function(
 ) -> Result<ReplacementExecution, ReplacementExecutionError> {
     let body = named_free_function(execution.module, &execution.name)?;
 
-    let mut executor = BodyExecutor::new(execution.module, body, execution.args)?;
+    let mut executor = BodyExecutor::new(execution.module, body, execution.args, execution.providers.clone())?;
     let value = if body.is_async {
         let task = executor.construct_task(body.clone(), executor.locals.clone(), body.span)?;
         executor.drive_task(&task, body.span)?
@@ -752,12 +952,19 @@ pub fn execute_prevalidated_free_function(
     let ownership_summary = canonical_ownership_summary(&executor.ownership_reads);
     let requirements_summary = canonical_runtime_requirements_summary(&executor.runtime_requirements);
     let task_summary = canonical_task_lifecycle_summary(&executor.task_lifecycle);
+    let provider_executions = execution
+        .providers
+        .as_ref()
+        .map(|runtime| runtime.provider_executions())
+        .unwrap_or_default();
+    let provider_summary = canonical_provider_execution_summary(&provider_executions);
     let output_identity = digest_output(&[
         body_snapshot.as_str(),
         value.observable_text().as_str(),
         ownership_summary.as_str(),
         requirements_summary.as_str(),
         task_summary.as_str(),
+        provider_summary.as_str(),
     ]);
     Ok(ReplacementExecution {
         value,
@@ -765,6 +972,7 @@ pub fn execute_prevalidated_free_function(
         ownership_reads: executor.ownership_reads,
         runtime_requirements: executor.runtime_requirements,
         task_lifecycle: executor.task_lifecycle,
+        provider_executions,
         output_identity,
     })
 }
@@ -1608,6 +1816,15 @@ fn validate_call_profile(
                     binding @ ArgumentBinding::Resolved { .. } => validate_argument_binding_profile(binding),
                 }
         }
+        // An admitted provider operation is executable when its plan is: an active provider, an authority that
+        // really names a capability, and one described input per evaluated argument. Whether *this run* has a host
+        // for it is a different question, answered by `validate_provider_operation_hosts` before execution starts.
+        Callee::ProviderOperation(plan) => {
+            if let Some(description) = unexecutable_provider_plan(plan, args.len()) {
+                return Err(unsupported(description, span));
+            }
+            true
+        }
         Callee::Helper(_) => false,
         _ => false,
     };
@@ -1618,6 +1835,47 @@ fn validate_call_profile(
         validate_operand_profile(arg, span, tuple_iteration_locals)?;
     }
     Ok(())
+}
+
+/// Why one provider-operation plan cannot be executed at all, or `None` when it can.
+///
+/// Every rule here is checked against the plan's own facts, never against a provider name, a call-site spelling, or
+/// an emitted Rust name, so the same answer holds for a local call, an import, an alias, and a re-export of one
+/// operation. Lowering already refuses an inactive provider and a non-capability authority, so reaching either here
+/// means a plan arrived from somewhere that skipped that gate — which is exactly when a runtime must be
+/// fail-closed rather than trusting its input.
+fn unexecutable_provider_plan(plan: &ProviderOperationPlan, argument_count: usize) -> Option<String> {
+    let declared = &plan.operation.declaration_name;
+    if plan.provider.state != ProviderActivationState::Active {
+        return Some(format!(
+            "provider operation `{declared}` whose provider is {} in this compilation",
+            plan.provider.state.as_str()
+        ));
+    }
+    if plan.required_capability.kind != SemanticSourceTargetKind::Capability {
+        return Some(format!(
+            "provider operation `{declared}` whose required authority does not name a capability declaration"
+        ));
+    }
+    // The plan claims to describe the values execution will actually see. One input per evaluated argument, each at
+    // a distinct written position, is what makes that claim checkable before a host is handed anything.
+    if plan.inputs.len() != argument_count {
+        return Some(format!(
+            "provider operation `{declared}` whose plan describes {} inputs for {argument_count} evaluated arguments",
+            plan.inputs.len()
+        ));
+    }
+    let mut written_positions = BTreeSet::new();
+    if !plan
+        .inputs
+        .iter()
+        .all(|input| input.written_position < argument_count && written_positions.insert(input.written_position))
+    {
+        return Some(format!(
+            "provider operation `{declared}` whose plan does not describe each evaluated argument exactly once"
+        ));
+    }
+    None
 }
 
 /// Validate only the structural facts every direct callable dispatcher can enforce before execution.
@@ -2031,6 +2289,12 @@ struct BodyExecutor {
     task_lifecycle: Vec<TaskLifecycleEvent>,
     /// The task whose Body IR this executor is currently polling, if any.
     active_task: Option<usize>,
+    /// The authority source, provider host, and receipt log admitted provider operations run against.
+    ///
+    /// Shared with every nested frame rather than cloned per frame: RFC 104 receipts are sequenced across one run,
+    /// so two frames each holding their own log would each believe it emitted receipt `#0`. `None` means this run
+    /// executes no provider operation, which the pre-execution gate has already turned into a refusal.
+    providers: Option<Rc<ProviderRuntime>>,
     /// A structured match expression may execute an arm whose body returns, breaks, or continues before the
     /// enclosing assignment has a value to store. Keep that flow explicit rather than assigning a placeholder and
     /// accidentally continuing execution after source-level control flow.
@@ -2039,7 +2303,12 @@ struct BodyExecutor {
 
 impl BodyExecutor {
     /// Bind the already-typechecked call arguments to their Body-IR parameter locals.
-    fn new(module: &BodyIrModule, body: &Body, args: &[ReplacementValue]) -> Result<Self, ReplacementExecutionError> {
+    fn new(
+        module: &BodyIrModule,
+        body: &Body,
+        args: &[ReplacementValue],
+        providers: Option<Rc<ProviderRuntime>>,
+    ) -> Result<Self, ReplacementExecutionError> {
         let mut executor = Self {
             module: module.clone(),
             locals: BTreeMap::new(),
@@ -2050,6 +2319,7 @@ impl BodyExecutor {
             next_task_id: 0,
             task_lifecycle: Vec::new(),
             active_task: None,
+            providers,
             pending_flow: None,
         };
         executor.record_body(body);
@@ -2069,14 +2339,20 @@ impl BodyExecutor {
             next_task_id: 0,
             task_lifecycle: Vec::new(),
             active_task: None,
+            providers: None,
             pending_flow: None,
         }
     }
 
     /// Build one isolated child frame while preserving execution-wide task identity allocation.
+    ///
+    /// The provider runtime is shared with the child rather than withheld, so a provider operation invoked inside a
+    /// nested callable is decided, receipted, and sequenced by the same run that would have decided it at the top
+    /// level. Withholding it would have turned a nested invocation into a silent refusal.
     fn child_with_locals(&self, locals: BTreeMap<LocalId, ReplacementValue>, steps: usize) -> Self {
         let mut child = Self::with_locals(&self.module, locals, steps);
         child.next_task_id = self.next_task_id;
+        child.providers = self.providers.clone();
         child
     }
 
@@ -2565,10 +2841,61 @@ impl BodyExecutor {
             Callee::Method(target) if matches!(target.name.as_str(), "map" | "filter") => {
                 self.construct_generator_adapter(target.name.as_str(), args, span)?
             }
+            Callee::ProviderOperation(plan) => self.execute_provider_operation(plan, args, span)?,
             _ => return Err(unsupported(format!("call to {}", callee_label(callee)), span)),
         };
         self.assign_local(local, value);
         Ok(Flow::Next)
+    }
+
+    /// Execute one admitted provider operation from its already-lowered plan.
+    ///
+    /// This executor's whole part in the vertical is here: it evaluates the call's operands into the inputs the plan
+    /// describes and hands both to the provider runtime. It decides no authority, publishes no receipt, and applies
+    /// no redaction; those belong to the RFC 104 contracts the runtime consumes. Whether the plan is executable at
+    /// all is answered once by [`unexecutable_provider_plan`] — at the pre-execution profile gate, and again by the
+    /// runtime immediately before it reaches a host — rather than a third time here.
+    ///
+    /// Notably, this never dispatches to the operation's own declaration body even when this module happens to
+    /// contain one. The plan names a *provider* operation, and executing the local declaration instead would
+    /// silently substitute source-local behavior for the service's.
+    fn execute_provider_operation(
+        &mut self,
+        plan: &ProviderOperationPlan,
+        args: &[&Operand],
+        span: HirSourceSpan,
+    ) -> Result<ReplacementValue, ReplacementExecutionError> {
+        let Some(runtime) = self.providers.clone() else {
+            return Err(unsupported(
+                format!(
+                    "provider operation `{}` without a provider runtime for this execution",
+                    plan.operation.declaration_name
+                ),
+                span,
+            ));
+        };
+        // The plan's runtime requirements are the executing body's too, and recording them here keeps a provider
+        // invocation's demands visible in the same evidence every other direct execution reports.
+        for requirement in &plan.runtime_requirements {
+            if !self.runtime_requirements.contains(requirement) {
+                self.runtime_requirements.push(requirement.clone());
+            }
+        }
+        let mut inputs = Vec::with_capacity(plan.inputs.len());
+        for input in &plan.inputs {
+            let operand = args
+                .get(input.written_position)
+                .ok_or_else(|| unsupported("provider operation input outside the call's arguments", span))?;
+            let value = self.evaluate_operand(operand, span)?;
+            inputs.push(ProviderInputValue {
+                slot: input.slot,
+                written_position: input.written_position,
+                ty: input.ty.clone(),
+                span: input.span,
+                value,
+            });
+        }
+        runtime.execute(plan, inputs)
     }
 
     /// Suspend the active direct task on one source-local task value and resume it with that task's result.
@@ -2787,7 +3114,7 @@ impl BodyExecutor {
                 span,
             ));
         }
-        validate_direct_body_profile(&body)?;
+        validate_direct_body_profile(&body, self.providers.as_deref())?;
         if body.is_async && !target.type_args.is_empty() {
             return Err(unsupported("generic async callable target", span));
         }
@@ -4780,7 +5107,6 @@ fn callee_label(callee: &Callee) -> String {
         Callee::Function(CallableTarget::Local(_)) => "stored callable".to_string(),
         Callee::Method(target) => format!("method `{}`", target.name),
         Callee::Helper(helper) => format!("runtime helper `{}`", helper_label(*helper)),
-        // Executing a provider operation is #1156's, and needs an authority decision this executor cannot make.
         // The label names the operation's *declaration* rather than the call site's spelling, because the plan's
         // canonical identity is the only thing that says which operation this is.
         Callee::ProviderOperation(plan) => {

--- a/src/backend/replacement/provider.rs
+++ b/src/backend/replacement/provider.rs
@@ -1,0 +1,687 @@
+//! Direct execution of one checked provider-service operation from an already-lowered plan (#1156).
+//!
+//! This is the replacement backend's first consumer of the three scoped upstream contracts the Slice 1 train
+//! delivered, and it consumes all three rather than growing provider-local equivalents of them. The
+//! [`ProviderOperationPlan`] says *which* operation was invoked and against *which* capability, and phrases the
+//! authority question through its own [`ProviderOperationPlan::authority_request`]. The
+//! [`AuthorityDecisionSource`] seam answers that question; nothing here inspects a grant set, interprets a mode, or
+//! decides what a denial means. The [`OperationReceipt`] records what happened, including the denial case where
+//! nothing happened at all; the backend's own execution receipt *references* it through [`ProviderReceiptLink`]
+//! rather than copying its authority, redaction, or replay semantics.
+//!
+//! ## The selected first operation
+//!
+//! The vertical executes one fixture-controlled operation: a ledger provider's `charge(account, amount)`, requiring
+//! the RFC 104 capability `host.ledger.charge`. It was selected because it exercises every path this issue asks for
+//! while still producing a deterministic observable:
+//!
+//! - **Deterministic result.** A charge settles to a value computed purely from its recorded inputs, so an allowed
+//!   invocation has one source-level observable with no clock, network, or ordering dependence.
+//! - **Activation.** A ledger provider is either selected and locally backed by this compilation or it is not, so the
+//!   plan's activation state is a real precondition rather than a flag invented for a test.
+//! - **Authority.** Moving money is exactly what RFC 104 governs, so a governed denial of `host.ledger.charge` is a
+//!   meaningful refusal instead of a contrived one.
+//! - **Redaction.** The operation naturally records two attributes at different sensitivities — the amount is public,
+//!   the account identifier is secret — so redaction classification is a property of the operation.
+//! - **Failure.** A charge can be refused by the ledger itself after authority was granted, which is precisely the
+//!   "allowed, then failed" distinction the receipt contract keeps separate from a denial.
+//! - **Cleanup.** A charge opens a settlement handle that must be released whether it settled or failed.
+//!
+//! ## Boundaries this module exists to hold
+//!
+//! Nothing here branches on a provider module name, a call-site spelling, or an emitted Rust name. A host is asked
+//! about an operation by [`CanonicalSymbolId`] and by nothing else, so a local call, an import, an alias, and a
+//! re-export of one operation all reach the same host entry. The provider key the plan carries is provenance for
+//! receipts and diagnostics only.
+//!
+//! Import is not authority. A plan exists because an operation was *admitted*, and admission is a lowering-time
+//! question about activation and capability identity. The authority question is asked here, once, at the moment an
+//! admitted operation is actually invoked — and a denial answers it before the host is reached by any call at all.
+
+use std::{cell::RefCell, rc::Rc};
+
+use incan_semantics_core::authority::AuthorityDecisionSource;
+use incan_semantics_core::body_ir::ProviderOperationPlan;
+use incan_semantics_core::receipts::{OperationReceipt, ReceiptAttribute, ReceiptStatus, ReplayClassification};
+use incan_semantics_core::{AuthorityDecision, CanonicalSymbolId, HirSourceSpan, IncanType, SymbolOrigin};
+
+use crate::backend::selection::{
+    BackendKind, BackendSelection, FallbackPolicy, digest_output, finalize_receipt, resolve_execution, select_backend,
+    unavailable_shadow_comparison,
+};
+use crate::frontend::diagnostics::DIAGNOSTIC_SCHEMA_VERSION;
+
+use super::{ReplacementExecutionError, ReplacementValue, runtime_failure, unexecutable_provider_plan, unsupported};
+
+/// Why every provider execution receipt this backend finalizes declares a non-green comparison.
+///
+/// Direct execution proves the replacement route ran; it proves nothing about agreement with the legacy route,
+/// which cannot execute a provider operation at all today. #1146 owns the receipt-bound paired comparison that
+/// could retire this reason, so recording it explicitly is what keeps an executed provider operation from being
+/// mistaken for a compared one.
+pub const PROVIDER_COMPARISON_UNAVAILABLE_REASON: &str = "a directly executed provider operation has no paired legacy observation to compare against; #1146 owns the \
+     receipt-bound source-observable comparison that could make this row green";
+
+/// One already-evaluated input handed to a provider host, with the plan facts describing it.
+///
+/// The value comes from the surrounding call's operands, and everything else comes from the plan's own
+/// [`incan_semantics_core::body_ir::ProviderOperationInput`]. Pairing them here is what lets a host record an
+/// attribute against the argument that actually carried the value, rather than against the whole call.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProviderInputValue {
+    /// Declared parameter slot this input supplies.
+    pub slot: usize,
+    /// Zero-based position among the call site's written arguments, which is also its evaluation order.
+    pub written_position: usize,
+    /// Checked type of the evaluated argument expression.
+    pub ty: IncanType,
+    /// Span of the argument expression itself.
+    pub span: HirSourceSpan,
+    /// The value direct execution evaluated for this argument.
+    pub value: ReplacementValue,
+}
+
+/// One authorized invocation of a provider operation, described to its host.
+///
+/// The host is told the operation's canonical identity and nothing that would let it re-resolve source. The
+/// provider key and module path travel as provenance so a host can label what it is doing, never as a dispatch key.
+#[derive(Debug, Clone, Copy)]
+pub struct ProviderInvocation<'plan, 'inputs> {
+    /// Canonical identity of the operation being invoked.
+    pub operation: &'plan CanonicalSymbolId,
+    /// Canonical identity of the capability whose authority was granted for this invocation.
+    pub capability: &'plan CanonicalSymbolId,
+    /// Stable key of the catalog record the operation was admitted from, carried as provenance.
+    pub provider_key: &'plan str,
+    /// The already-evaluated inputs, in written source order.
+    pub inputs: &'inputs [ProviderInputValue],
+    /// Span of the invocation, which is where any failure is reported.
+    pub call_span: HirSourceSpan,
+}
+
+/// What one provider host did when an authorized operation was invoked.
+///
+/// Both variants carry attributes and a replay classification because both are things that happened: an operation
+/// that failed after acquiring a connection still recorded what it attempted, and RFC 104 asks the runtime not to
+/// lose that. The host owns redaction — a value it declines to persist arrives as
+/// [`ReceiptAttribute::redacted`] — because giving redaction a second owner in this backend would eventually mean
+/// two answers about what was recorded.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ProviderOperationOutcome {
+    /// The operation ran to completion and produced a source-level value.
+    Completed {
+        /// The operation's source-level result.
+        value: ReplacementValue,
+        /// Attributes the host recorded, redacted or not.
+        attributes: Vec<ReceiptAttribute>,
+        /// How replayable this invocation is.
+        replay: ReplayClassification,
+    },
+    /// Authority was granted, and the operation itself failed.
+    Failed {
+        /// Source-observable description of the failure.
+        detail: String,
+        /// Attributes the host recorded before failing.
+        attributes: Vec<ReceiptAttribute>,
+        /// How replayable this invocation is.
+        replay: ReplayClassification,
+    },
+}
+
+/// Whatever can execute admitted provider operations for a run.
+///
+/// This is the second seam this vertical consumes rather than owns, and it is deliberately shaped like the first:
+/// a consumer holds `&dyn ProviderOperationHost` so a real provider runtime, a local stub, and a test double are
+/// interchangeable without the executor knowing which it has.
+///
+/// [`Self::operation_kind`] doubles as the resolution question. A host that returns `None` does not execute the
+/// operation, and the call is refused before authority is consulted and before any receipt exists. Implementors
+/// must keep it a pure description: it is called on paths — including a governed denial — where the operation must
+/// not run.
+pub trait ProviderOperationHost {
+    /// The publisher's own kind label for `operation`, or `None` when this host cannot execute it.
+    ///
+    /// The label is what a receipt records as its `operation_kind`, such as `ledger.charge`. It must not perform
+    /// the operation, acquire resources, or observe anything outside the host's own catalog.
+    fn operation_kind(&self, operation: &CanonicalSymbolId) -> Option<String>;
+
+    /// Invoke one operation whose authority was already granted.
+    ///
+    /// Reached only after an [`AuthorityDecisionSource`] allowed the invocation. A denied operation never arrives
+    /// here, which is the whole point of asking authority first.
+    fn invoke(&self, invocation: &ProviderInvocation<'_, '_>) -> ProviderOperationOutcome;
+
+    /// Release whatever [`Self::invoke`] acquired for one invocation.
+    ///
+    /// Called exactly once after every invocation that started, whether it completed or failed, and never for an
+    /// operation that was denied or refused before it started. A host with nothing to release implements this as a
+    /// no-op; a host that holds a connection, a transaction, or a settlement handle closes it here.
+    fn release(&self, operation: &CanonicalSymbolId, call_span: HirSourceSpan);
+}
+
+/// One transition in a provider operation's direct-execution lifecycle.
+///
+/// Recorded as report-only evidence and bound into the enclosing execution's output identity, in the same shape
+/// direct task frames already use. The vocabulary is closed on purpose: a reader must be able to tell "the host
+/// was never reached" from "the host ran and then released" without interpreting free text.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct ProviderLifecycleProjection {
+    /// Stable per-execution invocation identity in source execution order.
+    pub invocation_id: usize,
+    /// Stable lifecycle transition label.
+    pub event: &'static str,
+    /// Original source span that caused the transition.
+    pub span_start: usize,
+    /// Original source span that caused the transition.
+    pub span_end: usize,
+}
+
+/// Canonical, machine-readable rendering of one backend provider-execution receipt.
+///
+/// `operation_receipt_sequence_id` is a *reference* into the RFC 104 receipt log this runtime holds, not a restated
+/// copy of that receipt. A consumer that wants the authority decision, the recorded attributes, or the replay
+/// classification reads the operation receipt itself, so those facts keep exactly one owner.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct ProviderExecutionProjection {
+    /// Identity of the pre-invocation backend selection.
+    pub selection_identity: String,
+    /// Identity of the finalized backend execution receipt.
+    pub receipt_identity: String,
+    /// Sequence id of the referenced RFC 104 operation receipt.
+    pub operation_receipt_sequence_id: u64,
+    /// Stable label for what this backend execution did.
+    pub outcome: &'static str,
+    /// The explicit, non-green comparison state this execution recorded.
+    pub comparison_reason: String,
+}
+
+/// One backend selection/execution receipt for a directly executed provider operation.
+///
+/// This is the backend's own record of having selected the replacement backend and run something with it. It is
+/// deliberately a separate artifact from the operation receipt: the operation receipt answers "what did this
+/// capability-aware operation do", and this answers "which backend executed it, and what comparison state did that
+/// The backend's link from an execution record to the RFC 104 operation receipt it corresponds to.
+///
+/// [`incan_semantics_core::receipts`] deliberately exports no standalone cross-run reference: a sequence number
+/// alone means nothing outside the run that produced it, so linkage belongs to whichever producer owns both ends.
+/// This is the replacement backend's end of that link, and it carries the sequence id only — never a copy of the
+/// receipt's authority, redaction, or replay facts, which would give those two owners.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProviderReceiptLink {
+    /// The referenced receipt's sequence id within this run.
+    pub sequence_id: u64,
+}
+
+/// execution have". The link between them is [`Self::operation_receipt`] and only that.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProviderExecutionRecord {
+    /// The pre-invocation selection this execution was bound to.
+    pub selection: BackendSelection,
+    /// The finalized backend execution receipt.
+    pub receipt: crate::backend::selection::BackendExecutionReceipt,
+    /// Reference to the RFC 104 operation receipt this execution's authority and redaction semantics live on.
+    pub operation_receipt: ProviderReceiptLink,
+    /// Stable label for what this backend execution did.
+    pub outcome: &'static str,
+}
+
+impl ProviderExecutionRecord {
+    /// Project this record into the stable evidence shape identities and reports share.
+    #[must_use]
+    pub fn projection(&self) -> ProviderExecutionProjection {
+        ProviderExecutionProjection {
+            selection_identity: self.selection.identity.clone(),
+            receipt_identity: self.receipt.identity.clone(),
+            operation_receipt_sequence_id: self.operation_receipt.sequence_id,
+            outcome: self.outcome,
+            comparison_reason: PROVIDER_COMPARISON_UNAVAILABLE_REASON.to_string(),
+        }
+    }
+}
+
+/// One provider lifecycle transition observed during direct execution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ProviderLifecycleEvent {
+    invocation_id: usize,
+    event: &'static str,
+    span: HirSourceSpan,
+}
+
+/// Everything one run accumulated while executing provider operations.
+///
+/// Held behind a [`RefCell`] because the executor reaches the runtime through a shared handle that nested callable
+/// frames also hold: receipts must be sequenced across the whole run, not per frame, or two frames would each
+/// think they emitted receipt `#0`.
+#[derive(Debug, Default)]
+struct ProviderRuntimeState {
+    next_sequence_id: u64,
+    next_invocation_id: usize,
+    receipts: Vec<OperationReceipt>,
+    executions: Vec<ProviderExecutionRecord>,
+    lifecycle: Vec<ProviderLifecycleEvent>,
+}
+
+/// The authority source, provider host, and receipt log one direct execution runs against.
+///
+/// The caller builds this and keeps it, which is deliberate: a denial and a provider failure both stop the
+/// enclosing execution with an error, and their receipts must still be readable afterwards. Putting the receipt log
+/// in the runtime rather than in the successful-execution result is what makes a refused run as reportable as a
+/// successful one.
+pub struct ProviderRuntime {
+    authority: Rc<dyn AuthorityDecisionSource>,
+    host: Rc<dyn ProviderOperationHost>,
+    state: RefCell<ProviderRuntimeState>,
+}
+
+impl std::fmt::Debug for ProviderRuntime {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ProviderRuntime")
+            .field("state", &self.state)
+            .finish_non_exhaustive()
+    }
+}
+
+impl ProviderRuntime {
+    /// Build a runtime that decides authority through `authority` and executes operations through `host`.
+    #[must_use]
+    pub fn new(authority: Rc<dyn AuthorityDecisionSource>, host: Rc<dyn ProviderOperationHost>) -> Rc<Self> {
+        Rc::new(Self {
+            authority,
+            host,
+            state: RefCell::new(ProviderRuntimeState::default()),
+        })
+    }
+
+    /// Every RFC 104 operation receipt this run emitted, in emission order.
+    #[must_use]
+    pub fn operation_receipts(&self) -> Vec<OperationReceipt> {
+        self.state.borrow().receipts.clone()
+    }
+
+    /// Every backend selection/execution receipt this run finalized, in execution order.
+    #[must_use]
+    pub fn provider_executions(&self) -> Vec<ProviderExecutionRecord> {
+        self.state.borrow().executions.clone()
+    }
+
+    /// Every provider lifecycle transition this run observed, in execution order.
+    #[must_use]
+    pub fn lifecycle_evidence(&self) -> Vec<ProviderLifecycleProjection> {
+        self.state
+            .borrow()
+            .lifecycle
+            .iter()
+            .map(|event| ProviderLifecycleProjection {
+                invocation_id: event.invocation_id,
+                event: event.event,
+                span_start: event.span.start,
+                span_end: event.span.end,
+            })
+            .collect()
+    }
+
+    /// Whether this runtime's host can execute the operation named by `operation`.
+    ///
+    /// Consulted by the pre-execution profile gate so an unresolved operation refuses before anything runs, rather
+    /// than part-way through the enclosing body.
+    pub(super) fn resolves(&self, operation: &CanonicalSymbolId) -> bool {
+        self.host.operation_kind(operation).is_some()
+    }
+
+    /// Execute one admitted provider operation whose inputs direct execution has already evaluated.
+    ///
+    /// The order of the steps is the contract, not an implementation detail. Admission is re-checked before anything
+    /// else, because a plan that reached here claiming an inactive provider means an earlier gate was bypassed.
+    /// Resolution comes next, so an operation no host executes is refused while it is still true that nothing ran.
+    /// Authority is decided *after* those and *before* the host is invoked, which is what makes a denial structural:
+    /// the only call path that reaches [`ProviderOperationHost::invoke`] runs through an allowed decision.
+    pub(super) fn execute(
+        &self,
+        plan: &ProviderOperationPlan,
+        inputs: Vec<ProviderInputValue>,
+    ) -> Result<ReplacementValue, ReplacementExecutionError> {
+        let span = plan.call_span;
+        let declared = plan.operation.declaration_name.as_str();
+
+        // ---- Fail-closed admission: an unexecutable plan must never reach a host ----
+        // The rule lives in `unexecutable_provider_plan` and is consulted rather than restated, so the pre-execution
+        // gate and this last-line check cannot drift into disagreeing about which plans are executable.
+        if let Some(description) = unexecutable_provider_plan(plan, inputs.len()) {
+            return Err(unsupported(description, span));
+        }
+        let Some(operation_kind) = self.host.operation_kind(&plan.operation) else {
+            return Err(unsupported(
+                format!("provider operation `{declared}` that no provider host in this run executes"),
+                span,
+            ));
+        };
+
+        // ---- Authority: asked once, at invocation, through the plan's own request ----
+        let decision = self.authority.decide(&plan.authority_request());
+        if !decision.is_allowed() {
+            return Err(self.record_denial(plan, decision, operation_kind));
+        }
+
+        // ---- Invocation, then cleanup, then the receipt describing both ----
+        let invocation_id = self.next_invocation_id();
+        self.record_lifecycle(invocation_id, "invoked", span);
+        let outcome = self.host.invoke(&ProviderInvocation {
+            operation: &plan.operation,
+            capability: &plan.required_capability,
+            provider_key: plan.provider.provider_key.as_str(),
+            inputs: &inputs,
+            call_span: span,
+        });
+        let event = match &outcome {
+            ProviderOperationOutcome::Completed { .. } => "completed",
+            ProviderOperationOutcome::Failed { .. } => "failed",
+        };
+        self.record_lifecycle(invocation_id, event, span);
+
+        // Cleanup is unconditional for an invocation that started. A failed charge still holds the settlement
+        // handle it opened, and leaking it is exactly the outcome a lifecycle contract exists to prevent.
+        self.host.release(&plan.operation, span);
+        self.record_lifecycle(invocation_id, "released", span);
+
+        self.record_outcome(plan, decision, operation_kind, outcome)
+    }
+
+    /// Record a governed denial and return the diagnostic that reports it at the call site.
+    ///
+    /// A denial is never a success, so this returns the error itself rather than a `Result`: every path out of it is
+    /// a refusal, and the only question is whether the refusal is the denial or a failure to record it honestly.
+    /// Returning the error to the caller rather than raising it here keeps `return Err(...)` the single exit from
+    /// the denial branch, so no later statement can continue past a refusal.
+    fn record_denial(
+        &self,
+        plan: &ProviderOperationPlan,
+        decision: AuthorityDecision,
+        operation_kind: String,
+    ) -> ReplacementExecutionError {
+        let span = plan.call_span;
+        let reason = denial_reason_text(&decision);
+        let invocation_id = self.next_invocation_id();
+        let sequence_id = self.next_sequence_id();
+        // `denied` validates on construction and refuses to turn an allowed or non-governed decision into a
+        // durable governed-denial claim, so a receipt that exists is one the contract already accepted.
+        let receipt = match OperationReceipt::denied(sequence_id, plan.operation.clone(), decision, operation_kind) {
+            Ok(receipt) => receipt,
+            Err(violation) => return Self::receipt_contract_error(violation, span),
+        };
+        if let Err(error) = self.record_receipt(receipt, span) {
+            return error;
+        }
+        self.record_lifecycle(invocation_id, "denied", span);
+        let reference = ProviderReceiptLink { sequence_id };
+        if let Err(error) = self.finalize_execution(plan, reference, "denied", span) {
+            return error;
+        }
+        ReplacementExecutionError::ProviderAuthorityDenied {
+            operation: plan.operation.declaration_name.clone(),
+            reason,
+            receipt_sequence_id: sequence_id,
+            span,
+            span_start: span.start,
+            span_end: span.end,
+        }
+    }
+
+    /// Record the receipt for an invocation that actually ran, and surface its source-level result.
+    ///
+    /// The status is derived from what the host reported and from whether it withheld any attribute value, which is
+    /// the one classification this backend makes. It is a reading of the host's own redaction decision, never a
+    /// second redaction policy: a withheld value stays withheld, and the status simply stops claiming that a
+    /// receipt with withheld values recorded everything.
+    fn record_outcome(
+        &self,
+        plan: &ProviderOperationPlan,
+        decision: AuthorityDecision,
+        operation_kind: String,
+        outcome: ProviderOperationOutcome,
+    ) -> Result<ReplacementValue, ReplacementExecutionError> {
+        let span = plan.call_span;
+        let (status, attributes, replay, failure) = match outcome {
+            ProviderOperationOutcome::Completed {
+                value,
+                attributes,
+                replay,
+            } => {
+                // `Allowed` is a governed-only outcome: it claims authority was enforced and granted. A permissive
+                // or observed run never enforced anything, so its truthful success status is `Observed` -- the
+                // receipt contract rejects the stronger claim rather than letting a run overstate what happened.
+                let status = if attributes.iter().any(ReceiptAttribute::is_redacted) {
+                    ReceiptStatus::Redacted
+                } else if matches!(decision.mode, incan_semantics_core::AuthorityMode::Governed) {
+                    ReceiptStatus::Allowed
+                } else {
+                    ReceiptStatus::Observed
+                };
+                (status, attributes, replay, Ok(value))
+            }
+            ProviderOperationOutcome::Failed {
+                detail,
+                attributes,
+                replay,
+            } => (ReceiptStatus::Failed, attributes, replay, Err(detail)),
+        };
+
+        let sequence_id = self.next_sequence_id();
+        // The capability and the use-site span are derived from the decision rather than repeated here, so the two
+        // cannot drift apart in a stored receipt.
+        let receipt = OperationReceipt::new(
+            sequence_id,
+            plan.operation.clone(),
+            operation_kind,
+            status,
+            decision,
+            None,
+            attributes,
+            replay,
+        )
+        .map_err(|violation| Self::receipt_contract_error(violation, span))?;
+        self.record_receipt(receipt, span)?;
+        let reference = ProviderReceiptLink { sequence_id };
+        let label = match status {
+            ReceiptStatus::Redacted => "redacted",
+            ReceiptStatus::Observed => "observed",
+            ReceiptStatus::Failed => "failed",
+            _ => "allowed",
+        };
+        self.finalize_execution(plan, reference, label, span)?;
+
+        match failure {
+            Ok(value) => Ok(value),
+            Err(detail) => Err(ReplacementExecutionError::ProviderOperationFailed {
+                operation: plan.operation.declaration_name.clone(),
+                detail,
+                receipt_sequence_id: sequence_id,
+                span,
+                span_start: span.start,
+                span_end: span.end,
+            }),
+        }
+    }
+
+    /// Check one receipt against its own contract before it is retained as evidence.
+    ///
+    /// A receipt that contradicts itself is a runtime failure of the publisher, not a fact to store: RFC 104's
+    /// whole premise is that a receipt is believed by a reader with no way to re-derive the truth.
+    fn record_receipt(&self, receipt: OperationReceipt, _span: HirSourceSpan) -> Result<(), ReplacementExecutionError> {
+        // No validation here: `OperationReceipt`'s constructors validate and refuse to build a receipt that
+        // contradicts itself, so anything reaching this point is already a receipt the contract accepted.
+        self.state.borrow_mut().receipts.push(receipt);
+        Ok(())
+    }
+
+    /// Turn a refused receipt construction into a runtime failure at the operation's own span.
+    ///
+    /// A contract violation here is a defect in this backend rather than in the program being run: it means the
+    /// executor tried to record a claim the receipt contract rejects, such as a denial over an allowing decision.
+    fn receipt_contract_error(
+        violation: incan_semantics_core::receipts::ReceiptContractViolation,
+        span: HirSourceSpan,
+    ) -> ReplacementExecutionError {
+        runtime_failure(
+            format!("provider operation receipt contradicts itself: {violation}"),
+            span,
+        )
+    }
+
+    /// Declare, resolve, and finalize the backend receipt for one provider execution.
+    ///
+    /// Uses the ordinary #986 selection API rather than a provider-local receipt shape, and always records an
+    /// explicitly unavailable shadow comparison: a direct execution with no paired legacy observation must be
+    /// visibly non-green rather than silently uncompared.
+    fn finalize_execution(
+        &self,
+        plan: &ProviderOperationPlan,
+        operation_receipt: ProviderReceiptLink,
+        outcome: &'static str,
+        span: HirSourceSpan,
+    ) -> Result<(), ReplacementExecutionError> {
+        let selection = select_backend(
+            BackendKind::Replacement,
+            true,
+            true,
+            provider_source_identity(plan),
+            FallbackPolicy::Refuse,
+        );
+        let executed = resolve_execution(&selection, BackendKind::Replacement.is_implemented())
+            .map_err(|error| runtime_failure(format!("provider execution selection failed: {error}"), span))?;
+        let output_identity = digest_output(&[
+            selection.source_identity.as_str(),
+            outcome,
+            operation_receipt.sequence_id.to_string().as_str(),
+        ]);
+        let receipt = finalize_receipt(
+            &selection,
+            executed,
+            output_identity,
+            unavailable_shadow_comparison(selection.shadow_requested, PROVIDER_COMPARISON_UNAVAILABLE_REASON),
+            DIAGNOSTIC_SCHEMA_VERSION,
+        )
+        .map_err(|error| {
+            runtime_failure(
+                format!("provider execution receipt could not be finalized: {error}"),
+                span,
+            )
+        })?;
+        self.state.borrow_mut().executions.push(ProviderExecutionRecord {
+            selection,
+            receipt,
+            operation_receipt,
+            outcome,
+        });
+        Ok(())
+    }
+
+    /// Allocate the next receipt sequence id for this run.
+    fn next_sequence_id(&self) -> u64 {
+        let mut state = self.state.borrow_mut();
+        let sequence_id = state.next_sequence_id;
+        state.next_sequence_id += 1;
+        sequence_id
+    }
+
+    /// Allocate the next lifecycle invocation id for this run.
+    fn next_invocation_id(&self) -> usize {
+        let mut state = self.state.borrow_mut();
+        let invocation_id = state.next_invocation_id;
+        state.next_invocation_id += 1;
+        invocation_id
+    }
+
+    /// Append one lifecycle transition in execution order.
+    fn record_lifecycle(&self, invocation_id: usize, event: &'static str, span: HirSourceSpan) {
+        self.state.borrow_mut().lifecycle.push(ProviderLifecycleEvent {
+            invocation_id,
+            event,
+            span,
+        });
+    }
+}
+
+/// Render a denial as the text a source-owned diagnostic reports.
+///
+/// The suggested grant comes from the decision's own provenance, which the plan phrased through
+/// [`ProviderOperationPlan::authority_request`], so the remedy a user is offered is the one RFC 104 named rather
+/// than a spelling this backend invented.
+fn denial_reason_text(decision: &AuthorityDecision) -> String {
+    let reason = decision
+        .denial_reason()
+        .map_or("denied", incan_semantics_core::AuthorityDenialReason::as_str);
+    format!(
+        "{} authority for `{}` was {reason}; grant `{}` to permit it",
+        decision.mode.as_str(),
+        decision.capability.declaration_name,
+        decision.provenance.suggested_grant,
+    )
+}
+
+/// Derive the content identity of the plan one provider execution was selected for.
+///
+/// This is an identity digest component, never a user-facing spelling and never a dispatch key: it exists so two
+/// invocations of different operations, or of one operation at different call sites, cannot claim the same
+/// selection. The canonical identity's own parts are digested rather than rendered into a dotted path, precisely so
+/// nothing here can be mistaken for a second spelling of the operation.
+fn provider_source_identity(plan: &ProviderOperationPlan) -> String {
+    let inputs = plan
+        .inputs
+        .iter()
+        .map(|input| {
+            format!(
+                "slot={};written={};ty={};span={}..{}",
+                input.slot, input.written_position, input.ty, input.span.start, input.span.end
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("|");
+    digest_output(&[
+        canonical_identity_component(&plan.operation).as_str(),
+        canonical_identity_component(&plan.required_capability).as_str(),
+        plan.provider.provider_key.as_str(),
+        plan.provider.state.as_str(),
+        inputs.as_str(),
+        format!("{}..{}", plan.call_span.start, plan.call_span.end).as_str(),
+    ])
+}
+
+/// Render one canonical identity's own parts as a deterministic digest component.
+fn canonical_identity_component(symbol: &CanonicalSymbolId) -> String {
+    let origin = match &symbol.origin {
+        SymbolOrigin::Module(path) => format!("module:{}", path.join(".")),
+        SymbolOrigin::RustCrate(path) => format!("rust_crate:{}", path.join(".")),
+        SymbolOrigin::Package { library, module_path } => {
+            format!("package:{library}:{}", module_path.join("."))
+        }
+        SymbolOrigin::Builtin => "builtin".to_string(),
+    };
+    format!(
+        "{origin};name={};kind={:?};span={}..{}",
+        symbol.declaration_name, symbol.kind, symbol.declaration_span.start, symbol.declaration_span.end
+    )
+}
+
+/// Render provider executions as one deterministic output-identity component.
+///
+/// Empty when a run executed no provider operation, which keeps a scalar execution's evidence exactly as wide as
+/// what it actually observed.
+pub(super) fn canonical_provider_execution_summary(records: &[ProviderExecutionRecord]) -> String {
+    records
+        .iter()
+        .map(|record| {
+            let projection = record.projection();
+            format!(
+                "selection={};receipt={};operation_receipt={};outcome={}",
+                projection.selection_identity,
+                projection.receipt_identity,
+                projection.operation_receipt_sequence_id,
+                projection.outcome,
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("|")
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/backend/replacement/provider/tests.rs
+++ b/src/backend/replacement/provider/tests.rs
@@ -1,0 +1,781 @@
+//! Direct execution of the selected first provider-service operation, one path per test (#1156).
+//!
+//! Every fixture here goes through the real pipeline — source, typecheck, Body-IR lowering with a
+//! fixture-controlled provider catalog — so what the executor consumes is an actually-lowered
+//! [`ProviderOperationPlan`], not a hand-assembled one. The one exception is the fail-closed activation test, which
+//! deliberately mutates an already-lowered plan into a state lowering refuses to produce, because the point of that
+//! test is that the runtime does not trust its input.
+//!
+//! The fixture host keys on the operation's [`CanonicalSymbolId`] and on nothing else. That is not a stylistic
+//! choice: a host that matched a provider module name, a call-site spelling, or an emitted Rust name would be the
+//! exact duplication of source meaning this vertical exists to avoid, and a test that let one through would stop
+//! being evidence.
+
+use std::cell::RefCell;
+
+use incan_semantics_core::body_ir::{self as bir, ProviderActivationState, ProviderOperationPlan};
+use incan_semantics_core::receipts::{AttributeSensitivity, ReceiptStatus, ReplayClassification};
+use incan_semantics_core::{
+    AuthorityDenialReason, AuthorityMode, CanonicalSymbolId, HirSourceSpan, SemanticSourceTargetKind, SymbolOrigin,
+    authority::StaticAuthority,
+};
+
+use super::*;
+use crate::backend::replacement::{
+    ReplacementExecution, ReplacementExecutionError, ReplacementValue, execute_free_function,
+    execute_free_function_with_providers, prepare_free_function_execution_with_providers,
+};
+use crate::frontend::body_ir::build_body_ir_module_v0_with_provider_plan;
+use crate::frontend::body_ir::tests::provider_plan_from_checked_source;
+use crate::frontend::typechecker::TypeChecker;
+use crate::frontend::{ast, lexer, parser};
+
+/// A boxed error, so every fallible test can propagate with `?` instead of unwrapping.
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+/// The module the fixture operation is declared in.
+const MODULE_PATH: &[&str] = &["app"];
+
+/// The grant spelling the selected capability renders to, and therefore the one a governed run must hold.
+///
+/// It is derived from the fixture's own `capability ledger_charge` declaration rather than chosen here, because the
+/// decorator resolves the capability the provider manifest publishes. A grant spelling invented by the test would
+/// prove the executor honours a string no declaration produces.
+const LEDGER_GRANT: &str = "app.ledger_charge";
+
+/// One ledger charge, plus a same-module caller that invokes it.
+///
+/// `charge`'s own body deliberately returns a *different* value than the provider host does. Nothing should ever
+/// execute it: the plan names a provider operation, and running the local declaration instead would silently
+/// substitute source-local behavior for the service's. The difference is what makes that substitution visible.
+const LEDGER_FIXTURE_SOURCE: &str = r#"
+capability ledger_charge:
+  description = "Charge one approved ledger account"
+
+@provider_operation(ledger_charge)
+def charge(account: str, amount: int) -> int:
+  return amount
+
+def settle(account: str, amount: int) -> int:
+  return charge(account, amount)
+"#;
+
+/// What the fixture ledger does when an authorized charge reaches it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LedgerBehavior {
+    /// Settle the charge, adding a fixed fee so the result cannot be confused with the local declaration's.
+    Settle,
+    /// Settle the charge but withhold the account identifier from the receipt.
+    SettleWithSecretAccount,
+    /// Refuse the charge after authority was already granted.
+    Decline,
+}
+
+/// Everything the fixture ledger observed, so a test can assert on what did and did not happen.
+#[derive(Debug, Default)]
+struct LedgerLog {
+    /// One entry per [`ProviderOperationHost::invoke`] call, holding the amount it was asked to charge.
+    invocations: Vec<i64>,
+    /// How many settlement handles are currently open.
+    open_handles: i64,
+    /// How many times [`ProviderOperationHost::release`] ran.
+    releases: usize,
+    /// How many times this host was asked to describe an operation.
+    descriptions: usize,
+}
+
+/// A fixture ledger provider, addressed only by the canonical identity of the operation it owns.
+#[derive(Debug)]
+struct LedgerHost {
+    operation: CanonicalSymbolId,
+    behavior: LedgerBehavior,
+    log: RefCell<LedgerLog>,
+}
+
+impl LedgerHost {
+    /// Build a host that executes exactly `operation` and behaves as `behavior` when it is invoked.
+    fn new(operation: CanonicalSymbolId, behavior: LedgerBehavior) -> Self {
+        Self {
+            operation,
+            behavior,
+            log: RefCell::new(LedgerLog::default()),
+        }
+    }
+
+    /// The amounts this host was actually asked to charge, in invocation order.
+    fn invocations(&self) -> Vec<i64> {
+        self.log.borrow().invocations.clone()
+    }
+
+    /// How many settlement handles this host still holds open.
+    fn open_handles(&self) -> i64 {
+        self.log.borrow().open_handles
+    }
+
+    /// How many times this host released a settlement handle.
+    fn releases(&self) -> usize {
+        self.log.borrow().releases
+    }
+
+    /// How many times this host was asked to describe the operation without being asked to perform it.
+    fn descriptions(&self) -> usize {
+        self.log.borrow().descriptions
+    }
+
+    /// The integer amount carried by the input at written position 1, or an error naming what arrived instead.
+    fn amount(inputs: &[ProviderInputValue]) -> Result<i64, String> {
+        match inputs.iter().find(|input| input.written_position == 1) {
+            Some(ProviderInputValue {
+                value: ReplacementValue::Int(amount),
+                ..
+            }) => Ok(*amount),
+            other => Err(format!("a charge needs an integer amount, got {other:?}")),
+        }
+    }
+}
+
+impl ProviderOperationHost for LedgerHost {
+    fn operation_kind(&self, operation: &CanonicalSymbolId) -> Option<String> {
+        self.log.borrow_mut().descriptions += 1;
+        (operation == &self.operation).then(|| "ledger.charge".to_string())
+    }
+
+    fn invoke(&self, invocation: &ProviderInvocation<'_, '_>) -> ProviderOperationOutcome {
+        let amount = match LedgerHost::amount(invocation.inputs) {
+            Ok(amount) => amount,
+            Err(detail) => {
+                return ProviderOperationOutcome::Failed {
+                    detail,
+                    attributes: Vec::new(),
+                    replay: ReplayClassification::Unavailable,
+                };
+            }
+        };
+        {
+            let mut log = self.log.borrow_mut();
+            log.invocations.push(amount);
+            log.open_handles += 1;
+        }
+        match self.behavior {
+            LedgerBehavior::Settle => ProviderOperationOutcome::Completed {
+                value: ReplacementValue::Int(amount + 5),
+                attributes: vec![ReceiptAttribute::public("ledger.amount", amount.to_string())],
+                replay: ReplayClassification::FixtureRequired,
+            },
+            LedgerBehavior::SettleWithSecretAccount => ProviderOperationOutcome::Completed {
+                value: ReplacementValue::Int(amount + 5),
+                attributes: vec![
+                    ReceiptAttribute::public("ledger.amount", amount.to_string()),
+                    ReceiptAttribute::redacted("ledger.account", AttributeSensitivity::Secret),
+                ],
+                replay: ReplayClassification::FixtureRequired,
+            },
+            LedgerBehavior::Decline => ProviderOperationOutcome::Failed {
+                detail: format!("the ledger declined a charge of {amount}"),
+                attributes: vec![ReceiptAttribute::public("ledger.amount", amount.to_string())],
+                replay: ReplayClassification::FixtureRequired,
+            },
+        }
+    }
+
+    fn release(&self, _operation: &CanonicalSymbolId, _call_span: HirSourceSpan) {
+        let mut log = self.log.borrow_mut();
+        log.open_handles -= 1;
+        log.releases += 1;
+    }
+}
+
+/// Canonical identity of the same-module `def` named `name`, minted exactly as lowering mints it.
+///
+/// The spelling is only how this fixture *finds* the declaration whose identity becomes the catalog key; nothing
+/// downstream ever sees it.
+fn local_function_identity(program: &ast::Program, name: &str) -> Option<CanonicalSymbolId> {
+    let module_path: Vec<String> = MODULE_PATH.iter().map(|segment| (*segment).to_string()).collect();
+    program.declarations.iter().find_map(|declaration| {
+        let ast::Declaration::Function(function) = &declaration.node else {
+            return None;
+        };
+        (function.name == name).then(|| {
+            CanonicalSymbolId::module_declaration(
+                module_path.clone(),
+                name,
+                SemanticSourceTargetKind::Function,
+                HirSourceSpan::new(declaration.span.start, declaration.span.end),
+            )
+        })
+    })
+}
+
+/// Canonical identity of the RFC 104 capability a ledger charge needs.
+fn ledger_capability(kind: SemanticSourceTargetKind) -> CanonicalSymbolId {
+    CanonicalSymbolId::module_declaration(
+        vec!["host".to_string(), "ledger".to_string()],
+        "charge",
+        kind,
+        HirSourceSpan::new(1, 2),
+    )
+}
+
+/// The lowered fixture module plus the canonical identity of the operation it admits.
+struct LoweredFixture {
+    module: bir::BodyIrModule,
+    operation: CanonicalSymbolId,
+}
+
+impl LoweredFixture {
+    /// The single provider-operation plan the `settle` body lowered.
+    fn plan(&self) -> Result<&ProviderOperationPlan, String> {
+        let plans: Vec<&ProviderOperationPlan> = self
+            .module
+            .bodies
+            .iter()
+            .filter(|body| body.name == "settle")
+            .flat_map(|body| &body.block.stmts)
+            .filter_map(|statement| match &statement.kind {
+                bir::StatementKind::Call {
+                    callee: bir::Callee::ProviderOperation(plan),
+                    ..
+                } => Some(plan.as_ref()),
+                _ => None,
+            })
+            .collect();
+        match plans.as_slice() {
+            [plan] => Ok(plan),
+            other => Err(format!("expected exactly one lowered plan, got {}", other.len())),
+        }
+    }
+
+    /// Replace the lowered plan's provider activation, producing a plan lowering would have refused.
+    ///
+    /// Used only to prove the runtime is fail-closed rather than trusting the gate upstream of it.
+    fn force_activation(&mut self, state: ProviderActivationState) {
+        for body in &mut self.module.bodies {
+            for statement in &mut body.block.stmts {
+                if let bir::StatementKind::Call {
+                    callee: bir::Callee::ProviderOperation(plan),
+                    ..
+                } = &mut statement.kind
+                {
+                    plan.provider.state = state;
+                }
+            }
+        }
+    }
+}
+
+/// Lower the ledger fixture with `charge` admitted as a fixture-controlled provider operation.
+///
+/// The call site is told nothing. Admission travels entirely through the operation's canonical identity, which is
+/// why the same fixture proves both that an admitted call reaches the executor and that an unadmitted one does not.
+fn lower_fixture(activation: ProviderActivationState) -> Result<LoweredFixture, Box<dyn std::error::Error>> {
+    let tokens = lexer::lex(LEDGER_FIXTURE_SOURCE).map_err(|errors| std::io::Error::other(format!("{errors:?}")))?;
+    let program = parser::parse(&tokens).map_err(|errors| std::io::Error::other(format!("{errors:?}")))?;
+    let module_path: Vec<String> = MODULE_PATH.iter().map(|segment| (*segment).to_string()).collect();
+    let mut checker = TypeChecker::new();
+    checker.set_current_module_path(Some(module_path.clone()));
+    checker
+        .check_program(&program)
+        .map_err(|errors| std::io::Error::other(format!("{errors:?}")))?;
+
+    // Admission is projected from the checked provider manifest, never hand-filled here. #1213 made the catalogue
+    // private for exactly this reason: a test that registers its own entry would prove the executor works on a
+    // catalogue no producer could actually have published, which is the handwritten module exception #1156 exists
+    // to rule out. This shares the builder with #1213's own tests so both layers exercise one admission path.
+    let provider_plan = provider_plan_from_checked_source(checker.type_info(), activation)?;
+    let operation = local_function_identity(&program, "charge").ok_or("the fixture declares no `charge`")?;
+    let module =
+        build_body_ir_module_v0_with_provider_plan(&program, &module_path, checker.type_info(), &provider_plan)?;
+    Ok(LoweredFixture { module, operation })
+}
+
+/// Build the runtime one test runs against: a governed or permissive authority, and a ledger host.
+fn runtime(mode: AuthorityMode, grants: &[&str], host: Rc<LedgerHost>) -> Rc<ProviderRuntime> {
+    let authority = StaticAuthority::new(mode, grants.iter().map(|grant| (*grant).to_string()));
+    ProviderRuntime::new(Rc::new(authority), host)
+}
+
+/// Execute `settle("acct-1", 250)` against `providers`.
+fn settle(
+    module: &bir::BodyIrModule,
+    providers: &Rc<ProviderRuntime>,
+) -> Result<ReplacementExecution, ReplacementExecutionError> {
+    execute_free_function_with_providers(
+        module,
+        "settle",
+        &[ReplacementValue::Str("acct-1".to_string()), ReplacementValue::Int(250)],
+        providers,
+    )
+}
+
+/// The lifecycle transition labels one runtime recorded, in order.
+fn lifecycle_events(providers: &ProviderRuntime) -> Vec<&'static str> {
+    providers
+        .lifecycle_evidence()
+        .into_iter()
+        .map(|event| event.event)
+        .collect()
+}
+
+// ============================================================================
+// Allowed invocation
+// ============================================================================
+
+/// An allowed invocation runs the provider, not the operation's own local declaration, and its backend execution
+/// receipt references the RFC 104 operation receipt rather than restating it.
+#[test]
+fn an_allowed_provider_operation_executes_and_references_its_operation_receipt() -> TestResult {
+    let fixture = lower_fixture(ProviderActivationState::Active)?;
+    let host = Rc::new(LedgerHost::new(fixture.operation.clone(), LedgerBehavior::Settle));
+    let providers = runtime(AuthorityMode::Governed, &[LEDGER_GRANT], host.clone());
+
+    let execution = settle(&fixture.module, &providers)?;
+
+    assert_eq!(
+        execution.value,
+        ReplacementValue::Int(255),
+        "the provider settled the charge; the operation's own local body would have returned 250",
+    );
+    assert_eq!(host.invocations(), vec![250]);
+
+    let receipts = providers.operation_receipts();
+    let [receipt] = receipts.as_slice() else {
+        return Err(Box::from(format!(
+            "expected one operation receipt, got {}",
+            receipts.len()
+        )));
+    };
+    assert_eq!(receipt.status(), ReceiptStatus::Allowed);
+    assert_eq!(receipt.operation_kind(), "ledger.charge");
+    assert_eq!(
+        receipt.capability().origin,
+        SymbolOrigin::Module(vec!["app".to_string()]),
+        "the receipt names the capability identity the plan carried, not a grant spelling",
+    );
+    assert_eq!(receipt.operation(), &fixture.operation);
+    assert!(receipt.authority().is_allowed());
+    receipt.validate().map_err(|violation| violation.to_string())?;
+
+    let evidence = execution.provider_execution_evidence();
+    let [backend_receipt] = evidence.as_slice() else {
+        return Err(Box::from(format!(
+            "expected one backend provider execution, got {}",
+            evidence.len()
+        )));
+    };
+    assert_eq!(
+        backend_receipt.operation_receipt_sequence_id,
+        receipt.sequence_id(),
+        "the backend execution receipt must reference the operation receipt rather than copy it",
+    );
+    assert_eq!(backend_receipt.outcome, "allowed");
+    assert!(backend_receipt.selection_identity.starts_with("sha256:"));
+    assert!(backend_receipt.receipt_identity.starts_with("sha256:"));
+    assert_eq!(
+        backend_receipt.comparison_reason, PROVIDER_COMPARISON_UNAVAILABLE_REASON,
+        "an executed provider operation must declare an explicitly non-green comparison until #1146 lands",
+    );
+    Ok(())
+}
+
+// Runtime-requirement propagation is deliberately not asserted here, and the reason is upstream rather than a
+// gap in this executor. `@provider_operation` currently records `runtime_requirements: Vec::new()`, so a checked
+// provider manifest publishes none and every plan carries an empty list. A test could only pass by hand-injecting
+// a requirement into the catalogue -- the handwritten exception #1213's rework closed off -- or by asserting an
+// empty list flows through to an empty list, which asserts nothing. Neither is worth shipping. Once the
+// declaration side derives requirements, propagation belongs back here as a real assertion.
+
+/// Mode semantics belong to the authority seam: a permissive run allows a capability no grant set holds, and this
+/// backend neither knows nor decides that.
+#[test]
+fn a_permissive_run_executes_an_ungranted_provider_operation() -> TestResult {
+    let fixture = lower_fixture(ProviderActivationState::Active)?;
+    let host = Rc::new(LedgerHost::new(fixture.operation.clone(), LedgerBehavior::Settle));
+    let providers = runtime(AuthorityMode::Permissive, &[], host.clone());
+
+    let execution = settle(&fixture.module, &providers)?;
+
+    assert_eq!(execution.value, ReplacementValue::Int(255));
+    assert_eq!(host.invocations(), vec![250]);
+    Ok(())
+}
+
+// ============================================================================
+// Governed denial
+// ============================================================================
+
+/// A governed denial emits a denied receipt, reports a source-owned diagnostic, and never reaches the provider.
+///
+/// This is the invariant the whole delivery train exists to protect: the only path to
+/// [`ProviderOperationHost::invoke`] runs through an allowed decision, so a denial cannot leave the operation
+/// half-performed or performed-then-reported.
+#[test]
+fn a_governed_denial_emits_a_denied_receipt_without_invoking_the_provider() -> TestResult {
+    let fixture = lower_fixture(ProviderActivationState::Active)?;
+    let host = Rc::new(LedgerHost::new(fixture.operation.clone(), LedgerBehavior::Settle));
+    let providers = runtime(AuthorityMode::Governed, &[], host.clone());
+    let call_span = fixture.plan()?.call_span;
+
+    let error = settle(&fixture.module, &providers)
+        .err()
+        .ok_or("a governed run with no grant must refuse the charge")?;
+
+    let ReplacementExecutionError::ProviderAuthorityDenied { operation, reason, .. } = &error else {
+        return Err(Box::from(format!("expected an authority denial, got {error:?}")));
+    };
+    assert_eq!(operation, "charge");
+    assert!(
+        reason.contains(LEDGER_GRANT),
+        "a denial must name the grant that would permit it: {reason}",
+    );
+    assert_eq!(error.diagnostic_code(), "INCAN-R1156-DENIED");
+    assert_eq!(
+        error.primary_span(),
+        Some(call_span),
+        "a denial is reported at the invocation the source wrote",
+    );
+
+    assert!(
+        host.invocations().is_empty(),
+        "a denied operation must never reach the provider",
+    );
+    assert_eq!(host.releases(), 0, "nothing was acquired, so nothing may be released");
+    assert!(
+        host.descriptions() > 0,
+        "the host was still asked what kind of operation this is, which is a description and not a performance",
+    );
+
+    let receipts = providers.operation_receipts();
+    let [receipt] = receipts.as_slice() else {
+        return Err(Box::from(format!(
+            "a denial is a recorded outcome, not an absent one; got {} receipts",
+            receipts.len()
+        )));
+    };
+    assert_eq!(receipt.status(), ReceiptStatus::Denied);
+    assert!(receipt.attributes().is_empty(), "nothing ran, so nothing was recorded");
+    assert_eq!(receipt.replay(), ReplayClassification::Unavailable);
+    assert_eq!(
+        receipt.authority().denial_reason(),
+        Some(AuthorityDenialReason::NotGranted),
+    );
+    assert_eq!(
+        error.operation_receipt().map(|reference| reference.sequence_id),
+        Some(receipt.sequence_id()),
+    );
+    receipt.validate().map_err(|violation| violation.to_string())?;
+
+    assert_eq!(
+        lifecycle_events(&providers),
+        vec!["denied"],
+        "a denial records only that it was denied; there is no invocation to release",
+    );
+    Ok(())
+}
+
+/// A host ceiling denies a grant the invocation held, and this backend reports it without interpreting the rule.
+#[test]
+fn a_host_ceiling_denial_is_reported_without_being_reinterpreted() -> TestResult {
+    let fixture = lower_fixture(ProviderActivationState::Active)?;
+    let host = Rc::new(LedgerHost::new(fixture.operation.clone(), LedgerBehavior::Settle));
+    let authority = StaticAuthority::new(AuthorityMode::Governed, [LEDGER_GRANT.to_string()])
+        .with_ceiling(["host.fs.read".to_string()]);
+    let providers = ProviderRuntime::new(Rc::new(authority), host.clone());
+
+    let error = settle(&fixture.module, &providers)
+        .err()
+        .ok_or("a grant outside the host ceiling must be refused")?;
+
+    assert!(matches!(
+        error,
+        ReplacementExecutionError::ProviderAuthorityDenied { .. }
+    ));
+    assert!(host.invocations().is_empty());
+    let receipts = providers.operation_receipts();
+    let [receipt] = receipts.as_slice() else {
+        return Err(Box::from("a ceiling denial still emits its receipt"));
+    };
+    assert_eq!(
+        receipt.authority().denial_reason(),
+        Some(AuthorityDenialReason::OutsideCeiling),
+        "the denial reason is the authority source's answer, not one this backend derived",
+    );
+    Ok(())
+}
+
+// ============================================================================
+// Provider failure and lifecycle cleanup
+// ============================================================================
+
+/// A provider failure keeps its allowing authority decision, and releases what the invocation acquired.
+#[test]
+fn a_provider_failure_keeps_allowed_authority_and_still_releases() -> TestResult {
+    let fixture = lower_fixture(ProviderActivationState::Active)?;
+    let host = Rc::new(LedgerHost::new(fixture.operation.clone(), LedgerBehavior::Decline));
+    let providers = runtime(AuthorityMode::Governed, &[LEDGER_GRANT], host.clone());
+
+    let error = settle(&fixture.module, &providers)
+        .err()
+        .ok_or("a declined charge must surface as a failure")?;
+
+    let ReplacementExecutionError::ProviderOperationFailed { operation, detail, .. } = &error else {
+        return Err(Box::from(format!("expected a provider failure, got {error:?}")));
+    };
+    assert_eq!(operation, "charge");
+    assert!(
+        detail.contains("declined"),
+        "the provider's own reason survives: {detail}"
+    );
+    assert_eq!(error.diagnostic_code(), "INCAN-R1156-PROVIDER");
+
+    let receipts = providers.operation_receipts();
+    let [receipt] = receipts.as_slice() else {
+        return Err(Box::from("a failed invocation still emits its receipt"));
+    };
+    assert_eq!(receipt.status(), ReceiptStatus::Failed);
+    assert!(
+        receipt.authority().is_allowed(),
+        "a failure is not a denial: authority was granted and the operation itself failed",
+    );
+    receipt.validate().map_err(|violation| violation.to_string())?;
+
+    assert_eq!(host.invocations(), vec![250]);
+    assert_eq!(host.releases(), 1);
+    assert_eq!(
+        host.open_handles(),
+        0,
+        "a failed charge still holds the settlement handle it opened until cleanup runs",
+    );
+    assert_eq!(lifecycle_events(&providers), vec!["invoked", "failed", "released"]);
+    Ok(())
+}
+
+/// A successful invocation releases exactly once, after it completed and before execution continues.
+#[test]
+fn a_completed_invocation_releases_exactly_once_after_completing() -> TestResult {
+    let fixture = lower_fixture(ProviderActivationState::Active)?;
+    let host = Rc::new(LedgerHost::new(fixture.operation.clone(), LedgerBehavior::Settle));
+    let providers = runtime(AuthorityMode::Governed, &[LEDGER_GRANT], host.clone());
+
+    settle(&fixture.module, &providers)?;
+
+    assert_eq!(host.releases(), 1);
+    assert_eq!(host.open_handles(), 0);
+    assert_eq!(
+        lifecycle_events(&providers),
+        vec!["invoked", "completed", "released"],
+        "cleanup follows the outcome it is cleaning up after, and never precedes the invocation",
+    );
+    Ok(())
+}
+
+// ============================================================================
+// Redaction classification
+// ============================================================================
+
+/// A withheld attribute classifies the receipt as redacted, keeps its key and sensitivity, and never leaks a value.
+#[test]
+fn a_withheld_attribute_classifies_the_receipt_as_redacted() -> TestResult {
+    let fixture = lower_fixture(ProviderActivationState::Active)?;
+    let host = Rc::new(LedgerHost::new(
+        fixture.operation.clone(),
+        LedgerBehavior::SettleWithSecretAccount,
+    ));
+    let providers = runtime(AuthorityMode::Governed, &[LEDGER_GRANT], host);
+
+    let execution = settle(&fixture.module, &providers)?;
+
+    assert_eq!(execution.value, ReplacementValue::Int(255));
+    let receipts = providers.operation_receipts();
+    let [receipt] = receipts.as_slice() else {
+        return Err(Box::from("a redacted invocation still emits one receipt"));
+    };
+    assert_eq!(
+        receipt.status(),
+        ReceiptStatus::Redacted,
+        "a receipt with withheld values must stop claiming it recorded everything",
+    );
+    assert_eq!(receipt.redacted_keys(), vec!["ledger.account".to_string()]);
+    let withheld = receipt
+        .attributes()
+        .iter()
+        .find(|attribute| attribute.key() == "ledger.account")
+        .ok_or("the withheld attribute must keep its key")?;
+    assert_eq!(withheld.value(), None);
+    assert_eq!(withheld.sensitivity(), AttributeSensitivity::Secret);
+    assert!(
+        !receipt
+            .attributes()
+            .iter()
+            .any(|attribute| { attribute.value().is_some_and(|value| value.contains("acct-1")) }),
+        "the account identifier the call passed must not reach the receipt in the clear",
+    );
+    receipt.validate().map_err(|violation| violation.to_string())?;
+
+    let evidence = execution.provider_execution_evidence();
+    assert_eq!(
+        evidence.first().map(|record| record.outcome),
+        Some("redacted"),
+        "the backend execution receipt records the classification rather than re-deriving it later",
+    );
+    Ok(())
+}
+
+// ============================================================================
+// Activation and unresolved calls: refuse before execution, emit no receipt
+// ============================================================================
+
+/// An inactive provider never produces a plan at all, so there is nothing for an executor to run or receipt.
+#[test]
+fn a_disabled_provider_is_refused_by_lowering_before_a_plan_exists() -> TestResult {
+    let fixture = lower_fixture(ProviderActivationState::Disabled)?;
+    let host = Rc::new(LedgerHost::new(fixture.operation.clone(), LedgerBehavior::Settle));
+    let providers = runtime(AuthorityMode::Governed, &[LEDGER_GRANT], host.clone());
+
+    assert!(
+        fixture.plan().is_err(),
+        "a disabled provider must not reach a checked execution plan",
+    );
+    let error = settle(&fixture.module, &providers)
+        .err()
+        .ok_or("a refused operation cannot be executed")?;
+
+    assert_eq!(error.diagnostic_code(), "INCAN-R988-UNSUPPORTED");
+    assert!(
+        error.primary_span().is_some(),
+        "a refusal keeps its original source span"
+    );
+    assert!(host.invocations().is_empty());
+    assert!(
+        providers.operation_receipts().is_empty() && providers.provider_executions().is_empty(),
+        "a refusal that happened before execution has no receipt to emit",
+    );
+    Ok(())
+}
+
+/// The runtime is fail-closed about activation: a plan that claims an inactive provider is refused even though
+/// lowering would never have produced one.
+#[test]
+fn an_inactive_plan_is_refused_by_the_runtime_before_anything_executes() -> TestResult {
+    let mut fixture = lower_fixture(ProviderActivationState::Active)?;
+    fixture.force_activation(ProviderActivationState::Unavailable);
+    let host = Rc::new(LedgerHost::new(fixture.operation.clone(), LedgerBehavior::Settle));
+    let providers = runtime(AuthorityMode::Governed, &[LEDGER_GRANT], host.clone());
+    let call_span = fixture.plan()?.call_span;
+
+    let error = prepare_free_function_execution_with_providers(
+        &fixture.module,
+        "settle",
+        &[ReplacementValue::Str("acct-1".to_string()), ReplacementValue::Int(250)],
+        Some(&providers),
+    )
+    .err()
+    .ok_or("an unavailable provider must be refused")?;
+
+    assert_eq!(error.primary_span(), Some(call_span));
+    assert!(
+        error.to_string().contains("unavailable"),
+        "the refusal must say which activation state blocked it: {error}",
+    );
+    assert!(host.invocations().is_empty());
+    assert!(providers.operation_receipts().is_empty());
+    Ok(())
+}
+
+/// An operation no host in this run executes is refused before execution, at its source span, with no receipt.
+#[test]
+fn an_unresolved_provider_operation_is_refused_before_execution() -> TestResult {
+    let fixture = lower_fixture(ProviderActivationState::Active)?;
+    // A host that owns a different operation identity resolves nothing here, which is exactly the shape of a run
+    // whose provider set does not include the one the program invokes.
+    let other_operation = ledger_capability(SemanticSourceTargetKind::Function);
+    let host = Rc::new(LedgerHost::new(other_operation, LedgerBehavior::Settle));
+    let providers = runtime(AuthorityMode::Governed, &[LEDGER_GRANT], host.clone());
+    let call_span = fixture.plan()?.call_span;
+
+    let error = prepare_free_function_execution_with_providers(
+        &fixture.module,
+        "settle",
+        &[ReplacementValue::Str("acct-1".to_string()), ReplacementValue::Int(250)],
+        Some(&providers),
+    )
+    .err()
+    .ok_or("an operation no host executes must be refused")?;
+
+    assert_eq!(error.diagnostic_code(), "INCAN-R988-UNSUPPORTED");
+    assert_eq!(error.primary_span(), Some(call_span));
+    assert!(error.operation_receipt().is_none());
+    assert!(host.invocations().is_empty());
+    assert!(
+        providers.operation_receipts().is_empty() && providers.provider_executions().is_empty(),
+        "a call refused before execution must produce no execution receipt",
+    );
+    Ok(())
+}
+
+/// A run with no provider runtime refuses an admitted provider operation rather than falling back to anything.
+#[test]
+fn a_run_without_a_provider_runtime_refuses_visibly() -> TestResult {
+    let fixture = lower_fixture(ProviderActivationState::Active)?;
+    let call_span = fixture.plan()?.call_span;
+
+    let error = execute_free_function(
+        &fixture.module,
+        "settle",
+        &[ReplacementValue::Str("acct-1".to_string()), ReplacementValue::Int(250)],
+    )
+    .err()
+    .ok_or("without a provider runtime there is nothing that could execute the operation")?;
+
+    assert_eq!(error.diagnostic_code(), "INCAN-R988-UNSUPPORTED");
+    assert_eq!(error.primary_span(), Some(call_span));
+    Ok(())
+}
+
+// A plan whose required authority does not name a capability is no longer testable from this layer, and that is
+// the right outcome rather than a lost case. #1213's rework rejects such provider metadata *before* lowering can
+// mint a plan, so the executor can no longer be handed one — see
+// `src/frontend/body_ir/tests.rs`'s "corrupt provider metadata whose authority is not a capability is rejected
+// before lowering can mint a plan". Reconstructing it here would mean hand-filling a catalogue no producer could
+// publish, which is exactly what that rework closed off.
+
+// ============================================================================
+// Evidence identity
+// ============================================================================
+
+/// Two identical runs agree on their output identity, and a run that redacts differs from one that does not.
+///
+/// The provider evidence is bound into the execution's output identity, so a consumer cannot read one execution's
+/// identity and believe it describes a differently-receipted run.
+#[test]
+fn provider_evidence_is_bound_into_the_execution_output_identity() -> TestResult {
+    let fixture = lower_fixture(ProviderActivationState::Active)?;
+
+    let settled_host = Rc::new(LedgerHost::new(fixture.operation.clone(), LedgerBehavior::Settle));
+    let settled = settle(
+        &fixture.module,
+        &runtime(AuthorityMode::Governed, &[LEDGER_GRANT], settled_host),
+    )?;
+    let repeat_host = Rc::new(LedgerHost::new(fixture.operation.clone(), LedgerBehavior::Settle));
+    let repeated = settle(
+        &fixture.module,
+        &runtime(AuthorityMode::Governed, &[LEDGER_GRANT], repeat_host),
+    )?;
+    assert_eq!(
+        settled.output_identity, repeated.output_identity,
+        "the same source, arguments, and provider outcome must produce the same identity",
+    );
+
+    let redacted_host = Rc::new(LedgerHost::new(
+        fixture.operation.clone(),
+        LedgerBehavior::SettleWithSecretAccount,
+    ));
+    let redacted = settle(
+        &fixture.module,
+        &runtime(AuthorityMode::Governed, &[LEDGER_GRANT], redacted_host),
+    )?;
+    assert_ne!(
+        settled.output_identity, redacted.output_identity,
+        "a run whose receipt withheld a value is not the same observation as one that did not",
+    );
+    Ok(())
+}

--- a/src/frontend/body_ir.rs
+++ b/src/frontend/body_ir.rs
@@ -1000,7 +1000,7 @@ use provider_ops::{ProviderOperationCatalog, ProviderOperationRecord};
 use reads::*;
 
 #[cfg(test)]
-mod tests;
+pub(crate) mod tests;
 
 #[cfg(test)]
 mod tuple_destructure_interop_tests {

--- a/src/frontend/body_ir/tests.rs
+++ b/src/frontend/body_ir/tests.rs
@@ -5328,7 +5328,7 @@ fn assertion_kinds(body: &bir::Body) -> Vec<&bir::AssertionKind> {
 /// publication persists that checked pair into the provider manifest, and consumer lowering projects the selected
 /// manifest through its provider plan. Tests must not manually fill `ProviderOperationCatalog`, because that would
 /// bypass the compiler-owned producer contract #1213 adds.
-fn provider_plan_from_checked_source(
+pub(crate) fn provider_plan_from_checked_source(
     type_info: &TypeCheckInfo,
     state: bir::ProviderActivationState,
 ) -> Result<ProviderPlan, Box<dyn std::error::Error>> {

--- a/tests/parity_corpus_tests.rs
+++ b/tests/parity_corpus_tests.rs
@@ -20,11 +20,25 @@
 //! so a behavior change shows up as [`parity_corpus::ComparisonOutcome::Mismatch`] the next time this test runs.
 
 use incan::backend::IrCodegen;
-use incan::backend::replacement::ReplacementValue;
-use incan::frontend::body_ir::build_body_ir_module_v0;
+use incan::backend::replacement::provider::{
+    PROVIDER_COMPARISON_UNAVAILABLE_REASON, ProviderInputValue, ProviderInvocation, ProviderOperationHost,
+    ProviderOperationOutcome, ProviderRuntime,
+};
+use incan::backend::replacement::{ReplacementExecutionError, ReplacementValue, execute_free_function_with_providers};
+use incan::frontend::body_ir::{build_body_ir_module_v0, build_body_ir_module_v0_with_provider_plan};
 use incan::frontend::diagnostics::CompileError;
+use incan::frontend::library_manifest_index::LibraryManifestIndex;
 use incan::frontend::{lexer, parser, typechecker};
+use incan::library_manifest::{CompiledProviderMetadata, LibraryManifest, ProviderOperationMetadata};
+use incan::provider::{NamespaceAuthority, ProviderIdentity, ProviderPlan, ProviderProvenance, ProviderRecord};
+use incan_semantics_core::authority::StaticAuthority;
+use incan_semantics_core::receipts::{AttributeSensitivity, ReceiptAttribute, ReceiptStatus, ReplayClassification};
+use incan_semantics_core::{AuthorityMode, CanonicalSymbolId, HirSourceSpan};
+use std::cell::{Cell, RefCell};
+use std::collections::BTreeSet;
 use std::path::PathBuf;
+use std::rc::Rc;
+use std::sync::Arc;
 
 #[path = "support/parity_corpus.rs"]
 mod parity_corpus;
@@ -1145,6 +1159,459 @@ fn case_diagnostic_statement_tuple_unpack_of_non_tuple() -> ComparisonOutcome {
 }
 
 // ============================================================================
+// Provider-operation paths (#1156)
+// ============================================================================
+
+// The five rows below give the #1156 vertical's paths their own stable #987 dispositions. Each probe drives the
+// real pipeline -- source, typecheck, Body-IR lowering with a fixture-controlled provider catalog, direct
+// replacement execution -- against a fixture ledger host and a `StaticAuthority`, and asserts what that path is
+// contracted to do.
+//
+// None of them can be comparison-green, and none claims to be. The legacy backend cannot execute a provider
+// operation at all, so there is no second route to compare against until #1146 supplies the receipt-bound paired
+// comparison; each probe asserts that the execution it observed declared that non-green state explicitly rather
+// than leaving it implied.
+//
+// These rows carry a legacy-side corpus receipt because `ReplacementExecutionPlan` -- the corpus's own direct
+// execution shape -- names a function and concrete arguments, with nowhere to name the authority source and
+// provider host a provider operation needs. Their provider executions therefore produce real #986
+// selection/execution receipts inside the probe, which the probe asserts on, rather than corpus-visible
+// `ReceiptRef::ReplacementExecuted` evidence. Binding them into the corpus receipt is corpus-schema work in
+// `tests/support/parity_corpus.rs`, and belongs with #1146's comparison route rather than with this vertical.
+
+/// One ledger charge, plus a same-module caller that invokes it.
+///
+/// `charge`'s own body returns a different value than the provider host does, so a run that executed the local
+/// declaration instead of the provider would be visible in the observable rather than silent.
+const PROVIDER_CASE_SRC: &str = r#"
+capability ledger_charge:
+  description = "Charge one approved ledger account"
+
+@provider_operation(ledger_charge)
+def charge(account: str, amount: int) -> int:
+  return amount
+
+def settle(account: str, amount: int) -> int:
+  return charge(account, amount)
+"#;
+
+/// The grant spelling the selected capability renders to, and therefore the one a governed run must hold.
+const PROVIDER_GRANT: &str = "app.ledger_charge";
+
+/// What the fixture ledger does when an authorized charge reaches it.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum LedgerBehavior {
+    /// Settle the charge, adding a fixed fee so the result cannot be confused with the local declaration's.
+    Settle,
+    /// Settle the charge but withhold the account identifier from the receipt.
+    SettleWithSecretAccount,
+    /// Refuse the charge after authority was already granted.
+    Decline,
+}
+
+/// A fixture ledger provider, addressed only by the canonical identity of the operation it owns.
+///
+/// Keying on the identity rather than on a name is the contract, not a detail: a host that matched a provider
+/// module name, a call-site spelling, or an emitted Rust name would be the source-meaning duplication this vertical
+/// exists to avoid.
+struct CorpusLedgerHost {
+    operation: CanonicalSymbolId,
+    behavior: LedgerBehavior,
+    invocations: RefCell<Vec<i64>>,
+    releases: Cell<usize>,
+}
+
+impl CorpusLedgerHost {
+    /// Build a host that executes exactly `operation` and behaves as `behavior` when it is invoked.
+    fn new(operation: CanonicalSymbolId, behavior: LedgerBehavior) -> Self {
+        Self {
+            operation,
+            behavior,
+            invocations: RefCell::new(Vec::new()),
+            releases: Cell::new(0),
+        }
+    }
+
+    /// The integer amount carried by the input at written position 1, or an error naming what arrived instead.
+    fn amount(inputs: &[ProviderInputValue]) -> Result<i64, String> {
+        match inputs.iter().find(|input| input.written_position == 1) {
+            Some(ProviderInputValue {
+                value: ReplacementValue::Int(amount),
+                ..
+            }) => Ok(*amount),
+            other => Err(format!("a charge needs an integer amount, got {other:?}")),
+        }
+    }
+}
+
+impl ProviderOperationHost for CorpusLedgerHost {
+    fn operation_kind(&self, operation: &CanonicalSymbolId) -> Option<String> {
+        (operation == &self.operation).then(|| "ledger.charge".to_string())
+    }
+
+    fn invoke(&self, invocation: &ProviderInvocation<'_, '_>) -> ProviderOperationOutcome {
+        let amount = match CorpusLedgerHost::amount(invocation.inputs) {
+            Ok(amount) => amount,
+            Err(detail) => {
+                return ProviderOperationOutcome::Failed {
+                    detail,
+                    attributes: Vec::new(),
+                    replay: ReplayClassification::Unavailable,
+                };
+            }
+        };
+        self.invocations.borrow_mut().push(amount);
+        match self.behavior {
+            LedgerBehavior::Settle => ProviderOperationOutcome::Completed {
+                value: ReplacementValue::Int(amount + 5),
+                attributes: vec![ReceiptAttribute::public("ledger.amount", amount.to_string())],
+                replay: ReplayClassification::FixtureRequired,
+            },
+            LedgerBehavior::SettleWithSecretAccount => ProviderOperationOutcome::Completed {
+                value: ReplacementValue::Int(amount + 5),
+                attributes: vec![
+                    ReceiptAttribute::public("ledger.amount", amount.to_string()),
+                    ReceiptAttribute::redacted("ledger.account", AttributeSensitivity::Secret),
+                ],
+                replay: ReplayClassification::FixtureRequired,
+            },
+            LedgerBehavior::Decline => ProviderOperationOutcome::Failed {
+                detail: format!("the ledger declined a charge of {amount}"),
+                attributes: vec![ReceiptAttribute::public("ledger.amount", amount.to_string())],
+                replay: ReplayClassification::FixtureRequired,
+            },
+        }
+    }
+
+    fn release(&self, _operation: &CanonicalSymbolId, _call_span: HirSourceSpan) {
+        self.releases.set(self.releases.get() + 1);
+    }
+}
+
+/// Everything one provider path produced, in the shape the probes assert on.
+struct ProviderPathObservation {
+    /// The source-level value the execution produced, when it produced one.
+    value: Option<ReplacementValue>,
+    /// The stable diagnostic code the execution refused with, when it refused.
+    error_code: Option<&'static str>,
+    /// The status of the single RFC 104 operation receipt the run emitted, when it emitted one.
+    receipt_status: Option<ReceiptStatus>,
+    /// The keys whose values that receipt withheld.
+    redacted_keys: Vec<String>,
+    /// Whether the receipt's own authority decision allowed the operation.
+    authority_allowed: Option<bool>,
+    /// The amounts the ledger was actually asked to charge.
+    invocations: Vec<i64>,
+    /// How many settlement handles the ledger released.
+    releases: usize,
+    /// The lifecycle transitions the run recorded, in order.
+    lifecycle: Vec<&'static str>,
+    /// The backend execution receipts the run finalized, as `(outcome, referenced receipt sequence id)`.
+    backend_executions: Vec<(&'static str, u64)>,
+    /// Every comparison state those backend receipts declared.
+    comparison_reasons: Vec<String>,
+}
+
+/// Lower the ledger fixture, run `settle("acct-1", 250)` against a fixture host, and report what happened.
+///
+/// The catalog key is the operation's canonical identity, minted the way lowering mints it. Nothing tells the call
+/// site anything: admission travels entirely through that identity.
+fn observe_provider_path(
+    behavior: LedgerBehavior,
+    mode: AuthorityMode,
+    grants: &[&str],
+) -> Result<ProviderPathObservation, String> {
+    let tokens = lexer::lex(PROVIDER_CASE_SRC).map_err(|errors| format!("provider fixture lex failure: {errors:?}"))?;
+    let program = parser::parse(&tokens).map_err(|errors| format!("provider fixture parse failure: {errors:?}"))?;
+    let module_path = vec!["app".to_string()];
+    let mut checker = typechecker::TypeChecker::new();
+    checker.set_current_module_path(Some(module_path.clone()));
+    checker
+        .check_program(&program)
+        .map_err(|errors| format!("provider fixture typecheck failure: {errors:?}"))?;
+
+    // Admission is projected from a published provider manifest through a selected `ProviderPlan`, never
+    // hand-filled into the lowering catalogue -- which #1213 made private precisely so a consumer cannot invent
+    // admission a real producer could not have published.
+    let descriptors: Vec<ProviderOperationMetadata> = checker
+        .type_info()
+        .declarations
+        .provider_operations
+        .values()
+        .map(|declared| ProviderOperationMetadata {
+            operation: declared.operation.clone(),
+            required_capability: declared.required_capability.clone(),
+            runtime_requirements: declared.runtime_requirements.clone(),
+        })
+        .collect();
+    let operation = descriptors
+        .first()
+        .map(|descriptor| descriptor.operation.clone())
+        .ok_or("the provider fixture declares no checked provider operation")?;
+    let namespace_claims: BTreeSet<Vec<String>> = descriptors
+        .iter()
+        .filter_map(|descriptor| descriptor.operation.module_path().map(ToOwned::to_owned))
+        .collect();
+
+    let mut manifest = LibraryManifest::new("corpus_provider", "0.1.0");
+    manifest.contract_metadata.provider = CompiledProviderMetadata {
+        operation_descriptors: descriptors,
+        ..CompiledProviderMetadata::default()
+    };
+    let provider_plan = ProviderPlan::new(
+        LibraryManifestIndex::default(),
+        vec![ProviderRecord {
+            identity: ProviderIdentity {
+                name: "corpus_provider".to_string(),
+                version: "0.1.0".to_string(),
+                digest: "fixture:corpus-provider".to_string(),
+                feature_projection: BTreeSet::new(),
+            },
+            provenance: ProviderProvenance::Compiler,
+            authority: NamespaceAuthority::Compiler,
+            namespace_claims: namespace_claims.clone(),
+            available: true,
+            enabled: true,
+            manifest: Some(Arc::new(manifest)),
+            artifact: None,
+            implementation_facets: Vec::new(),
+        }],
+        namespace_claims,
+    )
+    .map_err(|error| error.to_string())?;
+    let module =
+        build_body_ir_module_v0_with_provider_plan(&program, &module_path, checker.type_info(), &provider_plan)
+            .map_err(|error| format!("provider fixture lowering failure: {error}"))?;
+
+    let host = Rc::new(CorpusLedgerHost::new(operation, behavior));
+    let authority = StaticAuthority::new(mode, grants.iter().map(|grant| (*grant).to_string()));
+    let providers = ProviderRuntime::new(Rc::new(authority), host.clone());
+    let executed = execute_free_function_with_providers(
+        &module,
+        "settle",
+        &[ReplacementValue::Str("acct-1".to_string()), ReplacementValue::Int(250)],
+        &providers,
+    );
+
+    let receipts = providers.operation_receipts();
+    let receipt = receipts.first();
+    // A receipt that contradicts its own fields would make every other assertion here meaningless, so the
+    // contract check runs before anything is reported.
+    if let Some(receipt) = receipt
+        && let Err(violation) = receipt.validate()
+    {
+        return Err(format!("the emitted operation receipt contradicts itself: {violation}"));
+    }
+    let executions = providers.provider_executions();
+    Ok(ProviderPathObservation {
+        value: executed.as_ref().ok().map(|execution| execution.value.clone()),
+        error_code: executed.as_ref().err().map(ReplacementExecutionError::diagnostic_code),
+        receipt_status: receipt.map(|receipt| receipt.status()),
+        redacted_keys: receipt.map(|receipt| receipt.redacted_keys()).unwrap_or_default(),
+        authority_allowed: receipt.map(|receipt| receipt.authority().is_allowed()),
+        invocations: host.invocations.borrow().clone(),
+        releases: host.releases.get(),
+        lifecycle: providers
+            .lifecycle_evidence()
+            .into_iter()
+            .map(|event| event.event)
+            .collect(),
+        backend_executions: executions
+            .iter()
+            .map(|record| {
+                let projection = record.projection();
+                (projection.outcome, projection.operation_receipt_sequence_id)
+            })
+            .collect(),
+        comparison_reasons: executions
+            .iter()
+            .map(|record| record.projection().comparison_reason)
+            .collect(),
+    })
+}
+
+/// Confirm that every backend execution the observation recorded declared an explicitly non-green comparison.
+fn provider_comparison_is_explicitly_non_green(observation: &ProviderPathObservation) -> Option<String> {
+    if observation.comparison_reasons.is_empty() {
+        return Some("a provider path recorded no backend execution receipt at all".to_string());
+    }
+    observation
+        .comparison_reasons
+        .iter()
+        .find(|reason| reason.as_str() != PROVIDER_COMPARISON_UNAVAILABLE_REASON)
+        .map(|reason| format!("a provider execution claimed a comparison state it cannot support: {reason}"))
+}
+
+/// Turn a provider path observation plus a claim about it into a corpus outcome, without panicking.
+fn provider_outcome(
+    observation: Result<ProviderPathObservation, String>,
+    claim: impl FnOnce(&ProviderPathObservation) -> Option<String>,
+) -> ComparisonOutcome {
+    let observation = match observation {
+        Ok(observation) => observation,
+        Err(reason) => return ComparisonOutcome::Incompatible { reason },
+    };
+    match provider_comparison_is_explicitly_non_green(&observation).or_else(|| claim(&observation)) {
+        Some(detail) => ComparisonOutcome::Mismatch { detail },
+        None => ComparisonOutcome::Match,
+    }
+}
+
+/// An allowed invocation runs the provider and binds a backend receipt to the operation receipt it describes.
+fn case_provider_allowed_invocation() -> ComparisonOutcome {
+    provider_outcome(
+        observe_provider_path(LedgerBehavior::Settle, AuthorityMode::Governed, &[PROVIDER_GRANT]),
+        |observed| {
+            if observed.value != Some(ReplacementValue::Int(255)) {
+                return Some(format!(
+                    "an allowed charge must produce the provider's settled value, got {:?}",
+                    observed.value
+                ));
+            }
+            if observed.receipt_status != Some(ReceiptStatus::Allowed) {
+                return Some(format!(
+                    "expected an allowed receipt, got {:?}",
+                    observed.receipt_status
+                ));
+            }
+            if observed.backend_executions != vec![("allowed", 0)] {
+                return Some(format!(
+                    "the backend receipt must reference the operation receipt it describes, got {:?}",
+                    observed.backend_executions
+                ));
+            }
+            None
+        },
+    )
+}
+
+/// A governed denial emits a denied receipt, reports a source-owned diagnostic, and never reaches the provider.
+fn case_provider_governed_denial() -> ComparisonOutcome {
+    provider_outcome(
+        observe_provider_path(LedgerBehavior::Settle, AuthorityMode::Governed, &[]),
+        |observed| {
+            if !observed.invocations.is_empty() {
+                return Some(format!(
+                    "a denied operation must never reach the provider, but it was invoked with {:?}",
+                    observed.invocations
+                ));
+            }
+            if observed.error_code != Some("INCAN-R1156-DENIED") {
+                return Some(format!(
+                    "a denial must report its own source-owned diagnostic, got {:?}",
+                    observed.error_code
+                ));
+            }
+            if observed.receipt_status != Some(ReceiptStatus::Denied) || observed.authority_allowed != Some(false) {
+                return Some(format!(
+                    "a denial is a recorded outcome over a refusing decision, got {:?}/{:?}",
+                    observed.receipt_status, observed.authority_allowed
+                ));
+            }
+            if observed.lifecycle != vec!["denied"] {
+                return Some(format!(
+                    "a denial acquires nothing, so it has nothing to release: {:?}",
+                    observed.lifecycle
+                ));
+            }
+            None
+        },
+    )
+}
+
+/// A provider failure keeps its allowing authority decision and reports its own diagnostic, not a denial's.
+fn case_provider_operation_failure() -> ComparisonOutcome {
+    provider_outcome(
+        observe_provider_path(LedgerBehavior::Decline, AuthorityMode::Governed, &[PROVIDER_GRANT]),
+        |observed| {
+            if observed.error_code != Some("INCAN-R1156-PROVIDER") {
+                return Some(format!(
+                    "a provider failure is not a denial and reports its own code, got {:?}",
+                    observed.error_code
+                ));
+            }
+            if observed.receipt_status != Some(ReceiptStatus::Failed) || observed.authority_allowed != Some(true) {
+                return Some(format!(
+                    "a failure keeps its allowing authority decision, got {:?}/{:?}",
+                    observed.receipt_status, observed.authority_allowed
+                ));
+            }
+            if observed.invocations != vec![250] {
+                return Some(format!(
+                    "a failure happens after the provider was reached, got {:?}",
+                    observed.invocations
+                ));
+            }
+            None
+        },
+    )
+}
+
+/// A withheld attribute classifies the receipt as redacted without changing what the operation returned.
+fn case_provider_redaction_classification() -> ComparisonOutcome {
+    provider_outcome(
+        observe_provider_path(
+            LedgerBehavior::SettleWithSecretAccount,
+            AuthorityMode::Governed,
+            &[PROVIDER_GRANT],
+        ),
+        |observed| {
+            if observed.receipt_status != Some(ReceiptStatus::Redacted) {
+                return Some(format!(
+                    "a receipt with a withheld value must stop claiming it recorded everything, got {:?}",
+                    observed.receipt_status
+                ));
+            }
+            if observed.redacted_keys != vec!["ledger.account".to_string()] {
+                return Some(format!(
+                    "a redacted attribute keeps its key, got {:?}",
+                    observed.redacted_keys
+                ));
+            }
+            if observed.value != Some(ReplacementValue::Int(255)) {
+                return Some(format!(
+                    "redaction changes what is recorded, not what the operation returned, got {:?}",
+                    observed.value
+                ));
+            }
+            if observed
+                .backend_executions
+                .iter()
+                .any(|(outcome, _)| *outcome != "redacted")
+            {
+                return Some(format!(
+                    "the backend receipt must record the classification, got {:?}",
+                    observed.backend_executions
+                ));
+            }
+            None
+        },
+    )
+}
+
+/// An invocation that failed still releases what it acquired, exactly once and after the failure.
+fn case_provider_lifecycle_cleanup() -> ComparisonOutcome {
+    provider_outcome(
+        observe_provider_path(LedgerBehavior::Decline, AuthorityMode::Governed, &[PROVIDER_GRANT]),
+        |observed| {
+            if observed.lifecycle != vec!["invoked", "failed", "released"] {
+                return Some(format!(
+                    "cleanup follows the outcome it cleans up after and never precedes the invocation: {:?}",
+                    observed.lifecycle
+                ));
+            }
+            if observed.releases != 1 {
+                return Some(format!(
+                    "an invocation that failed still releases what it acquired, exactly once; got {}",
+                    observed.releases
+                ));
+            }
+            None
+        },
+    )
+}
+
+// ============================================================================
 // Seed corpus
 // ============================================================================
 
@@ -1735,7 +2202,144 @@ fn seed_corpus() -> Vec<ParityCase> {
                 shadow_comparison: false,
             }),
         },
+        ParityCase {
+            id: "parity-987-1156-provider-allowed",
+            title: "An allowed provider operation executes and its backend receipt references the RFC 104 receipt",
+            category: BehaviorCategory::SupportedLanguageContract,
+            lane: EvidenceLane::DirectReplacementBodyIr,
+            evidence: "#1156; tests/parity_corpus_tests.rs::case_provider_allowed_invocation; src/backend/replacement/provider.rs",
+            disposition: Disposition::IntentionalMigration {
+                owning_issue: 1156,
+                migration_note: "New at cutover rather than preserved: the legacy backend cannot execute a \
+                                  provider-service operation at all, so this is a deliberate migration from \
+                                  \"refuse\" to \"execute under an RFC 104 authority decision\". The observable \
+                                  contract is the provider's own result plus an operation receipt the backend \
+                                  execution receipt references; generated Rust is not the contract. Comparison \
+                                  stays non-green until #1146 supplies a receipt-bound paired comparison, because \
+                                  there is no second route that can run this operation.",
+            },
+            source: PROVIDER_CASE_SRC,
+            evaluate: Some(case_provider_allowed_invocation),
+            replacement_execution: None,
+        },
+        ParityCase {
+            id: "parity-987-1156-provider-denied",
+            title: "A governed denial emits a denied receipt and never reaches the provider",
+            category: BehaviorCategory::SupportedLanguageContract,
+            lane: EvidenceLane::DirectReplacementBodyIr,
+            evidence: "#1156; tests/parity_corpus_tests.rs::case_provider_governed_denial; src/backend/replacement/provider.rs",
+            disposition: Disposition::IntentionalMigration {
+                owning_issue: 1156,
+                migration_note: "New at cutover: a governed run refuses an ungranted capability before the \
+                                  provider is reached, reports the refusal at the invocation's own source span, \
+                                  and still records the denial as a receipt. Migration guidance: the denial is a \
+                                  first-class recorded outcome, not an absence of one, so a consumer must read the \
+                                  receipt rather than infer refusal from a missing result. Comparison stays \
+                                  non-green until #1146.",
+            },
+            source: PROVIDER_CASE_SRC,
+            evaluate: Some(case_provider_governed_denial),
+            replacement_execution: None,
+        },
+        ParityCase {
+            id: "parity-987-1156-provider-failed",
+            title: "A provider failure keeps its allowing authority decision and reports its own diagnostic",
+            category: BehaviorCategory::SupportedLanguageContract,
+            lane: EvidenceLane::DirectReplacementBodyIr,
+            evidence: "#1156; tests/parity_corpus_tests.rs::case_provider_operation_failure; src/backend/replacement/provider.rs",
+            disposition: Disposition::IntentionalMigration {
+                owning_issue: 1156,
+                migration_note: "New at cutover: authority was granted and the operation itself failed, which is \
+                                  a different outcome from a denial and carries a different diagnostic code. \
+                                  Migration guidance: a consumer must not collapse the two, because only one of \
+                                  them is fixed by granting a capability. Comparison stays non-green until #1146.",
+            },
+            source: PROVIDER_CASE_SRC,
+            evaluate: Some(case_provider_operation_failure),
+            replacement_execution: None,
+        },
+        ParityCase {
+            id: "parity-987-1156-provider-redacted",
+            title: "A withheld provider attribute classifies its receipt as redacted without changing the result",
+            category: BehaviorCategory::SupportedLanguageContract,
+            lane: EvidenceLane::DirectReplacementBodyIr,
+            evidence: "#1156; tests/parity_corpus_tests.rs::case_provider_redaction_classification; src/backend/replacement/provider.rs",
+            disposition: Disposition::IntentionalMigration {
+                owning_issue: 1156,
+                migration_note: "New at cutover: the publishing host decides redaction and the receipt records \
+                                  the classification, so a withheld value keeps its key and sensitivity while its \
+                                  value never reaches a sink. Migration guidance: redaction has exactly one owner, \
+                                  and the backend must not re-derive it from the value later. Comparison stays \
+                                  non-green until #1146.",
+            },
+            source: PROVIDER_CASE_SRC,
+            evaluate: Some(case_provider_redaction_classification),
+            replacement_execution: None,
+        },
+        ParityCase {
+            id: "parity-987-1156-provider-cleanup",
+            title: "An invocation that failed still releases what it acquired, exactly once",
+            category: BehaviorCategory::SupportedLanguageContract,
+            lane: EvidenceLane::DirectReplacementBodyIr,
+            evidence: "#1156; tests/parity_corpus_tests.rs::case_provider_lifecycle_cleanup; src/backend/replacement/provider.rs",
+            disposition: Disposition::IntentionalMigration {
+                owning_issue: 1156,
+                migration_note: "New at cutover: cleanup is unconditional for an invocation that started, and \
+                                  never runs for one that was denied or refused before it started. Migration \
+                                  guidance: the lifecycle vocabulary is the contract a consumer reads, not the \
+                                  host's internal resource handling. Comparison stays non-green until #1146.",
+            },
+            source: PROVIDER_CASE_SRC,
+            evaluate: Some(case_provider_lifecycle_cleanup),
+            replacement_execution: None,
+        },
     ]
+}
+
+/// The #1156 provider paths each carry a stable disposition and none of them claims a comparison it cannot support.
+///
+/// Stated as its own test rather than left to the aggregate green-count assertion: the "every path has a stable
+/// #987 disposition" contract is about these five rows specifically, and an aggregate count would still pass if one
+/// of them quietly disappeared.
+#[test]
+fn every_provider_path_carries_a_stable_non_green_disposition() -> Result<(), Box<dyn std::error::Error>> {
+    let corpus = seed_corpus();
+    let expected = [
+        "parity-987-1156-provider-allowed",
+        "parity-987-1156-provider-denied",
+        "parity-987-1156-provider-failed",
+        "parity-987-1156-provider-redacted",
+        "parity-987-1156-provider-cleanup",
+    ];
+    for id in expected {
+        let case = corpus
+            .iter()
+            .find(|case| case.id == id)
+            .ok_or(format!("the #1156 corpus row `{id}` must remain in the corpus"))?;
+        match &case.disposition {
+            Disposition::IntentionalMigration { owning_issue, .. } if *owning_issue == 1156 => {}
+            disposition => {
+                return Err(
+                    format!("`{id}` must be an intentional migration owned by #1156, got {disposition:?}").into(),
+                );
+            }
+        }
+    }
+
+    let summary = parity_corpus::summarize(&seed_corpus());
+    for id in expected {
+        let report = summary
+            .cases
+            .iter()
+            .find(|case| case.id == id)
+            .ok_or(format!("the summary must report `{id}`"))?;
+        assert_eq!(
+            report.overall_state,
+            OverallState::NonGreenShadowUnavailable,
+            "`{id}` must stay non-green until #1146 supplies a receipt-bound paired comparison",
+        );
+    }
+    Ok(())
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

The replacement backend now executes a checked provider-service operation from Incan-owned facts. This is the first vertical proving Slice 1 has a path beyond source-local values, and it does it without a handwritten executor exception and without reading generated Rust.

Closes #1156.

## This PR contains the whole train

It is an **integration branch**: #1213's `ProviderOperationPlan` with #1212's operation receipt merged in, both on #1211's authority facts. Reviewing the pieces separately is still possible and probably easier — [#1233](https://github.com/encero-systems/incan/pull/1233) (authority), [#1235](https://github.com/encero-systems/incan/pull/1235) (receipt), [#1236](https://github.com/encero-systems/incan/pull/1236) (plan) — and this PR is what those add up to. It was built on them rather than beside them because the issue forbids inventing provider-local equivalents of any of the three.

## Type of change

- [x] New feature

## Area(s)

- [x] Compiler (frontend/backend/codegen)
- [x] Runtime / Core crates (stdlib/core/derive)

## The selected operation, recorded before implementation

A ledger provider's **`charge(account: str, amount: int) -> int`**, requiring capability `host.ledger.charge`. Recorded in `src/backend/replacement/provider.rs`'s module rustdoc.

It settles to a value derived purely from its recorded inputs, so the allowed path has one deterministic source-level observable — no clock, network, or ordering dependence — while still exercising every required path. A ledger is either selected and locally backed or not (activation). Moving money is exactly what RFC 104 governs, so a governed denial of `host.ledger.charge` is a real refusal rather than a contrived one. It naturally records two attributes at different sensitivities: public amount, secret account (redaction). It can decline after authority was granted (allowed-then-failed). And a charge opens a settlement handle that must be released whether it settled or failed (cleanup).

The fixture's `charge` declaration returns a **different** value than the host does, so a run that executed the local body instead of the provider shows up in the observable rather than passing silently.

## Boundaries

**No provider-name special cases.** Dispatch is structural on `Callee::ProviderOperation`; the host is asked about an operation by `CanonicalSymbolId` and nothing else, and the fixture hosts compare identity equality rather than `declaration_name`. `provider_key` and `declaration_name` appear only in receipt and diagnostic text, never as dispatch keys. I verified this independently of the implementation report: there are no string comparisons in `provider.rs` at all.

**Each contract is consumed, not reimplemented.** `plan.authority_request()` is called verbatim, with the plan's `requested_scope` and `suggested_grant` untouched. `self.authority.decide(..)` is the only authority evaluation in the file — modes, grant sets and ceilings are never inspected here, and the permissive-run and ceiling-denial tests prove the seam owns those rules. Denials go through `OperationReceipt::denied(..)`, every receipt is `validate()`d before being retained, and the backend receipt holds an `OperationReceiptRef`.

**Import is not authority.** The plan exists because lowering *admitted* the operation; `decide` is called only inside `execute`, at the invocation.

## Path coverage

| Path | Evidence |
| --- | --- |
| activation | refused by lowering before a plan exists, and fail-closed against a mutated inactive plan |
| allowed | value 255 (the provider's, not the local body's 250); receipt `Allowed`; backend receipt references the operation receipt's sequence id |
| denied | `INCAN-R1156-DENIED` at the call span, host never invoked, `Denied` receipt with no attributes and `Unavailable` replay; plus a ceiling denial reported without reinterpretation |
| failed | `INCAN-R1156-PROVIDER`, receipt `Failed` over an *allowing* decision |
| redacted | status `Redacted`, key and sensitivity survive, `acct-1` never appears in the clear, result unchanged |
| cleanup | lifecycle `invoked → completed\|failed → released`, zero open handles, exactly one release; a denial records only `denied` |
| unresolved | refused before execution with the source span, `operation_receipt()` is `None`, both receipt logs empty |

## Testing / verification

- [x] Manual verification described below

Manual verification notes, re-run independently of the implementation report:

- `cargo test --lib backend::replacement` — 16 passed, 0 failed
- `cargo test --test parity_corpus_tests` — 10 passed, 0 failed
- `cargo test --test replacement_backend_execution_tests` — 72 passed, 0 failed
- `cargo test --test shadow_comparison_tests` — 9 passed; `cargo test -p incan_semantics_core --lib` — 64 passed
- `cargo check --tests -p incan` clean, run because `ReplacementExecution` gained a field and `output_identity` gained a digest component
- `cargo clippy --lib --tests` clean; `cargo +nightly fmt` clean; rustdoc gate passed

**Mutation check on the invariant that matters most**: inserting a host invocation into the denial branch before its refusal returns failed two tests with the intended message — *"a denied operation must never reach the provider"*. A second mutation making `release` conditional on completion leaked a failed invocation's handle and failed the cleanup test.

No path claims comparison-green. Every row records an explicitly unavailable comparison pending #1146.

Slice-level gates (`make pre-commit`, full Oven suites, slice-wide CI) are deliberately deferred.

## Known limitations, stated rather than hidden

- **Corpus receipt reason text.** The five `parity-987-1156-provider-*` rows carry a shared legacy-side reason reading *"this row observes the legacy backend only"*, which is not true for them — they do execute the replacement backend inside their probe. Making it honest needs a `tests/support/parity_corpus.rs` change (`ReplacementExecutionPlan` has nowhere to name an authority source and a provider host). Documented in a comment above the rows; worth folding into #1146's comparison-route work.
- **Compatibility registry.** No `providers.*` feature was added to `replacement_compatibility_direct_execution_contribution`; that needs an incoming public-capability relation from the frozen v0.5 catalogue, outside this lane. The issue's "Done when" asks for #987 dispositions, which are delivered.
- **`canonical_identity_component`.** `body_ir::render_symbol_path` is private, so `provider.rs` renders the identity's parts itself for the selection digest. It is deliberately a digest component rather than a dotted path, so it cannot be mistaken for a second spelling of the identity; a public renderer would remove the duplication.

## Docs impact

- [x] No docs changes needed

## Checklist

- [x] I added/updated tests where it materially reduces regressions
