### PR TITLE
chore - drop refusal arms for constructs that now lower (#1101)

### DIFF
--- a/src/frontend/body_ir/refusals.rs
+++ b/src/frontend/body_ir/refusals.rs
@@ -32,18 +32,15 @@ pub(super) fn unsupported_top_level_declaration_label(declaration: &ast::Declara
 
 /// Short diagnostic label for a statement kind v0 does not lower.
 ///
-/// Statement-position `loop:` is named explicitly because it is the one entry here whose Body IR vocabulary
-/// already exists: [`BodyBuilder::lower_loop_expr`] emits [`bir::StatementKind::Loop`] for the expression
-/// spelling, and only [`BodyBuilder::lower_stmt_into`]'s dispatch is missing (#1101). Leaving it under the
-/// generic "statement" label made a five-line dispatch gap read like an unmodeled construct.
+/// Only reached from [`BodyBuilder::lower_stmt_into`]'s fallback arm, so every statement kind that arm dispatches
+/// by name is deliberately absent here -- statement-position `loop:` and `unsafe:` regions included, since #1162
+/// gave the first a lowering and the second a stated permanent refusal that carries its own reason.
 ///
 /// The raw vocabulary forms take the [`undesugared_label`] wording instead, because neither is a lowering gap:
 /// both are syntax the desugar pass owns and resolves before this module ever runs. An [`ast::Statement::Surface`]
 /// could be either, so it defers to [`surface_stmt_label`] to decide from its key.
 pub(super) fn unsupported_stmt_label(stmt: &ast::Statement) -> String {
     match stmt {
-        ast::Statement::Loop(_) => "statement-position `loop:`".to_string(),
-        ast::Statement::Unsafe(_) => "unsafe block".to_string(),
         ast::Statement::VocabExpressionItem(_) => undesugared_label("vocab expression item"),
         ast::Statement::Surface(surface) => surface_stmt_label(&surface.key),
         ast::Statement::VocabBlock(_) => undesugared_label("vocab block"),
@@ -119,7 +116,7 @@ pub(super) fn unsupported_provider_operation(
 /// Short diagnostic label for an expression kind v0 does not lower.
 ///
 /// Only reached from [`BodyBuilder::lower_expr_to_operand`]'s fallback arm, so every expression kind that arm
-/// dispatches by name -- closures and partial callables included, since #1124 gave both a real lowering -- is
+/// dispatches by name -- closures and partial callables since #1124, range values since #1165 -- is
 /// deliberately absent here. Async surface (`await`, `race for`) and vocab/scoped-DSL surface are named rather than
 /// left to the generic label, because a diagnostic reading only "expression" hides which one a program actually
 /// hit. The two are not the same kind of finding: async surface is remaining Body IR work under #1164, while a
@@ -127,7 +124,6 @@ pub(super) fn unsupported_provider_operation(
 pub(super) fn unsupported_expr_label(expr: &ast::Expr) -> String {
     match expr {
         ast::Expr::Yield(_) => "yield expression".to_string(),
-        ast::Expr::Range { .. } => "range expression outside a for-loop".to_string(),
         ast::Expr::Surface(surface) => surface_expr_label(&surface.payload),
         ast::Expr::VocabBlock(_) => undesugared_label("vocab block expression"),
         _ => "expression".to_string(),


### PR DESCRIPTION
## Summary

Three refusal-label arms became unreachable as their constructs gained lowerings, and each still carried a message describing a world that no longer exists.

Contributes to #1101.

## Type of change

- [x] Refactor / maintenance

## Area(s)

- [x] Compiler (frontend/backend/codegen)

## What changed

| Arm | Why it is dead |
| --- | --- |
| `Expr::Range` — *"range expression outside a for-loop"* | #1165 made a range a value that lowers anywhere |
| `Statement::Loop` | #1162 gave it a real lowering |
| `Statement::Unsafe` | #1162 gave it a stated permanent refusal carrying its own reason |

**A stale label is worse than none.** The generic fallback says only that something was not lowered; these three would have named a cause that is no longer true — a reader hitting "range expression outside a for-loop" would go looking for a for-loop restriction that does not exist.

Both function docs argued entirely from the gaps that have since closed — the statement doc explained at length why `loop:` was named "because only the dispatch is missing", which is precisely what #1162 fixed. They now state the actual rule: these labels name what the dispatch arm can still reach, and everything it handles by name is deliberately absent.

The catch-alls stay, as defensive defaults for a future variant.

## Testing / verification

- [x] Manual verification described below

Manual verification notes:

```
frontend::                    1270 passed, 0 failed
frontend::body_ir              221 passed, 0 failed
parity_corpus_tests              9 passed, 0 failed
replacement_backend_execution   75 passed, 0 failed
lang_registry_guardrails        21 passed, 0 failed
```

No generated-artifact drift across all four generators; clippy clean, fmt clean, rustdoc gate passed.

Full Oven gate not run: this removes unreachable match arms and rewrites two doc comments, with no reachable behavior change. Every test that exercises a refusal path still passes, which is the evidence that matters here.

## Docs impact

- [x] No docs changes needed

## Checklist

- [x] I added/updated tests where it materially reduces regressions

No new test: the arms are unreachable by construction, so a test could only assert something that cannot happen. The existing refusal tests passing unchanged is the real check.
