### PR TITLE
bugfix - read the stdlib privacy convention from the source spelling, not the projection (#1174)

### DIFF
--- a/src/backend/ir/emit/decls/mod.rs
+++ b/src/backend/ir/emit/decls/mod.rs
@@ -603,13 +603,13 @@ impl<'a> IrEmitter<'a> {
                 } else {
                     false
                 };
+            // The leading-underscore convention marks a declaration the stdlib keeps to itself, and it is a property
+            // of the *source* spelling. `emitted_binding_name()` is the RFC 120 projection for anything projected,
+            // and every projection begins with `__`, so reading privacy from it classified each projected stdlib
+            // export as private. Functions are projected and types are not, which is why a facade kept its types and
+            // silently dropped its functions.
             let should_reexport_item = |item: &super::super::decl::IrImportItem| {
-                let binding = if item.is_static {
-                    item.source_binding_name().to_string()
-                } else {
-                    item.emitted_binding_name()
-                };
-                if is_incan_source_stdlib && binding.starts_with('_') {
+                if is_incan_source_stdlib && item.source_binding_name().starts_with('_') {
                     return false;
                 }
                 export_item_import || item.force_reexport
@@ -622,12 +622,13 @@ impl<'a> IrEmitter<'a> {
                     } else {
                         item.emitted_binding_name()
                     };
-                    let private_type_like_binding = binding
+                    let source_binding = item.source_binding_name();
+                    let private_type_like_binding = source_binding
                         .trim_start_matches('_')
                         .chars()
                         .next()
                         .is_some_and(|ch| ch.is_ascii_uppercase());
-                    if is_incan_source_stdlib && binding.starts_with('_') && !private_type_like_binding {
+                    if is_incan_source_stdlib && source_binding.starts_with('_') && !private_type_like_binding {
                         return self.should_emit_import_binding(&binding)
                             || self.should_emit_extension_trait_import(&binding);
                     }


### PR DESCRIPTION
## Summary

A facade re-exporting stdlib functions silently dropped them. `pub from std.io import BytesIO, Endian, IoError` generated a module re-exporting only `Endian` and `IoError`, so a consumer's `use crate::io_facade::BytesIO;` could not resolve — the failure `integration_tests::binary_read_result_context_crosses_boundaries_issue955` reports, and the last known defect from the #1293 review.

The leading-underscore convention marks a declaration the stdlib keeps to itself, and it is a property of the **source** spelling. Both the item filter and `should_reexport_item` read it from `emitted_binding_name()` instead. For anything RFC 120 projects that name is the encoded projection, and every projection begins with `__`, so the convention classified each projected stdlib export as private and dropped it.

Instrumenting the emitter shows it directly:

```
BytesIO → ("BytesIO", "__incan_v1_0001…4279746573494f…", true)
Endian  → ("Endian",  "Endian",                          true)
```

That is also why the symptom looked like a type/function split. `BytesIO` is a `pub def` factory returning `_BytesIO` (`crates/incan_stdlib/stdlib/io.incn:536`), not a type. Functions are projected and types are not, so a facade kept its types and lost its functions.

## Type of change

- [x] Bug fix

## Area(s)

- [x] Compiler (frontend/backend/codegen)
- [x] Runtime / Core crates (stdlib/core/derive)

## Key details

- **User-facing behavior**: a facade over stdlib functions works. Before, `pub from std.io import BytesIO` produced a module without `BytesIO`, and any consumer resolving it by source name failed to compile.
- **Internals**: nine lines. The privacy convention now reads `source_binding_name()` in the two places that tested `emitted_binding_name()`. Result:

```rust
pub use crate::__incan_std::io::__incan_v1_…;
pub use crate::__incan_std::io::__incan_v1_… as BytesIO;
pub use crate::__incan_std::io::Endian;
pub use crate::__incan_std::io::IoError;
```

- **Risks**: contained, but this is emission, so worth stating plainly. An earlier attempt at this bug also rewrote the alias gate and added a deduplication set, and that combination regressed `from std.hash import file_digest`; it was reverted rather than patched. This changes only which name the privacy convention reads, and both fixtures were re-verified against a real Oven store.

## Testing / verification

- [x] `make test` / `cargo test`
- [ ] `make examples` (not run locally — Oven-dependent; CI covers it)
- [ ] `incan fmt --check .` (not relevant — no `.incn` changes)
- [x] Manual verification described below

Manual verification notes:

- Baked and built both fixtures against a real Oven store. The facade regains `BytesIO`; `from std.hash import file_digest` still builds, which is the case the earlier attempt broke.
- Full lib suite 3241 passed / 3 failed — the same three environment-dependent failures as the unmodified branch, so no regressions.
- Codegen (257) and stdlib (13) snapshots unchanged. Source-stdlib mode already emitted the source name correctly, which is why this only ever bit the packaged path.

**No new test is added, deliberately.** `binary_read_result_context_crosses_boundaries_issue955` already encodes exactly this case end to end and is the shard-1/4 failure this fixes; a unit-level codegen test cannot reproduce it, because source-stdlib mode was never broken. That asymmetry is itself the lesson from #1293 — hand-built and source-mode fixtures do not exercise the packaged producing path.

## Docs impact

- [x] No docs changes needed

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions
