### PR TITLE
ci(docs): publish a `latest` alias on versioned docs deploys

### DIFF
--- a/.github/workflows/docs_site_deploy.yml
+++ b/.github/workflows/docs_site_deploy.yml
@@ -96,4 +96,4 @@ jobs:
 
           export INCAN_DOCS_BASE_PREFIX="${MINOR}"
           make docs-build
-          mike deploy --push "${MINOR}"
+          mike deploy --push --update-aliases --alias-type redirect "${MINOR}" latest


### PR DESCRIPTION
## Summary

Docs URLs are versioned (`incan.io/v0.5/...`) and `incan.io/` redirects to `dev`, so there is no stable URL for "the current release's docs". Links in READMEs, community pages, and posts go stale on every minor release.

This PR makes the release deploy step also maintain a `latest` alias:

```yaml
mike deploy --push --update-aliases --alias-type redirect "${MINOR}" latest
```

`incan.io/latest/tooling/how-to/install_and_run/` then always resolves to the newest minor.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [x] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: a new `incan.io/latest/...` URL family that redirects to the current release docs. Existing `/vX.Y/` and `/dev/` URLs are unchanged.
- **Internals**: one-line change to the "Deploy versioned docs from release" step in `docs_site_deploy.yml`. Redirect-style alias (not a copy) because `INCAN_DOCS_BASE_PREFIX` bakes the `/vX.Y/` prefix into generated links at build time; a copied alias would mix `/latest/` and `/vX.Y/` URLs on the same page. `--update-aliases` lets the alias move to each new minor. mike 2.1.3 (pinned in `requirements-docs.txt`) supports both flags.
- **Risks**: none to existing versions. The alias is only created on release deploys; `dev` deploys are untouched. `latest` does not exist until the next release or a manual backfill (see below).

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- Workflow-only change; no compiler/tooling code touched.
- Verified flags against mike 2.1.3 docs (`--update-aliases`, `--alias-type redirect`).
- Suggested post-merge check: run the workflow via `workflow_dispatch` with `docs_version: v0.5`, then confirm `https://incan.io/latest/` redirects to `https://incan.io/v0.5/`.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [ ] I added/updated tests where it materially reduces regressions

## Follow-ups (not in this PR)

- Backfill the alias for the current release once merged: `mike deploy --push --update-aliases --alias-type redirect v0.5 latest` (or dispatch the workflow with `docs_version: v0.5`).
- Consider `mike set-default --push latest` so `incan.io/` lands on stable docs instead of `dev`.
- Point README / community links at `/latest/` once it exists.
