### PR TITLE
feature - thread RFC 120 canonical symbol identity from declaration sites through HIR and Body IR (#1042)

### DIFF
--- a/crates/incan_semantics_core/src/facts.rs
+++ b/crates/incan_semantics_core/src/facts.rs
@@ -783,6 +783,40 @@ impl CanonicalSymbolId {
             _ => None,
         }
     }
+
+    /// Render a deterministic, compact single-line spelling for maintainer-facing snapshots.
+    ///
+    /// This is a projection of the identity for humans; nothing may compare or dispatch on it. The shape is
+    /// `<kind>:<origin>::<name>[#<scope>]@<start>..<end>`, with member- and path-namespace identities prefixed by
+    /// their namespace so a member and a lexical binding sharing a spelling render visibly differently.
+    pub fn render_compact(&self) -> String {
+        let origin = match &self.origin {
+            SymbolOrigin::Module(path) => module_identity_for_path(path),
+            SymbolOrigin::Package { library, module_path } => {
+                let mut parts = vec![format!("pub::{library}")];
+                parts.extend(module_path.iter().cloned());
+                parts.join("::")
+            }
+            SymbolOrigin::RustCrate(path) => format!("rust::{}", path.join("::")),
+            SymbolOrigin::Builtin => "builtin".to_string(),
+        };
+        let namespace = match self.namespace {
+            SymbolNamespace::OrdinaryLexical => "",
+            SymbolNamespace::Member => "member/",
+            SymbolNamespace::ModulePath => "path/",
+        };
+        let scope = self
+            .scope_discriminant
+            .map(|ScopeDiscriminant(scope)| format!("#{scope}"))
+            .unwrap_or_default();
+        format!(
+            "{namespace}{}:{origin}::{}{scope}@{}..{}",
+            self.kind.as_str(),
+            self.declaration_name,
+            self.declaration_span.start,
+            self.declaration_span.end
+        )
+    }
 }
 
 impl fmt::Display for SemanticSourceTargetKind {

--- a/crates/incan_semantics_core/src/hir.rs
+++ b/crates/incan_semantics_core/src/hir.rs
@@ -8,7 +8,7 @@ use std::fmt::Write;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{CompilerNodeId, SemanticFactStore};
+use crate::{CanonicalSymbolId, CompilerNodeId, SemanticFactStore};
 
 /// A source byte range attached to a HIR node.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -51,6 +51,9 @@ impl HirModule {
             if let Some(type_fact_subject) = &decl.type_fact_subject {
                 let _ = write!(&mut out, " type_fact={type_fact_subject}");
             }
+            if let Some(canonical) = &decl.canonical {
+                let _ = write!(&mut out, " identity={}", canonical.render_compact());
+            }
             out.push('\n');
         }
         out
@@ -83,6 +86,14 @@ pub struct HirDeclaration {
     pub span: HirSourceSpan,
     /// Subject ID to query for a [`crate::SemanticFactKind::Type`] fact, when this declaration has one.
     pub type_fact_subject: Option<CompilerNodeId>,
+    /// RFC 120 canonical identity of this declaration, when the frontend proved one.
+    ///
+    /// For a local declaration this is the identity minted at its definition; for a single-binding import it is the
+    /// *declaring* module's identity, so an aliased import and its target declaration visibly share one identity in
+    /// the HIR handoff. `None` means unproven (multi-item imports, docstrings, declarations whose identity the
+    /// frontend does not yet export) — a consumer must not reconstruct one from [`Self::id`] or [`Self::name`],
+    /// which remain spelling-derived v0 surfaces.
+    pub canonical: Option<CanonicalSymbolId>,
 }
 
 /// Top-level declaration categories represented by HIR v0.
@@ -148,6 +159,7 @@ mod tests {
                 name: Some("run".to_string()),
                 span: HirSourceSpan::new(1, 24),
                 type_fact_subject: Some(decl_id),
+                canonical: None,
             }],
         };
 
@@ -177,6 +189,7 @@ mod tests {
                     name: Some("run".to_string()),
                     span: HirSourceSpan::new(1, 24),
                     type_fact_subject: Some(decl_id),
+                    canonical: None,
                 }],
             },
             facts,

--- a/src/frontend/body_ir.rs
+++ b/src/frontend/body_ir.rs
@@ -227,7 +227,6 @@ fn build_body_ir_module_v0_with_provider_operations(
         local_fieldless_enum_declarations: &local_fieldless_enum_declarations,
         local_value_enum_declarations: &local_value_enum_declarations,
         module_identity: &module_identity,
-        module_path,
         provider_operations,
     };
     let mut bodies = program
@@ -362,7 +361,6 @@ struct BodyIrLoweringFacts<'type_info, 'source> {
     local_fieldless_enum_declarations: &'source LocalFieldlessEnumDeclarations,
     local_value_enum_declarations: &'source LocalValueEnumDeclarations,
     module_identity: &'source str,
-    module_path: &'source [String],
     /// Provider operations this compilation admits, keyed by canonical identity rather than by any spelling.
     provider_operations: &'source ProviderOperationCatalog,
 }
@@ -459,8 +457,6 @@ struct BodyBuilder<'type_info, 'source> {
     local_value_enum_declarations: &'source LocalValueEnumDeclarations,
     /// Owning module identity used to construct a source-span declaration identity without consulting a backend.
     module_identity: &'source str,
-    /// Owning module path, used to build the RFC 120 origin of a declaration this module owns.
-    module_path: &'source [String],
     /// Provider operations this compilation admits, consulted only by canonical identity (see `provider_ops`).
     provider_operations: &'source ProviderOperationCatalog,
     /// Checked return type of the function/method currently being lowered, used only to retain `?` error routing.
@@ -513,7 +509,6 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
             local_fieldless_enum_declarations: lowering_facts.local_fieldless_enum_declarations,
             local_value_enum_declarations: lowering_facts.local_value_enum_declarations,
             module_identity: lowering_facts.module_identity,
-            module_path: lowering_facts.module_path,
             provider_operations: lowering_facts.provider_operations,
             owner_return_type,
             locals: Vec::new(),

--- a/src/frontend/body_ir/calls.rs
+++ b/src/frontend/body_ir/calls.rs
@@ -63,26 +63,6 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
         ))
     }
 
-    /// Build the RFC 120 identity of a declaration *this* module owns, from the declaration the call selected.
-    ///
-    /// The span is the one the caller already resolved to build [`DirectCallDeclaration::direct_call_id`], so the two
-    /// facts on a `NamedCallableTarget` are derived from one decision and cannot name different declarations. That
-    /// matters because locality must not be inferred from the recorded source target: an import binding of the same
-    /// spelling wins in `TypeChecker::source_target_for_symbol` regardless of what the call actually bound, so a local
-    /// declaration shadowed by a same-name import would otherwise be given the *import's* identity.
-    pub(super) fn local_callable_identity(
-        &self,
-        declared_name: &str,
-        declaration_span: ast::Span,
-    ) -> CanonicalSymbolId {
-        CanonicalSymbolId::module_declaration(
-            self.module_path.to_vec(),
-            declared_name,
-            SemanticSourceTargetKind::Function,
-            HirSourceSpan::new(declaration_span.start, declaration_span.end),
-        )
-    }
-
     /// Return the RFC 120 identity of an imported callable, when import resolution proved one.
     ///
     /// Only reached when this module declares no function of that spelling, so there is no local declaration for an
@@ -170,7 +150,9 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
                 builtin: None,
                 // The identity anchors to the declaration span, so the selected overload is as nameable as any other
                 // declaration; it is the *spelling* that cannot separate them, and the spelling is not the identity.
-                canonical: Some(self.local_callable_identity(name, *selected_span)),
+                // Consumed from the declaration's checked binding — minted once by the typechecker at the
+                // declaration site, never re-derived here from module path plus spelling.
+                canonical: binding.identity.clone(),
             });
         }
 
@@ -195,7 +177,9 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
                 declaration_span.end,
             )),
             builtin: None,
-            canonical: Some(self.local_callable_identity(name, *declaration_span)),
+            // Consumed from the declaration's checked binding — minted once by the typechecker at the declaration
+            // site, never re-derived here from module path plus spelling.
+            canonical: binding.identity.clone(),
         })
     }
 

--- a/src/frontend/body_ir/tests.rs
+++ b/src/frontend/body_ir/tests.rs
@@ -4103,7 +4103,6 @@ fn a_prefix_surface_keyword_that_is_not_await_is_refused_rather_than_treated_as_
     let local_fieldless_enum_declarations = LocalFieldlessEnumDeclarations::new();
     let local_value_enum_declarations = LocalValueEnumDeclarations::new();
     let provider_operations = ProviderOperationCatalog::new();
-    let module_path = vec!["m".to_string()];
     let lowering_facts = BodyIrLoweringFacts {
         type_info: &type_info,
         function_default_sources: &function_default_sources,
@@ -4112,7 +4111,6 @@ fn a_prefix_surface_keyword_that_is_not_await_is_refused_rather_than_treated_as_
         local_fieldless_enum_declarations: &local_fieldless_enum_declarations,
         local_value_enum_declarations: &local_value_enum_declarations,
         module_identity: "m",
-        module_path: &module_path,
         provider_operations: &provider_operations,
     };
     let mut builder = BodyBuilder::new(&lowering_facts, IncanType::Unknown);

--- a/src/frontend/hir.rs
+++ b/src/frontend/hir.rs
@@ -14,7 +14,7 @@ use incan_semantics_core::{
 pub fn build_hir_v0(program: &ast::Program, module_path: &[String], type_info: &TypeCheckInfo) -> HirModule {
     let module_identity = hir_module_identity(module_path);
     let facts = type_info.semantic_fact_store(module_path);
-    build_hir_v0_with_facts(program, module_identity, &facts)
+    build_hir_v0_with_facts(program, module_identity, type_info, &facts)
 }
 
 /// Build the bundled semantic module snapshot v0 for a typechecked module.
@@ -25,28 +25,56 @@ pub fn build_semantic_module_snapshot_v0(
 ) -> SemanticModuleSnapshot {
     let module_identity = hir_module_identity(module_path);
     let facts = type_info.semantic_fact_store(module_path);
-    let hir = build_hir_v0_with_facts(program, module_identity, &facts);
+    let hir = build_hir_v0_with_facts(program, module_identity, type_info, &facts);
     SemanticModuleSnapshot { hir, facts }
 }
 
 /// Build declaration-level HIR after semantic facts have already been collected.
-fn build_hir_v0_with_facts(program: &ast::Program, module_identity: String, facts: &SemanticFactStore) -> HirModule {
+///
+/// Each declaration's RFC 120 identity is *consumed* from the typechecker's exported facts — the span-keyed
+/// declaration identities for local declarations, and the local-name-keyed resolved import identities for
+/// single-binding imports — never re-derived here from module path plus spelling. A declaration with no exported
+/// identity carries none.
+fn build_hir_v0_with_facts(
+    program: &ast::Program,
+    module_identity: String,
+    type_info: &TypeCheckInfo,
+    facts: &SemanticFactStore,
+) -> HirModule {
     let declarations = program
         .declarations
         .iter()
         .map(|decl| {
             let (kind, name) = hir_decl_kind_and_name(&decl.node);
-            let id = name
-                .as_deref()
-                .map(|name| hir_named_decl_id(&module_identity, name))
-                .unwrap_or_else(|| hir_span_decl_id(&module_identity, decl.span));
+            // An import keeps its span-derived id even when named: a name-derived id would collide with a local
+            // declaration of the same spelling (which the import may legally shadow or be shadowed by), and
+            // spelling-derived ids are the v0 surface RFC 120 retires rather than extends.
+            let id = match &decl.node {
+                Declaration::Import(_) => hir_span_decl_id(&module_identity, decl.span),
+                _ => name
+                    .as_deref()
+                    .map(|name| hir_named_decl_id(&module_identity, name))
+                    .unwrap_or_else(|| hir_span_decl_id(&module_identity, decl.span)),
+            };
             let type_fact_subject = facts.type_facts_for(&id).next().is_some().then_some(id.clone());
+            let canonical = match &decl.node {
+                Declaration::Import(_) => name
+                    .as_deref()
+                    .and_then(|local| type_info.declarations.resolved_import_identities.get(local))
+                    .cloned(),
+                _ => type_info
+                    .declarations
+                    .declaration_identities
+                    .get(&(decl.span.start, decl.span.end))
+                    .cloned(),
+            };
             HirDeclaration {
                 id,
                 kind,
                 name,
                 span: HirSourceSpan::new(decl.span.start, decl.span.end),
                 type_fact_subject,
+                canonical,
             }
         })
         .collect();
@@ -59,9 +87,14 @@ fn build_hir_v0_with_facts(program: &ast::Program, module_identity: String, fact
 }
 
 /// Map a frontend declaration to the HIR v0 declaration category and optional name.
+///
+/// An import declaration is named by its single local binding when it introduces exactly one — the alias when
+/// written, the item name otherwise — so that binding's resolved identity can ride on the declaration. Multi-item
+/// and namespace imports stay anonymous in HIR v0; per-binding import declarations are RFC 120 Slice 4's remaining
+/// scope.
 fn hir_decl_kind_and_name(decl: &Declaration) -> (HirDeclarationKind, Option<String>) {
     match decl {
-        Declaration::Import(_) => (HirDeclarationKind::Import, None),
+        Declaration::Import(import) => (HirDeclarationKind::Import, single_import_binding_name(import)),
         Declaration::Const(decl) => (HirDeclarationKind::Const, Some(decl.name.clone())),
         Declaration::Static(decl) => (HirDeclarationKind::Static, Some(decl.name.clone())),
         Declaration::Model(decl) => (HirDeclarationKind::Model, Some(decl.name.clone())),
@@ -85,6 +118,23 @@ fn hir_decl_kind_and_name(decl: &Declaration) -> (HirDeclarationKind, Option<Str
         Declaration::VocabBlock(_) => (HirDeclarationKind::Docstring, None),
         Declaration::Docstring(_) => (HirDeclarationKind::Docstring, None),
     }
+}
+
+/// Return the one local binding name a `from ... import` declaration introduces, when it introduces exactly one.
+///
+/// The alias wins over the item name because the alias is the binding the module actually gains. `None` covers
+/// module/namespace imports and multi-item imports, whose bindings HIR v0 does not yet model individually.
+fn single_import_binding_name(import: &ast::ImportDecl) -> Option<String> {
+    let items = match &import.kind {
+        ast::ImportKind::From { items, .. }
+        | ast::ImportKind::PubFrom { items, .. }
+        | ast::ImportKind::RustFrom { items, .. } => items,
+        _ => return None,
+    };
+    let [item] = items.as_slice() else {
+        return None;
+    };
+    Some(item.alias.clone().unwrap_or_else(|| item.name.clone()))
 }
 
 /// Render a module path into the semantic module identity used by HIR v0.
@@ -164,6 +214,76 @@ def add(x: int, y: int = 1) -> int:
         assert!(snapshot.contains("decl function add decl:facts::snapshot::add"));
         assert!(snapshot.contains("\nfacts\n"));
         assert!(snapshot.contains("decl:facts::snapshot::add type=(int, int) -> int"));
+        Ok(())
+    }
+
+    /// RFC 120: a declaration's HIR record carries its minted identity, and a single-binding aliased import carries
+    /// the *declaring* module's identity — so the import and its target declaration are visibly one symbol in the
+    /// HIR handoff without consulting spellings.
+    #[test]
+    fn build_hir_v0_attaches_canonical_identities_to_declarations_and_single_imports()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let helper_source = r#"
+pub def helper() -> int:
+  return 1
+"#;
+        let main_source = r#"
+from helpers import helper as h
+
+def run() -> int:
+  return h()
+"#;
+        let helper_tokens = lexer::lex(helper_source).map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+        let helper_program =
+            parser::parse(&helper_tokens).map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+        let main_tokens = lexer::lex(main_source).map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+        let main_program = parser::parse(&main_tokens).map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+        let module_path = vec!["app".to_string()];
+        let mut checker = TypeChecker::new();
+        checker.set_current_module_path(Some(module_path.clone()));
+        checker
+            .check_with_imports(&main_program, &[("helpers", &helper_program)])
+            .map_err(|errs| std::io::Error::other(format!("{errs:?}")))?;
+
+        let hir = build_hir_v0(&main_program, &module_path, checker.type_info());
+
+        let import_decl = hir
+            .declarations
+            .iter()
+            .find(|decl| decl.kind == incan_semantics_core::HirDeclarationKind::Import)
+            .ok_or("import declaration missing from HIR")?;
+        assert_eq!(
+            import_decl.name.as_deref(),
+            Some("h"),
+            "a single-binding import is named by its local binding"
+        );
+        let import_identity = import_decl
+            .canonical
+            .as_ref()
+            .ok_or("single-binding import must carry its target's identity")?;
+        assert_eq!(import_identity.declaration_name, "helper");
+        assert_eq!(
+            import_identity.module_path(),
+            Some(["helpers".to_string()].as_slice()),
+            "the import carries the declaring module's identity, not the consumer's"
+        );
+
+        let run_decl = hir
+            .declarations
+            .iter()
+            .find(|decl| decl.name.as_deref() == Some("run"))
+            .ok_or("run declaration missing from HIR")?;
+        let run_identity = run_decl
+            .canonical
+            .as_ref()
+            .ok_or("local declaration must carry its identity")?;
+        assert_eq!(run_identity.module_path(), Some(["app".to_string()].as_slice()));
+
+        let snapshot = hir.render_snapshot();
+        assert!(
+            snapshot.contains("identity=function:helpers::helper"),
+            "the snapshot renders the import's declaring identity: {snapshot}"
+        );
         Ok(())
     }
 

--- a/src/frontend/symbols.rs
+++ b/src/frontend/symbols.rs
@@ -18,9 +18,62 @@ use incan_core::lang::types::numerics;
 use incan_core::lang::types::numerics::NumericTypeId;
 use incan_core::lang::types::stringlike;
 use incan_core::lang::types::stringlike::StringLikeId;
+use incan_semantics_core::{
+    CanonicalSymbolId, HirSourceSpan, ScopeDiscriminant, SemanticSourceTargetKind, SymbolNamespace, SymbolOrigin,
+};
 
 /// Unique identifier for symbols
 pub type SymbolId = usize;
+
+/// Classify one symbol-table definition into its RFC 120 declaration category, when the kind decides it.
+///
+/// `None` marks the shapes a [`SymbolKind`] alone cannot classify: overload sets (each overload owns a span-keyed
+/// identity; a set-level one would name an arbitrary member), `Type(Builtin)` placeholders (a generic binder and an
+/// imported-type stub share that representation, so the defining site must state the category), and module bindings
+/// (module-path-namespace identities are deferred until a consumer needs them). A `Variable` defaults to `Local`;
+/// parameter and receiver sites state their category explicitly via `SymbolTable::define_with_target_kind`.
+fn default_identity_kind(kind: &SymbolKind) -> Option<SemanticSourceTargetKind> {
+    match kind {
+        SymbolKind::Variable(_) => Some(SemanticSourceTargetKind::Local),
+        SymbolKind::Static(_) => Some(SemanticSourceTargetKind::Static),
+        SymbolKind::Function(_) => Some(SemanticSourceTargetKind::Function),
+        SymbolKind::FunctionOverloads(_) => None,
+        SymbolKind::Type(TypeInfo::Class(_)) => Some(SemanticSourceTargetKind::Class),
+        SymbolKind::Type(TypeInfo::Model(_)) => Some(SemanticSourceTargetKind::Model),
+        SymbolKind::Type(TypeInfo::TypeAlias) => Some(SemanticSourceTargetKind::TypeAlias),
+        SymbolKind::Type(TypeInfo::Newtype(info)) => Some(if info.is_rusttype {
+            SemanticSourceTargetKind::Rusttype
+        } else {
+            SemanticSourceTargetKind::Newtype
+        }),
+        SymbolKind::Type(TypeInfo::Enum(_)) => Some(SemanticSourceTargetKind::Enum),
+        SymbolKind::Type(TypeInfo::Builtin) => None,
+        SymbolKind::Trait(_) => Some(SemanticSourceTargetKind::Trait),
+        SymbolKind::Capability(_) => Some(SemanticSourceTargetKind::Capability),
+        SymbolKind::Variant(_) => Some(SemanticSourceTargetKind::Variant),
+        SymbolKind::Field(_) => Some(SemanticSourceTargetKind::Field),
+        SymbolKind::Property(_) => Some(SemanticSourceTargetKind::Property),
+        SymbolKind::Module(_) => None,
+        SymbolKind::RustItem(_) => Some(SemanticSourceTargetKind::RustItem),
+    }
+}
+
+/// Return which RFC 120 namespace an identity of this declaration category lives in.
+///
+/// Member declarations (fields, methods, properties, variants) are owned by their nominal type and reached
+/// `.`-directed, so their identities carry the member namespace even where a bare lexical convenience binding exists
+/// (a variant's bare spelling defers to real lexical bindings; the identity belongs to the member declaration).
+/// Everything the scope table binds otherwise is ordinary lexical.
+fn identity_namespace_for_kind(kind: &SemanticSourceTargetKind) -> SymbolNamespace {
+    match kind {
+        SemanticSourceTargetKind::Field
+        | SemanticSourceTargetKind::Method
+        | SemanticSourceTargetKind::Property
+        | SemanticSourceTargetKind::Variant => SymbolNamespace::Member,
+        SemanticSourceTargetKind::Module => SymbolNamespace::ModulePath,
+        _ => SymbolNamespace::OrdinaryLexical,
+    }
+}
 
 /// Canonical semantic name for anonymous union types (RFC 029).
 pub const UNION_TYPE_NAME: &str = "Union";
@@ -86,6 +139,24 @@ pub struct SymbolTable {
     scopes: Vec<Scope>,
     current_scope: usize,
     current_scope_binding_transaction: Option<HashMap<String, Option<SymbolId>>>,
+    /// RFC 120 canonical identities, minted once per definition and keyed by [`SymbolId`].
+    ///
+    /// This side map is the compiler's single declaration-site assignment point: every named definition that the
+    /// table can classify receives its identity here, at [`Self::define`] time, instead of each downstream consumer
+    /// re-deriving one from module path plus spelling. A definition the table cannot classify (an overload set, a
+    /// placeholder whose defining site did not state its kind) deliberately has no entry — absent means unproven,
+    /// never "rebuild it from the name".
+    identities: HashMap<SymbolId, CanonicalSymbolId>,
+    /// Module path owning locally-declared symbols, used as the minted [`SymbolOrigin`].
+    ///
+    /// Empty until the typechecker learns the module path; identities minted before that carry an empty module
+    /// origin, which `module_identity_for_path` renders as `<module>` — the same anonymous-module convention the
+    /// fact store already uses.
+    module_path: Vec<String>,
+    /// True only while [`Self::add_builtins`] runs, so [`Self::define`] leaves identity assignment to the explicit
+    /// registry identities that loop attaches (builtin aliases must carry the canonical registry spelling, which the
+    /// generic mint cannot know).
+    minting_builtins: bool,
 }
 
 impl SymbolTable {
@@ -96,11 +167,33 @@ impl SymbolTable {
             scopes: vec![Scope::new(None, ScopeKind::Module)],
             current_scope: 0,
             current_scope_binding_transaction: None,
+            identities: HashMap::new(),
+            module_path: Vec::new(),
+            minting_builtins: false,
         };
 
         // Add builtin types
+        table.minting_builtins = true;
         table.add_builtins();
+        table.minting_builtins = false;
         table
+    }
+
+    /// Record the module path that owns subsequently-defined local declarations.
+    ///
+    /// Called by the typechecker as soon as it knows its module identity, before user declarations are collected.
+    /// Builtins are already defined by then and keep their [`SymbolOrigin::Builtin`] identities.
+    pub fn set_module_path(&mut self, module_path: Vec<String>) {
+        self.module_path = module_path;
+    }
+
+    /// Return the RFC 120 canonical identity minted for a defined symbol, if the definition proved one.
+    ///
+    /// Absent means the definition was not classifiable at its site (overload set, unclassified placeholder,
+    /// module binding) or was an import whose target resolution did not prove an identity. Consumers must treat
+    /// absence as "unproven" and fail closed rather than reconstruct an identity from the symbol's spelling.
+    pub fn identity_of(&self, id: SymbolId) -> Option<&CanonicalSymbolId> {
+        self.identities.get(&id)
     }
 
     /// Populate the root scope with built-in type symbols.
@@ -108,42 +201,45 @@ impl SymbolTable {
         // Builtin types (from the canonical `incan_core::lang::types` registries).
         //
         // We define both canonical spellings and aliases so name lookup stays robust and we avoid
-        // drift between the compiler and the language vocabulary registries.
-        let mut builtin_types: Vec<&'static str> = Vec::new();
+        // drift between the compiler and the language vocabulary registries. Each entry pairs the
+        // defined spelling with its canonical registry spelling, so every alias records the one RFC 120
+        // registry identity instead of minting a second identity per spelling.
+        let mut builtin_types: Vec<(&'static str, &'static str)> = Vec::new();
         for t in numerics::NUMERIC_TYPES {
-            builtin_types.push(t.canonical);
-            builtin_types.extend_from_slice(t.aliases);
+            builtin_types.push((t.canonical, t.canonical));
+            builtin_types.extend(t.aliases.iter().map(|alias| (*alias, t.canonical)));
         }
         for t in stringlike::STRING_LIKE_TYPES {
-            builtin_types.push(t.canonical);
-            builtin_types.extend_from_slice(t.aliases);
+            builtin_types.push((t.canonical, t.canonical));
+            builtin_types.extend(t.aliases.iter().map(|alias| (*alias, t.canonical)));
         }
         for t in collections::COLLECTION_TYPES {
-            builtin_types.push(t.canonical);
-            builtin_types.extend_from_slice(t.aliases);
+            builtin_types.push((t.canonical, t.canonical));
+            builtin_types.extend(t.aliases.iter().map(|alias| (*alias, t.canonical)));
         }
         for t in surface_types::SURFACE_TYPES {
             // RFC 022: stdlib-scoped types must be explicitly imported (e.g. `from std.web import App`).
             // Only truly global surface types (Rust interop helpers) are injected here.
             if surface_types::is_global(t.item.id) {
-                builtin_types.push(t.item.canonical);
-                builtin_types.extend_from_slice(t.item.aliases);
+                builtin_types.push((t.item.canonical, t.item.canonical));
+                builtin_types.extend(t.item.aliases.iter().map(|alias| (*alias, t.item.canonical)));
             }
         }
         // Unit-ish types that are not yet modeled in `incan_core::lang::types`.
-        builtin_types.push(conventions::UNIT_TYPE_NAME);
-        builtin_types.push(conventions::NONE_TYPE_NAME);
-        builtin_types.push(UNION_TYPE_NAME);
+        builtin_types.push((conventions::UNIT_TYPE_NAME, conventions::UNIT_TYPE_NAME));
+        builtin_types.push((conventions::NONE_TYPE_NAME, conventions::NONE_TYPE_NAME));
+        builtin_types.push((UNION_TYPE_NAME, UNION_TYPE_NAME));
 
         // Deduplicate to avoid defining the same builtin twice.
         let mut seen: std::collections::HashSet<&'static str> = std::collections::HashSet::new();
-        for name in builtin_types.into_iter().filter(|n| seen.insert(*n)) {
-            self.define(Symbol {
+        for (name, canonical) in builtin_types.into_iter().filter(|(n, _)| seen.insert(*n)) {
+            let id = self.define(Symbol {
                 name: name.to_string(),
                 kind: SymbolKind::Type(TypeInfo::Builtin),
                 span: Span::default(),
                 scope: 0,
             });
+            self.record_builtin_identity(id, canonical);
         }
 
         // Builtin traits
@@ -152,7 +248,7 @@ impl SymbolTable {
                 TraitId::Awaitable => vec!["T".to_string()],
                 _ => Vec::new(),
             };
-            self.define(Symbol {
+            let id = self.define(Symbol {
                 name: info.canonical.to_string(),
                 kind: SymbolKind::Trait(TraitInfo {
                     type_params,
@@ -165,11 +261,12 @@ impl SymbolTable {
                 span: Span::default(),
                 scope: 0,
             });
+            self.record_builtin_identity(id, info.canonical);
         }
 
         // Builtin variants for Result and Option
         // Ok(T) and Err(E) for Result
-        self.define(Symbol {
+        let id = self.define(Symbol {
             name: constructors::as_str(constructors::ConstructorId::Ok).to_string(),
             kind: SymbolKind::Variant(VariantInfo {
                 enum_name: collections::as_str(CollectionTypeId::Result).to_string(),
@@ -178,7 +275,8 @@ impl SymbolTable {
             span: Span::default(),
             scope: 0,
         });
-        self.define(Symbol {
+        self.record_builtin_identity(id, constructors::as_str(constructors::ConstructorId::Ok));
+        let id = self.define(Symbol {
             name: constructors::as_str(constructors::ConstructorId::Err).to_string(),
             kind: SymbolKind::Variant(VariantInfo {
                 enum_name: collections::as_str(CollectionTypeId::Result).to_string(),
@@ -187,8 +285,9 @@ impl SymbolTable {
             span: Span::default(),
             scope: 0,
         });
+        self.record_builtin_identity(id, constructors::as_str(constructors::ConstructorId::Err));
         // Some(T) and None for Option
-        self.define(Symbol {
+        let id = self.define(Symbol {
             name: constructors::as_str(constructors::ConstructorId::Some).to_string(),
             kind: SymbolKind::Variant(VariantInfo {
                 enum_name: collections::as_str(CollectionTypeId::Option).to_string(),
@@ -197,7 +296,8 @@ impl SymbolTable {
             span: Span::default(),
             scope: 0,
         });
-        self.define(Symbol {
+        self.record_builtin_identity(id, constructors::as_str(constructors::ConstructorId::Some));
+        let id = self.define(Symbol {
             name: constructors::as_str(constructors::ConstructorId::None).to_string(),
             kind: SymbolKind::Variant(VariantInfo {
                 enum_name: collections::as_str(CollectionTypeId::Option).to_string(),
@@ -206,12 +306,13 @@ impl SymbolTable {
             span: Span::default(),
             scope: 0,
         });
+        self.record_builtin_identity(id, constructors::as_str(constructors::ConstructorId::None));
 
         // Builtin functions
         for name in std::iter::once(builtins::as_str(BuiltinFnId::Print))
             .chain(builtins::aliases(BuiltinFnId::Print).iter().copied())
         {
-            self.define(Symbol {
+            let id = self.define(Symbol {
                 name: name.to_string(),
                 kind: SymbolKind::Function(FunctionInfo {
                     params: vec![CallableParam::named("msg", ResolvedType::Str, ParamKind::Normal)],
@@ -225,8 +326,9 @@ impl SymbolTable {
                 span: Span::default(),
                 scope: 0,
             });
+            self.record_builtin_identity(id, builtins::as_str(BuiltinFnId::Print));
         }
-        self.define(Symbol {
+        let id = self.define(Symbol {
             name: builtins::as_str(BuiltinFnId::Len).to_string(),
             kind: SymbolKind::Function(FunctionInfo {
                 params: vec![CallableParam::named(
@@ -244,8 +346,9 @@ impl SymbolTable {
             span: Span::default(),
             scope: 0,
         });
+        self.record_builtin_identity(id, builtins::as_str(BuiltinFnId::Len));
         // range() builtin - returns an iterator
-        self.define(Symbol {
+        let id = self.define(Symbol {
             name: builtins::as_str(BuiltinFnId::Range).to_string(),
             kind: SymbolKind::Function(FunctionInfo {
                 params: vec![CallableParam::named("n", ResolvedType::Int, ParamKind::Normal)],
@@ -259,6 +362,7 @@ impl SymbolTable {
             span: Span::default(),
             scope: 0,
         });
+        self.record_builtin_identity(id, builtins::as_str(BuiltinFnId::Range));
     }
 
     /// Enter a new scope
@@ -280,9 +384,53 @@ impl SymbolTable {
         self.record_current_scope_binding_before_change(&symbol.name);
         symbol.scope = self.current_scope;
         let id = self.symbols.len();
+        if let Some(identity) = self.mint_identity(&symbol) {
+            self.identities.insert(id, identity);
+        }
         self.scopes[self.current_scope].symbols.insert(symbol.name.clone(), id);
         self.symbols.push(symbol);
         id
+    }
+
+    /// Define a symbol whose identity kind the defining site states explicitly.
+    ///
+    /// The generic [`Self::define`] mint classifies a definition from its [`SymbolKind`], which cannot distinguish a
+    /// parameter from a local (both are `Variable`) or a generic-binder placeholder from a builtin type (both are
+    /// `Type(Builtin)`). Sites that know the RFC 120 declaration category pass it here so the minted identity records
+    /// what was declared rather than how the table happens to represent it.
+    pub fn define_with_target_kind(&mut self, symbol: Symbol, kind: SemanticSourceTargetKind) -> SymbolId {
+        let identity = self.mint_identity_with_kind(&symbol, self.current_scope, kind);
+        let id = self.define(symbol);
+        self.identities.insert(id, identity);
+        id
+    }
+
+    /// Define an import, alias, or re-export binding carrying its resolved target's identity.
+    ///
+    /// RFC 120: a binding created by an import is a binding to an *existing* canonical symbol — it must carry the
+    /// declaring module's identity, never one minted from the importing module. `target_identity` is the identity
+    /// import resolution proved (see `TypeChecker::dependency_member_identity`); `None` records the binding as
+    /// unproven rather than inventing a consumer-module identity for it.
+    pub fn define_import_binding(&mut self, symbol: Symbol, target_identity: Option<CanonicalSymbolId>) -> SymbolId {
+        let id = self.define(symbol);
+        match target_identity {
+            Some(identity) => {
+                self.identities.insert(id, identity);
+            }
+            None => {
+                self.identities.remove(&id);
+            }
+        }
+        id
+    }
+
+    /// Remove a symbol's minted identity after its definition stops naming one declaration.
+    ///
+    /// The one current case is a module function symbol converted in place into an overload set: the identity minted
+    /// for the first declaration would otherwise keep naming an arbitrary member of the set. Overload declarations
+    /// keep their own span-keyed identities on `FunctionBindingInfo`.
+    pub fn clear_identity(&mut self, id: SymbolId) {
+        self.identities.remove(&id);
     }
 
     /// Define a symbol without replacing an existing same-scope lookup binding.
@@ -293,12 +441,148 @@ impl SymbolTable {
         self.record_current_scope_binding_before_change(&symbol.name);
         symbol.scope = self.current_scope;
         let id = self.symbols.len();
+        if let Some(identity) = self.mint_identity(&symbol) {
+            self.identities.insert(id, identity);
+        }
         self.scopes[self.current_scope]
             .symbols
             .entry(symbol.name.clone())
             .or_insert(id);
         self.symbols.push(symbol);
         id
+    }
+
+    // ---- RFC 120 canonical identity minting ----
+
+    /// Mint the canonical identity for one definition, when its symbol kind classifies it.
+    ///
+    /// Returns `None` while builtins are being registered (their loop attaches explicit registry identities so alias
+    /// spellings share the canonical entry), for overload sets (each overload declaration owns a span-keyed identity
+    /// of its own; a set-level identity would name an arbitrary member), and for definitions whose kind is a
+    /// placeholder the site must classify via [`Self::define_with_target_kind`].
+    fn mint_identity(&self, symbol: &Symbol) -> Option<CanonicalSymbolId> {
+        if self.minting_builtins {
+            return None;
+        }
+        let kind = default_identity_kind(&symbol.kind)?;
+        Some(self.mint_identity_with_kind(symbol, symbol.scope, kind))
+    }
+
+    /// Build one canonical identity for a definition with an already-decided declaration category.
+    ///
+    /// A `rust::` item's identity is anchored to its crate path with a zero declaration span: it has no Incan
+    /// declaration site, and the zero span keeps every module's import of one item structurally equal instead of
+    /// splitting per import site. Everything else is owned by the current module and anchored at its declaration
+    /// span, with the defining scope as discriminant for bindings that are not module-unique.
+    fn mint_identity_with_kind(
+        &self,
+        symbol: &Symbol,
+        scope: usize,
+        kind: SemanticSourceTargetKind,
+    ) -> CanonicalSymbolId {
+        let namespace = identity_namespace_for_kind(&kind);
+        let (origin, declaration_name, declaration_span) = match &symbol.kind {
+            SymbolKind::RustItem(info) => (
+                SymbolOrigin::RustCrate(info.path.split("::").map(str::to_string).collect()),
+                info.path.rsplit("::").next().unwrap_or(&symbol.name).to_string(),
+                HirSourceSpan::new(0, 0),
+            ),
+            _ => (
+                SymbolOrigin::Module(self.module_path.clone()),
+                symbol.name.clone(),
+                HirSourceSpan::new(symbol.span.start, symbol.span.end),
+            ),
+        };
+        // A member is owned by its nominal type and distinguished by its declaration span, not by which table scope
+        // its convenience binding happened to be defined in — so member identities never carry a scope discriminant
+        // and compare equal however they are reached.
+        let scope_discriminant =
+            (namespace != SymbolNamespace::Member && scope != 0).then_some(ScopeDiscriminant(scope));
+        CanonicalSymbolId {
+            namespace,
+            origin,
+            declaration_name,
+            kind,
+            scope_discriminant,
+            declaration_span,
+        }
+    }
+
+    /// Iterate the identities of module-scope declarations this module owns, paired with their declaration spans.
+    ///
+    /// Yields only definitions whose identity origin is the current module and whose declaration span is real —
+    /// builtins carry the registry origin and zero spans, and import/alias bindings carry another module's origin,
+    /// so none of those can masquerade as a local declaration here.
+    pub fn local_declaration_identities(&self) -> impl Iterator<Item = (Span, &CanonicalSymbolId)> + '_ {
+        self.symbols.iter().enumerate().filter_map(|(id, symbol)| {
+            if symbol.scope != 0 || symbol.span == Span::default() {
+                return None;
+            }
+            let identity = self.identities.get(&id)?;
+            if !matches!(&identity.origin, SymbolOrigin::Module(path) if path == &self.module_path) {
+                return None;
+            }
+            Some((symbol.span, identity))
+        })
+    }
+
+    /// Mint the canonical identity of one module-level declaration owned by the current module.
+    ///
+    /// The table is the single minting authority for RFC 120 identities, so sites that record declaration facts
+    /// outside the symbol table (function/partial bindings, method bindings) obtain their identity here rather than
+    /// assembling one from module path plus spelling themselves.
+    pub fn module_declaration_identity(
+        &self,
+        name: &str,
+        kind: SemanticSourceTargetKind,
+        span: Span,
+    ) -> CanonicalSymbolId {
+        CanonicalSymbolId::module_declaration(
+            self.module_path.clone(),
+            name,
+            kind,
+            HirSourceSpan::new(span.start, span.end),
+        )
+    }
+
+    /// Mint the canonical identity of one member declaration owned by a nominal type in the current module.
+    ///
+    /// Members live in RFC 120's member namespace: they are reached `.`-directed from an owner type, never through
+    /// the scope chain, so a member and a lexical binding sharing one spelling never compare equal. Two owners'
+    /// same-named members stay distinct through their declaration spans.
+    pub fn member_declaration_identity(
+        &self,
+        name: &str,
+        kind: SemanticSourceTargetKind,
+        span: Span,
+    ) -> CanonicalSymbolId {
+        CanonicalSymbolId {
+            namespace: SymbolNamespace::Member,
+            origin: SymbolOrigin::Module(self.module_path.clone()),
+            declaration_name: name.to_string(),
+            kind,
+            scope_discriminant: None,
+            declaration_span: HirSourceSpan::new(span.start, span.end),
+        }
+    }
+
+    /// Attach the explicit registry identity for one builtin definition.
+    ///
+    /// Builtin alias spellings (`i64` for `int`, `println` for `print`) are separate table entries, but RFC 120's
+    /// builtin fallback tier has one canonical entry per builtin — so every alias records the canonical registry
+    /// spelling as its declaration name and all spellings compare equal.
+    fn record_builtin_identity(&mut self, id: SymbolId, canonical_name: &str) {
+        self.identities.insert(
+            id,
+            CanonicalSymbolId {
+                namespace: SymbolNamespace::OrdinaryLexical,
+                origin: SymbolOrigin::Builtin,
+                declaration_name: canonical_name.to_string(),
+                kind: SemanticSourceTargetKind::Builtin,
+                scope_discriminant: None,
+                declaration_span: HirSourceSpan::new(0, 0),
+            },
+        );
     }
 
     /// Look up a symbol by name in the current scope chain

--- a/src/frontend/symbols.rs
+++ b/src/frontend/symbols.rs
@@ -2,7 +2,7 @@
 //!
 //! Tracks all named entities (types, functions, variables, traits) and their scopes.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::frontend::ast::{ParamKind, Receiver, Span, Type, TypeConstraintKey};
 use incan_core::interop::RustItemMetadata;
@@ -157,6 +157,10 @@ pub struct SymbolTable {
     /// registry identities that loop attaches (builtin aliases must carry the canonical registry spelling, which the
     /// generic mint cannot know).
     minting_builtins: bool,
+    /// Symbols defined through [`Self::define_import_binding`], marked so a later-arriving import-resolution proof
+    /// can be attached to exactly the binding it proves (see [`Self::backfill_import_identity`]) and never to an
+    /// unrelated same-spelled definition.
+    import_bindings: HashSet<SymbolId>,
 }
 
 impl SymbolTable {
@@ -170,6 +174,7 @@ impl SymbolTable {
             identities: HashMap::new(),
             module_path: Vec::new(),
             minting_builtins: false,
+            import_bindings: HashSet::new(),
         };
 
         // Add builtin types
@@ -413,6 +418,7 @@ impl SymbolTable {
     /// unproven rather than inventing a consumer-module identity for it.
     pub fn define_import_binding(&mut self, symbol: Symbol, target_identity: Option<CanonicalSymbolId>) -> SymbolId {
         let id = self.define(symbol);
+        self.import_bindings.insert(id);
         match target_identity {
             Some(identity) => {
                 self.identities.insert(id, identity);
@@ -431,6 +437,22 @@ impl SymbolTable {
     /// keep their own span-keyed identities on `FunctionBindingInfo`.
     pub fn clear_identity(&mut self, id: SymbolId) {
         self.identities.remove(&id);
+    }
+
+    /// Attach a later-proven import-resolution identity to the import binding it proves.
+    ///
+    /// Import materialization and identity proof do not always happen in one order, so a binding defined before its
+    /// proof was recorded starts identity-less. This attaches the proof to the *current* binding for `name` only
+    /// when that binding was defined as an import binding and still has no identity — a local declaration or
+    /// overload set that has since shadowed the import keeps its own facts, and a binding that already carries an
+    /// identity is never overwritten.
+    pub fn backfill_import_identity(&mut self, name: &str, identity: &CanonicalSymbolId) {
+        let Some(id) = self.lookup(name) else {
+            return;
+        };
+        if self.import_bindings.contains(&id) && !self.identities.contains_key(&id) {
+            self.identities.insert(id, identity.clone());
+        }
     }
 
     /// Define a symbol without replacing an existing same-scope lookup binding.
@@ -510,9 +532,12 @@ impl SymbolTable {
 
     /// Iterate the identities of module-scope declarations this module owns, paired with their declaration spans.
     ///
-    /// Yields only definitions whose identity origin is the current module and whose declaration span is real —
-    /// builtins carry the registry origin and zero spans, and import/alias bindings carry another module's origin,
-    /// so none of those can masquerade as a local declaration here.
+    /// Yields only definitions whose identity origin is the current module and whose declaration span is real:
+    /// builtins carry the registry origin and zero spans, and cross-module import bindings carry the declaring
+    /// module's origin, so neither can masquerade as a local declaration. A binding to a *same-module* declaration
+    /// (an `alias` targeting a local symbol) does pass the filter and yields its binding site paired with the
+    /// target declaration's identity — which is the RFC 120 answer for that site: the alias is a second binding to
+    /// the existing declaration, not a second declaration.
     pub fn local_declaration_identities(&self) -> impl Iterator<Item = (Span, &CanonicalSymbolId)> + '_ {
         self.symbols.iter().enumerate().filter_map(|(id, symbol)| {
             if symbol.scope != 0 || symbol.span == Span::default() {

--- a/src/frontend/typechecker/canonical_identity_tests.rs
+++ b/src/frontend/typechecker/canonical_identity_tests.rs
@@ -534,3 +534,39 @@ def read() -> None:
     assert_eq!(observed.kind, SemanticSourceTargetKind::Function);
     Ok(())
 }
+
+/// A reference that resolves to a local overload set must not inherit a shadowed import's identity.
+///
+/// Overload sets deliberately carry no set-level identity. When such a set shadows an earlier import of the same
+/// spelling, the reference-side recording must stay empty rather than reach past the actual binding to the import
+/// proof recorded for that local name — an identity fact for the wrong binding is worse than none.
+#[test]
+fn overload_set_shadowing_an_import_records_no_identity() -> Result<(), String> {
+    let provider = parse("pub def helper() -> int:\n  return 1\n", "overload-shadow provider");
+    let consumer_source = r#"
+from lib import helper
+
+def helper(value: int) -> int:
+  return value
+
+def helper(value: str) -> str:
+  return value
+
+def read() -> None:
+  observed = helper
+"#;
+    let consumer = parse(consumer_source, "overload-shadow consumer");
+    let mut checker = TypeChecker::new();
+    checker.set_current_module_path(Some(vec!["consumer".to_string()]));
+    // The reference errors ("cannot use overloaded function as a value"), which is expected and not the subject
+    // here; the recorded identity map must still be inspectable and must not carry the import's identity.
+    let _ = checker.check_with_imports(&consumer, &[("lib", &provider)]);
+
+    let reference_span = nth_span(consumer_source, "helper", 3)?;
+    assert_eq!(
+        checker.type_info().resolved_identity(reference_span),
+        None,
+        "an overload-set reference has no set-level identity and must not borrow the shadowed import's"
+    );
+    Ok(())
+}

--- a/src/frontend/typechecker/canonical_identity_tests.rs
+++ b/src/frontend/typechecker/canonical_identity_tests.rs
@@ -1,0 +1,536 @@
+//! RFC 120 conformance: canonical symbol identity at declaration sites and on resolved references.
+//!
+//! These tests pin the identity contract itself rather than any consumer: one compiler-owned identity is minted at
+//! each declaration site, an import/alias/re-export binding carries its *target's* identity, same-spelled bindings
+//! in different scopes stay distinct, and reference-side recording answers "do these two references mean the same
+//! thing" structurally. Body IR's consumption of these facts is pinned separately in
+//! `crate::frontend::body_ir::tests`.
+
+use incan_semantics_core::{CanonicalSymbolId, SemanticSourceTargetKind, SymbolNamespace, SymbolOrigin};
+
+use super::TypeChecker;
+use crate::frontend::ast::{Program, Span};
+use crate::frontend::{lexer, parser};
+
+/// Parse one test program, panicking with context on lex/parse failure.
+fn parse(source: &str, context: &str) -> Program {
+    let tokens = lexer::lex(source).unwrap_or_else(|errs| panic!("{context} lex failed: {errs:?}"));
+    parser::parse(&tokens).unwrap_or_else(|errs| panic!("{context} parse failed: {errs:?}"))
+}
+
+/// Check one standalone program and return the checker for identity inspection.
+fn check(source: &str, context: &str) -> Result<TypeChecker, String> {
+    let program = parse(source, context);
+    let mut checker = TypeChecker::new();
+    checker.set_current_module_path(Some(vec!["conformance".to_string()]));
+    checker
+        .check_program(&program)
+        .map_err(|errors| format!("{context} should typecheck: {errors:?}"))?;
+    Ok(checker)
+}
+
+/// Return the span of the `occurrence`-th appearance (0-based) of `needle` in `source`.
+fn nth_span(source: &str, needle: &str, occurrence: usize) -> Result<Span, String> {
+    source
+        .match_indices(needle)
+        .nth(occurrence)
+        .map(|(start, matched)| Span::new(start, start + matched.len()))
+        .ok_or_else(|| format!("occurrence {occurrence} of `{needle}` not found"))
+}
+
+/// Return the recorded reference identity at `span`, or an error naming the missing case.
+fn identity_at(checker: &TypeChecker, span: Span, context: &str) -> Result<CanonicalSymbolId, String> {
+    checker.type_info().resolved_identity(span).cloned().ok_or_else(|| {
+        format!(
+            "{context}: no resolved identity recorded at {}..{}",
+            span.start, span.end
+        )
+    })
+}
+
+/// A module-level declaration's identity is minted once and is independent of how often it is referenced.
+#[test]
+fn module_declaration_identity_is_reference_independent() -> Result<(), String> {
+    let source = r#"
+def helper() -> int:
+  return 1
+
+def first() -> int:
+  value = helper
+  return 1
+
+def second() -> int:
+  again = helper
+  return 2
+"#;
+    let checker = check(source, "reference independence")?;
+    let first_ref = identity_at(&checker, nth_span(source, "helper", 1)?, "first reference")?;
+    let second_ref = identity_at(&checker, nth_span(source, "helper", 2)?, "second reference")?;
+    assert_eq!(first_ref, second_ref, "two references must record one identity");
+    assert_eq!(first_ref.kind, SemanticSourceTargetKind::Function);
+    assert_eq!(first_ref.declaration_name, "helper");
+    assert_eq!(
+        first_ref.origin,
+        SymbolOrigin::Module(vec!["conformance".to_string()]),
+        "a module declaration is owned by its module"
+    );
+    assert_eq!(
+        first_ref.scope_discriminant, None,
+        "module-level declarations are module-unique and carry no discriminant"
+    );
+
+    let declaration = checker
+        .type_info()
+        .declarations
+        .declaration_identities
+        .values()
+        .find(|identity| identity.declaration_name == "helper")
+        .ok_or("declaration identity for `helper` must be exported")?;
+    assert_eq!(
+        declaration, &first_ref,
+        "references resolve to the declaration's identity"
+    );
+    Ok(())
+}
+
+/// Two same-spelled bindings in sibling blocks are different declarations with different identities.
+#[test]
+fn sibling_block_locals_get_distinct_identities() -> Result<(), String> {
+    let source = r#"
+def run() -> None:
+  if true:
+    left = 1
+    _ = left
+  if true:
+    left = 2
+    _ = left
+"#;
+    let checker = check(source, "sibling blocks")?;
+    // Occurrences: 0 = first binding, 1 = first reference, 2 = second binding, 3 = second reference.
+    let first = identity_at(&checker, nth_span(source, "left", 1)?, "first block reference")?;
+    let second = identity_at(&checker, nth_span(source, "left", 3)?, "second block reference")?;
+    assert_eq!(first.kind, SemanticSourceTargetKind::Local);
+    assert_eq!(second.kind, SemanticSourceTargetKind::Local);
+    assert_ne!(
+        first, second,
+        "same-spelled locals in sibling blocks must not collapse to one identity"
+    );
+    assert_ne!(
+        first.scope_discriminant, second.scope_discriminant,
+        "sibling blocks are different scopes, so the discriminants must differ"
+    );
+    Ok(())
+}
+
+/// `let` introduces a new binding with a fresh identity over an active outer binding; the outer binding's identity
+/// is unchanged and visible again after the block.
+#[test]
+fn let_shadowing_mints_a_new_identity_and_restores_the_outer_one() -> Result<(), String> {
+    let source = r#"
+def run() -> None:
+  mut shade = 1
+  first = shade
+  if true:
+    let shade = 2
+    second = shade
+  third = shade
+"#;
+    let checker = check(source, "let shadowing")?;
+    // Occurrences: 0 = outer binding, 1 = outer reference, 2 = `let` binding, 3 = shadowed reference,
+    // 4 = post-block reference.
+    let outer = identity_at(&checker, nth_span(source, "shade", 1)?, "outer reference")?;
+    let shadowed = identity_at(&checker, nth_span(source, "shade", 3)?, "shadowed reference")?;
+    let restored = identity_at(&checker, nth_span(source, "shade", 4)?, "post-block reference")?;
+    assert_ne!(outer, shadowed, "`let` must mint a fresh identity for the new binding");
+    assert_eq!(
+        outer, restored,
+        "the outer binding's identity is visible again after the block"
+    );
+    Ok(())
+}
+
+/// Plain assignment inside a nested block reassigns the outer binding: later references still carry the outer
+/// declaration's identity, not a new one.
+#[test]
+fn plain_assignment_preserves_the_target_binding_identity() -> Result<(), String> {
+    let source = r#"
+def run() -> None:
+  mut total = 1
+  first = total
+  if true:
+    total = 2
+  second = total
+"#;
+    let checker = check(source, "plain reassignment")?;
+    let before = identity_at(&checker, nth_span(source, "total", 1)?, "reference before block")?;
+    let after = identity_at(&checker, nth_span(source, "total", 3)?, "reference after block")?;
+    assert_eq!(
+        before, after,
+        "plain assignment reassigns the active binding and must not change its identity"
+    );
+    Ok(())
+}
+
+/// A generic binder has its own identity, scoped to the declaration that introduces it, distinct from any
+/// same-spelled concrete type and from another declaration's binder.
+#[test]
+fn generic_binder_identity_is_declaration_scoped() -> Result<(), String> {
+    let source = r#"
+model Holder:
+  value: int
+
+def wrap[T](value: T) -> T:
+  return value
+
+def echo[T](value: T) -> T:
+  return value
+"#;
+    let checker = check(source, "generic binders")?;
+    let binder_identities: Vec<CanonicalSymbolId> = checker
+        .symbols
+        .all_symbols()
+        .iter()
+        .enumerate()
+        .filter(|(_, symbol)| symbol.name == "T")
+        .filter_map(|(id, _)| checker.symbols.identity_of(id).cloned())
+        .filter(|identity| identity.kind == SemanticSourceTargetKind::GenericBinder)
+        .collect();
+    assert!(
+        binder_identities.len() >= 2,
+        "both binder declarations must carry GenericBinder identities, got {binder_identities:?}"
+    );
+    assert_ne!(
+        binder_identities[0], binder_identities[1],
+        "two declarations' binders are distinct declarations"
+    );
+    for binder in &binder_identities {
+        assert!(
+            binder.scope_discriminant.is_some(),
+            "a binder is bounded to its declaration's scope, so it must carry a discriminant"
+        );
+    }
+
+    let holder = checker
+        .type_info()
+        .declarations
+        .declaration_identities
+        .values()
+        .find(|identity| identity.declaration_name == "Holder")
+        .ok_or("model declaration identity must be exported")?;
+    assert_eq!(holder.kind, SemanticSourceTargetKind::Model);
+    assert!(
+        binder_identities.iter().all(|binder| binder != holder),
+        "a binder never compares equal to a concrete type declaration"
+    );
+    Ok(())
+}
+
+/// Parameters and receivers carry their own declaration categories, and a parameter's identity differs from a
+/// same-spelled local in another scope.
+#[test]
+fn parameter_and_receiver_identities_carry_their_categories() -> Result<(), String> {
+    let source = r#"
+class Greeter:
+  name: str
+
+  def greet(self, message: str) -> str:
+    return message
+"#;
+    let checker = check(source, "parameters and receivers")?;
+    let message = identity_at(&checker, nth_span(source, "message", 1)?, "parameter reference")?;
+    assert_eq!(message.kind, SemanticSourceTargetKind::Parameter);
+    assert!(message.scope_discriminant.is_some(), "parameters are scope-bounded");
+
+    // `self` reads resolve through their own dedicated path rather than ordinary identifier checking, so the
+    // receiver's identity is observed at its definition in the symbol table.
+    let receiver = checker
+        .symbols
+        .all_symbols()
+        .iter()
+        .enumerate()
+        .filter(|(_, symbol)| symbol.name == "self")
+        .filter_map(|(id, _)| checker.symbols.identity_of(id))
+        .find(|identity| identity.kind == SemanticSourceTargetKind::Receiver)
+        .ok_or("the receiver binding must carry a Receiver-kind identity")?;
+    assert!(receiver.scope_discriminant.is_some(), "receivers are scope-bounded");
+    Ok(())
+}
+
+/// A method declaration's identity lives in the member namespace; two owners' same-named methods stay distinct.
+#[test]
+fn member_method_identities_are_owner_distinct() -> Result<(), String> {
+    let source = r#"
+model First:
+  value: int
+
+  def describe(self) -> str:
+    return "first"
+
+model Second:
+  value: int
+
+  def describe(self) -> str:
+    return "second"
+"#;
+    let checker = check(source, "member methods")?;
+    let describe_identities: Vec<&CanonicalSymbolId> = checker
+        .type_info()
+        .declarations
+        .method_bindings_by_span
+        .values()
+        .filter_map(|binding| binding.identity.as_ref())
+        .filter(|identity| identity.declaration_name == "describe")
+        .collect();
+    assert_eq!(
+        describe_identities.len(),
+        2,
+        "both method declarations must carry identities"
+    );
+    assert_eq!(describe_identities[0].namespace, SymbolNamespace::Member);
+    assert_eq!(describe_identities[1].namespace, SymbolNamespace::Member);
+    assert_eq!(describe_identities[0].kind, SemanticSourceTargetKind::Method);
+    assert_ne!(
+        describe_identities[0], describe_identities[1],
+        "two owners' same-named methods are different declarations"
+    );
+    Ok(())
+}
+
+/// An import, its alias, and a re-export are bindings to one declaration: every spelling records one identity.
+#[test]
+fn import_alias_and_reexport_share_the_declaration_identity() -> Result<(), String> {
+    let lib = parse(
+        r#"
+pub def helper() -> int:
+  return 1
+"#,
+        "identity lib",
+    );
+    let api = parse(
+        r#"
+from lib import helper as h
+"#,
+        "identity api facade",
+    );
+    let consumer_source = r#"
+from lib import helper
+from lib import helper as h
+from api import h as run
+
+def use_all() -> None:
+  a = helper
+  b = h
+  c = run
+"#;
+    let consumer = parse(consumer_source, "identity consumer");
+    let mut checker = TypeChecker::new();
+    checker.set_current_module_path(Some(vec!["consumer".to_string()]));
+    checker
+        .check_with_imports(&consumer, &[("lib", &lib), ("api", &api)])
+        .map_err(|errors| format!("identity consumer should typecheck: {errors:?}"))?;
+
+    let direct = checker
+        .type_info()
+        .resolved_import_identity("helper")
+        .ok_or("direct import must prove an identity")?
+        .clone();
+    let aliased = checker
+        .type_info()
+        .resolved_import_identity("h")
+        .ok_or("aliased import must prove an identity")?
+        .clone();
+    let reexported = checker
+        .type_info()
+        .resolved_import_identity("run")
+        .ok_or("re-exported import must prove an identity")?
+        .clone();
+
+    assert_eq!(direct, aliased, "an alias binds the same declaration");
+    assert_eq!(
+        direct, reexported,
+        "a re-export resolves to the declaring module, never the facade"
+    );
+    assert_eq!(
+        direct.declaration_name, "helper",
+        "the declaration-site spelling survives every alias"
+    );
+    assert_eq!(direct.origin, SymbolOrigin::Module(vec!["lib".to_string()]));
+
+    // Reference-side recording sees the same identity through every spelling.
+    let helper_ref = identity_at(&checker, nth_span(consumer_source, "helper", 2)?, "direct reference")?;
+    let h_ref = identity_at(
+        &checker,
+        nth_span(consumer_source, "b = h", 0).map(|span| Span::new(span.end - 1, span.end))?,
+        "alias reference",
+    )?;
+    let run_ref = identity_at(&checker, nth_span(consumer_source, "run", 1)?, "re-export reference")?;
+    assert_eq!(helper_ref, direct);
+    assert_eq!(h_ref, direct);
+    assert_eq!(run_ref, direct);
+    Ok(())
+}
+
+/// Rebinding a core builtin-function spelling is not a collision, and the rebound declaration's identity differs
+/// from the builtin registry identity (#1116's settled contract as an identity fact).
+#[test]
+fn rebound_builtin_spelling_and_registry_builtin_are_distinct_identities() -> Result<(), String> {
+    let source = r#"
+def len(value: int) -> int:
+  return value + 1
+
+def shadowed() -> int:
+  return len(4)
+"#;
+    let checker = check(source, "builtin rebinding")?;
+
+    let local_len = checker
+        .type_info()
+        .declarations
+        .declaration_identities
+        .values()
+        .find(|identity| identity.declaration_name == "len")
+        .ok_or("the local `len` declaration must carry an identity")?;
+    assert_eq!(local_len.kind, SemanticSourceTargetKind::Function);
+    assert_eq!(local_len.origin, SymbolOrigin::Module(vec!["conformance".to_string()]));
+
+    let registry_len = checker
+        .symbols
+        .all_symbols()
+        .iter()
+        .enumerate()
+        .filter(|(_, symbol)| symbol.name == "len")
+        .filter_map(|(id, _)| checker.symbols.identity_of(id))
+        .find(|identity| identity.origin == SymbolOrigin::Builtin)
+        .ok_or("the builtin registry identity for `len` must still exist")?;
+    assert_eq!(registry_len.kind, SemanticSourceTargetKind::Builtin);
+    assert_ne!(
+        registry_len, local_len,
+        "the rebound spelling and the registry builtin are two different canonical identities"
+    );
+    Ok(())
+}
+
+/// Builtin alias spellings share one canonical registry identity instead of minting one identity per spelling.
+#[test]
+fn builtin_alias_spellings_share_one_registry_identity() -> Result<(), String> {
+    let checker = check("def noop() -> None:\n  pass\n", "builtin aliases")?;
+    let mut int_identities = Vec::new();
+    for (id, symbol) in checker.symbols.all_symbols().iter().enumerate() {
+        if (symbol.name == "int" || symbol.name == "i64")
+            && let Some(identity) = checker.symbols.identity_of(id)
+            && identity.origin == SymbolOrigin::Builtin
+        {
+            int_identities.push(identity.clone());
+        }
+    }
+    assert!(
+        int_identities.len() >= 2,
+        "expected canonical and alias spellings of the int builtin, got {int_identities:?}"
+    );
+    assert!(
+        int_identities.iter().all(|identity| identity == &int_identities[0]),
+        "every alias spelling must carry the one canonical registry identity: {int_identities:?}"
+    );
+    Ok(())
+}
+
+/// Consts and statics carry their declaration categories from the one mint point.
+#[test]
+fn const_and_static_identities_carry_their_categories() -> Result<(), String> {
+    let source = r#"
+const LIMIT: int = 10
+
+static counter: int = 0
+
+def read() -> int:
+  return LIMIT
+"#;
+    let checker = check(source, "const and static")?;
+    let limit = identity_at(&checker, nth_span(source, "LIMIT", 1)?, "const reference")?;
+    assert_eq!(limit.kind, SemanticSourceTargetKind::Const);
+    assert_eq!(limit.scope_discriminant, None);
+
+    let counter = checker
+        .type_info()
+        .declarations
+        .declaration_identities
+        .values()
+        .find(|identity| identity.declaration_name == "counter")
+        .ok_or("static declaration identity must be exported")?;
+    assert_eq!(counter.kind, SemanticSourceTargetKind::Static);
+    Ok(())
+}
+
+/// Two same-spelled module declarations are two declarations with two identities.
+///
+/// RFC 120's decided rule makes a duplicate module-scope declaration a *diagnostic* from the one shared
+/// binding-registration mechanism; that mechanism is Slice 3 of the RFC's implementation plan and is not delivered
+/// by the identity core. What the identity core must already guarantee — and what this test pins — is that the two
+/// declarations never collapse into one identity: whichever binding wins lookup, each declaration site keeps its
+/// own canonical identity, so the later collision diagnostic can name both declarations by identity and span.
+#[test]
+fn duplicate_module_declarations_keep_distinct_identities() -> Result<(), String> {
+    let source = r#"
+model User:
+  name: str
+
+model User:
+  age: int
+"#;
+    let checker = check(source, "duplicate declarations")?;
+    let user_identities: Vec<&CanonicalSymbolId> = checker
+        .type_info()
+        .declarations
+        .declaration_identities
+        .values()
+        .filter(|identity| identity.declaration_name == "User")
+        .collect();
+    assert_eq!(
+        user_identities.len(),
+        2,
+        "both declaration sites must keep their own exported identity"
+    );
+    assert_ne!(
+        user_identities[0], user_identities[1],
+        "two declaration sites are two identities, never one merged winner"
+    );
+    Ok(())
+}
+
+/// A local declaration over an imported binding keeps the local declaration's identity on later references.
+///
+/// The decided rule makes this collision a diagnostic once RFC 120 Slice 3's shared mechanism lands; the identity
+/// core pins the meaning-side half: the reference resolves to exactly one binding, and its identity is the local
+/// declaration's — not the import's, and not a blend of the two.
+#[test]
+fn local_declaration_over_import_resolves_to_the_local_identity() -> Result<(), String> {
+    let provider = parse("pub def helper() -> int:\n  return 1\n", "collision provider");
+    let consumer_source = r#"
+from lib import helper
+
+def helper() -> int:
+  return 2
+
+def read() -> None:
+  observed = helper
+"#;
+    let consumer = parse(consumer_source, "collision consumer");
+    let mut checker = TypeChecker::new();
+    checker.set_current_module_path(Some(vec!["consumer".to_string()]));
+    checker
+        .check_with_imports(&consumer, &[("lib", &provider)])
+        .map_err(|errors| format!("collision consumer should typecheck today: {errors:?}"))?;
+
+    let observed = identity_at(
+        &checker,
+        nth_span(consumer_source, "helper", 2)?,
+        "post-collision reference",
+    )?;
+    assert_eq!(
+        observed.origin,
+        SymbolOrigin::Module(vec!["consumer".to_string()]),
+        "the reference resolves to the local declaration, so it must carry the local identity"
+    );
+    assert_eq!(observed.kind, SemanticSourceTargetKind::Function);
+    Ok(())
+}

--- a/src/frontend/typechecker/check_decl.rs
+++ b/src/frontend/typechecker/check_decl.rs
@@ -2304,12 +2304,15 @@ impl TypeChecker {
     fn check_type_alias(&mut self, alias: &TypeAliasDecl) {
         self.symbols.enter_scope(ScopeKind::Block);
         for param in &alias.type_params {
-            self.symbols.define(Symbol {
-                name: param.name.clone(),
-                kind: SymbolKind::Type(TypeInfo::Builtin),
-                span: Span::default(),
-                scope: 0,
-            });
+            self.symbols.define_with_target_kind(
+                Symbol {
+                    name: param.name.clone(),
+                    kind: SymbolKind::Type(TypeInfo::Builtin), // Type-var placeholder
+                    span: Span::default(),
+                    scope: 0,
+                },
+                SemanticSourceTargetKind::GenericBinder,
+            );
         }
         self.validate_type_param_bound_type_names(&alias.type_params);
         let _ = self.resolve_type_checked(&alias.target);
@@ -3193,12 +3196,15 @@ impl TypeChecker {
 
         // Define type parameters
         for param in &model.type_params {
-            self.symbols.define(Symbol {
-                name: param.name.clone(),
-                kind: SymbolKind::Type(TypeInfo::Builtin), // Type var placeholder
-                span: Span::default(),
-                scope: 0,
-            });
+            self.symbols.define_with_target_kind(
+                Symbol {
+                    name: param.name.clone(),
+                    kind: SymbolKind::Type(TypeInfo::Builtin), // Type-var placeholder
+                    span: Span::default(),
+                    scope: 0,
+                },
+                SemanticSourceTargetKind::GenericBinder,
+            );
         }
 
         // Check traits exist and are satisfied (models can adopt storage-free traits, RFC 000).
@@ -3595,12 +3601,15 @@ impl TypeChecker {
 
         // Define type parameters before resolving class fields, trait adoptions, and method signatures.
         for param in &class.type_params {
-            self.symbols.define(Symbol {
-                name: param.name.clone(),
-                kind: SymbolKind::Type(TypeInfo::Builtin),
-                span: Span::default(),
-                scope: 0,
-            });
+            self.symbols.define_with_target_kind(
+                Symbol {
+                    name: param.name.clone(),
+                    kind: SymbolKind::Type(TypeInfo::Builtin), // Type-var placeholder
+                    span: Span::default(),
+                    scope: 0,
+                },
+                SemanticSourceTargetKind::GenericBinder,
+            );
         }
 
         self.validate_decorators_rejecting_user_defined(&class.decorators, "class");
@@ -3832,12 +3841,15 @@ impl TypeChecker {
         // scope and revisit every declaration-only surface during the semantic pass.
         let trait_type_params: Vec<String> = tr.type_params.iter().map(|param| param.name.clone()).collect();
         for param in &tr.type_params {
-            self.symbols.define(Symbol {
-                name: param.name.clone(),
-                kind: SymbolKind::Type(TypeInfo::Builtin),
-                span: Span::default(),
-                scope: 0,
-            });
+            self.symbols.define_with_target_kind(
+                Symbol {
+                    name: param.name.clone(),
+                    kind: SymbolKind::Type(TypeInfo::Builtin), // Type-var placeholder
+                    span: Span::default(),
+                    scope: 0,
+                },
+                SemanticSourceTargetKind::GenericBinder,
+            );
         }
         self.validate_type_param_bound_type_names(&tr.type_params);
         for supertrait in &tr.traits {
@@ -4085,12 +4097,15 @@ impl TypeChecker {
         self.symbols.enter_scope(ScopeKind::Block);
 
         for param in &nt.type_params {
-            self.symbols.define(Symbol {
-                name: param.name.clone(),
-                kind: SymbolKind::Type(TypeInfo::Builtin),
-                span: Span::default(),
-                scope: 0,
-            });
+            self.symbols.define_with_target_kind(
+                Symbol {
+                    name: param.name.clone(),
+                    kind: SymbolKind::Type(TypeInfo::Builtin), // Type-var placeholder
+                    span: Span::default(),
+                    scope: 0,
+                },
+                SemanticSourceTargetKind::GenericBinder,
+            );
         }
         self.validate_type_param_bound_type_names(&nt.type_params);
 
@@ -4416,12 +4431,15 @@ impl TypeChecker {
         let derives = self.extract_derive_names(&en.decorators);
 
         for param in &en.type_params {
-            self.symbols.define(Symbol {
-                name: param.name.clone(),
-                kind: SymbolKind::Type(TypeInfo::Builtin),
-                span: Span::default(),
-                scope: 0,
-            });
+            self.symbols.define_with_target_kind(
+                Symbol {
+                    name: param.name.clone(),
+                    kind: SymbolKind::Type(TypeInfo::Builtin), // Type-var placeholder
+                    span: Span::default(),
+                    scope: 0,
+                },
+                SemanticSourceTargetKind::GenericBinder,
+            );
         }
 
         let mut resolved_trait_adoptions = Vec::new();
@@ -5499,12 +5517,15 @@ impl TypeChecker {
 
         // Define type parameters so explicit generic bounds are visible in function-level type resolution.
         for param in &func.type_params {
-            self.symbols.define(Symbol {
-                name: param.name.clone(),
-                kind: SymbolKind::Type(TypeInfo::Builtin), // Type-var placeholder
-                span: Span::default(),
-                scope: 0,
-            });
+            self.symbols.define_with_target_kind(
+                Symbol {
+                    name: param.name.clone(),
+                    kind: SymbolKind::Type(TypeInfo::Builtin), // Type-var placeholder
+                    span: Span::default(),
+                    scope: 0,
+                },
+                SemanticSourceTargetKind::GenericBinder,
+            );
         }
         let active_bounds = self.type_param_bound_details_from_type_params(&func.type_params);
         self.current_type_param_bound_details.push(active_bounds);
@@ -5515,16 +5536,19 @@ impl TypeChecker {
         // binding. The function body still receives its ordinary parameter locals below.
         for (param, resolved_ty) in func.params.iter().zip(resolved_param_types) {
             let ty = local_type_for_param(param.node.kind, resolved_ty);
-            self.symbols.define(Symbol {
-                name: param.node.name.clone(),
-                kind: SymbolKind::Variable(VariableInfo {
-                    ty,
-                    is_mutable: false,
-                    is_used: false,
-                }),
-                span: param.span,
-                scope: 0,
-            });
+            self.symbols.define_with_target_kind(
+                Symbol {
+                    name: param.node.name.clone(),
+                    kind: SymbolKind::Variable(VariableInfo {
+                        ty,
+                        is_mutable: false,
+                        is_used: false,
+                    }),
+                    span: param.span,
+                    scope: 0,
+                },
+                SemanticSourceTargetKind::Parameter,
+            );
         }
 
         let return_type = self.resolve_type_checked(&func.return_type);
@@ -5752,24 +5776,30 @@ impl TypeChecker {
         });
 
         for type_param in owner_type_params {
-            self.symbols.define(Symbol {
-                name: type_param.clone(),
-                kind: SymbolKind::Type(TypeInfo::Builtin),
-                span: Span::default(),
-                scope: 0,
-            });
+            self.symbols.define_with_target_kind(
+                Symbol {
+                    name: type_param.clone(),
+                    kind: SymbolKind::Type(TypeInfo::Builtin), // Type-var placeholder
+                    span: Span::default(),
+                    scope: 0,
+                },
+                SemanticSourceTargetKind::GenericBinder,
+            );
         }
 
-        self.symbols.define(Symbol {
-            name: "self".to_string(),
-            kind: SymbolKind::Variable(VariableInfo {
-                ty: self_ty.clone(),
-                is_mutable: false,
-                is_used: true,
-            }),
-            span: Span::default(),
-            scope: 0,
-        });
+        self.symbols.define_with_target_kind(
+            Symbol {
+                name: "self".to_string(),
+                kind: SymbolKind::Variable(VariableInfo {
+                    ty: self_ty.clone(),
+                    is_mutable: false,
+                    is_used: true,
+                }),
+                span: Span::default(),
+                scope: 0,
+            },
+            SemanticSourceTargetKind::Receiver,
+        );
 
         let return_type = self.resolve_type_checked(&property.return_type);
         let effective_return_type = Self::concretize_self_type_in_annotation(&return_type, &self_ty);
@@ -5815,22 +5845,28 @@ impl TypeChecker {
 
         // Define owner type parameters so generic wrappers can use them in bodies and annotations.
         for type_param in owner_type_params {
-            self.symbols.define(Symbol {
-                name: type_param.clone(),
-                kind: SymbolKind::Type(TypeInfo::Builtin),
-                span: Span::default(),
-                scope: 0,
-            });
+            self.symbols.define_with_target_kind(
+                Symbol {
+                    name: type_param.clone(),
+                    kind: SymbolKind::Type(TypeInfo::Builtin), // Type-var placeholder
+                    span: Span::default(),
+                    scope: 0,
+                },
+                SemanticSourceTargetKind::GenericBinder,
+            );
         }
 
         // Define method type parameters so generic methods can use them in signatures and bodies.
         for type_param in &method.type_params {
-            self.symbols.define(Symbol {
-                name: type_param.name.clone(),
-                kind: SymbolKind::Type(TypeInfo::Builtin),
-                span: Span::default(),
-                scope: 0,
-            });
+            self.symbols.define_with_target_kind(
+                Symbol {
+                    name: type_param.name.clone(),
+                    kind: SymbolKind::Type(TypeInfo::Builtin), // Type-var placeholder
+                    span: Span::default(),
+                    scope: 0,
+                },
+                SemanticSourceTargetKind::GenericBinder,
+            );
         }
         if let Some(target) = &method.trait_target {
             let trait_name = target.node.name.as_str();
@@ -5852,16 +5888,19 @@ impl TypeChecker {
             if is_mutable {
                 self.mutable_bindings.insert("self".to_string());
             }
-            self.symbols.define(Symbol {
-                name: "self".to_string(),
-                kind: SymbolKind::Variable(VariableInfo {
-                    ty: self_ty.clone(),
-                    is_mutable,
-                    is_used: true,
-                }),
-                span: Span::default(),
-                scope: 0,
-            });
+            self.symbols.define_with_target_kind(
+                Symbol {
+                    name: "self".to_string(),
+                    kind: SymbolKind::Variable(VariableInfo {
+                        ty: self_ty.clone(),
+                        is_mutable,
+                        is_used: true,
+                    }),
+                    span: Span::default(),
+                    scope: 0,
+                },
+                SemanticSourceTargetKind::Receiver,
+            );
         }
         let is_classmethod = Self::method_has_decorator(method, DecoratorId::ClassMethod);
         let previous_classmethod_self_ty = self.current_classmethod_self_ty.take();
@@ -5880,16 +5919,19 @@ impl TypeChecker {
                 param.node.default.is_some(),
             ));
             let ty = local_type_for_param(param.node.kind, resolved_ty);
-            self.symbols.define(Symbol {
-                name: param.node.name.clone(),
-                kind: SymbolKind::Variable(VariableInfo {
-                    ty,
-                    is_mutable: false,
-                    is_used: false,
-                }),
-                span: param.span,
-                scope: 0,
-            });
+            self.symbols.define_with_target_kind(
+                Symbol {
+                    name: param.node.name.clone(),
+                    kind: SymbolKind::Variable(VariableInfo {
+                        ty,
+                        is_mutable: false,
+                        is_used: false,
+                    }),
+                    span: param.span,
+                    scope: 0,
+                },
+                SemanticSourceTargetKind::Parameter,
+            );
         }
 
         let return_type = self.resolve_type_checked(&method.return_type);
@@ -5898,6 +5940,11 @@ impl TypeChecker {
             FunctionBindingInfo {
                 params: checked_params,
                 return_type: return_type.clone(),
+                identity: Some(self.symbols.member_declaration_identity(
+                    &method.name,
+                    SemanticSourceTargetKind::Method,
+                    method_span,
+                )),
             },
         );
         let effective_return_type = Self::concretize_self_type_in_annotation(&return_type, &self_ty);

--- a/src/frontend/typechecker/check_expr/basics.rs
+++ b/src/frontend/typechecker/check_expr/basics.rs
@@ -45,7 +45,7 @@ impl TypeChecker {
             ));
         }
 
-        let Some(sym) = self.lookup_symbol(name) else {
+        let Some(sym_id) = self.symbols.lookup(name) else {
             if name == "log" {
                 self.type_info
                     .expressions
@@ -54,6 +54,31 @@ impl TypeChecker {
                 self.type_info.record_ambient_logger_binding(span);
                 return ResolvedType::Named("Logger".to_string());
             }
+            self.errors.push(errors::unknown_symbol(name, span));
+            return ResolvedType::Unknown;
+        };
+        // ---- RFC 120: record which canonical identity this reference resolved to ----
+        //
+        // The binding's minted identity wins. A module-scope binding without one falls back to the identity import
+        // resolution proved for this local name, covering import bindings materialized before their proof was
+        // recorded. The fallback is module-scope-only so an identity-less nested placeholder can never pick up an
+        // unrelated import's identity.
+        let resolved_identity = self.symbols.identity_of(sym_id).cloned().or_else(|| {
+            self.symbols.get(sym_id).filter(|sym| sym.scope == 0).and_then(|_| {
+                self.type_info
+                    .declarations
+                    .resolved_import_identities
+                    .get(name)
+                    .cloned()
+            })
+        });
+        if let Some(identity) = resolved_identity {
+            self.type_info
+                .expressions
+                .resolved_identities
+                .insert((span.start, span.end), identity);
+        }
+        let Some(sym) = self.symbols.get(sym_id) else {
             self.errors.push(errors::unknown_symbol(name, span));
             return ResolvedType::Unknown;
         };

--- a/src/frontend/typechecker/check_expr/basics.rs
+++ b/src/frontend/typechecker/check_expr/basics.rs
@@ -59,20 +59,10 @@ impl TypeChecker {
         };
         // ---- RFC 120: record which canonical identity this reference resolved to ----
         //
-        // The binding's minted identity wins. A module-scope binding without one falls back to the identity import
-        // resolution proved for this local name, covering import bindings materialized before their proof was
-        // recorded. The fallback is module-scope-only so an identity-less nested placeholder can never pick up an
-        // unrelated import's identity.
-        let resolved_identity = self.symbols.identity_of(sym_id).cloned().or_else(|| {
-            self.symbols.get(sym_id).filter(|sym| sym.scope == 0).and_then(|_| {
-                self.type_info
-                    .declarations
-                    .resolved_import_identities
-                    .get(name)
-                    .cloned()
-            })
-        });
-        if let Some(identity) = resolved_identity {
+        // Strictly the resolved binding's own identity: import bindings carry their proven target identity (attached
+        // at definition or back-filled when the proof lands — see `SymbolTable::backfill_import_identity`), so no
+        // name-keyed fallback exists here that a shadowing definition could make stale.
+        if let Some(identity) = self.symbols.identity_of(sym_id).cloned() {
             self.type_info
                 .expressions
                 .resolved_identities

--- a/src/frontend/typechecker/collect.rs
+++ b/src/frontend/typechecker/collect.rs
@@ -9,6 +9,7 @@ use crate::frontend::resolved_type_subst::{substitute_resolved_type, type_param_
 use crate::frontend::symbols::*;
 use crate::frontend::typechecker::helpers::freeze_const_type;
 use incan_core::lang::decorators::{self as core_decorators, DecoratorId};
+use incan_semantics_core::{CanonicalSymbolId, SemanticSourceTargetKind};
 
 use super::{
     FunctionBindingInfo, PartialProjectionInfo, PartialProjectionPreset, PartialProjectionTargetKind, TypeChecker,
@@ -192,6 +193,7 @@ impl TypeChecker {
     /// Register a module-level alias after concrete symbols have been collected.
     fn collect_alias(&mut self, alias: &AliasDecl, span: Span) {
         let target_name = alias.target.segments.join(".");
+        let target_identity = self.alias_target_identity(&alias.target.segments);
         let Some(kind) = self.alias_target_symbol_kind(&alias.target.segments) else {
             self.errors.push(CompileError::type_error(
                 format!("Alias '{}' targets unknown symbol '{}'", alias.name, target_name),
@@ -218,12 +220,49 @@ impl TypeChecker {
             }
         };
 
-        self.symbols.define(Symbol {
-            name: alias.name.clone(),
-            kind,
-            span,
-            scope: 0,
-        });
+        // RFC 083/RFC 120: an alias is a binding to the existing declaration, so it carries the target's
+        // identity — never a second identity minted for the alias spelling.
+        self.symbols.define_import_binding(
+            Symbol {
+                name: alias.name.clone(),
+                kind,
+                span,
+                scope: 0,
+            },
+            target_identity,
+        );
+    }
+
+    /// Resolve the RFC 120 identity an alias binding must carry, when resolution proves one.
+    ///
+    /// Single-segment targets take the identity of the module-scope symbol they name. Qualified targets resolve
+    /// through the same dependency-member path import resolution uses, so the alias lands on the declaring module
+    /// even through re-exports. An overload-set or otherwise unproven target yields `None` — the alias binding then
+    /// records no identity rather than an arbitrary or minted one.
+    fn alias_target_identity(&mut self, segments: &[String]) -> Option<CanonicalSymbolId> {
+        match segments {
+            [name] => {
+                let id = self.symbols.lookup(name)?;
+                self.symbols.identity_of(id).cloned()
+            }
+            [module_name, rest @ ..] => {
+                let member = rest.last()?;
+                let module_path = {
+                    let symbol = self.lookup_symbol(module_name)?;
+                    let SymbolKind::Module(info) = &symbol.kind else {
+                        return None;
+                    };
+                    if info.is_python {
+                        return None;
+                    }
+                    let mut module_path = info.path.clone();
+                    module_path.extend_from_slice(&rest[..rest.len().saturating_sub(1)]);
+                    module_path
+                };
+                self.dependency_member_identity(&ImportPath::simple(module_path), member)
+            }
+            [] => None,
+        }
     }
 
     /// Record the common metadata for any source binding that resolves to an overload set.
@@ -263,11 +302,18 @@ impl TypeChecker {
     ) {
         match kind {
             SymbolKind::Function(info) => {
+                let identity = self
+                    .type_info
+                    .declarations
+                    .resolved_import_identities
+                    .get(local_name)
+                    .cloned();
                 self.type_info.declarations.function_bindings.insert(
                     local_name.to_string(),
                     FunctionBindingInfo {
                         params: info.params.clone(),
                         return_type: info.return_type.clone(),
+                        identity,
                     },
                 );
             }
@@ -363,20 +409,23 @@ impl TypeChecker {
             return;
         };
 
-        self.symbols.define(Symbol {
-            name: partial.name.clone(),
-            kind: SymbolKind::Function(FunctionInfo {
-                params: params.clone(),
-                return_type: return_type.clone(),
-                is_async,
-                type_params,
-                type_param_bounds,
-                type_param_bound_details,
-                emitted_name: None,
-            }),
-            span,
-            scope: 0,
-        });
+        self.symbols.define_with_target_kind(
+            Symbol {
+                name: partial.name.clone(),
+                kind: SymbolKind::Function(FunctionInfo {
+                    params: params.clone(),
+                    return_type: return_type.clone(),
+                    is_async,
+                    type_params,
+                    type_param_bounds,
+                    type_param_bound_details,
+                    emitted_name: None,
+                }),
+                span,
+                scope: 0,
+            },
+            SemanticSourceTargetKind::Partial,
+        );
         self.type_info.record_partial_projection(PartialProjectionInfo {
             name: partial.name.clone(),
             target_path: partial.target.segments.clone(),
@@ -392,10 +441,18 @@ impl TypeChecker {
                 .collect(),
             external_library: None,
         });
-        self.type_info
-            .declarations
-            .function_bindings
-            .insert(partial.name.clone(), FunctionBindingInfo { params, return_type });
+        self.type_info.declarations.function_bindings.insert(
+            partial.name.clone(),
+            FunctionBindingInfo {
+                identity: Some(self.symbols.module_declaration_identity(
+                    &partial.name,
+                    SemanticSourceTargetKind::Partial,
+                    span,
+                )),
+                params,
+                return_type,
+            },
+        );
     }
 
     /// Resolve the callable surface that a top-level partial declaration projects from an already-resolved symbol.
@@ -580,17 +637,21 @@ impl TypeChecker {
             })
             .unwrap_or(ResolvedType::Unknown);
 
-        // Define as an immutable variable-like symbol for name resolution.
-        self.symbols.define(Symbol {
-            name: konst.name.clone(),
-            kind: SymbolKind::Variable(VariableInfo {
-                ty,
-                is_mutable: false,
-                is_used: false,
-            }),
-            span,
-            scope: 0,
-        });
+        // Define as an immutable variable-like symbol for name resolution. The identity category is stated
+        // explicitly: a `const` is not a body-local binding even though the table represents both as variables.
+        self.symbols.define_with_target_kind(
+            Symbol {
+                name: konst.name.clone(),
+                kind: SymbolKind::Variable(VariableInfo {
+                    ty,
+                    is_mutable: false,
+                    is_used: false,
+                }),
+                span,
+                scope: 0,
+            },
+            SemanticSourceTargetKind::Const,
+        );
     }
 
     /// Register a module-level static binding (first pass).
@@ -986,12 +1047,17 @@ impl TypeChecker {
         if self.symbols.lookup(name).is_some() {
             return;
         }
-        self.symbols.define(Symbol {
-            name: name.to_string(),
-            kind: SymbolKind::Trait(info),
-            span,
-            scope: 0,
-        });
+        // RFC 120: this binding names a dependency's trait declaration; its identity is unproven here rather than
+        // minted from the referencing module.
+        self.symbols.define_import_binding(
+            Symbol {
+                name: name.to_string(),
+                kind: SymbolKind::Trait(info),
+                span,
+                scope: 0,
+            },
+            None,
+        );
     }
 
     /// Register a trait declaration with its method signatures, supertraits, and requirements.
@@ -1563,6 +1629,11 @@ impl TypeChecker {
         let binding = FunctionBindingInfo {
             params: params.clone(),
             return_type: return_type.clone(),
+            identity: Some(self.symbols.module_declaration_identity(
+                &func.name,
+                SemanticSourceTargetKind::Function,
+                span,
+            )),
         };
         self.type_info
             .declarations
@@ -1605,6 +1676,9 @@ impl TypeChecker {
                     self.type_info
                         .record_function_overloads(func.name.clone(), overloads.clone());
                     existing_symbol.kind = SymbolKind::FunctionOverloads(overloads);
+                    // The symbol no longer names one declaration, so its minted identity must go: each overload
+                    // keeps its own span-keyed identity on `function_bindings_by_span`.
+                    self.symbols.clear_identity(existing_id);
                     return;
                 }
                 SymbolKind::FunctionOverloads(overloads) => {

--- a/src/frontend/typechecker/collect/stdlib_imports.rs
+++ b/src/frontend/typechecker/collect/stdlib_imports.rs
@@ -937,12 +937,21 @@ impl TypeChecker {
                         crate::frontend::typechecker::StaticBindingInfo { is_imported: true },
                     );
                 }
-                self.symbols.define(Symbol {
-                    name: alias.clone(),
-                    kind: imported_kind,
-                    span,
-                    scope: 0,
-                });
+                // RFC 120: the alias is a second binding to the already-materialized symbol, so it carries that
+                // symbol's identity rather than minting one of its own.
+                let target_identity = self
+                    .symbols
+                    .lookup(&item.name)
+                    .and_then(|id| self.symbols.identity_of(id).cloned());
+                self.symbols.define_import_binding(
+                    Symbol {
+                        name: alias.clone(),
+                        kind: imported_kind,
+                        span,
+                        scope: 0,
+                    },
+                    target_identity,
+                );
                 self.mark_static_binding_imported(&item.name);
                 return true;
             }
@@ -1076,14 +1085,28 @@ impl TypeChecker {
     }
 
     /// Define one already named imported symbol after root namespace validation.
+    ///
+    /// The binding carries the RFC 120 identity import resolution proved for this local name (see
+    /// [`Self::record_resolved_import_owner`]), or none at all — an import binding must never mint an identity from
+    /// the importing module. Reference-side recording also falls back to `resolved_import_identities` for
+    /// module-scope bindings, so a proof recorded after this definition still reaches consumers.
     fn define_named_import_symbol(&mut self, name: Ident, kind: SymbolKind, span: Span) -> SymbolId {
         self.validate_root_namespace(&name, span);
-        self.symbols.define(Symbol {
-            name,
-            kind,
-            span,
-            scope: 0,
-        })
+        let target_identity = self
+            .type_info
+            .declarations
+            .resolved_import_identities
+            .get(&name)
+            .cloned();
+        self.symbols.define_import_binding(
+            Symbol {
+                name,
+                kind,
+                span,
+                scope: 0,
+            },
+            target_identity,
+        )
     }
 
     /// Return all derived public module namespace paths carried by the checked API artifact.
@@ -1444,12 +1467,17 @@ impl TypeChecker {
             if let Some(mut kind) = flat_function {
                 self.remap_symbol_kind_with_import_aliases(&mut kind, &imported_type_aliases);
                 self.record_imported_function_binding(&local_name, &kind);
-                self.symbols.define(Symbol {
-                    name: local_name,
-                    kind,
-                    span,
-                    scope: 0,
-                });
+                // RFC 120: a compiled-library binding must not mint a consumer-module identity. Its declaring
+                // identity is unproven until the library manifest carries one (#1042 follow-up), so record none.
+                self.symbols.define_import_binding(
+                    Symbol {
+                        name: local_name,
+                        kind,
+                        span,
+                        scope: 0,
+                    },
+                    None,
+                );
                 continue;
             }
 
@@ -1532,12 +1560,17 @@ impl TypeChecker {
             );
         }
         Self::mark_compiled_class_field_provider(&mut kind, library);
-        self.symbols.define(Symbol {
-            name: local_name,
-            kind,
-            span,
-            scope: 0,
-        });
+        // RFC 120: a compiled-library binding must not mint a consumer-module identity. Its declaring identity is
+        // unproven until the library manifest carries one (#1042 follow-up), so record none.
+        self.symbols.define_import_binding(
+            Symbol {
+                name: local_name,
+                kind,
+                span,
+                scope: 0,
+            },
+            None,
+        );
     }
 
     /// Build the provider-aware type remapping shared by every import statement for one compiled library.
@@ -2460,12 +2493,17 @@ impl TypeChecker {
             );
         }
 
-        self.symbols.define(Symbol {
-            name: local_name,
-            kind,
-            span,
-            scope: 0,
-        });
+        // RFC 120: a compiled-library binding must not mint a consumer-module identity. Its declaring identity is
+        // unproven until the library manifest carries one (#1042 follow-up), so record none.
+        self.symbols.define_import_binding(
+            Symbol {
+                name: local_name,
+                kind,
+                span,
+                scope: 0,
+            },
+            None,
+        );
     }
 
     /// Attach the importing dependency key to every field reconstructed from one compiled class manifest.

--- a/src/frontend/typechecker/collect/stdlib_imports.rs
+++ b/src/frontend/typechecker/collect/stdlib_imports.rs
@@ -970,6 +970,10 @@ impl TypeChecker {
     /// keeps its existing meaning of the path as written at the import.
     fn record_resolved_import_owner(&mut self, module: &ImportPath, item: &ImportItem, local_name: &str) {
         if let Some(identity) = self.dependency_member_identity(module, &item.name) {
+            // A binding materialized before this proof starts identity-less; attach the proof to that binding —
+            // and only to an import binding — so reference-side recording never has to reach past the symbol
+            // table to a name-keyed map that a shadowing definition may have made stale.
+            self.symbols.backfill_import_identity(local_name, &identity);
             self.type_info
                 .declarations
                 .resolved_import_identities

--- a/src/frontend/typechecker/mod.rs
+++ b/src/frontend/typechecker/mod.rs
@@ -70,6 +70,8 @@ pub use type_info::{
 };
 pub(crate) use type_info::{ClassFieldDefaultInfo, semantic_type_from_resolved};
 #[cfg(test)]
+mod canonical_identity_tests;
+#[cfg(test)]
 mod tests;
 
 use std::cell::Cell;
@@ -2094,7 +2096,12 @@ impl TypeChecker {
         self.set_provider_plan(Arc::new(plan));
     }
 
+    /// Record the module path owning this checker's declarations.
+    ///
+    /// Also forwarded to the symbol table, whose RFC 120 identity minting uses it as the [`SymbolOrigin`] of every
+    /// locally-declared symbol; `None` resets to the anonymous-module origin.
     pub fn set_current_module_path(&mut self, path: Option<Vec<String>>) {
+        self.symbols.set_module_path(path.clone().unwrap_or_default());
         self.current_module_path = path;
     }
 
@@ -2134,6 +2141,21 @@ impl TypeChecker {
                 kind: kind.into(),
             },
         );
+    }
+
+    /// Export the RFC 120 identities minted for this module's own declarations into the lowering-facing artifacts.
+    ///
+    /// Runs once at the end of checking, when every declaration has been defined. The span-keyed map lets
+    /// declaration-level HIR attach each top-level declaration's identity without re-deriving it from module path
+    /// plus spelling; import/alias bindings are excluded here because they carry a target's identity and are already
+    /// exported by local name in `resolved_import_identities`.
+    fn export_declaration_identities(&mut self) {
+        for (span, identity) in self.symbols.local_declaration_identities() {
+            self.type_info
+                .declarations
+                .declaration_identities
+                .insert((span.start, span.end), identity.clone());
+        }
     }
 
     /// Retain one compiler-proven ordinary function call for checked C bridge/facade projection.
@@ -5357,6 +5379,9 @@ impl TypeChecker {
         self.validate_rust_module_and_extern(program);
         self.validate_source_type_names = false;
 
+        // ---- RFC 120: export the minted declaration identities for later stages ----
+        self.export_declaration_identities();
+
         // Split fatal errors from non-fatal diagnostics.
         let all = std::mem::take(&mut self.errors);
         let (fatal, non_fatal): (Vec<_>, Vec<_>) = all
@@ -6207,114 +6232,132 @@ impl TypeChecker {
     fn predeclare_dependency_decl(&mut self, decl: &Spanned<Declaration>) {
         match &decl.node {
             Declaration::Model(model) if self.lookup_symbol(model.name.as_str()).is_none() => {
-                self.symbols.define(Symbol {
-                    name: model.name.clone(),
-                    kind: SymbolKind::Type(TypeInfo::Model(ModelInfo {
-                        type_params: model.type_params.iter().map(|tp| tp.name.clone()).collect(),
-                        traits: Vec::new(),
-                        trait_adoptions: Vec::new(),
-                        derives: Vec::new(),
-                        fields: HashMap::new(),
-                        field_order: Vec::new(),
-                        properties: HashMap::new(),
-                        methods: HashMap::new(),
-                        method_overloads: HashMap::new(),
-                        method_aliases: HashMap::new(),
-                    })),
-                    span: decl.span,
-                    scope: 0,
-                });
+                self.symbols.define_import_binding(
+                    Symbol {
+                        name: model.name.clone(),
+                        kind: SymbolKind::Type(TypeInfo::Model(ModelInfo {
+                            type_params: model.type_params.iter().map(|tp| tp.name.clone()).collect(),
+                            traits: Vec::new(),
+                            trait_adoptions: Vec::new(),
+                            derives: Vec::new(),
+                            fields: HashMap::new(),
+                            field_order: Vec::new(),
+                            properties: HashMap::new(),
+                            methods: HashMap::new(),
+                            method_overloads: HashMap::new(),
+                            method_aliases: HashMap::new(),
+                        })),
+                        span: decl.span,
+                        scope: 0,
+                    },
+                    None,
+                );
             }
             Declaration::Class(class) if self.lookup_symbol(class.name.as_str()).is_none() => {
-                self.symbols.define(Symbol {
-                    name: class.name.clone(),
-                    kind: SymbolKind::Type(TypeInfo::Class(ClassInfo {
-                        type_params: class.type_params.iter().map(|tp| tp.name.clone()).collect(),
-                        extends: class.extends.clone(),
-                        traits: Vec::new(),
-                        trait_adoptions: Vec::new(),
-                        derives: Vec::new(),
-                        fields: HashMap::new(),
-                        field_defaults: Box::new(HashMap::new()),
-                        field_default_metadata: Box::new(HashMap::new()),
-                        field_provider_libraries: Box::new(HashMap::new()),
-                        field_order: Vec::new(),
-                        properties: HashMap::new(),
-                        methods: HashMap::new(),
-                        method_overloads: HashMap::new(),
-                        method_aliases: HashMap::new(),
-                    })),
-                    span: decl.span,
-                    scope: 0,
-                });
+                self.symbols.define_import_binding(
+                    Symbol {
+                        name: class.name.clone(),
+                        kind: SymbolKind::Type(TypeInfo::Class(ClassInfo {
+                            type_params: class.type_params.iter().map(|tp| tp.name.clone()).collect(),
+                            extends: class.extends.clone(),
+                            traits: Vec::new(),
+                            trait_adoptions: Vec::new(),
+                            derives: Vec::new(),
+                            fields: HashMap::new(),
+                            field_defaults: Box::new(HashMap::new()),
+                            field_default_metadata: Box::new(HashMap::new()),
+                            field_provider_libraries: Box::new(HashMap::new()),
+                            field_order: Vec::new(),
+                            properties: HashMap::new(),
+                            methods: HashMap::new(),
+                            method_overloads: HashMap::new(),
+                            method_aliases: HashMap::new(),
+                        })),
+                        span: decl.span,
+                        scope: 0,
+                    },
+                    None,
+                );
             }
             Declaration::Trait(tr) if self.lookup_symbol(tr.name.as_str()).is_none() => {
-                self.symbols.define(Symbol {
-                    name: tr.name.clone(),
-                    kind: SymbolKind::Trait(TraitInfo {
-                        type_params: tr.type_params.iter().map(|tp| tp.name.clone()).collect(),
-                        methods: HashMap::new(),
-                        method_aliases: HashMap::new(),
-                        properties: HashMap::new(),
-                        requires: Vec::new(),
-                        supertraits: Vec::new(),
-                    }),
-                    span: decl.span,
-                    scope: 0,
-                });
+                self.symbols.define_import_binding(
+                    Symbol {
+                        name: tr.name.clone(),
+                        kind: SymbolKind::Trait(TraitInfo {
+                            type_params: tr.type_params.iter().map(|tp| tp.name.clone()).collect(),
+                            methods: HashMap::new(),
+                            method_aliases: HashMap::new(),
+                            properties: HashMap::new(),
+                            requires: Vec::new(),
+                            supertraits: Vec::new(),
+                        }),
+                        span: decl.span,
+                        scope: 0,
+                    },
+                    None,
+                );
             }
             Declaration::TypeAlias(alias) if self.lookup_symbol(alias.name.as_str()).is_none() => {
-                self.symbols.define(Symbol {
-                    name: alias.name.clone(),
-                    kind: SymbolKind::Type(TypeInfo::TypeAlias),
-                    span: decl.span,
-                    scope: 0,
-                });
+                self.symbols.define_import_binding(
+                    Symbol {
+                        name: alias.name.clone(),
+                        kind: SymbolKind::Type(TypeInfo::TypeAlias),
+                        span: decl.span,
+                        scope: 0,
+                    },
+                    None,
+                );
             }
             Declaration::Newtype(nt) if self.lookup_symbol(nt.name.as_str()).is_none() => {
-                self.symbols.define(Symbol {
-                    name: nt.name.clone(),
-                    kind: SymbolKind::Type(TypeInfo::Newtype(NewtypeInfo {
-                        type_params: nt.type_params.iter().map(|tp| tp.name.clone()).collect(),
-                        is_rusttype: nt.is_rusttype,
-                        has_interop: !nt.interop_edges.is_empty(),
-                        underlying: ResolvedType::Unknown,
-                        constraints: Vec::new(),
-                        implicit_coercion_enabled: true,
-                        method_rebindings: HashMap::new(),
-                        traits: nt.traits.iter().map(|trait_ref| trait_ref.node.name.clone()).collect(),
-                        trait_adoptions: Vec::new(),
-                        derives: Vec::new(),
-                        method_aliases: HashMap::new(),
-                        methods: HashMap::new(),
-                        method_overloads: HashMap::new(),
-                    })),
-                    span: decl.span,
-                    scope: 0,
-                });
+                self.symbols.define_import_binding(
+                    Symbol {
+                        name: nt.name.clone(),
+                        kind: SymbolKind::Type(TypeInfo::Newtype(NewtypeInfo {
+                            type_params: nt.type_params.iter().map(|tp| tp.name.clone()).collect(),
+                            is_rusttype: nt.is_rusttype,
+                            has_interop: !nt.interop_edges.is_empty(),
+                            underlying: ResolvedType::Unknown,
+                            constraints: Vec::new(),
+                            implicit_coercion_enabled: true,
+                            method_rebindings: HashMap::new(),
+                            traits: nt.traits.iter().map(|trait_ref| trait_ref.node.name.clone()).collect(),
+                            trait_adoptions: Vec::new(),
+                            derives: Vec::new(),
+                            method_aliases: HashMap::new(),
+                            methods: HashMap::new(),
+                            method_overloads: HashMap::new(),
+                        })),
+                        span: decl.span,
+                        scope: 0,
+                    },
+                    None,
+                );
             }
             Declaration::Enum(en) if self.lookup_symbol(en.name.as_str()).is_none() => {
-                self.symbols.define(Symbol {
-                    name: en.name.clone(),
-                    kind: SymbolKind::Type(TypeInfo::Enum(EnumInfo {
-                        type_params: en.type_params.iter().map(|tp| tp.name.clone()).collect(),
-                        traits: en.traits.iter().map(|t| t.node.name.clone()).collect(),
-                        trait_adoptions: Vec::new(),
-                        variants: en.variants.iter().map(|v| v.node.name.clone()).collect(),
-                        variant_fields: HashMap::new(),
-                        variant_aliases: en
-                            .variant_aliases
-                            .iter()
-                            .map(|alias| (alias.node.name.clone(), alias.node.target.clone()))
-                            .collect(),
-                        value_enum: None,
-                        derives: Vec::new(),
-                        methods: HashMap::new(),
-                        method_overloads: HashMap::new(),
-                    })),
-                    span: decl.span,
-                    scope: 0,
-                });
+                self.symbols.define_import_binding(
+                    Symbol {
+                        name: en.name.clone(),
+                        kind: SymbolKind::Type(TypeInfo::Enum(EnumInfo {
+                            type_params: en.type_params.iter().map(|tp| tp.name.clone()).collect(),
+                            traits: en.traits.iter().map(|t| t.node.name.clone()).collect(),
+                            trait_adoptions: Vec::new(),
+                            variants: en.variants.iter().map(|v| v.node.name.clone()).collect(),
+                            variant_fields: HashMap::new(),
+                            variant_aliases: en
+                                .variant_aliases
+                                .iter()
+                                .map(|alias| (alias.node.name.clone(), alias.node.target.clone()))
+                                .collect(),
+                            value_enum: None,
+                            derives: Vec::new(),
+                            methods: HashMap::new(),
+                            method_overloads: HashMap::new(),
+                        })),
+                        span: decl.span,
+                        scope: 0,
+                    },
+                    None,
+                );
             }
             _ => {}
         }

--- a/src/frontend/typechecker/type_info.rs
+++ b/src/frontend/typechecker/type_info.rs
@@ -676,6 +676,14 @@ pub struct ExpressionArtifacts {
     /// The codegraph exporter consumes this instead of re-resolving names from syntax. Absence means the target is
     /// unsupported, ambiguous, degraded, or outside the current conservative source target set.
     pub source_targets: HashMap<(usize, usize), SourceTargetInfo>,
+    /// RFC 120 canonical identities of resolved references, keyed by reference expression span.
+    ///
+    /// This is the reference-side identity fact: a local, an import, an alias, and a re-export of one declaration
+    /// all record the *same* value here, so a consumer can decide "do these two references mean the same thing"
+    /// structurally, without comparing spellings. [`Self::source_targets`] stays the string-shaped codegraph
+    /// projection; it is never the identity. Absence means resolution did not prove an identity for that reference —
+    /// consumers fail closed rather than reconstruct one.
+    pub resolved_identities: HashMap<(usize, usize), CanonicalSymbolId>,
 }
 
 /// Const evaluation facts needed by runtime and emission boundaries.
@@ -816,6 +824,13 @@ pub struct DeclarationArtifacts {
     /// written path, so the proven identity is recorded here and is simply absent when resolution did not prove one.
     /// A re-export resolves to the identity of the module that *declares* the member, never to the facade.
     pub resolved_import_identities: HashMap<String, CanonicalSymbolId>,
+    /// RFC 120 identities of this module's own top-level declarations, keyed by declaration span.
+    ///
+    /// Exported from the symbol table's minting after checking so later stages (declaration-level HIR, semantic
+    /// snapshots) consume the minted identity instead of re-deriving one from module path plus spelling. Only
+    /// module-scope declaration kinds are exported; bindings that carry a *target's* identity (imports, aliases) are
+    /// found in [`Self::resolved_import_identities`] under their local name instead.
+    pub declaration_identities: HashMap<(usize, usize), CanonicalSymbolId>,
     /// Checked provider-operation declarations, keyed by their provider function's canonical identity.
     ///
     /// This is the producer-side fact that package publication persists. Body-IR lowering consumes the resulting
@@ -1409,6 +1424,13 @@ pub struct FunctionBindingInfo {
     pub params: Vec<CallableParam>,
     /// Typechecker-resolved source return type.
     pub return_type: ResolvedType,
+    /// RFC 120 canonical identity of this declaration, minted once when the binding is recorded.
+    ///
+    /// This is the declaration-side fact Body IR lowering consumes for `NamedCallableTarget::canonical` instead of
+    /// re-deriving an identity from module path plus spelling. Span-keyed entries always carry it for local
+    /// declarations (each overload keeps its own); name-keyed *imported* entries carry the declaring module's proven
+    /// identity or `None` when import resolution could not prove one — absent is never permission to reconstruct.
+    pub identity: Option<CanonicalSymbolId>,
 }
 
 /// Typechecker-resolved binding of one `model`/`class` construction's arguments to the declared field layout.
@@ -1624,6 +1646,14 @@ impl TypeCheckInfo {
     /// Return a compiler-proven source target for the expression at `span`, if one was recorded.
     pub fn source_target(&self, span: Span) -> Option<&SourceTargetInfo> {
         self.expressions.source_targets.get(&(span.start, span.end))
+    }
+
+    /// Return the RFC 120 canonical identity resolved for the reference at `span`, if resolution proved one.
+    ///
+    /// Absent means unproven — never permission to rebuild an identity from the reference's spelling or from
+    /// [`Self::source_target`], which is a string-shaped codegraph projection rather than an identity.
+    pub fn resolved_identity(&self, span: Span) -> Option<&CanonicalSymbolId> {
+        self.expressions.resolved_identities.get(&(span.start, span.end))
     }
 
     /// Return whether the identifier at `span` resolved to the ambient `std.logging` logger binding.

--- a/workspaces/docs-site/docs/RFCs/120_canonical_source_symbol_identity.md
+++ b/workspaces/docs-site/docs/RFCs/120_canonical_source_symbol_identity.md
@@ -1,6 +1,6 @@
 # RFC 120: canonical source symbol identity
 
-- **Status:** Planned
+- **Status:** In Progress
 - **Created:** 2026-08-19
 - **Author(s):** Danny Meijer (@dannymeijer)
 - **Related:**
@@ -285,6 +285,47 @@ Define and emit the versioned `incan-v1` payload for every linker-visible Incan-
 ### Cutover conformance
 
 The identity guarantees that must not regress at the v0.6 backend cutover belong in the backend-parity corpus rather than only in frontend unit tests, so a replacement backend cannot silently lose them. The matrix worth pinning is the cross-product of binding entry (local, import, alias, re-export), namespace (lexical, member, path), and scope nesting (module, function, block), plus explicit shadowing with `let` and with `mut`, one generic-binder case, and #1116's builtin contract: a rebound builtin-function spelling and the same name reached through `std.builtins.<name>` must carry two different canonical identities across the cutover. It also includes a release-artifact decode of the `incan-v1` payload after v0 mangling and demangling, plus classification fixtures proving non-Incan frames are never reported as source declarations.
+
+## Progress Checklist
+
+Items tick as their PRs merge. The slice structure above remains the governing map; this checklist is its trackable projection.
+
+### Predecessors (not owned by this RFC)
+
+- [x] #1132 statement-level tuple unpack lands first.
+- [x] #1072 assignment semantics, both halves, land together.
+
+### Identity core (Slices 1–2)
+
+- [ ] One compiler-owned identity mint at symbol definition, covering module declarations, locals, consts, statics, parameters, receivers, and generic binders, with scope discriminants.
+- [ ] Import, alias, and re-export bindings carry their resolved target's identity; unproven bindings carry none.
+- [ ] Builtin registry identities: every alias spelling records the one canonical registry identity.
+- [ ] Reference-side identity recording keyed by reference span, with the string-shaped source target retained as a projection.
+- [ ] Method declarations carry member-namespace identities; field/property declaration identities generalized.
+- [ ] Conformance: sibling-scope distinctness, alias/re-export equality, `let`/`mut` shadowing, builtin-rebinding distinctness, duplicate-declaration identity distinctness.
+
+### One shared binding mechanism (Slice 3)
+
+- [ ] Single binding-registration/collision entry point; duplicate declarations and imports become diagnostics.
+- [ ] `duplicate_alias`, `duplicate_trait_instantiation`, and the CLI-owned `duplicate_library_export` checks migrate to call sites of the shared mechanism.
+- [ ] Rebound builtin-function spellings keep reporting nothing.
+
+### Consumers (Slices 4–8)
+
+- [ ] HIR declarations carry canonical identity; single-binding imports carry their target's identity. (Identity fact delivered; the id-derivation rework and per-binding import declarations remain.)
+- [ ] Body IR callable targets consume the typechecker-minted identity instead of re-deriving one. (Delivered for direct calls; local resolution by identity remains.)
+- [ ] Body IR resolves locals by identity so no resolver-resolved reference degrades to an external local.
+- [ ] Diagnostics name canonical declaration sites regardless of the referencing binding.
+- [ ] LSP definition/references/hover resolve through identity.
+- [ ] Codegraph keys records on identity rather than the string triple.
+
+### Recoverable projection (Slice 9)
+
+- [ ] `incan-v1` emitted-name payload with DD-0002 toolchain record and decode fixtures (#1174).
+
+### Cutover conformance
+
+- [ ] Identity matrix rows land in the backend-parity corpus.
 
 ## Design decisions
 


### PR DESCRIPTION
## Summary

This PR delivers the canonical-identity core of RFC 120 (#1042): the symbol table becomes the compiler's single identity mint, every classifiable declaration receives its `CanonicalSymbolId` at its declaration site, and resolution, semantic facts, HIR, and Body IR consume that fact instead of re-deriving identities from module path plus spelling. Import, alias, and re-export bindings carry their resolved *target's* identity — so a local reference, an aliased import, and a re-export of one declaration record one structurally equal identity — and unproven bindings record none rather than a consumer-module guess.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [x] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [x] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: none yet. Accepted programs, diagnostics, and generated code are unchanged; this lands the compiler-owned identity model those surfaces will consume. The HIR snapshot rendering gains an `identity=` fact per declaration that proved one.
- **Internals**:
  - `SymbolTable::define` mints one `CanonicalSymbolId` per classifiable definition (side map keyed by `SymbolId`), with scope discriminants for non-module scopes. Explicit categories at the sites that know them: parameters, receivers, generic binders (previously indistinguishable builtin-kinded placeholders), consts, partials. Builtin alias spellings (`i64`, `println`, …) all record the one canonical registry identity.
  - `define_import_binding` is the import/alias/re-export path: the binding carries the identity import resolution proved (`dependency_member_identity`), or none. Compiled-library (`pub::`) member bindings deliberately record none until the library manifest carries declaration identities (follow-up recorded on #1042).
  - Reference-side: `ExpressionArtifacts::resolved_identities` records the resolved identity per reference span in `check_ident`; the string-shaped `SourceTargetInfo` stays as the codegraph projection, never the identity.
  - `FunctionBindingInfo` and `method_bindings_by_span` carry declaration identities (methods in the member namespace). Body IR call lowering now consumes `binding.identity` and its local re-mint helper (`local_callable_identity`) plus the builder's `module_path` field are deleted — Body IR can no longer derive an identity from spelling on that path.
  - HIR v0 declarations carry `canonical: Option<CanonicalSymbolId>`; a single-binding `from … import x as y` is named by its local binding and carries the *declaring* module's identity while keeping a span-derived id (a name-derived id could collide with a same-spelled local declaration).
  - A symbol converted in place into an overload set drops its set-level identity; each overload keeps its own span-keyed identity.
- **Risks**: identity minting touches every `SymbolTable::define` path, so a mis-classified site would record a wrong-provenance identity (mitigated by the import-site audit in this diff, fail-closed `None` defaults, and the conformance suite). Behavior of existing consumers is pinned by the untouched, green Body IR identity tests (`one_declaration_keeps_one_identity_across_local_imported_aliased_and_reexported_calls`, overload and owning-module cases).

## Testing / verification

- [x] Focused `cargo test` suites (repository-wide gate deliberately left to slice-level integration, per maintainer policy):
  - `cargo test --lib frontend::` — 1321 passed, 0 failed (includes 13 new conformance tests in `src/frontend/typechecker/canonical_identity_tests.rs` and a new HIR identity test)
  - `cargo test --lib backend::` — 605 passed, 0 failed
  - `cargo test -p incan_semantics_core --lib` — 69 passed
- [ ] `make examples` (not relevant: no codegen/behavior change)
- [x] `make fmt`, `cargo clippy --lib --tests -p incan -p incan_semantics_core` (clean), `make pre-commit-fast` (green: fmt-check, rustdoc gate, version gate, agents-doc-sync, cargo check)
- [x] Manual verification described below

Manual verification notes:

- New conformance coverage: sibling-block same-spelled locals get distinct identities; `let`/`mut` shadowing mints a fresh identity and restores the outer one; plain assignment preserves the target binding's identity; generic binders are declaration-scoped and never equal a concrete type; import/alias/re-export record one identity equal through every spelling; a rebound `len` and the registry builtin are distinct identities (and rebinding still reports nothing, per #1116's settled contract); duplicate module declarations keep two distinct identities.
- Collision *diagnostics* for duplicate declarations/imports are deliberately not in this PR: today's silent last-wins binding is pinned at the identity level, and the one shared binding-registration/collision mechanism is RFC 120 Slice 3 (see the RFC's Progress Checklist).
- `mkdocs build --strict` passes after the RFC edit.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/RFCs/120_canonical_source_symbol_identity.md` — status `Planned` → `In Progress` plus a new `## Progress Checklist` projecting the RFC's slice map into trackable items. Rustdoc added across every touched module (mechanically gated).

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

---

**RFC lifecycle**: RFC 120 is now `In Progress`; this PR implements its identity core (Slices 1–2, the Body IR callable consumption of Slice 5's contract, and the identity fact of Slice 4). Remaining RFC scope stays open on #1042: the shared collision mechanism (Slice 3), Body IR local resolution by identity (Slice 5), diagnostics naming declaration sites (Slice 6), LSP (Slice 7), codegraph keying (Slice 8), and the recoverable emitted-name projection (Slice 9, #1174). Refs #1042 — deliberately not a closing keyword.
