### PR TITLE
bugfix - resolve an imported member through the module graph before the spelled provider path (#1042)

### DIFF
--- a/src/frontend/typechecker/mod.rs
+++ b/src/frontend/typechecker/mod.rs
@@ -6727,6 +6727,21 @@ impl TypeChecker {
     /// A symbol kind, name, module key, and span are insufficient proof: absent canonical data must stay absent rather
     /// than being reconstructed into a plausible but invented declaration.
     pub(crate) fn dependency_member_identity(&self, module: &ImportPath, item_name: &str) -> Option<CanonicalSymbolId> {
+        // Resolve through the consumer's own module graph first. `dependency_source_import_candidates` already
+        // orders a granted SDK provider ahead of ordinary candidates for a `std.*` path, so provider precedence is
+        // preserved without keying on the spelling here.
+        let current_module_path = self.current_module_path.as_deref().unwrap_or_default();
+        if let Some(identity) = self.dependency_member_identity_from(current_module_path, module, item_name, 0) {
+            return Some(identity);
+        }
+
+        // Fall back to the provider registry keyed by the spelled path. A compiled provider is reachable by the path
+        // its manifest publishes even when the consumer's source graph contains no module of that name, which is the
+        // case this originally existed to serve.
+        //
+        // It must stay a fallback. Running it first let the spelling pre-empt resolution: `from helpers import
+        // render` inside `pkg.app` selects the sibling `pkg.helpers`, but a root `helpers` declaring the same member
+        // answered instead -- a module the import did not select.
         if module.parent_levels == 0 {
             let provider_key = canonicalize_source_module_segments(&module.segments).join(".");
             if self
@@ -6741,8 +6756,7 @@ impl TypeChecker {
                     .cloned();
             }
         }
-        let current_module_path = self.current_module_path.as_deref().unwrap_or_default();
-        self.dependency_member_identity_from(current_module_path, module, item_name, 0)
+        None
     }
 
     /// Resolve one imported member to its declaring identity, using `from_module_path` as the resolution base.


### PR DESCRIPTION
## Summary

`a_sibling_relative_import_is_owned_by_the_module_resolution_actually_selected` fails on `0.6.0-dev.2`:

```
left:  Module(["helpers"])          the path the import spelled
right: Module(["pkg", "helpers"])   the module resolution selected
```

A bare `from helpers import render` inside `pkg.app` selects the sibling `pkg.helpers`, but the canonical identity recorded the **spelling** whenever a root module of that name also declared the member — a module the import did not select.

This is the same defect the identity model exists to remove, one layer below the validator fixes in #1293. Those taught the validator to stop comparing spellings; the identity it compares was itself minted from one. The validator relaxation was masking how far this reached.

## Type of change

- [x] Bug fix

## Area(s)

- [x] Compiler (frontend/backend/codegen)

## Key details

- **User-facing behavior**: an imported member's canonical identity names the module resolution actually selected. Previously a sibling import could be attributed to a same-named root module.
- **Internals**: `dependency_member_identity` opened with a lookup keyed on `module.segments` — the spelled path — and returned *before* the candidate walk beneath it. That walk resolves sibling-then-root and is the part that knows which module the import selected, so the spelling pre-empted resolution for every bare import whose leaf name also existed at the root. The provider registry keyed on the spelled path is now a fallback.
- **Risks**: provider precedence. It is preserved, and did not depend on running first: `dependency_source_import_candidates` already orders a granted SDK provider ahead of ordinary candidates for a `std.*` path. A compiled provider also stays reachable by the path its manifest publishes when the consumer's graph has no module of that name — the case the lookup existed to serve.

**A narrower fix was tried and rejected.** Gating the fast path on a `std.*` spelling broke `sdk_provider_import_retains_manifest_canonical_identity`, because that fixture publishes module path `["helpers"]` rather than a `std.*` path. Ordering, not spelling, is what separates these cases — which is the same lesson as the bug itself.

## Testing / verification

- [x] `make test` / `cargo test`
- [ ] `make examples` (not run locally — Oven-dependent)
- [ ] `incan fmt --check .` (not relevant)
- [x] Manual verification described below

Manual verification notes:

- Lib suite goes from **3240 passed / 4 failed to 3241 / 3** on the same tree. The formerly failing sibling test passes; `sdk_provider_import_retains_manifest_canonical_identity` still passes; nothing else changed. The remaining three are the Oven-environment failures a fresh worktree produces.
- `make fmt`, changed-rustdoc gate, and clippy are clean.

## Docs impact

- [x] No docs changes needed

## Additional context

This test is red on `0.6.0-dev.2` — it was failing on #1293 before that merged, so it arrived with it. It is not caused by #1301/#1302/#1303/#1304, all of which branch from the same commit; #1301 reproduces it with a test-only change.

Two further defects on that branch are recorded but not addressed here: `pub X = alias Y` produces an `ApiAlias` with `projected_function: None` while the validator requires callable metadata for a canonical callable target, and several generated-Rust assertions still pin pre-projection spellings.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions
