### PR TITLE
bugfix - protect print and println source bindings (1249)

### DIFF
--- a/crates/incan_core/src/lang/builtins.rs
+++ b/crates/incan_core/src/lang/builtins.rs
@@ -197,6 +197,11 @@ pub const BUILTIN_FUNCTIONS: &[BuiltinFnInfo] = &[
     ),
 ];
 
+/// Builtin identities whose canonical spelling and registered aliases cannot be replaced by source bindings.
+///
+/// This is intentionally narrower than [`BUILTIN_FUNCTIONS`]: adding a builtin does not reserve its spelling.
+const PROTECTED_BINDING_BUILTINS: &[BuiltinFnId] = &[BuiltinFnId::Print];
+
 /// Return the canonical spelling for a builtin function.
 ///
 /// ## Parameters
@@ -282,6 +287,23 @@ pub fn from_str(name: &str) -> Option<BuiltinFnId> {
         .map(|b| b.id)
 }
 
+/// Return the protected builtin identity for a source binding spelling.
+///
+/// Protected bindings stay globally available: source declarations, imports, and lexical bindings cannot replace
+/// their canonical spelling or any registered alias. The policy is intentionally narrower than the builtin registry;
+/// adding a builtin does not protect its spelling unless its stable identifier is added here.
+///
+/// ## Parameters
+/// - `name`: Candidate source binding spelling.
+///
+/// ## Returns
+/// - `Some(BuiltinFnId)` when `name` names a protected builtin or one of its registry aliases.
+/// - `None` for ordinary source bindings and unprotected builtins.
+pub fn protected_binding_builtin(name: &str) -> Option<BuiltinFnId> {
+    let builtin = from_str(name)?;
+    PROTECTED_BINDING_BUILTINS.contains(&builtin).then_some(builtin)
+}
+
 const fn info(
     id: BuiltinFnId,
     canonical: &'static str,
@@ -299,5 +321,18 @@ const fn info(
         since,
         stability: Stability::Stable,
         examples: &[],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BuiltinFnId, protected_binding_builtin};
+
+    /// Protect the selected builtin's canonical spelling and aliases without changing unrelated builtins.
+    #[test]
+    fn protected_binding_policy_includes_print_and_its_registered_aliases() {
+        assert_eq!(protected_binding_builtin("print"), Some(BuiltinFnId::Print));
+        assert_eq!(protected_binding_builtin("println"), Some(BuiltinFnId::Print));
+        assert_eq!(protected_binding_builtin("len"), None);
     }
 }

--- a/crates/incan_syntax/src/diagnostics/catalog/errors/types.rs
+++ b/crates/incan_syntax/src/diagnostics/catalog/errors/types.rs
@@ -4,6 +4,7 @@
 //! field/alias validation, mutability, and pattern matching.
 
 use crate::ast::Span;
+use incan_core::lang::builtins::{self, BuiltinFnId};
 use incan_core::lang::derives::{self, DeriveId};
 
 use crate::diagnostics::CompileError;
@@ -17,6 +18,22 @@ pub fn unknown_symbol(name: &str, span: Span) -> CompileError {
 
 pub fn duplicate_definition(name: &str, span: Span) -> CompileError {
     CompileError::type_error(format!("Duplicate definition of '{}'", name), span)
+}
+
+/// Report a source binding that attempts to replace a protected builtin spelling.
+pub fn protected_builtin_binding(name: &str, builtin: BuiltinFnId, span: Span) -> CompileError {
+    let canonical = builtins::as_str(builtin);
+    CompileError::type_error(
+        format!(
+            "Cannot bind '{}': it is a protected builtin binding for '{}'",
+            name, canonical
+        ),
+        span,
+    )
+    .with_hint(format!(
+        "Choose a different name; '{}' and its registered aliases remain globally available",
+        canonical
+    ))
 }
 
 /// Report a value enum declaration that attempts to use type parameters.

--- a/src/frontend/typechecker/check_decl.rs
+++ b/src/frontend/typechecker/check_decl.rs
@@ -2187,15 +2187,36 @@ impl TypeChecker {
             Declaration::Import(_) => {} // Already handled
             Declaration::Const(konst) => self.check_const(konst, decl.span),
             Declaration::Static(static_decl) => self.check_static(static_decl, decl.span),
-            Declaration::Model(model) => self.check_model(model),
-            Declaration::Class(class) => self.check_class(class),
-            Declaration::Trait(tr) => self.check_trait(tr),
+            Declaration::Model(model) => {
+                self.validate_protected_type_param_bindings(&model.type_params, decl.span);
+                self.check_model(model);
+            }
+            Declaration::Class(class) => {
+                self.validate_protected_type_param_bindings(&class.type_params, decl.span);
+                self.check_class(class);
+            }
+            Declaration::Trait(tr) => {
+                self.validate_protected_type_param_bindings(&tr.type_params, decl.span);
+                self.check_trait(tr);
+            }
             Declaration::Alias(_) => {} // Alias targets are validated during collection.
             Declaration::Partial(partial) => self.check_partial_decl(partial),
-            Declaration::TypeAlias(alias) => self.check_type_alias(alias),
-            Declaration::Newtype(nt) => self.check_newtype(nt),
-            Declaration::Enum(en) => self.check_enum(en),
-            Declaration::Function(func) => self.check_function(func, decl.span),
+            Declaration::TypeAlias(alias) => {
+                self.validate_protected_type_param_bindings(&alias.type_params, decl.span);
+                self.check_type_alias(alias);
+            }
+            Declaration::Newtype(nt) => {
+                self.validate_protected_type_param_bindings(&nt.type_params, decl.span);
+                self.check_newtype(nt);
+            }
+            Declaration::Enum(en) => {
+                self.validate_protected_type_param_bindings(&en.type_params, decl.span);
+                self.check_enum(en);
+            }
+            Declaration::Function(func) => {
+                self.validate_protected_type_param_bindings(&func.type_params, decl.span);
+                self.check_function(func, decl.span);
+            }
             Declaration::TestModule(test_module) => self.check_test_module(test_module),
             Declaration::VocabBlock(_) => self.errors.push(CompileError::syntax(
                 "raw vocabulary declarations must be desugared before type checking".to_string(),
@@ -2203,6 +2224,17 @@ impl TypeChecker {
             )),
             Declaration::Capability(cap) => self.check_capability_decl(cap, decl.span),
             Declaration::Docstring(_) => {} // Docstrings don't need checking
+        }
+    }
+
+    /// Reject protected builtin spellings in a declaration-owned generic parameter list.
+    ///
+    /// Generic parameters are inserted into the ordinary lexical symbol table, so they can displace a bare callable
+    /// root even though their source role is type-only. [`TypeParam`] retains no individual source span; callers pass
+    /// the nearest enclosing declaration or method span rather than fabricating a byte range.
+    fn validate_protected_type_param_bindings(&mut self, type_params: &[TypeParam], owner_span: Span) {
+        for type_param in type_params {
+            self.validate_protected_builtin_binding(&type_param.name, owner_span);
         }
     }
 
@@ -5515,6 +5547,7 @@ impl TypeChecker {
         // binding. The function body still receives its ordinary parameter locals below.
         for (param, resolved_ty) in func.params.iter().zip(resolved_param_types) {
             let ty = local_type_for_param(param.node.kind, resolved_ty);
+            self.validate_protected_builtin_binding(&param.node.name, param.span);
             self.symbols.define(Symbol {
                 name: param.node.name.clone(),
                 kind: SymbolKind::Variable(VariableInfo {
@@ -5807,6 +5840,7 @@ impl TypeChecker {
         owner_type_params: &[String],
         owner_params: &[TypeParam],
     ) {
+        self.validate_protected_type_param_bindings(&method.type_params, method_span);
         self.symbols.enter_scope(ScopeKind::Method {
             receiver: method.receiver,
         });
@@ -5880,6 +5914,7 @@ impl TypeChecker {
                 param.node.default.is_some(),
             ));
             let ty = local_type_for_param(param.node.kind, resolved_ty);
+            self.validate_protected_builtin_binding(&param.node.name, param.span);
             self.symbols.define(Symbol {
                 name: param.node.name.clone(),
                 kind: SymbolKind::Variable(VariableInfo {

--- a/src/frontend/typechecker/check_expr/access.rs
+++ b/src/frontend/typechecker/check_expr/access.rs
@@ -367,6 +367,7 @@ impl TypeChecker {
             .zip(signature.params.iter())
             .map(|(param, expected)| {
                 let ty = expected.resolved_ty.clone();
+                self.validate_protected_builtin_binding(&param.node.name, param.span);
                 self.symbols.define(Symbol {
                     name: param.node.name.clone(),
                     kind: SymbolKind::Variable(VariableInfo {

--- a/src/frontend/typechecker/check_expr/comps.rs
+++ b/src/frontend/typechecker/check_expr/comps.rs
@@ -150,6 +150,7 @@ impl TypeChecker {
             .iter()
             .map(|p| {
                 let ty = self.resolve_type_checked(&p.node.ty);
+                self.validate_protected_builtin_binding(&p.node.name, p.span);
                 self.symbols.define(Symbol {
                     name: p.node.name.clone(),
                     kind: SymbolKind::Variable(VariableInfo {
@@ -202,6 +203,7 @@ impl TypeChecker {
             .zip(expected_params.iter())
             .map(|(param, expected)| {
                 let ty = expected.ty.clone();
+                self.validate_protected_builtin_binding(&param.node.name, param.span);
                 self.symbols.define(Symbol {
                     name: param.node.name.clone(),
                     kind: SymbolKind::Variable(VariableInfo {

--- a/src/frontend/typechecker/check_expr/control_flow.rs
+++ b/src/frontend/typechecker/check_expr/control_flow.rs
@@ -221,6 +221,7 @@ impl TypeChecker {
         race: &RaceForExpr,
         span: Span,
     ) -> ResolvedType {
+        self.validate_protected_builtin_binding(&race.binding, span);
         if !self.in_async_body {
             self.errors.push(errors::await_outside_async(span));
             return ResolvedType::Unknown;

--- a/src/frontend/typechecker/check_expr/match_.rs
+++ b/src/frontend/typechecker/check_expr/match_.rs
@@ -213,6 +213,7 @@ impl TypeChecker {
         match &pattern.node {
             Pattern::Wildcard => {}
             Pattern::Binding(name) => {
+                self.validate_protected_builtin_binding(name, pattern.span);
                 self.symbols.define(Symbol {
                     name: name.clone(),
                     kind: SymbolKind::Variable(VariableInfo {

--- a/src/frontend/typechecker/check_stmt.rs
+++ b/src/frontend/typechecker/check_stmt.rs
@@ -747,6 +747,7 @@ impl TypeChecker {
             value_ty
         };
 
+        self.validate_protected_builtin_binding(&assign.name, span);
         self.symbols.define(Symbol {
             name: assign.name.clone(),
             kind: SymbolKind::Variable(VariableInfo {
@@ -839,6 +840,7 @@ impl TypeChecker {
         }
 
         let is_mutable = matches!(binding, BindingKind::Mutable);
+        self.validate_protected_builtin_binding(name, statement_span);
         self.symbols.define(Symbol {
             name: name.to_string(),
             kind: SymbolKind::Variable(VariableInfo {
@@ -1473,6 +1475,7 @@ impl TypeChecker {
     ) {
         match &pattern.node {
             Pattern::Binding(name) => {
+                self.validate_protected_builtin_binding(name, pattern.span);
                 self.symbols.define(Symbol {
                     name: name.clone(),
                     kind: SymbolKind::Variable(VariableInfo {
@@ -1647,6 +1650,7 @@ impl TypeChecker {
                 AssertIsPatternKind::Err => scrutinee_ty.result_err_type().cloned().unwrap_or(ResolvedType::Unknown),
                 AssertIsPatternKind::None => ResolvedType::Unit,
             };
+            self.validate_protected_builtin_binding(&name, span);
             self.symbols.define(Symbol {
                 name,
                 kind: SymbolKind::Variable(VariableInfo {

--- a/src/frontend/typechecker/collect/stdlib_imports.rs
+++ b/src/frontend/typechecker/collect/stdlib_imports.rs
@@ -202,8 +202,9 @@ impl StdlibFromImportContext {
 }
 
 impl TypeChecker {
-    /// Reject names that shadow reserved root namespaces.
+    /// Reject source names that shadow reserved root namespaces or protected builtin bindings.
     pub(super) fn validate_root_namespace(&mut self, name: &str, span: Span) {
+        self.validate_protected_builtin_binding(name, span);
         if name == stdlib::STDLIB_ROOT || name == "rust" {
             self.errors.push(errors::reserved_root_namespace(name, span));
         }
@@ -264,6 +265,8 @@ impl TypeChecker {
         let same_root = path.segments.first().map(|segment| segment.as_str()) == Some(&name);
         if !same_root {
             self.validate_root_namespace(&name, span);
+        } else {
+            self.validate_protected_builtin_binding(&name, span);
         }
         let normalized_path = canonicalize_source_module_segments(&path.segments);
         self.define_import_symbol(name, normalized_path, false, span);
@@ -1372,6 +1375,9 @@ impl TypeChecker {
 
         for item in items {
             let local_name = item.alias.clone().unwrap_or_else(|| item.name.clone());
+            if self.validate_protected_builtin_binding(&local_name, span) {
+                continue;
+            }
             self.validate_root_namespace(&local_name, span);
             if let Some(existing_kind) = self.existing_local_symbol_kind(&local_name) {
                 self.errors.push(errors::pub_library_import_name_collision(

--- a/src/frontend/typechecker/mod.rs
+++ b/src/frontend/typechecker/mod.rs
@@ -100,7 +100,6 @@ use incan_core::interop::{
     metadata_free_method_signature, render_rust_type_shape_path, rust_display_is_owned_string,
     split_top_level_rust_args, strip_rust_borrow_lifetimes,
 };
-use incan_core::lang::conventions;
 use incan_core::lang::decorators::{self as core_decorators, DecoratorId};
 use incan_core::lang::errors as runtime_errors;
 use incan_core::lang::stdlib;
@@ -112,6 +111,7 @@ use incan_core::lang::traits::{self as builtin_traits, TraitId};
 use incan_core::lang::types::collections::CollectionTypeId;
 use incan_core::lang::types::numerics::{self, NumericFamily, NumericTypeId};
 use incan_core::lang::types::stringlike::StringLikeId;
+use incan_core::lang::{builtins, conventions};
 use incan_semantics_core::{CanonicalSymbolId, HirSourceSpan, SemanticSourceTargetKind};
 
 /// Type checker state.
@@ -643,6 +643,25 @@ impl TypeChecker {
             #[cfg(feature = "rust_inspect")]
             rust_inspect_registry_source_authority: RustInspectRegistrySourceAuthority::default(),
         }
+    }
+
+    /// Reject a source binding that would replace a protected builtin spelling.
+    ///
+    /// The registry resolves canonical and alias spellings to one stable builtin identity, while the protected policy
+    /// deliberately selects only the identities that must remain globally available.
+    ///
+    /// Returns whether this call emitted the protected-binding diagnostic, allowing callers with further name-collision
+    /// recovery to avoid obscuring the primary error.
+    pub(in crate::frontend::typechecker) fn validate_protected_builtin_binding(
+        &mut self,
+        name: &str,
+        span: Span,
+    ) -> bool {
+        let Some(builtin) = builtins::protected_binding_builtin(name) else {
+            return false;
+        };
+        self.errors.push(errors::protected_builtin_binding(name, builtin, span));
+        true
     }
 
     /// Push a new loop context before checking a loop body.

--- a/src/frontend/typechecker/tests.rs
+++ b/src/frontend/typechecker/tests.rs
@@ -18416,6 +18416,31 @@ def build() -> LibWidget:
     assert!(result.is_ok(), "expected alias recovery to typecheck, got: {result:?}");
 }
 
+/// #1249: a public import cannot introduce either spelling of the protected print builtin.
+#[test]
+fn test_pub_import_alias_cannot_replace_protected_print_builtin_issue1249() -> Result<(), String> {
+    for alias in ["print", "println"] {
+        let source = format!("from pub::mylib import make_widget as {alias}\n");
+        let errors = check_str_with_library_index_err(
+            &source,
+            library_index_with_mylib_exports(),
+            "public import aliases must not replace protected print bindings",
+        )?;
+        assert_eq!(
+            errors.len(),
+            1,
+            "protected public import alias `{alias}` should report only its primary diagnostic, got {errors:?}"
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|error| error.message.contains("protected builtin binding")),
+            "expected protected-binding diagnostic for `{alias}`, got {errors:?}"
+        );
+    }
+    Ok(())
+}
+
 /// Regression for #892: callable signatures retain provider identity across separate import statements.
 #[test]
 fn test_pub_from_split_import_alias_preserves_provider_identity_issue892() {

--- a/tests/protected_builtin_binding_tests.rs
+++ b/tests/protected_builtin_binding_tests.rs
@@ -1,0 +1,140 @@
+//! Frontend regressions for the protected `print` builtin binding and its `println` alias.
+
+use incan::frontend::diagnostics::CompileError;
+use incan::frontend::{lexer, parser, typechecker};
+
+/// Type-check `source`, retaining compiler diagnostics rather than process-level rendering.
+fn check_source(source: &str) -> Result<Vec<CompileError>, String> {
+    let tokens = lexer::lex(source).map_err(|errors| format!("lex failed: {errors:?}"))?;
+    let program = parser::parse(&tokens).map_err(|errors| format!("parse failed: {errors:?}"))?;
+    let mut checker = typechecker::TypeChecker::new();
+    match checker.check_program(&program) {
+        Ok(()) => Ok(Vec::new()),
+        Err(errors) => Ok(errors),
+    }
+}
+
+/// Assert that a source binding is rejected at an original source span for one protected spelling.
+fn assert_protected_binding(source: &str, spelling: &str) -> Result<(), String> {
+    let errors = check_source(source)?;
+    let error = errors
+        .iter()
+        .find(|error| error.message.contains("protected builtin binding"))
+        .ok_or_else(|| format!("expected protected-binding diagnostic for `{spelling}`, got {errors:?}"))?;
+    let covers_source_spelling = source
+        .match_indices(spelling)
+        .any(|(start, _)| error.span.start <= start && error.span.end >= start + spelling.len());
+    if !covers_source_spelling {
+        return Err(format!(
+            "expected diagnostic for `{spelling}` to cover its original source spelling, got {:?}",
+            error.span
+        ));
+    }
+    Ok(())
+}
+
+/// Every covered source binding form rejects both registry-owned output spellings.
+#[test]
+fn source_bindings_cannot_replace_print_or_println_issue1249() -> Result<(), String> {
+    for (spelling, source) in [
+        ("print", "def print(value: str) -> None:\n    pass\n"),
+        ("println", "def println(value: str) -> None:\n    pass\n"),
+        ("print", "def main(print: str) -> None:\n    pass\n"),
+        ("println", "def main(println: str) -> None:\n    pass\n"),
+        (
+            "print",
+            "def display[print](value: print) -> None:\n    print(\"hello\")\n",
+        ),
+        (
+            "println",
+            "def display[println](value: println) -> None:\n    println(\"hello\")\n",
+        ),
+        ("print", "def main() -> None:\n    print = \"local\"\n"),
+        ("println", "def main() -> None:\n    println = \"local\"\n"),
+        ("print", "def main() -> None:\n    for print in [1]:\n        pass\n"),
+        (
+            "println",
+            "def main() -> None:\n    for println in [1]:\n        pass\n",
+        ),
+        (
+            "print",
+            "def main(value: Option[str]) -> None:\n    match value:\n        case Some(print):\n            pass\n",
+        ),
+        (
+            "println",
+            "def main(value: Option[str]) -> None:\n    match value:\n        case Some(println):\n            pass\n",
+        ),
+        (
+            "print",
+            "def main() -> int:\n    print, value = (1, 2)\n    return print + value\n",
+        ),
+        (
+            "println",
+            "def main() -> int:\n    total = 0\n    for println, value in [(1, 2)]:\n        total = println + value\n    return total\n",
+        ),
+        (
+            "print",
+            "def main() -> int:\n    operation = (print) => print\n    return operation(1)\n",
+        ),
+        (
+            "println",
+            "def main() -> list[int]:\n    return [println for println in [1, 2]]\n",
+        ),
+        (
+            "print",
+            "const print: int = 1\n\n\ndef main() -> int:\n    return print\n",
+        ),
+        (
+            "println",
+            "static println: int = 1\n\n\ndef main() -> int:\n    return println\n",
+        ),
+        (
+            "println",
+            "from std.hash import sha1 as println\n\n\ndef main() -> int:\n    return 1\n",
+        ),
+        (
+            "print",
+            "import std.async\n\n\nasync def fast() -> int:\n    return 1\n\n\nasync def slow() -> int:\n    return 2\n\n\nasync def main() -> int:\n    return race for print:\n        await fast() => print\n        await slow() => print\n",
+        ),
+        (
+            "print",
+            "def main() -> int:\n    mut print: int = 1\n    print += 1\n    return print\n",
+        ),
+        ("print", "import std.web as print\n"),
+        ("println", "import std.web as println\n"),
+    ] {
+        assert_protected_binding(source, spelling)?;
+    }
+    Ok(())
+}
+
+/// Unprotected builtins retain their existing ordinary source-binding behavior.
+#[test]
+fn unrelated_builtin_names_remain_shadowable_issue1249() -> Result<(), String> {
+    let errors =
+        check_source("def len(value: int) -> int:\n    return value + 1\n\n\ndef main() -> int:\n    return len(1)\n")?;
+    assert!(errors.is_empty(), "unprotected len must remain shadowable: {errors:?}");
+    Ok(())
+}
+
+/// Member and field names occupy a distinct namespace from protected free-function bindings.
+#[test]
+fn fields_and_members_named_print_remain_ordinary_source_names_issue1249() -> Result<(), String> {
+    let source = r#"
+model Reporter:
+    print: str
+
+    def print(self) -> str:
+        return self.print
+
+def main() -> str:
+    reporter = Reporter(print="field")
+    return reporter.print()
+"#;
+    let errors = check_source(source)?;
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(format!("field/member spelling must remain unreserved, got {errors:?}"))
+    }
+}

--- a/tests/protected_generic_binding_tests.rs
+++ b/tests/protected_generic_binding_tests.rs
@@ -1,0 +1,105 @@
+//! Frontend regressions for protected builtin spellings used as generic type parameters.
+
+use incan::frontend::diagnostics::CompileError;
+use incan::frontend::{lexer, parser, typechecker};
+
+/// Type-check `source`, retaining compiler diagnostics rather than process-level rendering.
+fn check_source(source: &str) -> Result<Vec<CompileError>, String> {
+    let tokens = lexer::lex(source).map_err(|errors| format!("lex failed: {errors:?}"))?;
+    let program = parser::parse(&tokens).map_err(|errors| format!("parse failed: {errors:?}"))?;
+    let mut checker = typechecker::TypeChecker::new();
+    match checker.check_program(&program) {
+        Ok(()) => Ok(Vec::new()),
+        Err(errors) => Ok(errors),
+    }
+}
+
+/// Assert that a protected generic parameter is rejected at its enclosing source declaration span.
+///
+/// `TypeParam` retains no name span, so the declaration/method span is the nearest source-backed diagnostic location.
+fn assert_protected_generic_binding(source: &str, spelling: &str, declaration: &str) -> Result<(), String> {
+    let errors = check_source(source)?;
+    let error = errors
+        .iter()
+        .find(|error| error.message.contains("protected builtin binding"))
+        .ok_or_else(|| format!("expected protected-binding diagnostic for `{spelling}`, got {errors:?}"))?;
+    let declaration_start = source
+        .find(declaration)
+        .ok_or_else(|| format!("missing declaration `{declaration}` in test source"))?;
+    if error.span.start > declaration_start || error.span.end < declaration_start + declaration.len() {
+        return Err(format!(
+            "expected diagnostic for `{spelling}` to cover declaration `{declaration}` at {declaration_start}..{}, got {:?}",
+            declaration_start + declaration.len(),
+            error.span
+        ));
+    }
+    Ok(())
+}
+
+/// Every source-owned generic parameter list rejects both protected builtin spellings.
+#[test]
+fn generic_type_parameters_cannot_replace_protected_builtin_call_roots_issue1249() -> Result<(), String> {
+    for spelling in ["print", "println"] {
+        let function_name = format!("generic_{spelling}");
+        let method_owner = format!("Methods_{spelling}");
+        let model_name = format!("Model_{spelling}");
+        let class_name = format!("Class_{spelling}");
+        let trait_name = format!("Trait_{spelling}");
+        let enum_name = format!("Enum_{spelling}");
+        let newtype_name = format!("Token_{spelling}");
+        let alias_name = format!("Values_{spelling}");
+
+        let cases = [
+            (
+                format!("def {function_name}"),
+                format!("def {function_name}[{spelling}](value: {spelling}) -> None:\n  {spelling}(\"hello\")\n"),
+            ),
+            (
+                "def transform".to_string(),
+                format!(
+                    "class {method_owner}:\n  def transform[{spelling}](self, value: {spelling}) -> {spelling}:\n    return value\n"
+                ),
+            ),
+            (
+                format!("model {model_name}"),
+                format!("model {model_name}[{spelling}]:\n  value: {spelling}\n"),
+            ),
+            (
+                format!("class {class_name}"),
+                format!("class {class_name}[{spelling}]:\n  value: {spelling}\n"),
+            ),
+            (
+                format!("trait {trait_name}"),
+                format!("trait {trait_name}[{spelling}]:\n  def value(self) -> {spelling}: ...\n"),
+            ),
+            (
+                format!("enum {enum_name}"),
+                format!("enum {enum_name}[{spelling}]:\n  Value({spelling})\n"),
+            ),
+            (
+                format!("type {newtype_name}"),
+                format!("type {newtype_name}[{spelling}] = newtype {spelling}\n"),
+            ),
+            (
+                format!("type {alias_name}"),
+                format!("type {alias_name}[{spelling}] = list[{spelling}]\n"),
+            ),
+        ];
+
+        for (declaration, source) in cases {
+            assert_protected_generic_binding(&source, spelling, &declaration)?;
+        }
+    }
+    Ok(())
+}
+
+/// Generic parameters that do not replace protected builtin roots remain legal.
+#[test]
+fn ordinary_generic_type_parameters_remain_valid_issue1249() -> Result<(), String> {
+    let errors = check_source("def identity[T](value: T) -> T:\n  return value\n\nclass Box[U]:\n  value: U\n")?;
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(format!("ordinary generic parameters must remain valid, got {errors:?}"))
+    }
+}

--- a/tests/replacement_backend_execution_tests.rs
+++ b/tests/replacement_backend_execution_tests.rs
@@ -4144,11 +4144,9 @@ fn both_backends_render_a_multi_argument_print_the_same_way() -> Result<(), Box<
     Ok(())
 }
 
+/// Protected output bindings must be rejected before a replacement Body-IR module can be constructed.
 #[test]
-fn replacement_print_respects_a_source_declaration_that_shadows_the_builtin() -> Result<(), Box<dyn std::error::Error>>
-{
-    // Resolving the builtin from a registry must not steal a name the source declared. A module defining its own
-    // `print` means that declaration, and lowering only marks the builtin when nothing in source took the spelling.
+fn replacement_frontend_refuses_a_source_declaration_named_print() -> Result<(), Box<dyn std::error::Error>> {
     let source = r#"
 def print(value: int) -> int:
   return value + 1
@@ -4156,14 +4154,12 @@ def print(value: int) -> int:
 def main() -> int:
   return print(41)
 "#;
-    let module = lower_typed_body_ir(source)?;
-    let execution = execute_free_function(&module, "main", &[])?;
-
-    assert_eq!(execution.value, ReplacementValue::Int(42));
+    let error = lower_typed_body_ir(source)
+        .err()
+        .ok_or("redefining print must fail typechecking")?;
     assert!(
-        execution.emitted_output().is_empty(),
-        "a shadowing declaration must not emit builtin output: {:?}",
-        execution.emitted_output()
+        error.to_string().contains("protected builtin binding"),
+        "the frontend must report the protected output binding: {error}"
     );
     Ok(())
 }

--- a/workspaces/docs-site/docs/language/reference/imports_and_modules.md
+++ b/workspaces/docs-site/docs/language/reference/imports_and_modules.md
@@ -52,7 +52,7 @@ import utils::format_currency as fmt
 
 ### Imported names and core builtin functions
 
-An explicit import creates a normal binding in the importing module. If it has the same spelling as an ambient core builtin function, the import wins for unqualified calls. This lets a domain library use a natural name without an alias solely to avoid a builtin collision.
+An explicit import normally creates a binding in the importing module. `print` and its registered `println` alias are protected output bindings, so an import cannot use either spelling. Other ambient core builtin functions remain ordinary bindings: an import with the same spelling wins for unqualified calls. This lets a domain library use a natural name without an alias solely to avoid an unrelated builtin collision.
 
 ```incan
 # aggregates.incn
@@ -68,7 +68,7 @@ def report() -> int:
   return local_total + builtin_total
 ```
 
-`std.builtins.<name>` is the explicit escape hatch when an unqualified builtin-function name is shadowed. It always selects the core builtin function; it does not import a source module or create generated runtime code.
+`std.builtins.<name>` is the explicit escape hatch when an unprotected builtin-function name is shadowed. It always selects the core builtin function; it does not import a source module or create generated runtime code.
 
 ## Published library namespaces
 
@@ -267,7 +267,9 @@ set()               # Empty Set
 set(iterable)       # Convert to Set
 ```
 
-Every core builtin function is also reachable through `std.builtins.<name>`. This is an explicit escape path for code that needs the core builtin when an inner scope or an imported DSL gives the unqualified name a different meaning:
+Every core builtin function is also reachable through `std.builtins.<name>`. This is an explicit escape path for code that needs an unprotected core builtin when an inner scope or an imported DSL gives the unqualified name a different meaning. `print` and `println` cannot be rebound, so they remain globally available.
+
+Source declarations, imports, local bindings, value parameters, and generic type parameters cannot use either protected spelling as a binding. Fields and methods may still be named `print` or `println`, because selecting a member does not replace the bare builtin name.
 
 ```incan
 def total(values: list[int]) -> int:

--- a/workspaces/docs-site/docs/release_notes/0_6.md
+++ b/workspaces/docs-site/docs/release_notes/0_6.md
@@ -67,6 +67,7 @@ The CLI, LSP, Architect, MCP tools, and Rust/Oven views will consume the same so
 
 - **Language**: Plain assignment inside a nested block now reassigns the nearest enclosing binding — requiring `mut` and a compatible type — instead of silently creating a new block-local; `let` and `mut` remain the explicit shadowing forms, and `mut name = value` now declares a new binding over an active name rather than being rejected as mutation of an immutable one. This brings assignment behavior to the documented scoping contract. (#1072, #1248)
 - **Language**: `print` and `println` now render every argument, space-separated. Previously every argument after the first was silently dropped in generated Rust, with no diagnostic. (#1248)
+- **Language**: `print` and `println` are protected builtin bindings: source declarations, imports, parameters, and local bindings cannot replace them. Fields and methods with these names remain valid. (#1249)
 - **Compiler**: Unreachable code after an unconditional return is reported. (#1117, #1134)
 
 ## What this does not claim


### PR DESCRIPTION
## Summary

Make `print` and its registered `println` alias immutable source bindings. Attempts to replace either name now fail typechecking, while same-spelled fields/methods and shadowing of unrelated builtins remain valid. This is the independently reviewable frontend packet of #1249, not its full output/comparison implementation.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [x] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [x] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: Declarations, imports, value and generic parameters, locals, destructuring, closure/comprehension bindings, patterns and race bindings cannot displace `print`/`println`. Fields and methods occupy their existing separate namespace; other builtins such as `len` remain shadowable.
- **Internals**: The existing builtin registry resolves canonical names and aliases to `BuiltinFnId::Print`; one protected-identity policy is consumed by frontend binding validation. Diagnostics retain source spans. Public-library aliases report one primary protected-binding error.
- **Risks**: Source that previously redefined an output builtin now intentionally fails compilation. Generic parameters use their enclosing declaration/method span because individual type-parameter spans are not retained; no synthetic byte offsets are introduced.

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- Red: a generic parameter named `print` displaced the callable root without any diagnostic. Review held publication until all relevant generic owners were validated.
- Green in the publication worktree: `cargo test --locked --test protected_builtin_binding_tests --test protected_generic_binding_tests --test replacement_backend_execution_tests` — 3 + 2 + 89 tests passed. The focused suites cover 23 source-form cases and 16 generic owner/spelling cases, plus unprotected-builtin, member/field and ordinary-generic controls.
- The public-library alias regression and core registry policy test passed independently.
- `cargo clippy --locked -p incan -p incan_core -p incan_syntax --all-targets --all-features -- -D warnings` passed.
- `make fmt`, `make fmt-check`, changed-rustdoc gate, strict docs build with renderer/component checks, and `git diff --check` passed. The reference generator produced no generated diff.
- Focused checks only, per the Slice 2 packet workflow. No full pre-commit, Oven or whole-Slice gate, version bump, or cutover acceptance claim.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

- `workspaces/docs-site/docs/language/reference/imports_and_modules.md`: protected output names and the unchanged escape hatch for other builtins.
- `workspaces/docs-site/docs/release_notes/0_6.md`: user-visible binding protection.
- No design record is added or required.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Base: `0.6.0-dev.2`. Part of #1249; leave that issue open for ordinary program IO, separate comparison transport, output-aware parity and remaining builtin coverage. No RFC lifecycle transition or #1247 implementation is included.
