### PR TITLE
chore - backfill the implementing PR for 29 closed implemented RFCs (#1300)

### DIFF
--- a/workspaces/docs-site/docs/RFCs/closed/implemented/004_async_fixtures.md
+++ b/workspaces/docs-site/docs/RFCs/closed/implemented/004_async_fixtures.md
@@ -5,7 +5,7 @@
 - **Author(s):** Danny Meijer (@dannymeijer)
 - **Related:** RFC 018 (testing), RFC 019 (runner testing)
 - **Issue:** [#78](https://github.com/encero-systems/incan/issues/78)
-- **RFC PR:** —
+- **RFC PR:** [#494](https://github.com/encero-systems/incan/pull/494)
 - **Written against:** v0.1
 - **Shipped in:** v0.3.0-dev.31
 

--- a/workspaces/docs-site/docs/RFCs/closed/implemented/006_generators.md
+++ b/workspaces/docs-site/docs/RFCs/closed/implemented/006_generators.md
@@ -6,7 +6,7 @@
 - **Related:** RFC 016 (loop and break value), RFC 019 (runner testing), RFC 068 (protocol hooks for core language syntax)
 - **Issue:** https://github.com/encero-systems/incan/issues/324
 - **Follow-up:** RFC 088 (iterator adapter surface), implemented by https://github.com/encero-systems/incan/issues/127
-- **RFC PR:** —
+- **RFC PR:** [#503](https://github.com/encero-systems/incan/pull/503)
 - **Written against:** v0.1
 - **Shipped in:** v0.3
 

--- a/workspaces/docs-site/docs/RFCs/closed/implemented/009_sized_integers.md
+++ b/workspaces/docs-site/docs/RFCs/closed/implemented/009_sized_integers.md
@@ -5,7 +5,7 @@
 - **Author(s):** Danny Meijer (@dannymeijer)
 - **Related:** RFC 005 (Rust interop)
 - **Issue:** https://github.com/encero-systems/incan/issues/325
-- **RFC PR:** —
+- **RFC PR:** [#504](https://github.com/encero-systems/incan/pull/504)
 - **Written against:** v0.1
 - **Shipped in:** v0.3
 

--- a/workspaces/docs-site/docs/RFCs/closed/implemented/010_tempfile.md
+++ b/workspaces/docs-site/docs/RFCs/closed/implemented/010_tempfile.md
@@ -5,7 +5,7 @@
 - **Author(s):** Danny Meijer (@dannymeijer)
 - **Related:** RFC 019 (runner testing), RFC 023 (stdlib namespacing and compiler handoff), RFC 055 (`std.fs` path-centric filesystem APIs), RFC 056 (`std.io` in-memory byte streams)
 - **Issue:** [#79](https://github.com/encero-systems/incan/issues/79)
-- **RFC PR:** —
+- **RFC PR:** [#517](https://github.com/encero-systems/incan/pull/517)
 - **Written against:** v0.1
 - **Shipped in:** v0.3
 

--- a/workspaces/docs-site/docs/RFCs/closed/implemented/013_rust_crate_dependencies.md
+++ b/workspaces/docs-site/docs/RFCs/closed/implemented/013_rust_crate_dependencies.md
@@ -9,7 +9,7 @@
     - RFC 015 (project lifecycle + `incan.toml`)
     - RFC 020 (Cargo offline/locked policy)
 - **Issue:** [#72](https://github.com/encero-systems/incan/issues/72)
-- **RFC PR:** —
+- **RFC PR:** [#132](https://github.com/encero-systems/incan/pull/132)
 - **Written against:** v0.1
 - **Shipped in:** v0.2
 

--- a/workspaces/docs-site/docs/RFCs/closed/implemented/017_validated_newtypes_with_implicit_coercion.md
+++ b/workspaces/docs-site/docs/RFCs/closed/implemented/017_validated_newtypes_with_implicit_coercion.md
@@ -5,7 +5,7 @@
 - **Author(s):** Danny Meijer (@dannymeijer)
 - **Related:** RFC 021 (model field metadata and aliases)
 - **Issue:** https://github.com/encero-systems/incan/issues/75
-- **RFC PR:** —
+- **RFC PR:** [#524](https://github.com/encero-systems/incan/pull/524)
 - **Written against:** v0.2
 - **Shipped in:** v0.3.0-dev.39
 

--- a/workspaces/docs-site/docs/RFCs/closed/implemented/018_testing.md
+++ b/workspaces/docs-site/docs/RFCs/closed/implemented/018_testing.md
@@ -5,7 +5,7 @@
 - **Author(s):** Danny Meijer (@dannymeijer)
 - **Related:** RFC 019 (test runner and CLI), RFC 001 (language portions; superseded), RFC 002 (language portions; superseded)
 - **Issue:** https://github.com/encero-systems/incan/issues/76
-- **RFC PR:** —
+- **RFC PR:** [#410](https://github.com/encero-systems/incan/pull/410)
 - **Implementation PRs:** https://github.com/encero-systems/incan/pull/410, https://github.com/encero-systems/incan/pull/435
 - **Written against:** v0.1
 - **Shipped in:** v0.3

--- a/workspaces/docs-site/docs/RFCs/closed/implemented/020_offline_locked_reproducible_builds.md
+++ b/workspaces/docs-site/docs/RFCs/closed/implemented/020_offline_locked_reproducible_builds.md
@@ -5,7 +5,7 @@
 - **Author(s):** Danny Meijer (@dannymeijer)
 - **Related:** RFC 013 (dependency + lockfile direction), RFC 015 (project lifecycle CLI), RFC 019 (test runner + CLI)
 - **Issue:** https://github.com/encero-systems/incan/issues/38
-- **RFC PR:** —
+- **RFC PR:** [#469](https://github.com/encero-systems/incan/pull/469)
 - **Written against:** v0.1
 - **Shipped in:** v0.3
 

--- a/workspaces/docs-site/docs/RFCs/closed/implemented/021_model_field_metadata_and_aliases.md
+++ b/workspaces/docs-site/docs/RFCs/closed/implemented/021_model_field_metadata_and_aliases.md
@@ -7,7 +7,7 @@
     - RFC 005 (Rust interop)
     - RFC 017 (constrained types)
 - **Issue:** [#94](https://github.com/encero-systems/incan/issues/94)
-- **RFC PR:** —
+- **RFC PR:** [#99](https://github.com/encero-systems/incan/pull/99)
 - **Written against:** v0.1
 - **Shipped in:** v0.1
 

--- a/workspaces/docs-site/docs/RFCs/closed/implemented/022_stdlib_namespacing_and_compiler_handoff.md
+++ b/workspaces/docs-site/docs/RFCs/closed/implemented/022_stdlib_namespacing_and_compiler_handoff.md
@@ -10,7 +10,7 @@
     - RFC 020 (offline/locked policy)
     - RFC 051 (`JsonValue`)
 - **Issue:** [#120](https://github.com/encero-systems/incan/issues/120)
-- **RFC PR:** —
+- **RFC PR:** [#124](https://github.com/encero-systems/incan/pull/124)
 - **Written against:** v0.1
 - **Shipped in:** v0.2
 

--- a/workspaces/docs-site/docs/RFCs/closed/implemented/024_extensible_derive_protocol.md
+++ b/workspaces/docs-site/docs/RFCs/closed/implemented/024_extensible_derive_protocol.md
@@ -10,7 +10,7 @@
     - RFC 023 (compilable stdlib and rust.module binding)
     - RFC 025 (multi-instantiation trait dispatch)
 - **Issue:** https://github.com/encero-systems/incan/issues/148
-- **RFC PR:** —
+- **RFC PR:** [#522](https://github.com/encero-systems/incan/pull/522)
 - **Written against:** v0.1
 - **Shipped in:** v0.3
 

--- a/workspaces/docs-site/docs/RFCs/closed/implemented/025_multi_instantiation_trait_dispatch.md
+++ b/workspaces/docs-site/docs/RFCs/closed/implemented/025_multi_instantiation_trait_dispatch.md
@@ -9,7 +9,7 @@
     - RFC 023 (compilable stdlib and rust.module binding)
     - RFC 024 (extensible derive protocol)
 - **Issue:** https://github.com/encero-systems/incan/issues/150
-- **RFC PR:** —
+- **RFC PR:** [#452](https://github.com/encero-systems/incan/pull/452)
 - **Written against:** v0.1
 - **Shipped in:** v0.3
 

--- a/workspaces/docs-site/docs/RFCs/closed/implemented/029_union_types.md
+++ b/workspaces/docs-site/docs/RFCs/closed/implemented/029_union_types.md
@@ -5,7 +5,7 @@
 - **Author(s):** Danny Meijer (@dannymeijer)
 - **Related:** RFC 028 (trait-based operator overloading)
 - **Issue:** [#163](https://github.com/encero-systems/incan/issues/163)
-- **RFC PR:** —
+- **RFC PR:** [#449](https://github.com/encero-systems/incan/pull/449)
 - **Written against:** v0.2
 - **Shipped in:** v0.3
 

--- a/workspaces/docs-site/docs/RFCs/closed/implemented/030_std_collections.md
+++ b/workspaces/docs-site/docs/RFCs/closed/implemented/030_std_collections.md
@@ -6,7 +6,7 @@
 - **Author(s):** Danny Meijer (@dannymeijer)
 - **Related:** RFC 022 (stdlib namespacing), RFC 023 (compilable stdlib), RFC 028 (operator overloading)
 - **Issue:** [#164](https://github.com/encero-systems/incan/issues/164)
-- **RFC PR:** —
+- **RFC PR:** [#530](https://github.com/encero-systems/incan/pull/530)
 - **Written against:** v0.2
 - **Shipped in:** v0.3
 

--- a/workspaces/docs-site/docs/RFCs/closed/implemented/035_first_class_function_references.md
+++ b/workspaces/docs-site/docs/RFCs/closed/implemented/035_first_class_function_references.md
@@ -7,7 +7,7 @@
     - [RFC 036] (User-defined decorators — depends on this RFC)
     - [RFC 005] (Rust interop — `@rust.extern` functions already passable via this mechanism)
 - **Issue:** [#169](https://github.com/encero-systems/incan/issues/169)
-- **RFC PR:** —
+- **RFC PR:** [#182](https://github.com/encero-systems/incan/pull/182)
 - **Target version:** 0.2
 - **Shipped in:** v0.2
 

--- a/workspaces/docs-site/docs/RFCs/closed/implemented/036_user_defined_decorators.md
+++ b/workspaces/docs-site/docs/RFCs/closed/implemented/036_user_defined_decorators.md
@@ -14,7 +14,7 @@
     - RFC 037 (Native web and HTTP stdlib redesign — consumer of `@app.get` / `@app.post`)
     - RFC 084 (RHS partial callable presets — future decorator factory ergonomics)
 - **Issue:** [#170](https://github.com/encero-systems/incan/issues/170), [#640](https://github.com/encero-systems/incan/issues/640)
-- **RFC PR:** —
+- **RFC PR:** [#523](https://github.com/encero-systems/incan/pull/523)
 - **Written against:** v0.2
 - **Shipped in:** v0.3
 

--- a/workspaces/docs-site/docs/RFCs/closed/implemented/038_variadic_positional_args_and_keyword_capture.md
+++ b/workspaces/docs-site/docs/RFCs/closed/implemented/038_variadic_positional_args_and_keyword_capture.md
@@ -7,7 +7,7 @@
     - RFC 035 (First-class named function references)
     - RFC 039 (`race` for awaitable concurrency)
 - **Issue:** [#83](https://github.com/encero-systems/incan/issues/83)
-- **RFC PR:** —
+- **RFC PR:** [#439](https://github.com/encero-systems/incan/pull/439)
 - **Written against:** v0.2
 - **Shipped in:** 0.3
 

--- a/workspaces/docs-site/docs/RFCs/closed/implemented/039_race_for_awaitable_concurrency.md
+++ b/workspaces/docs-site/docs/RFCs/closed/implemented/039_race_for_awaitable_concurrency.md
@@ -11,7 +11,7 @@
     - RFC 035 (First-class named function references)
     - RFC 038 (Variadic positional args and keyword-argument capture)
 - **Issue:** [#173](https://github.com/encero-systems/incan/issues/173)
-- **RFC PR:** —
+- **RFC PR:** [#536](https://github.com/encero-systems/incan/pull/536)
 - **Written against:** v0.2
 - **Shipped in:** v0.3
 

--- a/workspaces/docs-site/docs/RFCs/closed/implemented/043_rust_trait_impl_from_incan.md
+++ b/workspaces/docs-site/docs/RFCs/closed/implemented/043_rust_trait_impl_from_incan.md
@@ -11,7 +11,7 @@
     - RFC 005 (Rust interop)
     - RFC 023 (Compilable stdlib & Rust module binding)
 - **Issue:** https://github.com/encero-systems/incan/issues/200
-- **RFC PR:** —
+- **RFC PR:** [#538](https://github.com/encero-systems/incan/pull/538)
 - **Written against:** v0.2
 - **Shipped in:** v0.3
 

--- a/workspaces/docs-site/docs/RFCs/closed/implemented/044_open_ended_trait_methods.md
+++ b/workspaces/docs-site/docs/RFCs/closed/implemented/044_open_ended_trait_methods.md
@@ -8,7 +8,7 @@
     - RFC 026 (Superseded — archival; Rust trait contracts on wrappers: RFC 043)
     - RFC 003 (traits and derives)
 - **Issue:** https://github.com/encero-systems/incan/issues/201
-- **RFC PR:** —
+- **RFC PR:** [#531](https://github.com/encero-systems/incan/pull/531)
 - **Written against:** v0.2
 - **Shipped in:** v0.3
 

--- a/workspaces/docs-site/docs/RFCs/closed/implemented/047_lightweight_directed_graph_stdlib.md
+++ b/workspaces/docs-site/docs/RFCs/closed/implemented/047_lightweight_directed_graph_stdlib.md
@@ -9,7 +9,7 @@
     - RFC 030 (std collections)
     - RFC 033 (`ctx` — contrast only; graphs are not ambient singletons)
 - **Issue:** https://github.com/encero-systems/incan/issues/204
-- **RFC PR:** —
+- **RFC PR:** [#513](https://github.com/encero-systems/incan/pull/513)
 - **Written against:** v0.2
 - **Shipped in:** v0.3.0-dev.37
 

--- a/workspaces/docs-site/docs/RFCs/closed/implemented/051_json_value.md
+++ b/workspaces/docs-site/docs/RFCs/closed/implemented/051_json_value.md
@@ -8,7 +8,7 @@
     - RFC 025 (multi-instantiation trait dispatch)
     - RFC 050 (enum methods and enum trait adoption)
 - **Issue:** https://github.com/encero-systems/incan/issues/335
-- **RFC PR:** —
+- **RFC PR:** [#594](https://github.com/encero-systems/incan/pull/594)
 - **Written against:** v0.2
 - **Shipped in:** v0.3
 

--- a/workspaces/docs-site/docs/RFCs/closed/implemented/056_std_io.md
+++ b/workspaces/docs-site/docs/RFCs/closed/implemented/056_std_io.md
@@ -12,7 +12,7 @@
     - RFC 041 (first-class Rust interop authoring)
     - RFC 055 (`std.fs` path-centric filesystem APIs)
 - **Issue:** https://github.com/encero-systems/incan/issues/291
-- **RFC PR:** —
+- **RFC PR:** [#511](https://github.com/encero-systems/incan/pull/511)
 - **Written against:** v0.2
 - **Shipped in:** v0.3.0-dev.37
 

--- a/workspaces/docs-site/docs/RFCs/closed/implemented/058_std_datetime.md
+++ b/workspaces/docs-site/docs/RFCs/closed/implemented/058_std_datetime.md
@@ -8,7 +8,7 @@
     - RFC 023 (compilable stdlib and Rust module binding)
     - RFC 055 (`std.fs` path-centric filesystem APIs)
 - **Issue:** https://github.com/encero-systems/incan/issues/292
-- **RFC PR:** —
+- **RFC PR:** [#528](https://github.com/encero-systems/incan/pull/528)
 - **Written against:** v0.2
 - **Shipped in:** v0.3
 

--- a/workspaces/docs-site/docs/RFCs/closed/implemented/059_std_regex.md
+++ b/workspaces/docs-site/docs/RFCs/closed/implemented/059_std_regex.md
@@ -7,7 +7,7 @@
     - RFC 022 (namespaced stdlib modules and compiler handoff)
     - RFC 023 (compilable stdlib and Rust module binding)
 - **Issue:** https://github.com/encero-systems/incan/issues/294
-- **RFC PR:** —
+- **RFC PR:** [#584](https://github.com/encero-systems/incan/pull/584)
 - **Written against:** v0.2
 - **Shipped in:** 0.3.0-dev.46
 

--- a/workspaces/docs-site/docs/RFCs/closed/implemented/065_std_hash.md
+++ b/workspaces/docs-site/docs/RFCs/closed/implemented/065_std_hash.md
@@ -10,7 +10,7 @@
     - RFC 056 (`std.io` in-memory byte streams and binary parsing helpers)
     - RFC 064 (`std.encoding` binary-text encoding and decoding)
 - **Issue:** https://github.com/encero-systems/incan/issues/343
-- **RFC PR:** —
+- **RFC PR:** [#578](https://github.com/encero-systems/incan/pull/578)
 - **Written against:** v0.2
 - **Shipped in:** v0.3
 

--- a/workspaces/docs-site/docs/RFCs/closed/implemented/068_protocol_hooks_for_core_language_syntax.md
+++ b/workspaces/docs-site/docs/RFCs/closed/implemented/068_protocol_hooks_for_core_language_syntax.md
@@ -9,7 +9,7 @@
     - RFC 050 (enum methods and enum trait adoption)
     - RFC 051 (`JsonValue` for `std.json`)
 - **Issue:** [#86](https://github.com/encero-systems/incan/issues/86)
-- **RFC PR:** —
+- **RFC PR:** [#490](https://github.com/encero-systems/incan/pull/490)
 - **Written against:** v0.2
 - **Shipped in:** v0.3
 

--- a/workspaces/docs-site/docs/RFCs/closed/implemented/069_list_repeat_std_helper.md
+++ b/workspaces/docs-site/docs/RFCs/closed/implemented/069_list_repeat_std_helper.md
@@ -6,7 +6,7 @@
 - **Related:**
     - RFC 030 (std collections baseline)
 - **Issue:** https://github.com/encero-systems/incan/issues/385
-- **RFC PR:** —
+- **RFC PR:** [#521](https://github.com/encero-systems/incan/pull/521)
 - **Written against:** v0.2
 - **Shipped in:** v0.3.0-dev.38
 

--- a/workspaces/docs-site/docs/RFCs/closed/implemented/070_result_combinators_for_result_types.md
+++ b/workspaces/docs-site/docs/RFCs/closed/implemented/070_result_combinators_for_result_types.md
@@ -6,7 +6,7 @@
 - **Related:**
     - RFC 000 (core error handling and `Result` model)
 - **Issue:** https://github.com/encero-systems/incan/issues/386
-- **RFC PR:** —
+- **RFC PR:** [#519](https://github.com/encero-systems/incan/pull/519)
 - **Written against:** v0.2
 - **Shipped in:** v0.3
 


### PR DESCRIPTION
## Summary

`- **RFC PR:**` records the PR that **implemented** an RFC, not the one that introduced it. The nine entries already filled follow that meaning — #454 is "implement RFC 028 operator overloading", #572 is "implement std.uuid RFC 060". Following an implemented RFC to the code that delivered it worked for **9 of 70**.

This fills 29 more, taking coverage to **38 of the 67** that carry the field.

Closes #1300.

## Type of change

- [x] Documentation

## Area(s)

- [x] Documentation

## Key details

- **User-facing behavior**: an implemented RFC now links to the PR that delivered it.
- **Internals**: none. Only the `RFC PR:` line changed — 29 files, one line each.
- **Risks**: wrong attribution, which is the real risk here because a wrong link reads as authoritative in a way a blank does not. Addressed by method rather than by care:

Each RFC was resolved by searching merged PRs whose title names it, filling only where exactly one candidate existed. **The method was validated against the nine already-filled entries before being applied.** It reproduced six exactly and returned nothing for three whose PR titles do not name the RFC. It never proposed a different PR than the one recorded — it under-resolves rather than mis-resolves.

Two were disambiguated by reading titles rather than left blank:

- **RFC 018 → #410** ("implement RFC 018 testing primitives") rather than #435, which closes it alongside RFC 019.
- **RFC 043 → #538** rather than #209, a docs PR about sundowning RFC 026 in favour of it.

### Deliberately left blank

Eighteen RFCs have no merged PR naming them in its title: 019, 040, 045, 046, 048, 049, 054, 055, 061, 064, 071, 072, 083, 084, 088, 101, 113, 115.

Three carry no `RFC PR` field at all: 005, 011, 023.

These need someone who remembers the work. Guessing would be worse than the gap.

## Testing / verification

- [ ] `make test` / `cargo test` (not relevant — docs only)
- [ ] `make examples` (not relevant)
- [ ] `incan fmt --check .` (not relevant)
- [x] Manual verification described below

Manual verification notes:

- `mkdocs build --strict` passes.
- `git diff` confirms 29 files, 29 insertions, 29 deletions — every change is a single `RFC PR:` line, and a diff filtered to exclude that line is empty.

## Docs impact

- [x] Docs updated

**Note on scope.** This edits files under `closed/`, which are otherwise immutable. That is deliberate and narrow: filling a traceability field completes the record of what shipped rather than rewriting a decision, and no other line of any closed RFC changed. It should not be read as license to touch closed RFC content — see #1293, where a normative rule change to closed RFC 046 was reverted for exactly that reason.

#1300 also asks for the `bump-rfc` guidance to capture this at the Implemented transition so the field stops needing a sweep. Not done here; it belongs with the skill change rather than the data change.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions
