### PR TITLE
feature - lower pattern conditions and destructuring comprehension clauses in Body IR (#1161)

### DIFF
--- a/src/frontend/body_ir/comprehensions.rs
+++ b/src/frontend/body_ir/comprehensions.rs
@@ -115,26 +115,6 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
                 out,
             );
         };
-        let ast::Pattern::Binding(first_name) = &first_pattern.node else {
-            return self.unsupported_operand(
-                "generator for-clause pattern is not a simple binding".to_string(),
-                scope,
-                hir_span_value,
-                out,
-            );
-        };
-        if generator.clauses.iter().any(|clause| {
-            matches!(clause, ast::ComprehensionClause::For { pattern, .. }
-                if !matches!(pattern.node, ast::Pattern::Binding(_)))
-        }) {
-            return self.unsupported_operand(
-                "generator for-clause pattern is not a simple binding".to_string(),
-                scope,
-                hir_span_value,
-                out,
-            );
-        }
-
         // The first source is the legacy adapter chain's eager boundary. Lowering it before creating the rvalue
         // preserves source-visible construction timing; all remaining expression lowering below writes only into
         // `generator_stmts` and therefore happens at poll time.
@@ -185,14 +165,19 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
         }
 
         let first_loop_scope = self.new_scope(Some(generator_scope), hir_span_value);
-        let first_total_reads = count_reads_in_expr(first_name, &generator.expr.node)
-            + count_reads_in_comprehension_clauses(first_name, remaining_clauses);
-        let first_local = self.declare_new_local_with_reads(
-            first_name.clone(),
-            self.resolve_ty(first_pattern.span),
+        // The first clause binds through the same helpers a statement `for` uses, so a destructuring generator
+        // clause produces the same facts as the equivalent loop (#1161). The item type comes from the pattern's own
+        // span, which the typechecker records for comprehension clauses as it does for a statement `for`.
+        let first_item_ty = self.resolve_ty(first_pattern.span);
+        let first_local = self.declare_for_item_local(
+            first_pattern,
+            &first_item_ty,
             first_loop_scope,
             hir_span(first_pattern.span),
-            first_total_reads,
+            &|name| {
+                count_reads_in_expr(name, &generator.expr.node)
+                    + count_reads_in_comprehension_clauses(name, remaining_clauses)
+            },
         );
 
         let mut generator_stmts = Vec::new();
@@ -247,6 +232,19 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
             },
             span: hir_span_value,
         }];
+        // Project the pattern's fields straight after `IterNext` has written the item, the same ordering
+        // `lower_for` uses, so every nested binding reads through a projection of a value that already exists.
+        self.bind_for_pattern(
+            first_pattern,
+            &first_item_ty,
+            first_local,
+            first_loop_scope,
+            &|name| {
+                count_reads_in_expr(name, &generator.expr.node)
+                    + count_reads_in_comprehension_clauses(name, remaining_clauses)
+            },
+            &mut first_loop_stmts,
+        );
         let terminal = ComprehensionTerminal::GeneratorYield {
             element: &generator.expr,
         };
@@ -353,27 +351,34 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
                 });
             }
             ast::ComprehensionClause::For { pattern, iter } => {
-                let ast::Pattern::Binding(var_name) = &pattern.node else {
-                    self.push_unsupported_stmt(
-                        "comprehension for-clause pattern is not a simple binding".to_string(),
-                        span,
-                        out,
-                    );
-                    return;
-                };
-                let var_ty = self.resolve_ty(pattern.span);
+                // A destructuring clause binds exactly as the equivalent statement `for` does, through the same two
+                // helpers (#1125): one declares the item local, the other projects the pattern's fields out of it.
+                // Two spellings of the same iteration producing different bindings is the drift #1161 closes.
+                //
+                // The item type comes from the pattern's own span, which the typechecker now records for
+                // comprehension clauses exactly as it does for a statement `for`.
+                let item_ty = self.resolve_ty(pattern.span);
                 let loop_scope = self.new_scope(Some(scope), span);
-                let total_reads = terminal.count_reads(var_name) + count_reads_in_comprehension_clauses(var_name, tail);
-                let pattern_local =
-                    self.declare_new_local_with_reads(var_name.clone(), var_ty, loop_scope, span, total_reads);
+                let item_local = self.declare_for_item_local(pattern, &item_ty, loop_scope, span, &|name| {
+                    terminal.count_reads(name) + count_reads_in_comprehension_clauses(name, tail)
+                });
+                let bind_ty = item_ty.clone();
                 self.lower_general_iteration(
                     iter,
-                    pattern_local,
+                    item_local,
                     scope,
                     loop_scope,
                     span,
                     out,
                     move |builder, loop_scope, body_stmts| {
+                        builder.bind_for_pattern(
+                            pattern,
+                            &bind_ty,
+                            item_local,
+                            loop_scope,
+                            &|name| terminal.count_reads(name) + count_reads_in_comprehension_clauses(name, tail),
+                            body_stmts,
+                        );
                         builder.lower_comprehension_clauses(tail, terminal, loop_scope, span, body_stmts);
                         builder.insert_scope_drops(body_stmts, loop_scope);
                     },

--- a/src/frontend/body_ir/comprehensions.rs
+++ b/src/frontend/body_ir/comprehensions.rs
@@ -359,9 +359,11 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
                 // comprehension clauses exactly as it does for a statement `for`.
                 let item_ty = self.resolve_ty(pattern.span);
                 let loop_scope = self.new_scope(Some(scope), span);
-                let item_local = self.declare_for_item_local(pattern, &item_ty, loop_scope, span, &|name| {
-                    terminal.count_reads(name) + count_reads_in_comprehension_clauses(name, tail)
-                });
+                // One counter, used by both helpers: a clause name is read by the remaining clauses and by the
+                // terminal, and the two helpers must agree on that or a binding's last-use lands in the wrong place.
+                let reads =
+                    move |name: &str| terminal.count_reads(name) + count_reads_in_comprehension_clauses(name, tail);
+                let item_local = self.declare_for_item_local(pattern, &item_ty, loop_scope, span, &reads);
                 let bind_ty = item_ty.clone();
                 self.lower_general_iteration(
                     iter,
@@ -371,14 +373,7 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
                     span,
                     out,
                     move |builder, loop_scope, body_stmts| {
-                        builder.bind_for_pattern(
-                            pattern,
-                            &bind_ty,
-                            item_local,
-                            loop_scope,
-                            &|name| terminal.count_reads(name) + count_reads_in_comprehension_clauses(name, tail),
-                            body_stmts,
-                        );
+                        builder.bind_for_pattern(pattern, &bind_ty, item_local, loop_scope, &reads, body_stmts);
                         builder.lower_comprehension_clauses(tail, terminal, loop_scope, span, body_stmts);
                         builder.insert_scope_drops(body_stmts, loop_scope);
                     },

--- a/src/frontend/body_ir/control_flow.rs
+++ b/src/frontend/body_ir/control_flow.rs
@@ -491,7 +491,9 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
         };
         let Some(range) = range else {
             let loop_scope = self.new_scope(Some(scope), span);
-            let item_local = self.declare_for_item_local(&for_stmt.pattern, &item_ty, loop_scope, span, &for_stmt.body);
+            let item_local = self.declare_for_item_local(&for_stmt.pattern, &item_ty, loop_scope, span, &|name| {
+                count_reads_in_stmts(name, &for_stmt.body)
+            });
             self.lower_general_iteration(
                 &for_stmt.iter,
                 item_local,
@@ -505,7 +507,7 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
                         &item_ty,
                         item_local,
                         loop_scope,
-                        &for_stmt.body,
+                        &|name| count_reads_in_stmts(name, &for_stmt.body),
                         body_stmts,
                     );
                     builder.lower_block_into(&for_stmt.body, loop_scope, body_stmts);
@@ -750,7 +752,9 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
         // per-iteration item local at all -- unlike the general path, where `IterNext` must still write the polled
         // item somewhere for the poll itself to happen.
         if !matches!(for_stmt.pattern.node, ast::Pattern::Wildcard) {
-            let item_local = self.declare_for_item_local(&for_stmt.pattern, item_ty, loop_scope, span, &for_stmt.body);
+            let item_local = self.declare_for_item_local(&for_stmt.pattern, item_ty, loop_scope, span, &|name| {
+                count_reads_in_stmts(name, &for_stmt.body)
+            });
             body_stmts.push(bir::Statement {
                 kind: bir::StatementKind::Assign {
                     place: bir::Place::from_local(item_local),
@@ -763,7 +767,7 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
                 item_ty,
                 item_local,
                 loop_scope,
-                &for_stmt.body,
+                &|name| count_reads_in_stmts(name, &for_stmt.body),
                 &mut body_stmts,
             );
         }
@@ -817,11 +821,11 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
         item_ty: &IncanType,
         loop_scope: bir::ScopeId,
         span: HirSourceSpan,
-        body: &[ast::Spanned<ast::Statement>],
+        reads: &dyn Fn(&str) -> usize,
     ) -> bir::LocalId {
         match &pattern.node {
             ast::Pattern::Binding(name) => {
-                let total_reads = count_reads_in_stmts(name, body);
+                let total_reads = reads(name);
                 self.declare_new_local_with_reads(name.clone(), item_ty.clone(), loop_scope, span, total_reads)
             }
             _ => self.new_temp(item_ty.clone(), loop_scope, span),
@@ -841,14 +845,14 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
         item_ty: &IncanType,
         item_local: bir::LocalId,
         loop_scope: bir::ScopeId,
-        body: &[ast::Spanned<ast::Statement>],
+        reads: &dyn Fn(&str) -> usize,
         out: &mut Vec<bir::Statement>,
     ) {
         if matches!(pattern.node, ast::Pattern::Binding(_)) {
             return;
         }
         let item_place = bir::Place::from_local(item_local);
-        self.bind_for_pattern_fields(pattern, item_ty, &item_place, loop_scope, body, out);
+        self.bind_for_pattern_fields(pattern, item_ty, &item_place, loop_scope, reads, out);
     }
 
     /// Recursively bind one `for`-pattern node against `place`, the (already projected) part of the produced item
@@ -879,7 +883,7 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
         expected_ty: &IncanType,
         place: &bir::Place,
         loop_scope: bir::ScopeId,
-        body: &[ast::Spanned<ast::Statement>],
+        reads: &dyn Fn(&str) -> usize,
         out: &mut Vec<bir::Statement>,
     ) {
         let span = hir_span(pattern.span);
@@ -888,7 +892,7 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
             ast::Pattern::Binding(name) => {
                 let (fact, last_use) = self.ownership_fact_for_place(place, expected_ty);
                 let element = bir::Operand::place(place.clone(), fact, last_use);
-                let total_reads = count_reads_in_stmts(name, body);
+                let total_reads = reads(name);
                 let local =
                     self.declare_new_local_with_reads(name.clone(), expected_ty.clone(), loop_scope, span, total_reads);
                 out.push(bir::Statement {
@@ -904,7 +908,7 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
                 for (index, (item, element_ty)) in items.iter().zip(&element_types).enumerate() {
                     let mut field_place = place.clone();
                     field_place.projection.push(bir::PlaceElem::Field(index.to_string()));
-                    self.bind_for_pattern_fields(item, element_ty, &field_place, loop_scope, body, out);
+                    self.bind_for_pattern_fields(item, element_ty, &field_place, loop_scope, reads, out);
                 }
             }
             ast::Pattern::Literal(_) | ast::Pattern::Constructor(..) | ast::Pattern::Group(_) | ast::Pattern::Or(_) => {

--- a/src/frontend/body_ir/control_flow.rs
+++ b/src/frontend/body_ir/control_flow.rs
@@ -307,8 +307,15 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
             let scrutinee_place = builder.lower_expr_to_place(value, loop_scope, body_stmts);
             let scrutinee = bir::Operand::place(scrutinee_place.clone(), bir::OwnershipFact::Borrow, false);
 
+            // Exactly one arm runs per iteration, so a fact the matched arm established must not survive into code
+            // that could instead have reached the exhausted arm. `push_loop` intersects at the loop boundary, which
+            // covers today's shape because the match is the body's only statement -- but relying on that would make
+            // this correct by accident, and wrong the moment a statement is appended after it.
+            let layouts_before_arms = builder.materialized_range_locals.clone();
             let matched_arm =
                 builder.lower_statement_pattern_arm(pattern, &scrutinee_ty, &scrutinee_place, loop_scope, body, span);
+            builder.materialized_range_locals =
+                intersect_range_layouts(vec![layouts_before_arms, builder.materialized_range_locals.clone()]);
             let exhausted_arm = bir::MatchArm {
                 pattern: bir::Pattern::Wildcard,
                 guard_stmts: Vec::new(),

--- a/src/frontend/body_ir/control_flow.rs
+++ b/src/frontend/body_ir/control_flow.rs
@@ -68,9 +68,12 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
         span: HirSourceSpan,
         out: &mut Vec<bir::Statement>,
     ) {
-        let ast::Condition::Expr(cond_expr) = &if_stmt.condition else {
-            self.push_unsupported_stmt("if-let pattern condition".to_string(), span, out);
-            return;
+        let cond_expr = match &if_stmt.condition {
+            ast::Condition::Expr(cond_expr) => cond_expr,
+            ast::Condition::Let { pattern, value } => {
+                self.lower_if_let(pattern, value, &if_stmt.then_body, scope, span, out);
+                return;
+            }
         };
         let cond = self.lower_expr_to_operand(cond_expr, scope, out);
 
@@ -221,6 +224,114 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
         });
     }
 
+    /// Lower `if let P = subject:` as a two-arm [`bir::Rvalue::Match`].
+    ///
+    /// Desugaring to a match rather than an `If` plus a synthesized pattern test is deliberate, and follows
+    /// [`bir::Rvalue::Match`]'s own rule: match stays one structured node so a target backend's native `match`
+    /// performs the destructuring and dispatch, instead of this stage re-deriving them as a chain of tests.
+    ///
+    /// The parser accepts no `else` or `elif` on an `if let` (see its `test_parse_if_let_rejects_else_branch`), so
+    /// the fallback arm is always empty. That also settles the binding scope for free: the pattern's names exist in
+    /// the matched arm only, and there is no sibling branch that could observe them.
+    ///
+    /// A failed match is ordinary control flow, so no [`bir::PanicFact`] is recorded -- unlike `assert value is P`,
+    /// which panics on the same shape.
+    fn lower_if_let(
+        &mut self,
+        pattern: &ast::Spanned<ast::Pattern>,
+        value: &ast::Spanned<ast::Expr>,
+        then_body: &[ast::Spanned<ast::Statement>],
+        scope: bir::ScopeId,
+        span: HirSourceSpan,
+        out: &mut Vec<bir::Statement>,
+    ) {
+        if !match_pattern_is_supported(&pattern.node) {
+            self.push_unsupported_stmt("`if let` with a byte-string literal pattern".to_string(), span, out);
+            return;
+        }
+        let scrutinee_ty = self.resolve_ty(value.span);
+        let scrutinee_place = self.lower_expr_to_place(value, scope, out);
+        let scrutinee = bir::Operand::place(scrutinee_place.clone(), bir::OwnershipFact::Borrow, false);
+
+        let layouts_before = self.materialized_range_locals.clone();
+        let matched_arm =
+            self.lower_statement_pattern_arm(pattern, &scrutinee_ty, &scrutinee_place, scope, then_body, span);
+        let layouts_after_match = self.materialized_range_locals.clone();
+
+        // The unmatched path runs none of the body, so it leaves the entry facts untouched.
+        self.materialized_range_locals = intersect_range_layouts(vec![layouts_before, layouts_after_match]);
+
+        let unmatched_arm = bir::MatchArm {
+            pattern: bir::Pattern::Wildcard,
+            guard_stmts: Vec::new(),
+            guard: None,
+            body_stmts: Vec::new(),
+            result: bir::Operand::Constant(bir::Constant::Unit),
+        };
+        self.push_assign_temp(
+            bir::Rvalue::Match {
+                scrutinee,
+                arms: vec![matched_arm, unmatched_arm],
+            },
+            IncanType::Primitive(IncanPrimitiveType::Unit),
+            scope,
+            span,
+            out,
+        );
+    }
+
+    /// Lower `while let P = subject:` as a [`bir::StatementKind::Loop`] whose body matches, then breaks.
+    ///
+    /// The subject is lowered *inside* the loop body so it is re-evaluated each iteration, which is what makes the
+    /// loop terminate: `while let Some(item) = iterator.next():` depends on the call running again every time.
+    /// Hoisting it would turn a draining loop into an infinite one.
+    ///
+    /// The unmatched arm breaks rather than recording a panic fact, because exhausting the pattern is how this loop
+    /// is meant to end.
+    fn lower_while_let(
+        &mut self,
+        pattern: &ast::Spanned<ast::Pattern>,
+        value: &ast::Spanned<ast::Expr>,
+        body: &[ast::Spanned<ast::Statement>],
+        scope: bir::ScopeId,
+        span: HirSourceSpan,
+        out: &mut Vec<bir::Statement>,
+    ) {
+        if !match_pattern_is_supported(&pattern.node) {
+            self.push_unsupported_stmt("`while let` with a byte-string literal pattern".to_string(), span, out);
+            return;
+        }
+        let loop_scope = self.new_scope(Some(scope), span);
+        self.push_loop(loop_scope, None, span, out, |builder, loop_scope, body_stmts| {
+            let scrutinee_ty = builder.resolve_ty(value.span);
+            let scrutinee_place = builder.lower_expr_to_place(value, loop_scope, body_stmts);
+            let scrutinee = bir::Operand::place(scrutinee_place.clone(), bir::OwnershipFact::Borrow, false);
+
+            let matched_arm =
+                builder.lower_statement_pattern_arm(pattern, &scrutinee_ty, &scrutinee_place, loop_scope, body, span);
+            let exhausted_arm = bir::MatchArm {
+                pattern: bir::Pattern::Wildcard,
+                guard_stmts: Vec::new(),
+                guard: None,
+                body_stmts: vec![bir::Statement {
+                    kind: bir::StatementKind::Break { value: None },
+                    span,
+                }],
+                result: bir::Operand::Constant(bir::Constant::Unit),
+            };
+            builder.push_assign_temp(
+                bir::Rvalue::Match {
+                    scrutinee,
+                    arms: vec![matched_arm, exhausted_arm],
+                },
+                IncanType::Primitive(IncanPrimitiveType::Unit),
+                loop_scope,
+                span,
+                body_stmts,
+            );
+        });
+    }
+
     /// Lower a value-producing `loop:` expression (`ast::Expr::Loop`) into a [`bir::StatementKind::Loop`] plus a
     /// dedicated result local that every `break value` inside the loop's *own* body (not a nested loop's --
     /// enforced by [`Self::loop_break_targets`]) assigns into before exiting. The typechecker resolves this
@@ -291,9 +402,12 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
         span: HirSourceSpan,
         out: &mut Vec<bir::Statement>,
     ) {
-        let ast::Condition::Expr(cond_expr) = &while_stmt.condition else {
-            self.push_unsupported_stmt("while-let pattern condition".to_string(), span, out);
-            return;
+        let cond_expr = match &while_stmt.condition {
+            ast::Condition::Expr(cond_expr) => cond_expr,
+            ast::Condition::Let { pattern, value } => {
+                self.lower_while_let(pattern, value, &while_stmt.body, scope, span, out);
+                return;
+            }
         };
 
         let loop_scope = self.new_scope(Some(scope), span);

--- a/src/frontend/body_ir/match_.rs
+++ b/src/frontend/body_ir/match_.rs
@@ -186,6 +186,62 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
     /// `src/backend/ir/lower/expr/patterns.rs`), which this bucket deliberately does not mirror -- see
     /// [`bir::Pattern`]'s own docs.
     #[allow(clippy::too_many_arguments)]
+    /// Lower one pattern arm whose body is a statement block, restoring the enclosing bindings afterwards.
+    ///
+    /// Shared by the `if let` and `while let` desugarings (#1161), which both need the same three steps: test a
+    /// pattern, run a block with its bindings in scope, then put the enclosing bindings back so they cannot leak
+    /// past the construct. A `match` arm deliberately does not use this -- its body may be a single expression and
+    /// it may carry a guard, both of which change what the arm produces.
+    ///
+    /// Restoring is what makes `if let`'s scoping honest: the pattern's names belong to the `then` branch only, and
+    /// an `else` branch lowered afterwards must not see them.
+    pub(super) fn lower_statement_pattern_arm(
+        &mut self,
+        pattern: &ast::Spanned<ast::Pattern>,
+        scrutinee_ty: &IncanType,
+        scrutinee_place: &bir::Place,
+        scope: bir::ScopeId,
+        body: &[ast::Spanned<ast::Statement>],
+        span: HirSourceSpan,
+    ) -> bir::MatchArm {
+        let arm_scope = self.new_scope(Some(scope), span);
+        let mut seen: HashMap<String, bir::LocalId> = HashMap::new();
+        let mut saved_bindings: Vec<(String, Option<bir::LocalId>)> = Vec::new();
+        let lowered_pattern = self.lower_match_pattern(
+            pattern,
+            scrutinee_ty,
+            scrutinee_place,
+            arm_scope,
+            &PatternReadScope::FollowingStatements(body),
+            &mut seen,
+            &mut saved_bindings,
+        );
+
+        let mut body_stmts = Vec::new();
+        self.lower_block_into(body, arm_scope, &mut body_stmts);
+        self.insert_scope_drops(&mut body_stmts, arm_scope);
+
+        for (name, previous) in saved_bindings {
+            match previous {
+                Some(local) => {
+                    self.bindings.insert(name, local);
+                }
+                None => {
+                    self.bindings.remove(&name);
+                }
+            }
+        }
+
+        bir::MatchArm {
+            pattern: lowered_pattern,
+            guard_stmts: Vec::new(),
+            guard: None,
+            body_stmts,
+            // A statement-block arm produces no value, exactly as a `match` arm with a block body does.
+            result: bir::Operand::Constant(bir::Constant::Unit),
+        }
+    }
+
     pub(super) fn lower_match_pattern(
         &mut self,
         pattern: &ast::Spanned<ast::Pattern>,

--- a/src/frontend/body_ir/tests.rs
+++ b/src/frontend/body_ir/tests.rs
@@ -7024,3 +7024,91 @@ fn projection_through_an_active_feature_lowers_exactly_as_an_ungated_program_doe
     );
     Ok(())
 }
+
+// ---- Pattern conditions (#1161) ----
+
+/// `if let` lowers to the single-arm match RFC 049 describes, with an implicit non-matching fallthrough.
+#[test]
+fn if_let_lowers_to_a_single_arm_match_with_an_empty_fallback() -> Result<(), Box<dyn std::error::Error>> {
+    let source = concat!(
+        "def run(o: Option[int]) -> int:\n",
+        "  mut total = 0\n",
+        "  if let Some(v) = o:\n",
+        "    total = v\n",
+        "  return total\n",
+    );
+    let module = build(source, &["m", "if_let"])?;
+    let snapshot = module.render_snapshot();
+
+    assert!(
+        !snapshot.contains("unsupported("),
+        "`if let` must lower without a placeholder: {snapshot}"
+    );
+    assert!(
+        snapshot.contains("Some(bind("),
+        "the pattern must bind its payload: {snapshot}"
+    );
+    // RFC 049's own reading: a single-arm `match` plus an implicit `_ => pass`.
+    assert!(
+        snapshot.contains("_ => const(())"),
+        "the non-matching path must be an explicit wildcard arm: {snapshot}"
+    );
+    Ok(())
+}
+
+/// A failed pattern condition is control flow, not a panic.
+#[test]
+fn if_let_records_no_panic_fact_for_a_non_matching_pattern() -> Result<(), Box<dyn std::error::Error>> {
+    let source = concat!(
+        "def run(o: Option[int]) -> int:\n",
+        "  mut total = 0\n",
+        "  if let Some(v) = o:\n",
+        "    total = v\n",
+        "  return total\n",
+    );
+    let module = build(source, &["m", "if_let_panic"])?;
+    let body = body_named(&module, "run")?;
+
+    // `assert value is P` panics on the same shape; a pattern *condition* must not.
+    assert!(
+        body.panic_facts.is_empty(),
+        "a non-matching `if let` is ordinary control flow, not a panic: {:?}",
+        body.panic_facts
+    );
+    Ok(())
+}
+
+/// `while let` re-evaluates its subject each iteration and exits by breaking when the pattern stops matching.
+#[test]
+fn while_let_re_evaluates_its_subject_and_breaks_when_exhausted() -> Result<(), Box<dyn std::error::Error>> {
+    // The subject is a call precisely so re-evaluation is observable: a hoisted subject would call `pop` once and
+    // loop forever on the same value.
+    let source = concat!(
+        "def pop() -> Option[int]:\n",
+        "  return None\n",
+        "\n",
+        "def run() -> int:\n",
+        "  mut total = 0\n",
+        "  while let Some(item) = pop():\n",
+        "    total = total + item\n",
+        "  return total\n",
+    );
+    let module = build(source, &["m", "while_let"])?;
+    let snapshot = module.render_snapshot();
+
+    assert!(
+        !snapshot.contains("unsupported("),
+        "`while let` must lower without a placeholder: {snapshot}"
+    );
+    let loop_at = snapshot.find("loop").ok_or("expected a loop statement")?;
+    let call_at = snapshot.find("call fn:pop").ok_or("expected the subject call")?;
+    assert!(
+        call_at > loop_at,
+        "the subject must be re-evaluated inside the loop, not hoisted above it: {snapshot}"
+    );
+    assert!(
+        snapshot.contains("break"),
+        "an exhausted pattern must break rather than panic: {snapshot}"
+    );
+    Ok(())
+}

--- a/src/frontend/body_ir/tests.rs
+++ b/src/frontend/body_ir/tests.rs
@@ -7175,3 +7175,41 @@ fn a_destructuring_comprehension_binds_like_the_equivalent_statement_for() -> Re
     }
     Ok(())
 }
+
+/// `if let` accepts pattern alternation (RFC 071), and lowering must not narrow that.
+#[test]
+fn if_let_lowers_an_alternated_pattern() -> Result<(), Box<dyn std::error::Error>> {
+    let source = concat!(
+        "enum Shape:\n",
+        "  Circle(int)\n",
+        "  Square(int)\n",
+        "  Blank\n",
+        "\n",
+        "def run(s: Shape) -> int:\n",
+        "  mut n = 0\n",
+        "  if let Shape.Circle(v) | Shape.Square(v) = s:\n",
+        "    n = v\n",
+        "  return n\n",
+    );
+    let module = build(source, &["m", "if_let_alt"])?;
+    let snapshot = module.render_snapshot();
+
+    assert!(
+        !snapshot.contains("unsupported("),
+        "an alternated `if let` pattern must lower: {snapshot}"
+    );
+    // Both alternatives bind the same name, so it must be one declared local rather than two.
+    let bindings: Vec<&str> = snapshot.lines().filter(|line| line.contains(" v : ")).collect();
+    assert_eq!(bindings.len(), 1, "`v` must be a single declared local: {bindings:?}");
+    assert!(
+        bindings[0].contains("[binding]"),
+        "`v` must be a source binding, not a temp or external: {}",
+        bindings[0]
+    );
+    // Its type is `?` here, and that is deliberately *not* asserted as a defect of this change: an equivalent
+    // statement `match` over the same alternated constructor pattern produces exactly the same `?`. This lowering
+    // reuses `lower_match_pattern` rather than reimplementing it, so it inherits that gap rather than widening it.
+    // Narrowing the generic constructor path's field types belongs with the same #1101 work that leaves
+    // `assert o is Some(v)` typed `?`.
+    Ok(())
+}

--- a/src/frontend/body_ir/tests.rs
+++ b/src/frontend/body_ir/tests.rs
@@ -586,17 +586,24 @@ fn lowers_division_and_assert_as_explicit_panic_facts() -> Result<(), Box<dyn st
 #[test]
 fn unsupported_constructs_lower_to_an_explicit_placeholder_instead_of_panicking()
 -> Result<(), Box<dyn std::error::Error>> {
-    // #1123 supports lazy generator expressions with simple binding clauses. A destructuring clause still needs
-    // a generator-specific binding/poll representation, so it must refuse the complete expression rather than
-    // partly lowering it as an eager list or silently dropping the pattern.
+    // This case was the refusal's own pin until #1161: a destructuring generator clause used to refuse the whole
+    // expression rather than bind its pattern. It now lowers, so the test asserts the positive behaviour instead of
+    // freezing a hole -- the clause's names become real bindings projected out of the polled item, exactly as the
+    // equivalent statement `for` produces them.
     let source = "def pick(x: int) -> int:\n  gen = (left + right for left, right in [(1, 2)])\n  return x\n";
     let module = build(source, &["m", "unsupported"])?;
     let snapshot = module.render_snapshot();
 
     assert!(
-        snapshot.contains("unsupported(generator for-clause pattern is not a simple binding)"),
-        "should record an explicit placeholder rather than panicking: {snapshot}"
+        !snapshot.contains("unsupported("),
+        "a destructuring generator clause must lower rather than refuse: {snapshot}"
     );
+    for binding in ["left", "right"] {
+        assert!(
+            snapshot.contains(&format!(" {binding} : int [binding]")),
+            "the clause must bind `{binding}` with the tuple element's resolved type: {snapshot}"
+        );
+    }
     Ok(())
 }
 
@@ -2861,10 +2868,17 @@ fn a_closure_does_not_capture_names_a_nested_destructuring_pattern_binds() -> Re
     let module = build(source, &["m", "closure_pattern_capture"])?;
     let snapshot = module.render_snapshot();
 
-    assert!(
-        !snapshot.contains(" a : ") && !snapshot.contains(" b : "),
-        "clause-bound names must not become captured locals of the enclosing closure: {snapshot}"
-    );
+    // Asserting the names are absent entirely only held while a destructuring clause was *refused*; #1161 lowers
+    // one, so `a` and `b` now exist as the clause's own bindings. The property this test is actually for is
+    // narrower and unchanged: neither may be captured from an enclosing scope where it does not exist.
+    for binding in [" a : ", " b : "] {
+        for line in snapshot.lines().filter(|line| line.contains(binding)) {
+            assert!(
+                !line.contains("[captured]"),
+                "a clause-bound name must not be captured from the enclosing closure: {line}"
+            );
+        }
+    }
     assert!(
         snapshot.contains("[captured]"),
         "the closure should still capture the one name it really reads from the enclosing scope: {snapshot}"
@@ -7110,5 +7124,54 @@ fn while_let_re_evaluates_its_subject_and_breaks_when_exhausted() -> Result<(), 
         snapshot.contains("break"),
         "an exhausted pattern must break rather than panic: {snapshot}"
     );
+    Ok(())
+}
+
+/// A destructuring comprehension binds the same facts the equivalent statement `for` does.
+///
+/// This is the parity the issue turns on: two spellings of one iteration must not differ in representability, and
+/// the earlier gap was not the binding but its *type* -- the comprehension bound `a` as `?` where the statement
+/// form bound it as `int`.
+#[test]
+fn a_destructuring_comprehension_binds_like_the_equivalent_statement_for() -> Result<(), Box<dyn std::error::Error>> {
+    let comprehension = build(
+        concat!(
+            "def run(pairs: List[Tuple[int, int]]) -> List[int]:\n",
+            "  return [a + b for a, b in pairs]\n",
+        ),
+        &["m", "comp"],
+    )?;
+    let statement_form = build(
+        concat!(
+            "def run(pairs: List[Tuple[int, int]]) -> int:\n",
+            "  mut total = 0\n",
+            "  for a, b in pairs:\n",
+            "    total = total + a + b\n",
+            "  return total\n",
+        ),
+        &["m", "stmt"],
+    )?;
+
+    let comp_snapshot = comprehension.render_snapshot();
+    assert!(
+        !comp_snapshot.contains("unsupported("),
+        "a destructuring comprehension must lower without a placeholder: {comp_snapshot}"
+    );
+
+    for (name, module) in [("comprehension", &comprehension), ("statement for", &statement_form)] {
+        let body = body_named(module, "run")?;
+        for binding in ["a", "b"] {
+            let local = sole_local_named(body, binding)?;
+            let declared = body
+                .locals
+                .get(local.index())
+                .ok_or_else(|| format!("{name}: `{binding}` is missing from the body's locals"))?;
+            assert_eq!(
+                declared.ty,
+                IncanType::Primitive(IncanPrimitiveType::Int),
+                "{name}: `{binding}` must carry the tuple element's resolved type, not `?`",
+            );
+        }
+    }
     Ok(())
 }

--- a/src/frontend/typechecker/check_expr/comps.rs
+++ b/src/frontend/typechecker/check_expr/comps.rs
@@ -63,6 +63,12 @@ impl TypeChecker {
                 ComprehensionClause::For { pattern, iter } => {
                     let iter_ty = self.check_expr(iter);
                     let elem_ty = self.infer_iterator_element_type_from_expr(iter, &iter_ty);
+                    // Record the element type at the pattern's own span, exactly as `check_for_stmt` does for a
+                    // statement `for` (#1125). Body IR reads a clause pattern's type back through
+                    // `TypeCheckInfo::expr_type`, so without this a destructuring clause binds names typed
+                    // `Unknown` even though the element type is fully resolved right here -- and the same
+                    // source destructured by a statement `for` would bind them concretely (#1161).
+                    self.record_expr_type(pattern.span, elem_ty.clone());
                     self.define_for_pattern_bindings(pattern, &elem_ty);
                 }
                 ComprehensionClause::If(condition) => {
@@ -88,6 +94,8 @@ impl TypeChecker {
         let elem_ty = self.infer_iterator_element_type_from_expr(&comp.iter, &iter_ty);
 
         self.symbols.enter_scope(ScopeKind::Block);
+        // See `check_generator_expr` for why the element type is recorded at the pattern's span.
+        self.record_expr_type(comp.pattern.span, elem_ty.clone());
         self.define_for_pattern_bindings(&comp.pattern, &elem_ty);
 
         if let Some(filter) = &comp.filter {
@@ -110,6 +118,8 @@ impl TypeChecker {
         let elem_ty = self.infer_iterator_element_type_from_expr(&comp.iter, &iter_ty);
 
         self.symbols.enter_scope(ScopeKind::Block);
+        // See `check_generator_expr` for why the element type is recorded at the pattern's span.
+        self.record_expr_type(comp.pattern.span, elem_ty.clone());
         self.define_for_pattern_bindings(&comp.pattern, &elem_ty);
 
         if let Some(filter) = &comp.filter {


### PR DESCRIPTION
## Summary

Body IR lowered patterns in two positions — `match` arms and plain `for` headers. Every other position refused. This closes the remaining three.

Closes #1161.

## Type of change

- [x] New feature

## Area(s)

- [x] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)

## Key details

**No data-model change**, as the issue predicted. `StatementKind::If`, `StatementKind::Loop`, `Rvalue::Match`, `PatternBinding` and the scope machinery already carried everything needed.

**`if let` becomes a two-arm `Rvalue::Match`** — the pattern arm plus an explicit `_ => const(())`. Desugaring to a match rather than an `If` plus a synthesized pattern test follows `Rvalue::Match`'s own documented rule: match stays one structured node so a target backend's native `match` performs the destructuring, instead of this stage re-deriving it as a chain of tests. It is also the shape RFC 049 already describes — *"a single-arm `match` plus implicit `_ => pass`"* — which I arrived at from the Body IR docs before finding the RFC said it.

**`while let` becomes a loop that matches, then breaks.** The subject is lowered *inside* the body so it re-evaluates each iteration, which is what makes the loop terminate; hoisting it would turn a draining loop into an infinite one. A test pins that ordering rather than trusting it.

**Neither records a panic fact.** A pattern that does not match is control flow. That is the one semantic difference from `assert value is P`, which panics on the same shape, so it has its own test.

**Destructuring comprehension and generator clauses** bind through the same two helpers a statement `for` uses. Those took a statement slice purely to count reads, which a comprehension has none of, so they now take a read counter; the statement callers pass their own body and nothing about their behaviour changes.

## The typechecker half is what actually closed the gap

Comprehension clauses computed the element type and discarded it, so a destructuring clause bound names typed `Unknown` while the same source destructured by a statement `for` bound them concretely. All three forms now record it at the pattern's own span, as `check_for_stmt` has since #1125.

That asymmetry is why an earlier attempt at this issue was parked: the bindings were there, the types were not. There is no set comprehension, so three forms is the whole set.

## Scope note

The issue asks for a test proving bindings are absent from an `if let`'s `else` branch. **The parser accepts no `else` or `elif` on an `if let`** — it is single-arm by RFC 049's explicit decision, with a `test_parse_if_let_rejects_else_branch` pinning it. So that criterion describes a shape the language does not have, and the binding scope settles for free: there is no sibling branch that could observe the names. Filed #1243 to revisit the restriction for 0.7, since RFC 049 scoped it "in v1".

## Two existing tests changed, both for one reason

Their assertions were only correct while the construct was refused:

- the generator refusal test pinned the hole itself, and is now the positive case;
- the closure-capture test asserted the clause's names were absent *entirely*, which held only because nothing bound them. Its own comment states the real property — they must not be **captured** — so it now asserts that.

This is the fourth time in this slice that an assertion turned out to be valid only because a feature was missing. Worth a shared helper if it keeps recurring.

## Testing / verification

- [x] Manual verification described below

```
frontend::                    1274 passed, 0 failed
frontend::body_ir              225 passed, 0 failed
parity_corpus_tests             10 passed, 0 failed
replacement_backend_execution   75 passed, 0 failed
shadow_comparison_tests          9 passed, 0 failed
lang_registry_guardrails        21 passed, 0 failed
```

No generated-artifact drift across all four generators; clippy clean, fmt clean, rustdoc gate passed.

The full Oven gate is deliberately left for after this lands, so it runs once over the completed slice rather than over an intermediate state.

## Docs impact

- [x] No docs changes needed

## Checklist

- [x] I added/updated tests where it materially reduces regressions
