### PR TITLE
feature - record generic authority decision context (#1029)

### DIFF
--- a/crates/incan_semantics_core/src/authority.rs
+++ b/crates/incan_semantics_core/src/authority.rs
@@ -1,6 +1,6 @@
 //! The compiler-to-runtime seam for RFC 104 authority decisions.
 //!
-//! [`crate::facts`] defines what an authority decision *is*. This module defines how a consumer *obtains* one, and it
+//! The `facts` module defines what an authority decision *is*. This module defines how a consumer *obtains* one, and it
 //! exists so that no consumer has to define grant semantics of its own. A provider-operation plan, a runtime
 //! entrypoint, and a test harness all ask the same question through [`AuthorityDecisionSource`] and all receive the
 //! same [`AuthorityDecision`].
@@ -46,10 +46,15 @@ impl AuthorityRequest {
     }
 
     /// Build the grant context a decision about this request carries.
-    fn grant_context(&self, ceiling_applied: bool) -> AuthorityGrantContext {
+    fn grant_context(
+        &self,
+        effective_grants: Vec<CanonicalSymbolId>,
+        ceiling: Option<Vec<CanonicalSymbolId>>,
+    ) -> AuthorityGrantContext {
         AuthorityGrantContext {
             requested_scope: self.requested_scope.clone(),
-            ceiling_applied,
+            effective_grants,
+            ceiling,
         }
     }
 }
@@ -73,13 +78,18 @@ pub trait AuthorityDecisionSource {
 #[derive(Debug, Clone)]
 pub struct StaticAuthority {
     mode: AuthorityMode,
-    granted: BTreeSet<String>,
-    ceiling: Option<BTreeSet<String>>,
+    granted: BTreeSet<CanonicalSymbolId>,
+    ceiling: Option<BTreeSet<CanonicalSymbolId>>,
 }
 
 impl StaticAuthority {
-    /// Build an authority source for `mode` granting exactly `granted`, with no host ceiling.
-    pub fn new(mode: AuthorityMode, granted: impl IntoIterator<Item = String>) -> Self {
+    /// Build an authority source for `mode` granting exactly these canonical capability identities, with no host
+    /// ceiling.
+    ///
+    /// A grant is the compiler-resolved capability identity, never its rendered diagnostic spelling. That keeps a
+    /// request for one package or module capability from acquiring authority through another capability that happens
+    /// to render to the same text.
+    pub fn new(mode: AuthorityMode, granted: impl IntoIterator<Item = CanonicalSymbolId>) -> Self {
         Self {
             mode,
             granted: granted.into_iter().collect(),
@@ -92,13 +102,13 @@ impl StaticAuthority {
     /// RFC 104 makes the ceiling a grant source distinct from the invocation's own request, combined by
     /// **intersection and never union**: an invocation can only ever receive less than its ceiling allows, however
     /// much it asks for. A grant outside the ceiling is therefore denied even though it was requested.
-    pub fn with_ceiling(mut self, ceiling: impl IntoIterator<Item = String>) -> Self {
+    pub fn with_ceiling(mut self, ceiling: impl IntoIterator<Item = CanonicalSymbolId>) -> Self {
         self.ceiling = Some(ceiling.into_iter().collect());
         self
     }
 
-    /// The effective grant set: the request bounded by the ceiling, when one is supplied.
-    pub fn effective_grants(&self) -> BTreeSet<String> {
+    /// The effective project grant set bounded by the host ceiling, when one is supplied.
+    pub fn effective_grants(&self) -> BTreeSet<CanonicalSymbolId> {
         match &self.ceiling {
             Some(ceiling) => self.granted.intersection(ceiling).cloned().collect(),
             None => self.granted.clone(),
@@ -106,10 +116,24 @@ impl StaticAuthority {
     }
 }
 
+impl Default for StaticAuthority {
+    /// Build the default observe-mode authority source with no explicit grants or ceiling.
+    fn default() -> Self {
+        Self::new(AuthorityMode::default(), Vec::new())
+    }
+}
+
 impl AuthorityDecisionSource for StaticAuthority {
     fn decide(&self, request: &AuthorityRequest) -> AuthorityDecision {
-        let ceiling_applied = self.ceiling.is_some();
-        let grant = request.grant_context(ceiling_applied);
+        let effective_grants = self.effective_grants();
+        let grant = request.grant_context(
+            effective_grants
+                .iter()
+                .filter(|grant| *grant == &request.capability)
+                .cloned()
+                .collect(),
+            self.ceiling.as_ref().map(|values| values.iter().cloned().collect()),
+        );
         let provenance = request.provenance();
 
         // Permissive and observe runs never deny; the difference between them is whether receipts are emitted, which
@@ -118,17 +142,16 @@ impl AuthorityDecisionSource for StaticAuthority {
             return AuthorityDecision::allowed(request.capability.clone(), self.mode, grant, provenance);
         }
 
-        let requested = &request.suggested_grant;
         let outside_ceiling = self
             .ceiling
             .as_ref()
-            .is_some_and(|ceiling| !ceiling.contains(requested));
+            .is_some_and(|ceiling| !ceiling.contains(&request.capability));
 
         // Report the ceiling first: an invocation that asked for authority its host never permitted is a different
         // failure from one that simply never asked, and only the former tells the caller their request was capped.
         let reason = if outside_ceiling {
             Some(AuthorityDenialReason::OutsideCeiling)
-        } else if !self.granted.contains(requested) {
+        } else if !self.granted.contains(&request.capability) {
             Some(AuthorityDenialReason::NotGranted)
         } else {
             None
@@ -178,6 +201,19 @@ mod tests {
         assert_eq!(decision.mode, AuthorityMode::Permissive);
     }
 
+    /// Ordinary development observes authority use unless an invoking project selects another mode.
+    #[test]
+    fn the_default_authority_source_observes_an_ungranted_capability() {
+        let authority = StaticAuthority::default();
+
+        let decision = authority.decide(&request());
+
+        assert!(decision.is_allowed());
+        assert_eq!(decision.mode, AuthorityMode::Observe);
+        assert!(decision.grant.effective_grants.is_empty());
+        assert_eq!(decision.grant.ceiling, None);
+    }
+
     /// A governed run denies what was never granted, and says so in a way a consumer can branch on.
     #[test]
     fn a_governed_run_denies_a_capability_that_was_never_granted() {
@@ -193,9 +229,10 @@ mod tests {
     /// A governed run allows what was granted, and preserves the requested scope on the decision.
     #[test]
     fn a_governed_run_allows_a_granted_capability_and_keeps_its_scope() {
-        let authority = StaticAuthority::new(AuthorityMode::Governed, ["host.http.request".to_string()]);
+        let request = request();
+        let authority = StaticAuthority::new(AuthorityMode::Governed, [request.capability.clone()]);
 
-        let decision = authority.decide(&request());
+        let decision = authority.decide(&request);
 
         assert!(decision.is_allowed());
         assert_eq!(
@@ -207,17 +244,24 @@ mod tests {
     /// A ceiling bounds the grant by intersection: requesting more than the ceiling allows yields less, never more.
     #[test]
     fn a_ceiling_denies_a_grant_the_invocation_requested_but_the_host_did_not_permit() {
-        let authority = StaticAuthority::new(AuthorityMode::Governed, ["host.http.request".to_string()])
-            .with_ceiling(["host.fs.read".to_string()]);
+        let request = request();
+        let ceiling = CanonicalSymbolId::module_declaration(
+            vec!["host".to_string(), "fs".to_string()],
+            "read",
+            SemanticSourceTargetKind::Capability,
+            crate::HirSourceSpan::new(30, 40),
+        );
+        let authority =
+            StaticAuthority::new(AuthorityMode::Governed, [request.capability.clone()]).with_ceiling([ceiling.clone()]);
 
-        let decision = authority.decide(&request());
+        let decision = authority.decide(&request);
 
         assert!(
             !decision.is_allowed(),
             "an invocation cannot widen its own authority past its ceiling",
         );
         assert_eq!(decision.denial_reason(), Some(AuthorityDenialReason::OutsideCeiling));
-        assert!(decision.grant.ceiling_applied);
+        assert_eq!(decision.grant.ceiling, Some(vec![ceiling]));
         assert!(
             authority.effective_grants().is_empty(),
             "the effective grant is the intersection of ceiling and request, not their union",
@@ -227,28 +271,73 @@ mod tests {
     /// A grant present in both the request and the ceiling survives the intersection.
     #[test]
     fn a_ceiling_keeps_a_grant_that_both_sides_permit() {
-        let authority = StaticAuthority::new(
-            AuthorityMode::Governed,
-            ["host.http.request".to_string(), "host.fs.read".to_string()],
-        )
-        .with_ceiling(["host.http.request".to_string()]);
+        let request = request();
+        let other_capability = CanonicalSymbolId::module_declaration(
+            vec!["host".to_string(), "fs".to_string()],
+            "read",
+            SemanticSourceTargetKind::Capability,
+            crate::HirSourceSpan::new(30, 40),
+        );
+        let authority = StaticAuthority::new(AuthorityMode::Governed, [request.capability.clone(), other_capability])
+            .with_ceiling([request.capability.clone()]);
 
-        let decision = authority.decide(&request());
+        let decision = authority.decide(&request);
 
         assert!(decision.is_allowed());
         assert_eq!(
             authority.effective_grants(),
-            ["host.http.request".to_string()].into_iter().collect(),
+            [request.capability.clone()].into_iter().collect(),
             "only the capability both sides permit survives",
         );
+    }
+
+    /// A durable decision retains the actual grant intersection and the ceiling that bounded it.
+    #[test]
+    fn a_ceiling_decision_carries_the_effective_grant_and_applicable_constraint() {
+        let request = request();
+        let other_capability = CanonicalSymbolId::module_declaration(
+            vec!["host".to_string(), "fs".to_string()],
+            "read",
+            SemanticSourceTargetKind::Capability,
+            crate::HirSourceSpan::new(30, 40),
+        );
+        let authority = StaticAuthority::new(AuthorityMode::Governed, [request.capability.clone(), other_capability])
+            .with_ceiling([request.capability.clone()]);
+
+        let decision = authority.decide(&request);
+
+        assert!(decision.is_allowed());
+        assert_eq!(decision.grant.effective_grants, vec![request.capability.clone()]);
+        assert_eq!(decision.grant.ceiling, Some(vec![request.capability]));
+    }
+
+    /// A diagnostic suggestion is never an authority key: only the request capability identity can be granted.
+    #[test]
+    fn a_governed_run_rejects_a_capability_that_only_borrows_an_allowed_diagnostic_spelling() {
+        let mut mismatched = request();
+        let granted = mismatched.capability.clone();
+        mismatched.capability = CanonicalSymbolId::module_declaration(
+            vec!["host".to_string(), "fs".to_string()],
+            "read",
+            SemanticSourceTargetKind::Capability,
+            crate::HirSourceSpan::new(30, 40),
+        );
+        let authority = StaticAuthority::new(AuthorityMode::Governed, [granted]);
+
+        let decision = authority.decide(&mismatched);
+
+        assert!(!decision.is_allowed());
+        assert_eq!(decision.denial_reason(), Some(AuthorityDenialReason::NotGranted));
+        assert_eq!(decision.provenance.suggested_grant, "host.http.request");
     }
 
     /// The seam must be usable through a trait object so a host, a local run, and a test double are interchangeable.
     #[test]
     fn the_seam_is_object_safe() {
-        let authority = StaticAuthority::new(AuthorityMode::Governed, ["host.http.request".to_string()]);
+        let request = request();
+        let authority = StaticAuthority::new(AuthorityMode::Governed, [request.capability.clone()]);
         let source: &dyn AuthorityDecisionSource = &authority;
 
-        assert!(source.decide(&request()).is_allowed());
+        assert!(source.decide(&request).is_allowed());
     }
 }

--- a/crates/incan_semantics_core/src/facts.rs
+++ b/crates/incan_semantics_core/src/facts.rs
@@ -177,7 +177,7 @@ pub enum SemanticFactValue {
     SourceTarget(SemanticSourceTarget),
     CanonicalIdentity(CanonicalSymbolId),
     RegistryEntry(SemanticRegistryEntry),
-    AuthorityDecision(AuthorityDecision),
+    AuthorityDecision(Box<AuthorityDecision>),
     Flag(bool),
 }
 
@@ -209,7 +209,7 @@ impl SemanticFactValue {
 
     /// Build one RFC 104 authority-decision fact value.
     pub fn authority_decision(value: AuthorityDecision) -> Self {
-        Self::AuthorityDecision(value)
+        Self::AuthorityDecision(Box::new(value))
     }
 
     /// Render a deterministic maintainer-facing fact payload snapshot.
@@ -511,12 +511,19 @@ impl SemanticSourceTargetKind {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AuthorityMode {
-    /// Operations run normally and receipts may be disabled.
+    /// Operations run normally with authority reporting disabled.
     Permissive,
     /// Operations run normally and receipts are emitted.
     Observe,
     /// Operations require granted capabilities and receipts are emitted.
     Governed,
+}
+
+impl Default for AuthorityMode {
+    /// Observe authority-bearing operations unless a project-owned policy selects another mode.
+    fn default() -> Self {
+        Self::Observe
+    }
 }
 
 impl AuthorityMode {
@@ -576,14 +583,17 @@ pub enum AuthorityOutcome {
 ///
 /// RFC 104 makes the ceiling a distinct grant source from the per-invocation request, and requires the effective grant
 /// to be their **intersection, never their union**: an invocation can only ever receive less than its ceiling allows,
-/// regardless of what it asks for. Recording whether a ceiling applied is therefore part of the decision, because
-/// `Allowed` under a ceiling and `Allowed` with no ceiling are different facts about the run.
+/// regardless of what it asks for. The durable fact retains both the resulting grant set and the exact ceiling, because
+/// `Allowed` under a ceiling and `Allowed` with no constraint are different facts about the run.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct AuthorityGrantContext {
     /// Scope dimensions the operation requested, as `(dimension, value)` in the capability's declaration order.
     pub requested_scope: Vec<(String, String)>,
-    /// Whether a host ceiling bounded this invocation.
-    pub ceiling_applied: bool,
+    /// The invocation's effective canonical capability grants after project policy and any host ceiling were
+    /// intersected.
+    pub effective_grants: Vec<CanonicalSymbolId>,
+    /// The host-supplied capability ceiling that constrained this invocation, when one applied.
+    pub ceiling: Option<Vec<CanonicalSymbolId>>,
 }
 
 /// Enough provenance to raise a source-owned governed denial diagnostic.
@@ -675,17 +685,47 @@ impl std::fmt::Display for AuthorityDecision {
             AuthorityOutcome::Allowed => "allowed".to_string(),
             AuthorityOutcome::Denied(reason) => format!("denied:{}", reason.as_str()),
         };
-        let ceiling = if self.grant.ceiling_applied { " ceiling" } else { "" };
+        let grants = render_authority_grants(&self.grant.effective_grants);
+        let ceiling = self
+            .grant
+            .ceiling
+            .as_ref()
+            .map_or_else(|| "none".to_string(), |values| render_authority_grants(values));
         write!(
             f,
-            "{} {} {}{} <- {}",
+            "{} {} {} grants=[{}] ceiling=[{}] <- {}",
             self.capability.declaration_name,
             self.mode.as_str(),
             outcome,
+            grants,
             ceiling,
             self.provenance.operation.declaration_name
         )
     }
+}
+
+/// Render canonical grant identities for an inspectable maintainer-facing fact snapshot.
+fn render_authority_grants(grants: &[CanonicalSymbolId]) -> String {
+    grants.iter().map(render_authority_grant).collect::<Vec<_>>().join(",")
+}
+
+/// Render every identity component that distinguishes one canonical capability grant from another.
+fn render_authority_grant(grant: &CanonicalSymbolId) -> String {
+    let origin = match &grant.origin {
+        SymbolOrigin::Module(path) => format!("module:{}", path.join(".")),
+        SymbolOrigin::Package { library, module_path } => {
+            format!("package:{library}:{}", module_path.join("."))
+        }
+        SymbolOrigin::RustCrate(path) => format!("rust:{}", path.join(".")),
+        SymbolOrigin::Builtin => "builtin".to_string(),
+    };
+    format!(
+        "{origin}:{}:{}@{}..{}",
+        grant.kind.as_str(),
+        grant.declaration_name,
+        grant.declaration_span.start,
+        grant.declaration_span.end
+    )
 }
 
 /// Render a module path into the identity string used by HIR, Body IR, and declaration identities.
@@ -990,6 +1030,18 @@ mod tests {
         (capability, provenance)
     }
 
+    /// Build a distinct canonical capability for ceiling and identity-separation tests.
+    fn fs_read_capability() -> super::CanonicalSymbolId {
+        use super::{CanonicalSymbolId, SemanticSourceTargetKind};
+
+        CanonicalSymbolId::module_declaration(
+            vec!["host".to_string(), "fs".to_string()],
+            "read",
+            SemanticSourceTargetKind::Capability,
+            crate::HirSourceSpan::new(30, 40),
+        )
+    }
+
     /// An allowed decision must be actionable without a consumer re-reading source or emitted Rust.
     #[test]
     fn an_allowed_authority_decision_carries_its_mode_and_grant_context() {
@@ -997,11 +1049,12 @@ mod tests {
 
         let (capability, provenance) = authority_fixture();
         let decision = AuthorityDecision::allowed(
-            capability,
+            capability.clone(),
             AuthorityMode::Governed,
             AuthorityGrantContext {
                 requested_scope: vec![("host".to_string(), "api.example.com".to_string())],
-                ceiling_applied: true,
+                effective_grants: vec![capability.clone()],
+                ceiling: Some(vec![capability.clone()]),
             },
             provenance,
         );
@@ -1009,10 +1062,8 @@ mod tests {
         assert!(decision.is_allowed());
         assert_eq!(decision.denial_reason(), None);
         assert_eq!(decision.mode, AuthorityMode::Governed);
-        assert!(
-            decision.grant.ceiling_applied,
-            "a ceiling bounds the effective grant by intersection, so whether one applied is part of the decision",
-        );
+        assert_eq!(decision.grant.effective_grants, vec![capability.clone()]);
+        assert_eq!(decision.grant.ceiling, Some(vec![capability]));
         assert_eq!(decision.provenance.suggested_grant, "host.http.request");
     }
 
@@ -1022,13 +1073,15 @@ mod tests {
         use super::{AuthorityDecision, AuthorityDenialReason, AuthorityGrantContext, AuthorityMode};
 
         let (capability, provenance) = authority_fixture();
+        let ceiling = fs_read_capability();
         let decision = AuthorityDecision::denied(
             capability,
             AuthorityMode::Governed,
             AuthorityDenialReason::OutsideCeiling,
             AuthorityGrantContext {
                 requested_scope: Vec::new(),
-                ceiling_applied: true,
+                effective_grants: Vec::new(),
+                ceiling: Some(vec![ceiling]),
             },
             provenance,
         );
@@ -1067,7 +1120,8 @@ mod tests {
             AuthorityDenialReason::NotGranted,
             AuthorityGrantContext {
                 requested_scope: Vec::new(),
-                ceiling_applied: false,
+                effective_grants: Vec::new(),
+                ceiling: None,
             },
             provenance,
         );

--- a/crates/incan_semantics_core/src/receipts.rs
+++ b/crates/incan_semantics_core/src/receipts.rs
@@ -550,7 +550,7 @@ fn status_matches_authority(status: ReceiptStatus, authority: &AuthorityDecision
                     | ReceiptStatus::Partial,
             )
             | (
-                AuthorityMode::Permissive | AuthorityMode::Observe,
+                AuthorityMode::Observe,
                 true,
                 ReceiptStatus::Observed
                     | ReceiptStatus::Failed
@@ -605,7 +605,8 @@ mod tests {
         };
         let grant = AuthorityGrantContext {
             requested_scope: Vec::new(),
-            ceiling_applied: false,
+            effective_grants: Vec::new(),
+            ceiling: None,
         };
         if allowed {
             AuthorityDecision::allowed(capability, mode, grant, provenance)
@@ -829,11 +830,6 @@ mod tests {
             (AuthorityMode::Governed, true, ReceiptStatus::Redacted),
             (AuthorityMode::Governed, true, ReceiptStatus::Skipped),
             (AuthorityMode::Governed, true, ReceiptStatus::Partial),
-            (AuthorityMode::Permissive, true, ReceiptStatus::Observed),
-            (AuthorityMode::Permissive, true, ReceiptStatus::Failed),
-            (AuthorityMode::Permissive, true, ReceiptStatus::Redacted),
-            (AuthorityMode::Permissive, true, ReceiptStatus::Skipped),
-            (AuthorityMode::Permissive, true, ReceiptStatus::Partial),
             (AuthorityMode::Observe, true, ReceiptStatus::Observed),
             (AuthorityMode::Observe, true, ReceiptStatus::Failed),
             (AuthorityMode::Observe, true, ReceiptStatus::Redacted),
@@ -861,6 +857,8 @@ mod tests {
             (AuthorityMode::Governed, true, ReceiptStatus::Observed),
             (AuthorityMode::Governed, false, ReceiptStatus::Failed),
             (AuthorityMode::Permissive, true, ReceiptStatus::Allowed),
+            (AuthorityMode::Permissive, true, ReceiptStatus::Observed),
+            (AuthorityMode::Permissive, true, ReceiptStatus::Failed),
             (AuthorityMode::Observe, true, ReceiptStatus::Denied),
         ];
         for (mode, allowed, status) in invalid {

--- a/src/backend/replacement/mod.rs
+++ b/src/backend/replacement/mod.rs
@@ -1130,7 +1130,8 @@ pub enum ReplacementExecutionError {
     /// Authority was granted and the provider operation itself failed.
     ///
     /// Separate from a denial because the two have nothing in common but their visibility: here the operation ran,
-    /// its receipt records `failed` over an *allowing* decision, and any resource it acquired was released.
+    /// any resource it acquired was released, and governed or observed runs retain a failed receipt. Permissive
+    /// execution deliberately reports no receipt.
     #[error(
         "replacement backend provider operation `{operation}` failed at original Incan source span \
          {span_start}..{span_end}: {detail}"
@@ -1140,8 +1141,8 @@ pub enum ReplacementExecutionError {
         operation: String,
         /// Source-observable description of the provider's own failure.
         detail: String,
-        /// Sequence id of the failed RFC 104 operation receipt this invocation produced.
-        receipt_sequence_id: u64,
+        /// Sequence id of the failed RFC 104 operation receipt, when reporting was enabled.
+        receipt_sequence_id: Option<u64>,
         /// Original Incan source span carried by the operation's plan.
         span: HirSourceSpan,
         /// Start byte offset duplicated for typed error formatting.
@@ -1183,19 +1184,24 @@ impl ReplacementExecutionError {
 
     /// Return the RFC 104 operation receipt this outcome emitted, when it emitted one.
     ///
-    /// Only the two provider outcomes do. A refusal that happened before the operation was invoked — an unsupported
-    /// construct, an inactive provider, an unresolved operation — deliberately has no receipt to name, which is the
-    /// structural form of "nothing ran, so nothing was recorded".
+    /// Governed denials always do; provider failures do when reporting was enabled. A refusal that happened before
+    /// the operation was invoked — an unsupported construct, an inactive provider, an unresolved operation — and a
+    /// reporting-disabled permissive invocation deliberately have no receipt to name.
     pub const fn operation_receipt(&self) -> Option<super::replacement::provider::ProviderReceiptLink> {
         match self {
             Self::ProviderAuthorityDenied {
                 receipt_sequence_id, ..
-            }
-            | Self::ProviderOperationFailed {
-                receipt_sequence_id, ..
             } => Some(super::replacement::provider::ProviderReceiptLink {
                 sequence_id: *receipt_sequence_id,
             }),
+            Self::ProviderOperationFailed {
+                receipt_sequence_id, ..
+            } => match receipt_sequence_id {
+                Some(sequence_id) => Some(super::replacement::provider::ProviderReceiptLink {
+                    sequence_id: *sequence_id,
+                }),
+                None => None,
+            },
             Self::MissingFunction { .. }
             | Self::ArgumentCount { .. }
             | Self::Unsupported { .. }

--- a/src/backend/replacement/provider.rs
+++ b/src/backend/replacement/provider.rs
@@ -43,7 +43,9 @@ use std::{cell::RefCell, rc::Rc};
 use incan_semantics_core::authority::AuthorityDecisionSource;
 use incan_semantics_core::body_ir::ProviderOperationPlan;
 use incan_semantics_core::receipts::{OperationReceipt, ReceiptAttribute, ReceiptStatus, ReplayClassification};
-use incan_semantics_core::{AuthorityDecision, CanonicalSymbolId, HirSourceSpan, IncanType, SymbolOrigin};
+use incan_semantics_core::{
+    AuthorityDecision, AuthorityMode, CanonicalSymbolId, HirSourceSpan, IncanType, SymbolOrigin,
+};
 
 use crate::backend::selection::{
     BackendKind, BackendSelection, FallbackPolicy, digest_output, finalize_receipt, resolve_execution, select_backend,
@@ -362,7 +364,7 @@ impl ProviderRuntime {
             return Err(self.record_denial(plan, decision, operation_kind));
         }
 
-        // ---- Invocation, then cleanup, then the receipt describing both ----
+        // ---- Invocation, then cleanup, then policy-selected reporting ----
         let invocation_id = self.next_invocation_id();
         self.record_lifecycle(invocation_id, "invoked", span);
         let outcome = self.host.invoke(&ProviderInvocation {
@@ -440,18 +442,22 @@ impl ProviderRuntime {
         outcome: ProviderOperationOutcome,
     ) -> Result<ReplacementValue, ReplacementExecutionError> {
         let span = plan.call_span;
+        if matches!(decision.mode, AuthorityMode::Permissive) {
+            return Self::return_unreported_outcome(plan, outcome);
+        }
+
         let (status, attributes, replay, failure) = match outcome {
             ProviderOperationOutcome::Completed {
                 value,
                 attributes,
                 replay,
             } => {
-                // `Allowed` is a governed-only outcome: it claims authority was enforced and granted. A permissive
-                // or observed run never enforced anything, so its truthful success status is `Observed` -- the
-                // receipt contract rejects the stronger claim rather than letting a run overstate what happened.
+                // `Allowed` is a governed-only outcome: it claims authority was enforced and granted. An observed
+                // run never enforced anything, so its truthful success status is `Observed` -- the receipt contract
+                // rejects the stronger claim rather than letting a run overstate what happened.
                 let status = if attributes.iter().any(ReceiptAttribute::is_redacted) {
                     ReceiptStatus::Redacted
-                } else if matches!(decision.mode, incan_semantics_core::AuthorityMode::Governed) {
+                } else if matches!(decision.mode, AuthorityMode::Governed) {
                     ReceiptStatus::Allowed
                 } else {
                     ReceiptStatus::Observed
@@ -494,11 +500,35 @@ impl ProviderRuntime {
             Err(detail) => Err(ReplacementExecutionError::ProviderOperationFailed {
                 operation: plan.operation.declaration_name.clone(),
                 detail,
-                receipt_sequence_id: sequence_id,
+                receipt_sequence_id: Some(sequence_id),
                 span,
                 span_start: span.start,
                 span_end: span.end,
             }),
+        }
+    }
+
+    /// Return a permissive invocation result without retaining authority or backend execution evidence.
+    ///
+    /// RFC 104 defines permissive as the explicit reporting-disabled escape hatch. The operation still executes and
+    /// still releases its host resources, but it must not construct an `Observed` operation receipt or a backend
+    /// execution record that would claim to reference one.
+    fn return_unreported_outcome(
+        plan: &ProviderOperationPlan,
+        outcome: ProviderOperationOutcome,
+    ) -> Result<ReplacementValue, ReplacementExecutionError> {
+        match outcome {
+            ProviderOperationOutcome::Completed { value, .. } => Ok(value),
+            ProviderOperationOutcome::Failed { detail, .. } => {
+                Err(ReplacementExecutionError::ProviderOperationFailed {
+                    operation: plan.operation.declaration_name.clone(),
+                    detail,
+                    receipt_sequence_id: None,
+                    span: plan.call_span,
+                    span_start: plan.call_span.start,
+                    span_end: plan.call_span.end,
+                })
+            }
         }
     }
 

--- a/src/backend/replacement/provider/tests.rs
+++ b/src/backend/replacement/provider/tests.rs
@@ -38,11 +38,9 @@ type TestResult = Result<(), Box<dyn std::error::Error>>;
 /// The module the fixture operation is declared in.
 const MODULE_PATH: &[&str] = &["app"];
 
-/// The grant spelling the selected capability renders to, and therefore the one a governed run must hold.
+/// The diagnostic grant spelling the selected capability renders to.
 ///
-/// It is derived from the fixture's own `capability ledger_charge` declaration rather than chosen here, because the
-/// decorator resolves the capability the provider manifest publishes. A grant spelling invented by the test would
-/// prove the executor honours a string no declaration produces.
+/// Policy itself receives the canonical capability identity in [`LoweredFixture::capability`], never this string.
 const LEDGER_GRANT: &str = "app.ledger_charge";
 
 /// One ledger charge, plus a same-module caller that invokes it.
@@ -241,6 +239,7 @@ fn ledger_capability(kind: SemanticSourceTargetKind) -> CanonicalSymbolId {
 struct LoweredFixture {
     module: bir::BodyIrModule,
     operation: CanonicalSymbolId,
+    capability: CanonicalSymbolId,
 }
 
 impl LoweredFixture {
@@ -351,16 +350,28 @@ fn lower_fixture_source(
     // private for exactly this reason: a test that registers its own entry would prove the executor works on a
     // catalogue no producer could actually have published, which is the handwritten module exception #1156 exists
     // to rule out. This shares the builder with #1213's own tests so both layers exercise one admission path.
+    let capability = checker
+        .type_info()
+        .declarations
+        .provider_operations
+        .values()
+        .next()
+        .map(|declared| declared.required_capability.clone())
+        .ok_or("the checked fixture exposes no provider capability")?;
     let provider_plan = provider_plan_from_checked_source(checker.type_info(), activation)?;
     let operation = local_function_identity(&program, "charge").ok_or("the fixture declares no `charge`")?;
     let module =
         build_body_ir_module_v0_with_provider_plan(&program, &module_path, checker.type_info(), &provider_plan)?;
-    Ok(LoweredFixture { module, operation })
+    Ok(LoweredFixture {
+        module,
+        operation,
+        capability,
+    })
 }
 
-/// Build the runtime one test runs against: a governed or permissive authority, and a ledger host.
-fn runtime(mode: AuthorityMode, grants: &[&str], host: Rc<LedgerHost>) -> Rc<ProviderRuntime> {
-    let authority = StaticAuthority::new(mode, grants.iter().map(|grant| (*grant).to_string()));
+/// Build the runtime one test runs against from an optional canonical capability grant and a ledger host.
+fn runtime(mode: AuthorityMode, grant: Option<&CanonicalSymbolId>, host: Rc<LedgerHost>) -> Rc<ProviderRuntime> {
+    let authority = StaticAuthority::new(mode, grant.into_iter().cloned());
     ProviderRuntime::new(Rc::new(authority), host)
 }
 
@@ -486,7 +497,7 @@ fn lifecycle_events(providers: &ProviderRuntime) -> Vec<&'static str> {
 fn an_allowed_provider_operation_executes_and_references_its_operation_receipt() -> TestResult {
     let fixture = lower_fixture(ProviderActivationState::Active)?;
     let host = Rc::new(LedgerHost::new(fixture.operation.clone(), LedgerBehavior::Settle));
-    let providers = runtime(AuthorityMode::Governed, &[LEDGER_GRANT], host.clone());
+    let providers = runtime(AuthorityMode::Governed, Some(&fixture.capability), host.clone());
 
     let execution = settle(&fixture.module, &providers)?;
 
@@ -544,18 +555,42 @@ fn an_allowed_provider_operation_executes_and_references_its_operation_receipt()
 // empty list flows through to an empty list, which asserts nothing. Neither is worth shipping. Once the
 // declaration side derives requirements, propagation belongs back here as a real assertion.
 
-/// Mode semantics belong to the authority seam: a permissive run allows a capability no grant set holds, and this
-/// backend neither knows nor decides that.
+/// Permissive is the reporting-disabled escape hatch: it executes an ungranted operation but retains neither an
+/// operation receipt nor a backend execution record that could claim to reference one.
 #[test]
-fn a_permissive_run_executes_an_ungranted_provider_operation() -> TestResult {
+fn a_permissive_run_executes_an_ungranted_provider_operation_without_receipts() -> TestResult {
     let fixture = lower_fixture(ProviderActivationState::Active)?;
     let host = Rc::new(LedgerHost::new(fixture.operation.clone(), LedgerBehavior::Settle));
-    let providers = runtime(AuthorityMode::Permissive, &[], host.clone());
+    let providers = runtime(AuthorityMode::Permissive, None, host.clone());
 
     let execution = settle(&fixture.module, &providers)?;
 
     assert_eq!(execution.value, ReplacementValue::Int(255));
     assert_eq!(host.invocations(), vec![250]);
+    assert!(providers.operation_receipts().is_empty());
+    assert!(providers.provider_executions().is_empty());
+    assert_eq!(lifecycle_events(&providers), vec!["invoked", "completed", "released"]);
+    Ok(())
+}
+
+/// The project-default authority mode observes an invoked operation without treating its source declaration or import
+/// as a grant. The decision is made only after the plan reaches runtime invocation.
+#[test]
+fn the_default_authority_mode_observes_an_ungranted_provider_operation_at_invocation() -> TestResult {
+    let fixture = lower_fixture(ProviderActivationState::Active)?;
+    let host = Rc::new(LedgerHost::new(fixture.operation.clone(), LedgerBehavior::Settle));
+    let providers = ProviderRuntime::new(Rc::new(StaticAuthority::default()), host.clone());
+
+    let execution = settle(&fixture.module, &providers)?;
+
+    assert_eq!(execution.value, ReplacementValue::Int(255));
+    assert_eq!(host.invocations(), vec![250]);
+    let receipts = providers.operation_receipts();
+    let [receipt] = receipts.as_slice() else {
+        return Err(Box::from("one observed invocation must produce one operation receipt"));
+    };
+    assert_eq!(receipt.authority().mode, AuthorityMode::Observe);
+    assert_eq!(receipt.status(), ReceiptStatus::Observed);
     Ok(())
 }
 
@@ -572,7 +607,7 @@ fn a_permissive_run_executes_an_ungranted_provider_operation() -> TestResult {
 fn a_governed_denial_emits_a_denied_receipt_without_invoking_the_provider() -> TestResult {
     let fixture = lower_fixture(ProviderActivationState::Active)?;
     let host = Rc::new(LedgerHost::new(fixture.operation.clone(), LedgerBehavior::Settle));
-    let providers = runtime(AuthorityMode::Governed, &[], host.clone());
+    let providers = runtime(AuthorityMode::Governed, None, host.clone());
     let call_span = fixture.plan()?.call_span;
 
     let error = settle(&fixture.module, &providers)
@@ -637,8 +672,13 @@ fn a_governed_denial_emits_a_denied_receipt_without_invoking_the_provider() -> T
 fn a_host_ceiling_denial_is_reported_without_being_reinterpreted() -> TestResult {
     let fixture = lower_fixture(ProviderActivationState::Active)?;
     let host = Rc::new(LedgerHost::new(fixture.operation.clone(), LedgerBehavior::Settle));
-    let authority = StaticAuthority::new(AuthorityMode::Governed, [LEDGER_GRANT.to_string()])
-        .with_ceiling(["host.fs.read".to_string()]);
+    let ceiling = CanonicalSymbolId::module_declaration(
+        vec!["host".to_string(), "fs".to_string()],
+        "read",
+        SemanticSourceTargetKind::Capability,
+        HirSourceSpan::new(30, 40),
+    );
+    let authority = StaticAuthority::new(AuthorityMode::Governed, [fixture.capability.clone()]).with_ceiling([ceiling]);
     let providers = ProviderRuntime::new(Rc::new(authority), host.clone());
 
     let error = settle(&fixture.module, &providers)
@@ -666,12 +706,34 @@ fn a_host_ceiling_denial_is_reported_without_being_reinterpreted() -> TestResult
 // Provider failure and lifecycle cleanup
 // ============================================================================
 
+/// A permissive failure remains source-visible but cannot create a receipt reference while reporting is disabled.
+#[test]
+fn a_permissive_provider_failure_is_unreported() -> TestResult {
+    let fixture = lower_fixture(ProviderActivationState::Active)?;
+    let host = Rc::new(LedgerHost::new(fixture.operation.clone(), LedgerBehavior::Decline));
+    let providers = runtime(AuthorityMode::Permissive, None, host.clone());
+
+    let error = settle(&fixture.module, &providers)
+        .err()
+        .ok_or("a declined permissive charge must surface as a failure")?;
+
+    assert!(matches!(
+        error,
+        ReplacementExecutionError::ProviderOperationFailed { .. }
+    ));
+    assert_eq!(error.operation_receipt(), None);
+    assert!(providers.operation_receipts().is_empty());
+    assert!(providers.provider_executions().is_empty());
+    assert_eq!(lifecycle_events(&providers), vec!["invoked", "failed", "released"]);
+    Ok(())
+}
+
 /// A provider failure keeps its allowing authority decision, and releases what the invocation acquired.
 #[test]
 fn a_provider_failure_keeps_allowed_authority_and_still_releases() -> TestResult {
     let fixture = lower_fixture(ProviderActivationState::Active)?;
     let host = Rc::new(LedgerHost::new(fixture.operation.clone(), LedgerBehavior::Decline));
-    let providers = runtime(AuthorityMode::Governed, &[LEDGER_GRANT], host.clone());
+    let providers = runtime(AuthorityMode::Governed, Some(&fixture.capability), host.clone());
 
     let error = settle(&fixture.module, &providers)
         .err()
@@ -714,7 +776,7 @@ fn a_provider_failure_keeps_allowed_authority_and_still_releases() -> TestResult
 fn a_completed_invocation_releases_exactly_once_after_completing() -> TestResult {
     let fixture = lower_fixture(ProviderActivationState::Active)?;
     let host = Rc::new(LedgerHost::new(fixture.operation.clone(), LedgerBehavior::Settle));
-    let providers = runtime(AuthorityMode::Governed, &[LEDGER_GRANT], host.clone());
+    let providers = runtime(AuthorityMode::Governed, Some(&fixture.capability), host.clone());
 
     settle(&fixture.module, &providers)?;
 
@@ -740,7 +802,7 @@ fn a_withheld_attribute_classifies_the_receipt_as_redacted() -> TestResult {
         fixture.operation.clone(),
         LedgerBehavior::SettleWithSecretAccount,
     ));
-    let providers = runtime(AuthorityMode::Governed, &[LEDGER_GRANT], host);
+    let providers = runtime(AuthorityMode::Governed, Some(&fixture.capability), host);
 
     let execution = settle(&fixture.module, &providers)?;
 
@@ -789,7 +851,7 @@ fn a_withheld_attribute_classifies_the_receipt_as_redacted() -> TestResult {
 fn a_disabled_provider_is_refused_by_lowering_before_a_plan_exists() -> TestResult {
     let fixture = lower_fixture(ProviderActivationState::Disabled)?;
     let host = Rc::new(LedgerHost::new(fixture.operation.clone(), LedgerBehavior::Settle));
-    let providers = runtime(AuthorityMode::Governed, &[LEDGER_GRANT], host.clone());
+    let providers = runtime(AuthorityMode::Governed, Some(&fixture.capability), host.clone());
 
     assert!(
         fixture.plan().is_err(),
@@ -819,7 +881,7 @@ fn an_inactive_plan_is_refused_by_the_runtime_before_anything_executes() -> Test
     let mut fixture = lower_fixture(ProviderActivationState::Active)?;
     fixture.force_activation(ProviderActivationState::Unavailable);
     let host = Rc::new(LedgerHost::new(fixture.operation.clone(), LedgerBehavior::Settle));
-    let providers = runtime(AuthorityMode::Governed, &[LEDGER_GRANT], host.clone());
+    let providers = runtime(AuthorityMode::Governed, Some(&fixture.capability), host.clone());
     let call_span = fixture.plan()?.call_span;
 
     let error = prepare_free_function_execution_with_providers(
@@ -849,7 +911,7 @@ fn an_unresolved_provider_operation_is_refused_before_execution() -> TestResult 
     // whose provider set does not include the one the program invokes.
     let other_operation = ledger_capability(SemanticSourceTargetKind::Function);
     let host = Rc::new(LedgerHost::new(other_operation, LedgerBehavior::Settle));
-    let providers = runtime(AuthorityMode::Governed, &[LEDGER_GRANT], host.clone());
+    let providers = runtime(AuthorityMode::Governed, Some(&fixture.capability), host.clone());
     let call_span = fixture.plan()?.call_span;
 
     let error = prepare_free_function_execution_with_providers(
@@ -913,12 +975,12 @@ fn provider_evidence_is_bound_into_the_execution_output_identity() -> TestResult
     let settled_host = Rc::new(LedgerHost::new(fixture.operation.clone(), LedgerBehavior::Settle));
     let settled = settle(
         &fixture.module,
-        &runtime(AuthorityMode::Governed, &[LEDGER_GRANT], settled_host),
+        &runtime(AuthorityMode::Governed, Some(&fixture.capability), settled_host),
     )?;
     let repeat_host = Rc::new(LedgerHost::new(fixture.operation.clone(), LedgerBehavior::Settle));
     let repeated = settle(
         &fixture.module,
-        &runtime(AuthorityMode::Governed, &[LEDGER_GRANT], repeat_host),
+        &runtime(AuthorityMode::Governed, Some(&fixture.capability), repeat_host),
     )?;
     assert_eq!(
         settled.output_identity, repeated.output_identity,
@@ -931,7 +993,7 @@ fn provider_evidence_is_bound_into_the_execution_output_identity() -> TestResult
     ));
     let redacted = settle(
         &fixture.module,
-        &runtime(AuthorityMode::Governed, &[LEDGER_GRANT], redacted_host),
+        &runtime(AuthorityMode::Governed, Some(&fixture.capability), redacted_host),
     )?;
     assert_ne!(
         settled.output_identity, redacted.output_identity,

--- a/src/backend/replacement/provider/tests/host_preflight_tests.rs
+++ b/src/backend/replacement/provider/tests/host_preflight_tests.rs
@@ -67,7 +67,7 @@ fn malformed_named_binding_refuses_at_the_caller_before_provider_discovery() -> 
 fn assert_hosted_deferred(source: &str, args: &[ReplacementValue], expected_stdout: &[u8]) -> TestResult {
     let fixture = lower_fixture_source(source, ProviderActivationState::Active)?;
     let host = Rc::new(LedgerHost::new(fixture.operation.clone(), LedgerBehavior::Settle));
-    let providers = runtime(AuthorityMode::Governed, &[LEDGER_GRANT], host.clone());
+    let providers = runtime(AuthorityMode::Governed, Some(&fixture.capability), host.clone());
     let prepared = prepare_free_function_execution_with_providers(&fixture.module, "settle", args, Some(&providers))?;
     assert!(host.invocations().is_empty());
     assert!(providers.operation_receipts().is_empty());
@@ -187,7 +187,7 @@ fn unreachable_provider_function_is_not_preflighted() -> TestResult {
 fn nested_hosted_operation_still_requires_invocation_authority() -> TestResult {
     let fixture = lower_fixture_source(STORED_CLOSURE_PROVIDER_FIXTURE_SOURCE, ProviderActivationState::Active)?;
     let host = Rc::new(LedgerHost::new(fixture.operation.clone(), LedgerBehavior::Settle));
-    let providers = runtime(AuthorityMode::Governed, &[], host.clone());
+    let providers = runtime(AuthorityMode::Governed, None, host.clone());
     let args = [ReplacementValue::Str("acct-1".to_string()), ReplacementValue::Int(250)];
     let prepared = prepare_free_function_execution_with_providers(&fixture.module, "settle", &args, Some(&providers))?;
     assert!(providers.operation_receipts().is_empty());
@@ -287,7 +287,7 @@ def settle() -> int:
         let span = unique_source_span(&source, "charge(\"acct-1\", 250)")?;
         assert_missing_host_preflight(&fixture, "settle", &args, span, b"")?;
         let host = Rc::new(LedgerHost::new(fixture.operation.clone(), LedgerBehavior::Settle));
-        let providers = runtime(AuthorityMode::Governed, &[], host.clone());
+        let providers = runtime(AuthorityMode::Governed, None, host.clone());
         let prepared =
             prepare_free_function_execution_with_providers(&fixture.module, "settle", &args, Some(&providers))?;
         let mut stdout = Vec::new();
@@ -451,7 +451,7 @@ fn unhosted_provider_operation_in_reachable_sibling_refuses_during_preparation()
 fn reachable_sibling_provider_operation_uses_the_matching_host() -> TestResult {
     let fixture = lower_fixture_source(SIBLING_PROVIDER_SOURCE, ProviderActivationState::Active)?;
     let host = Rc::new(LedgerHost::new(fixture.operation.clone(), LedgerBehavior::Settle));
-    let providers = runtime(AuthorityMode::Governed, &[LEDGER_GRANT], host.clone());
+    let providers = runtime(AuthorityMode::Governed, Some(&fixture.capability), host.clone());
     let args = [ReplacementValue::Str("acct-1".to_string()), ReplacementValue::Int(250)];
     let prepared = prepare_free_function_execution_with_providers(&fixture.module, "settle", &args, Some(&providers))?;
     assert_eq!(
@@ -504,7 +504,7 @@ fn reachable_sibling_provider_operation_with_mismatched_host_refuses_during_prep
         ledger_capability(SemanticSourceTargetKind::Function),
         LedgerBehavior::Settle,
     ));
-    let providers = runtime(AuthorityMode::Governed, &[LEDGER_GRANT], host.clone());
+    let providers = runtime(AuthorityMode::Governed, Some(&fixture.capability), host.clone());
     let args = [ReplacementValue::Str("acct-1".to_string()), ReplacementValue::Int(250)];
 
     match prepare_free_function_execution_with_providers(&fixture.module, "settle", &args, Some(&providers)) {

--- a/tests/parity_corpus_tests.rs
+++ b/tests/parity_corpus_tests.rs
@@ -1552,7 +1552,7 @@ fn observe_provider_path(
             .map_err(|error| format!("provider fixture lowering failure: {error}"))?;
 
     let host = Rc::new(CorpusLedgerHost::new(operation, behavior));
-    let authority = StaticAuthority::new(mode, grant_capability.then_some(required_capability).into_iter());
+    let authority = StaticAuthority::new(mode, grant_capability.then_some(required_capability));
     let providers = ProviderRuntime::new(Rc::new(authority), host.clone());
     let executed = execute_free_function_with_providers(
         &module,

--- a/tests/parity_corpus_tests.rs
+++ b/tests/parity_corpus_tests.rs
@@ -1365,9 +1365,6 @@ def settle(account: str, amount: int) -> int:
   return charge(account, amount)
 "#;
 
-/// The grant spelling the selected capability renders to, and therefore the one a governed run must hold.
-const PROVIDER_GRANT: &str = "app.ledger_charge";
-
 /// What the fixture ledger does when an authorized charge reaches it.
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum LedgerBehavior {
@@ -1489,7 +1486,7 @@ struct ProviderPathObservation {
 fn observe_provider_path(
     behavior: LedgerBehavior,
     mode: AuthorityMode,
-    grants: &[&str],
+    grant_capability: bool,
 ) -> Result<ProviderPathObservation, String> {
     let tokens = lexer::lex(PROVIDER_CASE_SRC).map_err(|errors| format!("provider fixture lex failure: {errors:?}"))?;
     let program = parser::parse(&tokens).map_err(|errors| format!("provider fixture parse failure: {errors:?}"))?;
@@ -1514,10 +1511,11 @@ fn observe_provider_path(
             runtime_requirements: declared.runtime_requirements.clone(),
         })
         .collect();
-    let operation = descriptors
+    let descriptor = descriptors
         .first()
-        .map(|descriptor| descriptor.operation.clone())
         .ok_or("the provider fixture declares no checked provider operation")?;
+    let operation = descriptor.operation.clone();
+    let required_capability = descriptor.required_capability.clone();
     let namespace_claims: BTreeSet<Vec<String>> = descriptors
         .iter()
         .filter_map(|descriptor| descriptor.operation.module_path().map(ToOwned::to_owned))
@@ -1554,7 +1552,7 @@ fn observe_provider_path(
             .map_err(|error| format!("provider fixture lowering failure: {error}"))?;
 
     let host = Rc::new(CorpusLedgerHost::new(operation, behavior));
-    let authority = StaticAuthority::new(mode, grants.iter().map(|grant| (*grant).to_string()));
+    let authority = StaticAuthority::new(mode, grant_capability.then_some(required_capability).into_iter());
     let providers = ProviderRuntime::new(Rc::new(authority), host.clone());
     let executed = execute_free_function_with_providers(
         &module,
@@ -1630,7 +1628,7 @@ fn provider_outcome(
 /// An allowed invocation runs the provider and binds a backend receipt to the operation receipt it describes.
 fn case_provider_allowed_invocation() -> ComparisonOutcome {
     provider_outcome(
-        observe_provider_path(LedgerBehavior::Settle, AuthorityMode::Governed, &[PROVIDER_GRANT]),
+        observe_provider_path(LedgerBehavior::Settle, AuthorityMode::Governed, true),
         |observed| {
             if observed.value != Some(ReplacementValue::Int(255)) {
                 return Some(format!(
@@ -1658,7 +1656,7 @@ fn case_provider_allowed_invocation() -> ComparisonOutcome {
 /// A governed denial emits a denied receipt, reports a source-owned diagnostic, and never reaches the provider.
 fn case_provider_governed_denial() -> ComparisonOutcome {
     provider_outcome(
-        observe_provider_path(LedgerBehavior::Settle, AuthorityMode::Governed, &[]),
+        observe_provider_path(LedgerBehavior::Settle, AuthorityMode::Governed, false),
         |observed| {
             if !observed.invocations.is_empty() {
                 return Some(format!(
@@ -1692,7 +1690,7 @@ fn case_provider_governed_denial() -> ComparisonOutcome {
 /// A provider failure keeps its allowing authority decision and reports its own diagnostic, not a denial's.
 fn case_provider_operation_failure() -> ComparisonOutcome {
     provider_outcome(
-        observe_provider_path(LedgerBehavior::Decline, AuthorityMode::Governed, &[PROVIDER_GRANT]),
+        observe_provider_path(LedgerBehavior::Decline, AuthorityMode::Governed, true),
         |observed| {
             if observed.error_code != Some("INCAN-R1156-PROVIDER") {
                 return Some(format!(
@@ -1720,11 +1718,7 @@ fn case_provider_operation_failure() -> ComparisonOutcome {
 /// A withheld attribute classifies the receipt as redacted without changing what the operation returned.
 fn case_provider_redaction_classification() -> ComparisonOutcome {
     provider_outcome(
-        observe_provider_path(
-            LedgerBehavior::SettleWithSecretAccount,
-            AuthorityMode::Governed,
-            &[PROVIDER_GRANT],
-        ),
+        observe_provider_path(LedgerBehavior::SettleWithSecretAccount, AuthorityMode::Governed, true),
         |observed| {
             if observed.receipt_status != Some(ReceiptStatus::Redacted) {
                 return Some(format!(
@@ -1762,7 +1756,7 @@ fn case_provider_redaction_classification() -> ComparisonOutcome {
 /// An invocation that failed still releases what it acquired, exactly once and after the failure.
 fn case_provider_lifecycle_cleanup() -> ComparisonOutcome {
     provider_outcome(
-        observe_provider_path(LedgerBehavior::Decline, AuthorityMode::Governed, &[PROVIDER_GRANT]),
+        observe_provider_path(LedgerBehavior::Decline, AuthorityMode::Governed, true),
         |observed| {
             if observed.lifecycle != vec!["invoked", "failed", "released"] {
                 return Some(format!(

--- a/workspaces/docs-site/docs/RFCs/104_ambient_runtime_capabilities_and_receipts.md
+++ b/workspaces/docs-site/docs/RFCs/104_ambient_runtime_capabilities_and_receipts.md
@@ -1,6 +1,6 @@
 # RFC 104: Ambient Runtime Capabilities and Receipts
 
-- **Status:** Planned
+- **Status:** In Progress
 - **Created:** 2026-05-24
 - **Author(s):** Danny Meijer (@dannymeijer)
 - **Related:**
@@ -97,13 +97,13 @@ def fetch_status() -> int:
     return response.status.code
 ```
 
-A normal run may behave just like a normal program:
+A normal run observes authority-bearing operations while keeping ordinary development unblocked:
 
 ```text
 incan run status.incn
 ```
 
-An observed run asks the runtime to emit a machine-readable report:
+The run can export those observed facts as a machine-readable report:
 
 ```text
 incan run status.incn --report json
@@ -225,8 +225,8 @@ A host may also supply a capability ceiling: a maximum grant set sourced from ou
 
 The runtime should support at least these conceptual modes:
 
-- `permissive`: operations run normally and receipts may be disabled.
-- `observe`: operations run normally and receipts are emitted.
+- `permissive`: operations run normally with reporting explicitly disabled; this is an escape hatch rather than the default.
+- `observe`: operations run normally and receipts are emitted; this is the default for ordinary development.
 - `governed`: operations require granted capabilities and receipts are emitted.
 
 The user-facing shape is:
@@ -236,7 +236,7 @@ incan run app.incn --report json
 incan run app.incn --allow host.env.read,host.http.request --report json
 ```
 
-`incan run` defaults to `permissive`: ordinary local development stays ordinary, and nothing is denied or exported without an explicit flag. `incan test` defaults to `governed` with nothing pre-granted, so a test that unexpectedly reaches the real filesystem or network fails with a capability diagnostic instead of silently succeeding -- the same test-isolation property most test frameworks already enforce by convention, made structural here instead. A typed action runs under whatever mode and grants its invoking context provides (a CI job's explicit `--allow`, a host's policy-selected grant set); this RFC does not define a third default distinct from `incan run` and `incan test`, since actions are never invoked in a vacuum.
+`incan run` defaults to `observe`: ordinary local development stays ordinary and records authority facts without unexpectedly denying an undeclared access. `permissive` is an explicit escape hatch for runs that must disable observation. `incan test` defaults to `governed` with nothing pre-granted, so a test that unexpectedly reaches the real filesystem or network fails with a capability diagnostic instead of silently succeeding -- the same test-isolation property most test frameworks already enforce by convention, made structural here instead. A typed action runs under whatever mode and grants its invoking context provides (a CI job's explicit `--allow`, a host's policy-selected grant set); this RFC does not define a third default distinct from `incan run` and `incan test`, since actions are never invoked in a vacuum.
 
 ### Capability declarations
 
@@ -488,11 +488,54 @@ Generated build artifacts and run reports should be ordinary artifacts that RFC 
 - **LSP / Docs tooling**: editors and docs can surface capability declarations, required grants, denial diagnostics, and report artifacts.
 - **Policy / CI / Agents**: policy and automation can consume capability declarations, action dry-runs, receipt schemas, and actual receipts to decide whether runs, actions, generated artifacts, or proposed changes are acceptable.
 
+## Implementation Plan
+
+### Phase 1: Compiler-owned declarations and decision facts
+
+- Resolve capability declarations and provider-operation requirements as canonical semantic identities.
+- Preserve capability, operation, source span, execution mode, effective grant or denial, ceiling, and denial reason in one generic authority decision.
+- Apply authority only when an admitted authority-bearing operation is invoked, never when its module is imported.
+
+### Phase 2: Project policy and execution boundaries
+
+- Let a Loaf project declare target selection, execution policy, and environment grants without allowing source to grant host authority to itself.
+- Have Oven enforce the selected project policy and link each execution to the stable authority decision.
+
+### Phase 3: Receipts and report consumers
+
+- Extend the #1028 operation-receipt, redaction, replay, and report work across stdlib and package boundaries.
+- Keep receipts linked to authority decisions rather than duplicating authority or policy semantics.
+
+### Phase 4: Remaining language and tooling integration
+
+- Add typed-action declaration alignment, standard-library host capability families, diagnostics, semantic inspection, and user-facing documentation.
+
+## Progress Checklist
+
+### Compiler semantic facts
+
+- [x] Parse and resolve source capability declarations as checked canonical identities.
+- [x] Publish provider-operation capability requirements and lower an admitted call to a canonical provider-operation plan.
+- [x] Establish a generic authority-decision fact and a first invocation-time provider consumer without provider-local allow/deny fields.
+- [ ] Connect the project-owned Loaf policy, target selection, and environment grants to the authority decision source.
+- [ ] Have Oven enforce selected project policy and record the stable decision link for all later execution consumers.
+
+### Runtime and package integration
+
+- [ ] Implement broad standard-library host capability publishers and constraint matchers.
+- [ ] Integrate package declarations and typed-action capability alignment.
+
+### Receipts, inspection, and documentation
+
+- [ ] Complete #1028 durable receipt production, redaction, replay, and report surfaces.
+- [ ] Expose static declarations and runtime facts through semantic inspection.
+- [ ] Document the user-facing policy, report, and diagnostic surfaces.
+
 ## Design Decisions
 
 - **Capability identities are checked symbols, not strings:** a capability's fully-qualified identity is derived from where it is declared (package or toolchain identity plus module path), never typed by the author. Two packages cannot collide on a capability name because the namespace segment comes from an identity a registry already enforces as unique. A capability reference at a use site resolves like an import; a misspelled or nonexistent reference is a compile error, not a runtime surprise.
 - **Capability declarations live in source**, as a first-class `capability` declaration form, because deriving identity from declaration location requires the declaration to be real, compiler-resolved syntax rather than manifest or metadata.
-- **Default run modes:** `incan run` defaults to `permissive`; `incan test` defaults to `governed` with nothing pre-granted, enforcing the same test-isolation property most test frameworks already assume by convention. Typed actions run under whatever mode and grants their invoking context provides; there is no third default.
+- **Default run modes:** `incan run` defaults to `observe`; it records authority facts without unexpectedly denying ordinary development access. `permissive` is an explicit escape hatch that disables observation, while `incan test` defaults to `governed` with nothing pre-granted, enforcing the same test-isolation property most test frameworks already assume by convention. Typed actions run under whatever mode and grants their invoking context provides; there is no third default.
 - **Minimum stable host capability set is exactly the nine already proposed** in Reference-level explanation (`host.env.read`, `host.fs.read`, `host.fs.write`, `host.process.spawn`, `host.http.request`, `host.clock.read`, `host.random`, `host.model.invoke`, `host.tool.invoke`), fixed and not package-extensible.
 - **Scoped grants:** a capability declares its own typed `scope` schema (host capabilities via `std.runtime`'s own declarations, package capabilities via their own). Scope values bind at grant time, never in a static declaration such as `@action(caps=[...])`, and are checked against the real operation's attributes at the moment it happens, independent of the declaring code.
 - **No implicit host-capability grants:** a package capability's `requires` list documents which host capabilities its implementation needs, for tooling and policy to inspect, but granting the package capability never automatically grants what it requires. Those must always be listed and granted separately.


### PR DESCRIPTION
## Summary

Advances the bounded compiler-owned authority fact packet for RFC 104 and #1029 on top of landed Slice 1 provider-operation identity and plan work.

- Defaults the generic authority source to `observe`, so ordinary development records an ungranted invoked provider operation instead of denying it.
- Stores and compares policy grants and ceilings as compiler-proven `CanonicalSymbolId` values. `suggested_grant` remains diagnostic provenance only; it cannot authorize a different capability.
- Retains one generic `AuthorityDecision` with canonical capability and operation identity, mode, outcome or denial reason, applicable grant/ceiling constraints, scope, and source provenance.
- Applies authority at provider invocation, without provider-local allow or deny state.
- Defines `permissive` as the reporting-disabled escape hatch: provider execution creates neither an `OperationReceipt` nor a `ProviderExecutionRecord`.
- Leaves all release metadata at `0.6.0-dev.1`; the active Slice 2 integration branch owns `0.6.0-dev.2`.

This PR does not close #1029 because the RFC remains partially implemented. It does not change sibling #1023.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [x] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [x] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [x] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: no public Loaf/Oven policy CLI is claimed here. The generic source defaults to observed decisions; project policy, target selection, environment grants, and Oven enforcement remain later work.
- **Internals**: `AuthorityDecision` is the single durable generic decision seam. Provider invocation consumes it, while #1028 remains the owner of durable operation receipts, redaction, replay, and reports.
- **Risks**: scope matchers, project grants, Oven enforcement, broad runtime capability families, #1028 receipt work, and final inspection/conformance remain out of scope. The repository-wide full gate needs a larger dedicated cache to rerun fully.

## Testing / verification

- [x] `cargo test --locked -p incan_semantics_core` - 72 passed
- [x] `cargo test --locked --lib backend::replacement::provider::tests` - 14 passed
- [x] `cargo test --locked --test parity_corpus_tests --no-run`
- [x] `make fmt`, `git diff --check`, semantic and root Clippy with warnings denied
- [x] `cargo doc --locked --no-deps -p incan_semantics_core` and `cargo doc --locked --no-deps --lib` (existing unrelated rustdoc warnings remain)
- [ ] `make pre-commit` - not claimed passed. Its earlier run required 24,296,928 KiB, above the task-owned 20 GiB cache ceiling; the volume currently has 11 GiB free.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

If docs updated:

- Link(s): `workspaces/docs-site/docs/RFCs/104_ambient_runtime_capabilities_and_receipts.md`

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Refs #1029