### PR TITLE
chore - freeze the CLI-to-compiler reach-in surface with a ratcheting guardrail (#1297)

### DIFF
--- a/tests/cli_layering_guardrails.rs
+++ b/tests/cli_layering_guardrails.rs
@@ -1,0 +1,164 @@
+//! Guard the CLI-to-compiler layering boundary against further erosion.
+//!
+//! The CLI is meant to orchestrate the compiler, not to reimplement it. Where that boundary slipped, one rule ended
+//! up with two implementations that could disagree: RFC 120 records that "a check living in the CLI could not agree
+//! with one living in the frontend by construction", and #1293 found a live instance -- manifest export projection
+//! in `src/cli/commands/build.rs` disagreeing with the validator in `src/library_manifest/` about which hop of a
+//! re-export chain a path described.
+//!
+//! This suite does not refactor anything and does not judge the existing reach-ins. It records them, so the set can
+//! only shrink. Removing an entry is the work tracked by #1298; adding one fails here first.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+const BASELINE_PATH: &str = "tests/fixtures/cli_layering/cli_compiler_reach_in.json";
+const CLI_ROOT: &str = "src/cli";
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+/// One recorded file and the compiler modules it is currently allowed to reach.
+#[derive(Debug, Deserialize)]
+struct BaselineFile {
+    path: String,
+    reaches: Vec<String>,
+}
+
+/// The recorded CLI-to-compiler reach-in surface.
+#[derive(Debug, Deserialize)]
+struct Baseline {
+    files: Vec<BaselineFile>,
+}
+
+/// Resolve the repository root from this test's manifest directory.
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// Collect the distinct `crate::frontend::*` and `crate::backend::*` modules one source file names.
+///
+/// Matching is textual and deliberately coarse: it keys on `crate::<layer>::<module>` rather than on resolved item
+/// paths, because the concern is which compiler areas the CLI reaches into at all, not how many times or through
+/// which item. A coarser key also keeps the baseline readable and its diffs meaningful.
+fn compiler_modules_named_by(source: &str) -> BTreeSet<String> {
+    let mut modules = BTreeSet::new();
+    for (index, _) in source.match_indices("crate::") {
+        let rest = &source[index + "crate::".len()..];
+        let mut segments = rest.split("::");
+        let Some(layer) = segments.next() else { continue };
+        if layer != "frontend" && layer != "backend" {
+            continue;
+        }
+        let Some(module) = segments.next() else { continue };
+        let module: String = module
+            .chars()
+            .take_while(|character| character.is_ascii_alphanumeric() || *character == '_')
+            .collect();
+        // Only a module segment counts. `crate::backend::IrCodegen` names a type re-exported from the layer root,
+        // which is the sanctioned entry point; `crate::backend::ir` reaches past it into the layer's internals, and
+        // that is the distinction this guard is about. Rust's naming convention separates the two reliably.
+        if !module.starts_with(|character: char| character.is_ascii_lowercase()) {
+            continue;
+        }
+        modules.insert(format!("crate::{layer}::{module}"));
+    }
+    modules
+}
+
+/// Walk `src/cli` and report the compiler modules each file reaches into.
+fn observed_reach_in(root: &Path) -> Result<BTreeMap<String, BTreeSet<String>>, Box<dyn std::error::Error>> {
+    let mut observed = BTreeMap::new();
+    let mut pending = vec![root.join(CLI_ROOT)];
+    while let Some(directory) = pending.pop() {
+        for entry in fs::read_dir(&directory)? {
+            let path = entry?.path();
+            if path.is_dir() {
+                pending.push(path);
+                continue;
+            }
+            if path.extension().and_then(|extension| extension.to_str()) != Some("rs") {
+                continue;
+            }
+            let modules = compiler_modules_named_by(&fs::read_to_string(&path)?);
+            if modules.is_empty() {
+                continue;
+            }
+            let relative = path
+                .strip_prefix(root)?
+                .to_str()
+                .ok_or("a CLI source path was not valid UTF-8")?
+                .replace('\\', "/");
+            observed.insert(relative, modules);
+        }
+    }
+    Ok(observed)
+}
+
+/// The CLI layer may not reach into compiler internals it has not already reached into.
+///
+/// A failure here is not a request to update the baseline. It means a CLI file gained a dependency on a compiler
+/// area, which is the direction #1298 is trying to reverse. Move the logic behind the frontend or backend boundary
+/// instead; regenerate the baseline only when an entry is being *removed*.
+#[test]
+fn cli_does_not_reach_further_into_the_compiler_than_recorded() -> TestResult {
+    let root = repo_root();
+    let baseline: Baseline = serde_json::from_str(&fs::read_to_string(root.join(BASELINE_PATH))?)?;
+    let recorded: BTreeMap<String, BTreeSet<String>> = baseline
+        .files
+        .into_iter()
+        .map(|file| (file.path, file.reaches.into_iter().collect()))
+        .collect();
+    let observed = observed_reach_in(&root)?;
+
+    let mut added: Vec<String> = Vec::new();
+    for (path, modules) in &observed {
+        let allowed = recorded.get(path);
+        for module in modules {
+            if !allowed.is_some_and(|allowed| allowed.contains(module)) {
+                added.push(format!("  {path} now reaches {module}"));
+            }
+        }
+    }
+    assert!(
+        added.is_empty(),
+        "the CLI layer reaches further into the compiler than {BASELINE_PATH} records:\n{}\n\nMove the logic behind \
+         the frontend or backend boundary rather than widening the baseline. See #1298.",
+        added.join("\n")
+    );
+    Ok(())
+}
+
+/// The recorded baseline must not describe reach-ins that no longer exist.
+///
+/// Keeping it exact is what makes the ratchet mean something: once a dependency is removed, the baseline shrinks with
+/// it and cannot silently return later.
+#[test]
+fn the_cli_layering_baseline_records_no_stale_entries() -> TestResult {
+    let root = repo_root();
+    let baseline: Baseline = serde_json::from_str(&fs::read_to_string(root.join(BASELINE_PATH))?)?;
+    let observed = observed_reach_in(&root)?;
+
+    let mut stale: Vec<String> = Vec::new();
+    for file in &baseline.files {
+        match observed.get(&file.path) {
+            None => stale.push(format!("  {} no longer reaches into the compiler at all", file.path)),
+            Some(modules) => {
+                for recorded in &file.reaches {
+                    if !modules.contains(recorded) {
+                        stale.push(format!("  {} no longer reaches {recorded}", file.path));
+                    }
+                }
+            }
+        }
+    }
+    assert!(
+        stale.is_empty(),
+        "{BASELINE_PATH} records reach-ins that no longer exist:\n{}\n\nRegenerate the baseline to lock the \
+         improvement in.",
+        stale.join("\n")
+    );
+    Ok(())
+}

--- a/tests/fixtures/cli_layering/cli_compiler_reach_in.json
+++ b/tests/fixtures/cli_layering/cli_compiler_reach_in.json
@@ -1,0 +1,155 @@
+{
+  "comment": "Baseline of compiler internals the CLI layer reaches into. This list ratchets DOWN only: removing an entry is the goal, adding one fails tests/cli_layering_guardrails.rs. See issue #1297 and the sibling extraction chore #1298.",
+  "files": [
+    {
+      "path": "src/cli/commands/binding_inspect.rs",
+      "reaches": [
+        "crate::frontend::ast",
+        "crate::frontend::typechecker"
+      ]
+    },
+    {
+      "path": "src/cli/commands/build.rs",
+      "reaches": [
+        "crate::backend::project",
+        "crate::backend::replacement",
+        "crate::backend::selection",
+        "crate::backend::shadow",
+        "crate::frontend::api_metadata",
+        "crate::frontend::ast",
+        "crate::frontend::body_ir",
+        "crate::frontend::contract_metadata",
+        "crate::frontend::diagnostics",
+        "crate::frontend::lexer",
+        "crate::frontend::library_exports",
+        "crate::frontend::library_manifest_index",
+        "crate::frontend::module",
+        "crate::frontend::parser",
+        "crate::frontend::registry_metadata",
+        "crate::frontend::symbols",
+        "crate::frontend::typechecker"
+      ]
+    },
+    {
+      "path": "src/cli/commands/build_report.rs",
+      "reaches": [
+        "crate::backend::selection"
+      ]
+    },
+    {
+      "path": "src/cli/commands/codegraph.rs",
+      "reaches": [
+        "crate::frontend::ast",
+        "crate::frontend::diagnostics",
+        "crate::frontend::registry_metadata",
+        "crate::frontend::typechecker"
+      ]
+    },
+    {
+      "path": "src/cli/commands/common.rs",
+      "reaches": [
+        "crate::backend::c_abi",
+        "crate::backend::ir",
+        "crate::backend::project",
+        "crate::frontend::ast",
+        "crate::frontend::body_ir",
+        "crate::frontend::contract_metadata",
+        "crate::frontend::hir",
+        "crate::frontend::library_manifest_index",
+        "crate::frontend::module",
+        "crate::frontend::testing_markers",
+        "crate::frontend::typechecker"
+      ]
+    },
+    {
+      "path": "src/cli/commands/diagnostics.rs",
+      "reaches": [
+        "crate::backend::c_abi",
+        "crate::frontend::ast",
+        "crate::frontend::diagnostics"
+      ]
+    },
+    {
+      "path": "src/cli/commands/format.rs",
+      "reaches": [
+        "crate::frontend::diagnostics"
+      ]
+    },
+    {
+      "path": "src/cli/commands/lock.rs",
+      "reaches": [
+        "crate::backend::project",
+        "crate::frontend::ast",
+        "crate::frontend::library_manifest_index"
+      ]
+    },
+    {
+      "path": "src/cli/commands/shadow_support.rs",
+      "reaches": [
+        "crate::backend::selection",
+        "crate::backend::shadow"
+      ]
+    },
+    {
+      "path": "src/cli/commands/tools.rs",
+      "reaches": [
+        "crate::frontend::api_metadata",
+        "crate::frontend::contract_metadata",
+        "crate::frontend::diagnostics",
+        "crate::frontend::feature_metadata",
+        "crate::frontend::library_manifest_index",
+        "crate::frontend::registry_metadata",
+        "crate::frontend::typechecker"
+      ]
+    },
+    {
+      "path": "src/cli/commands/vocab_extraction.rs",
+      "reaches": [
+        "crate::backend::project"
+      ]
+    },
+    {
+      "path": "src/cli/mod.rs",
+      "reaches": [
+        "crate::backend::selection"
+      ]
+    },
+    {
+      "path": "src/cli/prelude.rs",
+      "reaches": [
+        "crate::frontend::ast"
+      ]
+    },
+    {
+      "path": "src/cli/test_runner/discovery.rs",
+      "reaches": [
+        "crate::frontend::ast",
+        "crate::frontend::ast_walk",
+        "crate::frontend::decorator_resolution",
+        "crate::frontend::testing_markers"
+      ]
+    },
+    {
+      "path": "src/cli/test_runner/execution.rs",
+      "reaches": [
+        "crate::frontend::ast",
+        "crate::frontend::decorator_resolution",
+        "crate::frontend::lexer",
+        "crate::frontend::library_manifest_index",
+        "crate::frontend::module",
+        "crate::frontend::parser",
+        "crate::frontend::testing_markers",
+        "crate::frontend::vocab_desugar_pass"
+      ]
+    },
+    {
+      "path": "src/cli/test_runner/module_graph.rs",
+      "reaches": [
+        "crate::frontend::ast",
+        "crate::frontend::library_manifest_index",
+        "crate::frontend::module",
+        "crate::frontend::vocab_desugar_pass"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Records the compiler internals the CLI layer reaches into today, so the set can only shrink. Refactors nothing.

`src/cli/commands/build.rs` is 14,153 production lines and names 17 top-level crate modules, reaching `crate::frontend::ast` 21 times and `crate::frontend::library_exports` 12 times. That has already cost correctness: the two-hop re-export defect found while reviewing #1293 lives at `build.rs:2983-3025`, where manifest projection logic in the CLI disagreed with the validator in `src/library_manifest/` about which hop of a re-export chain a path described. RFC 120 records the same failure mode for the older design — "a check living in the CLI could not agree with one living in the frontend by construction".

Closes #1297. Sibling to #1298 (move the logic behind the frontend boundary) and #1299 (split the Oven cluster).

**Ordering matters.** This should land before #1260, #1261, and #1262. Those are public-boundary work that touches exactly these files; landing the guard afterwards would ratchet a baseline that had already grown by three slices.

## Type of change

- [x] Refactor / maintenance
- [x] CI / tooling

## Area(s)

- [x] Tooling (CLI/formatter/test runner)
- [x] Compiler (frontend/backend/codegen)

## Key details

- **User-facing behavior**: none. Test-only.
- **Internals**: `tests/cli_layering_guardrails.rs` plus a 70-entry baseline at `tests/fixtures/cli_layering/cli_compiler_reach_in.json`, modelled on the existing `tests/vocab_guardrails.rs` + `semantic_string_audit.json` pattern.
- **Risks**: low. The main design risk was granularity, so the scan keys on `crate::<layer>::<module>` and counts module segments only. `crate::backend::IrCodegen` names a type re-exported from the layer root, which is the sanctioned entry point; `crate::backend::ir` reaches past it into the layer's internals, and that is the distinction being guarded. Rust's naming convention separates the two reliably.

Two tests, so the baseline stays honest in both directions:

- a new reach-in fails, naming the file and module;
- a baseline entry that no longer exists also fails, which forces the file to shrink when a dependency is removed rather than letting it drift stale.

## Testing / verification

- [x] `make test` / `cargo test`
- [ ] `make examples` (not relevant — test-only)
- [ ] `incan fmt --check .` (not relevant — no `.incn` changes)
- [x] Manual verification described below

Manual verification notes:

- Both directions exercised against the real tree, not a synthetic fixture. Appending a `crate::frontend::library_exports` reference to `src/cli/commands/lock.rs` fails with `src/cli/commands/lock.rs now reaches crate::frontend::library_exports`; adding a phantom baseline entry fails as stale with the same precision. Both reverted, suite green.
- `make fmt`, the changed-rustdoc gate, and clippy on the new target are clean.

## Docs impact

- [x] No docs changes needed

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions
