### PR TITLE
bugfix - validate retained plain-model constructor layout (1255)

### DIFF
--- a/crates/incan_semantics_core/src/body_ir.rs
+++ b/crates/incan_semantics_core/src/body_ir.rs
@@ -159,8 +159,9 @@ impl BodyIrModule {
 /// The exact local declaration and canonical field layout for one direct-executable plain model.
 ///
 /// The record is module-scoped and deliberately excludes classes, enums, imported nominals, generic models, and
-/// behavior-bearing models. Its field order is the checked constructor-slot order; a direct runtime must pair it
-/// with [`ConstructorTarget::binding`] rather than treating constructor argument spelling as layout evidence.
+/// behavior-bearing models. Its field order is the checked constructor-slot order; a direct runtime must compare it
+/// with [`ConstructorTarget::canonical_field_layout`] before applying [`ConstructorTarget::binding`], rather than
+/// treating constructor argument spelling as layout evidence.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NominalDeclaration {
     /// Exact source-local declaration identity, derived from the declaration source span.
@@ -2330,6 +2331,12 @@ pub struct ConstructorTarget {
     /// An absent identity is not permission to look up [`Self::name`] in another compiler structure: imports,
     /// aliases, classes, generic models, and any unretained nominal target must refuse at the constructor span.
     pub direct_declaration_id: Option<CompilerNodeId>,
+    /// Canonical declared field names retained with the exact source-local declaration selected for this call.
+    ///
+    /// This is present only beside [`Self::direct_declaration_id`] and comes from the same checked Body-IR
+    /// declaration snapshot. Consumers compare it with the module declaration before binding operands, so a
+    /// malformed declaration cannot shift values merely by changing field order or names after lowering.
+    pub canonical_field_layout: Option<Vec<String>>,
     /// Resolved binding of the surrounding aggregate's operands to the type's declared fields.
     pub binding: ArgumentBinding,
 }

--- a/src/backend/replacement/mod.rs
+++ b/src/backend/replacement/mod.rs
@@ -2286,6 +2286,12 @@ fn validate_nominal_constructor_target(
             span,
         ));
     }
+    if target.canonical_field_layout.is_none() {
+        return Err(unsupported(
+            format!("constructor `{}` without a checked canonical field layout", target.name),
+            span,
+        ));
+    }
     let ArgumentBinding::Resolved {
         arguments,
         defaulted_slots,
@@ -4641,6 +4647,18 @@ impl BodyExecutor {
                     "constructor `{}` disagrees with its source-local declaration identity",
                     target.name
                 ),
+                span,
+            ));
+        }
+        let canonical_field_layout = target.canonical_field_layout.as_deref().ok_or_else(|| {
+            unsupported(
+                format!("constructor `{}` without a checked canonical field layout", target.name),
+                span,
+            )
+        })?;
+        if declaration.fields != canonical_field_layout {
+            return Err(unsupported(
+                "canonical field layout disagrees with checked constructor facts",
                 span,
             ));
         }

--- a/src/frontend/body_ir.rs
+++ b/src/frontend/body_ir.rs
@@ -331,9 +331,10 @@ type LocalFunctionDeclarations = HashMap<String, Vec<ast::Span>>;
 /// Plain source-local models whose checked declaration layout is retained for direct nominal execution.
 ///
 /// This frontend map intentionally contains only non-generic, behavior-free models. It is used only while lowering
-/// a checked constructor call to attach an exact declaration identity; the resulting [`bir::NominalDeclaration`]
-/// records are the direct executor's sole layout authority. Classes, trait-adopting models, and models carrying
-/// methods/properties/aliases are absent rather than being approximated as inert field bags.
+/// a checked constructor call to attach the exact declaration identity and selected field layout. The direct executor
+/// compares that target snapshot with the resulting [`bir::NominalDeclaration`] before binding slots. Classes,
+/// trait-adopting models, and models carrying methods/properties/aliases are absent rather than being approximated
+/// as inert field bags.
 type LocalNominalDeclarations = HashMap<String, bir::NominalDeclaration>;
 
 /// Source-local fieldless normal enums whose canonical unit variants are retained for direct comparison.

--- a/src/frontend/body_ir/calls.rs
+++ b/src/frontend/body_ir/calls.rs
@@ -346,17 +346,26 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
         };
         let ty = self.resolve_ty(span);
         // A constructor field binding proves argument slots, but not that this constructor names one of the plain
-        // source-local models this Body-IR module retained. Preserve an identity only from that local registry;
-        // imports, aliases, classes, generic models, and absent/malformed names remain represented with `None` so
-        // a direct executor can refuse at this construction span rather than guessing from `name`.
-        let direct_declaration_id = self.local_nominal_declarations.get(name).and_then(|declaration| {
-            (declaration.fields.len() == field_binding.field_count).then(|| declaration.direct_declaration_id.clone())
-        });
+        // source-local models this Body-IR module retained. Preserve the selected declaration's identity and layout
+        // together; imports, aliases, classes, generic models, and absent/malformed names retain neither fact, so a
+        // direct executor can refuse at this construction span rather than guessing from `name`.
+        let (direct_declaration_id, canonical_field_layout) = self
+            .local_nominal_declarations
+            .get(name)
+            .filter(|declaration| declaration.fields.len() == field_binding.field_count)
+            .map(|declaration| {
+                (
+                    Some(declaration.direct_declaration_id.clone()),
+                    Some(declaration.fields.clone()),
+                )
+            })
+            .unwrap_or((None, None));
         self.push_assign_temp(
             bir::Rvalue::Aggregate(
                 bir::AggregateKind::Constructor(bir::ConstructorTarget {
                     name: name.to_string(),
                     direct_declaration_id,
+                    canonical_field_layout,
                     binding,
                 }),
                 fixed_elements(operands),

--- a/src/frontend/body_ir/tests.rs
+++ b/src/frontend/body_ir/tests.rs
@@ -3311,6 +3311,11 @@ fn source_local_model_construction_retains_its_declaration_identity_and_canonica
         target.direct_declaration_id.as_ref(),
         Some(&declaration.direct_declaration_id)
     );
+    assert_eq!(
+        target.canonical_field_layout.as_deref(),
+        Some(declaration.fields.as_slice()),
+        "the constructor must retain the checked layout independently from the mutable module declaration"
+    );
     let bir::ArgumentBinding::Resolved {
         arguments,
         defaulted_slots,

--- a/tests/replacement_backend_execution_tests.rs
+++ b/tests/replacement_backend_execution_tests.rs
@@ -12,7 +12,9 @@ use incan::backend::selection::{
 use incan::frontend::body_ir::build_body_ir_module_v0;
 use incan::frontend::typechecker::TypeChecker;
 use incan::frontend::{lexer, parser};
-use incan_semantics_core::body_ir::{BodyIrModule, OwnershipFact, Rvalue, StatementKind, TryErrorRouting};
+use incan_semantics_core::body_ir::{
+    BodyIrModule, ConstructorTarget, OwnershipFact, Rvalue, StatementKind, TryErrorRouting,
+};
 use incan_semantics_core::{CompilerNodeId, IncanType};
 
 /// Lower one self-contained, typechecked source module into the Body IR the replacement backend consumes.
@@ -26,6 +28,72 @@ fn lower_typed_body_ir(source: &str) -> Result<BodyIrModule, Box<dyn std::error:
         .check_program(&program)
         .map_err(|errors| std::io::Error::other(format!("{errors:?}")))?;
     Ok(build_body_ir_module_v0(&program, &module_path, checker.type_info()))
+}
+
+/// Legal source used to isolate malformed retained constructor facts after checked lowering.
+const PAIR_CONSTRUCTION_SOURCE: &str = r#"
+model Pair:
+  left: int
+  right: int
+
+def main() -> int:
+  pair = Pair(left=40, right=2)
+  return pair.left
+"#;
+
+/// Locate the one Pair construction whose post-lowering facts each malformed-IR test changes deliberately.
+fn pair_constructor_target_mut(
+    module: &mut BodyIrModule,
+) -> Result<&mut ConstructorTarget, Box<dyn std::error::Error>> {
+    let main = module
+        .bodies
+        .iter_mut()
+        .find(|body| body.name == "main")
+        .ok_or("fixture must lower the main Body-IR body")?;
+    main.block
+        .stmts
+        .iter_mut()
+        .find_map(|statement| match &mut statement.kind {
+            StatementKind::Assign {
+                rvalue: Rvalue::Aggregate(incan_semantics_core::body_ir::AggregateKind::Constructor(target), _),
+                ..
+            } => Some(target),
+            _ => None,
+        })
+        .ok_or("fixture must lower its model construction as a constructor aggregate".into())
+}
+
+/// Require malformed retained Pair facts to refuse before direct execution can yield a result or receipt input.
+///
+/// The public command cannot accept malformed internal Body IR, so this direct-executor seam is the honest proof:
+/// an `Err` has no `ReplacementExecution` result that a command could bind into a successful receipt.
+fn assert_malformed_pair_constructor_refusal(
+    module: &BodyIrModule,
+    expected_description: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let error = match execute_free_function(module, "main", &[]) {
+        Ok(execution) => {
+            return Err(format!(
+                "malformed retained Pair facts must refuse instead of executing, got {:?}",
+                execution.value
+            )
+            .into());
+        }
+        Err(error) => error,
+    };
+    let constructor_start = PAIR_CONSTRUCTION_SOURCE
+        .find("Pair(left=40, right=2)")
+        .ok_or("fixture must contain the model constructor")?;
+    let span = error
+        .primary_span()
+        .ok_or("malformed retained Pair facts must retain a source span")?;
+    assert_eq!(span.start, constructor_start);
+    assert_eq!(span.end, constructor_start + "Pair(left=40, right=2)".len());
+    assert!(
+        error.to_string().contains(expected_description),
+        "the refusal must name the malformed retained fact: {error}"
+    );
+    Ok(())
 }
 
 /// Locate the compiler binary built for this integration-test invocation.
@@ -703,6 +771,94 @@ def main() -> int:
         "the refusal must name the foreign declaration identity: {error}"
     );
     Ok(())
+}
+
+/// Refuse a constructor when its retained declaration layout no longer matches checked constructor slots.
+///
+/// This injects malformed Body IR after lowering; valid source cannot reorder the retained declaration. The direct
+/// executor must fail at the original construction rather than return a value with fields shifted by the mutation.
+#[test]
+fn replacement_refuses_a_reordered_nominal_declaration_layout_at_the_original_constructor_span()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mut module = lower_typed_body_ir(PAIR_CONSTRUCTION_SOURCE)?;
+    let declaration = module
+        .nominal_declarations
+        .iter_mut()
+        .find(|declaration| declaration.name == "Pair")
+        .ok_or("fixture must retain the source-local Pair declaration")?;
+    let [left, right] = declaration.fields.as_mut_slice() else {
+        return Err("fixture must retain Pair's two canonical fields".into());
+    };
+    std::mem::swap(left, right);
+
+    assert_malformed_pair_constructor_refusal(
+        &module,
+        "canonical field layout disagrees with checked constructor facts",
+    )
+}
+
+/// Refuse a constructor missing the checked layout that pairs its numeric slots with retained field names.
+#[test]
+fn replacement_refuses_a_nominal_constructor_missing_checked_field_layout_at_the_original_span()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mut module = lower_typed_body_ir(PAIR_CONSTRUCTION_SOURCE)?;
+    pair_constructor_target_mut(&mut module)?.canonical_field_layout = None;
+
+    assert_malformed_pair_constructor_refusal(&module, "constructor `Pair` without a checked canonical field layout")
+}
+
+/// Refuse a constructor whose independently retained layout omits one checked field slot.
+#[test]
+fn replacement_refuses_a_nominal_constructor_with_a_short_checked_field_layout_at_the_original_span()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mut module = lower_typed_body_ir(PAIR_CONSTRUCTION_SOURCE)?;
+    let layout = pair_constructor_target_mut(&mut module)?
+        .canonical_field_layout
+        .as_mut()
+        .ok_or("fixture must retain Pair's checked canonical field layout")?;
+    let removed = layout
+        .pop()
+        .ok_or("fixture must retain the right field in Pair's checked layout")?;
+    assert_eq!(removed, "right");
+
+    assert_malformed_pair_constructor_refusal(
+        &module,
+        "canonical field layout disagrees with checked constructor facts",
+    )
+}
+
+/// Refuse a constructor whose independently retained layout changes one canonical field name.
+#[test]
+fn replacement_refuses_a_nominal_constructor_with_a_renamed_checked_field_at_the_original_span()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mut module = lower_typed_body_ir(PAIR_CONSTRUCTION_SOURCE)?;
+    let layout = pair_constructor_target_mut(&mut module)?
+        .canonical_field_layout
+        .as_mut()
+        .ok_or("fixture must retain Pair's checked canonical field layout")?;
+    let first = layout
+        .first_mut()
+        .ok_or("fixture must retain the left field in Pair's checked layout")?;
+    *first = "renamed".to_string();
+
+    assert_malformed_pair_constructor_refusal(
+        &module,
+        "canonical field layout disagrees with checked constructor facts",
+    )
+}
+
+/// Refuse a constructor whose retained declaration identity points outside the current Body-IR module.
+#[test]
+fn replacement_refuses_a_foreign_nominal_constructor_identity_at_the_original_span()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mut module = lower_typed_body_ir(PAIR_CONSTRUCTION_SOURCE)?;
+    pair_constructor_target_mut(&mut module)?.direct_declaration_id =
+        Some(CompilerNodeId::declaration_span("foreign", 0, 12));
+
+    assert_malformed_pair_constructor_refusal(
+        &module,
+        "constructor `Pair` targets a declaration outside this Body-IR module",
+    )
 }
 
 /// Refuse a constructor whose source-local declaration identity is absent instead of recovering it from its name.


### PR DESCRIPTION
## Summary

Refuse malformed retained plain-model constructor layouts before they can shift field values during direct replacement execution. Source-local plain-model construction already shipped in dev.1; this PR closes #1255's remaining defensive-validation gap and does not claim a new model profile.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [x] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: Valid plain-model construction, including reordered named arguments, is unchanged. Malformed internal constructor identity/layout facts refuse at the original construction span rather than yielding shifted values.
- **Internals**: `ConstructorTarget` retains the canonical field-name layout beside the selected source-local declaration identity. Replacement compares that snapshot to the module declaration before evaluating operands. There is no source reparse, generated-Rust recovery, or second nominal admission registry.
- **Risks**: The internal Body-IR target shape gains one optional fact. Unretained or malformed facts are refused. Current Body IR has no independent per-field type fact, so this patch does not claim type-tampering validation.

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- Red regression: reversing only retained `Pair` declaration fields after checked lowering wrongly returned `Int(2)` instead of refusing.
- Green: focused lowering unit; `cargo test --test replacement_backend_execution_tests` (94); `cargo test --test parity_corpus_tests` (10, including existing `replacement-body-v0-013`); `cargo test --test replacement_example_coverage` (1, baseline unchanged).
- Malformed cases: reordered declaration, absent/short/renamed checked layout, and foreign declaration identity. Each preserves the original constructor span and returns an error, so no successful execution product exists to bind into a receipt. The CLI has no malformed-IR input path; this is a direct-executor proof, not a fabricated CLI scenario.
- `make fmt`, `make fmt-check`, `cargo clippy --workspace --all-targets -- -D warnings`, changed-rustdoc and diff checks passed.
- Controller publication-worktree recheck: all 13 targeted refusal tests, formatting, rustdocs, and diff checks passed.
- Full pre-commit, full Oven and whole-Slice gates were deliberately deferred per the Slice 2 packet workflow. This is not a full release or cutover acceptance claim.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

Updated internal Body-IR and lowering rustdocs describe the retained layout and validation boundary. No public language behavior or supported-profile expansion needs new user documentation, release version, or design record.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Base: `0.6.0-dev.2`. #1250 remains open for #1256. No RFC lifecycle transition or broader Slice 2 completion is claimed.

Closes #1255
