### PR TITLE
bugfix - resolve a same-module alias target against its own module when projecting callable metadata (#989)

### DIFF
--- a/src/frontend/api_metadata.rs
+++ b/src/frontend/api_metadata.rs
@@ -837,6 +837,7 @@ pub fn materialize_api_alias_projections(modules: &mut [CheckedApiMetadata]) {
                 ApiDeclaration::Alias(alias) => aliases.push(ApiAliasProjectionRequest {
                     path: declaration_path(&module.module_path, &alias.name),
                     target_path: normalized_api_target_path(&alias.target_path),
+                    module_path: module.module_path.clone(),
                     name: alias.name.clone(),
                     anchor: alias.anchor.clone(),
                 }),
@@ -852,8 +853,24 @@ pub fn materialize_api_alias_projections(modules: &mut [CheckedApiMetadata]) {
             if projections.contains_key(&alias.path) {
                 continue;
             }
-            if let Some(target) = projections.get(&alias.target_path) {
-                projections.insert(alias.path.clone(), projected_function_for_alias(alias, target));
+            // An alias whose target lives in its own module records that target unqualified, because that is how the
+            // source writes it: `pub run = alias helper` inside `provider` records `["helper"]`. Projections are
+            // keyed by resolved declaration path, `["provider", "helper"]`, so the two never met and every
+            // same-module alias published no callable metadata at all.
+            //
+            // Resolve against the alias's own module first, then fall back to the path as written for a target that
+            // really is module-qualified. The recorded `target_path` is deliberately left alone: it is compared
+            // against the identity graph downstream, and rewriting it here would move that comparison rather than
+            // fix this one.
+            let qualified =
+                (alias.target_path.len() == 1).then(|| declaration_path(&alias.module_path, &alias.target_path[0]));
+            let resolved = qualified
+                .as_ref()
+                .and_then(|path| projections.get(path))
+                .or_else(|| projections.get(&alias.target_path));
+            if let Some(target) = resolved {
+                let projection = projected_function_for_alias(alias, target);
+                projections.insert(alias.path.clone(), projection);
                 changed = true;
             }
         }
@@ -1063,6 +1080,8 @@ pub fn api_declaration_public_name(declaration: &ApiDeclaration) -> Option<&str>
 struct ApiAliasProjectionRequest {
     path: Vec<String>,
     target_path: Vec<String>,
+    /// The module the alias is declared in, used to resolve a target written without a module qualifier.
+    module_path: Vec<String>,
     name: String,
     anchor: SourceAnchor,
 }

--- a/src/frontend/typechecker/tests.rs
+++ b/src/frontend/typechecker/tests.rs
@@ -2582,6 +2582,56 @@ def unpack(vault: Vault) -> str:
     );
 }
 
+/// A public alias targeting a function in its own module publishes that function's callable metadata.
+///
+/// The projection pass keys candidates by resolved declaration path, `["provider", "helper"]`, while an alias whose
+/// target lives in its own module records the target as the source writes it, `["helper"]`. The two never met, so
+/// every same-module alias published `projected_function: None` and any consumer requiring callable metadata for a
+/// canonical callable target refused it.
+///
+/// The existing coverage did not catch this because it aliases across modules, where the recorded target is already
+/// qualified and the lookup happens to line up.
+#[test]
+fn a_same_module_public_alias_publishes_its_target_callable_metadata() -> Result<(), String> {
+    let source = "pub def helper(value: int) -> int:\n  return value + 1\n\npub run = alias helper\n";
+    let ast = parse_program(source, "same-module alias provider");
+    let mut checker = TypeChecker::new();
+    checker.set_current_module_path(Some(vec!["provider".to_string()]));
+    checker
+        .check_program(&ast)
+        .map_err(|errors| format!("same-module alias provider should typecheck: {errors:?}"))?;
+
+    let mut api_modules = vec![collect_checked_api_metadata(
+        &ast,
+        &checker,
+        vec!["provider".to_string()],
+    )];
+    materialize_api_alias_projections(&mut api_modules);
+
+    let alias = api_modules
+        .iter()
+        .flat_map(|module| module.declarations.iter())
+        .find_map(|declaration| match declaration {
+            ApiDeclaration::Alias(alias) if alias.name == "run" => Some(alias),
+            _ => None,
+        })
+        .ok_or("the checked API must publish the `run` alias")?;
+    let projected = alias
+        .projected_function
+        .as_ref()
+        .ok_or("a same-module alias must publish its target's callable metadata")?;
+    assert_eq!(
+        projected.callable.name, "run",
+        "a projection is published under the alias's own name"
+    );
+    assert_eq!(
+        projected.source_path,
+        vec!["provider".to_string(), "helper".to_string()],
+        "the projection must point at the declaration the alias targets"
+    );
+    Ok(())
+}
+
 #[test]
 fn test_class_private_parent_field_access_rejected_in_child_method() {
     let source = r#"


### PR DESCRIPTION
## Summary

A public alias whose target lives in its own module published **no callable metadata at all**.

`pub run = alias helper` inside `provider` records its target as the source writes it — `["helper"]` — while `materialize_api_alias_projections` keys candidates by resolved declaration path — `["provider", "helper"]`. The two never met, so `projected_function` stayed `None` for every same-module alias, and any consumer requiring callable metadata for a canonical callable target refused the export.

Same spelling-versus-resolution shape as the other identity defects on this branch, in the checked-API producer.

## Type of change

- [x] Bug fix

## Area(s)

- [x] Compiler (frontend/backend/codegen)

## Key details

- **User-facing behavior**: a same-module public alias now publishes its target's callable shape and decorators, as a cross-module one already did.
- **Internals**: resolve a single-segment target against the alias's own module first, then fall back to the path as written for a target that really is module-qualified. The recorded `target_path` is **deliberately left alone** — the identity graph compares against it downstream, and rewriting it here would move that comparison rather than fix this one.
- **Risks**: low and bounded. The new lookup only fires for a single-segment target that resolves in the alias's own module; anything else takes the existing path unchanged.

**Why it shipped:** the existing coverage aliases *across* modules, where the recorded target is already qualified and the lookup happens to line up. The blind spot was the same-module shape.

## Testing / verification

- [x] `make test` / `cargo test`
- [ ] `make examples` (not run locally — Oven-dependent)
- [ ] `incan fmt --check .` (not relevant)
- [x] Manual verification described below

Manual verification notes:

- New test verified **both directions**: it passes with the fix and fails on the previous pass with `a same-module alias must publish its target's callable metadata`.
- Lib suite unchanged at 3241 passed / 4 failed — the four being this worktree's environment-dependent failures.
- `make fmt`, changed-rustdoc gate, and clippy clean.

## Scope note

**This does not by itself make `incan build --lib` accept the shape**, and I want that explicit rather than implied.

The identity-graph arm that consumes this metadata (`api_declaration_backs_identity_entry`) also compares whole `target_path`s between two differently-qualified records, and re-applies the `Alias | Function` kind whitelist that `validate_export_identity_binding` documents as wrong. Both are real defects, both were explored on this branch, and **both were backed out** rather than shipped in a change whose test does not demonstrate them. They belong with a fixture that proves the end-to-end shape.

Related: `pub from provider import run as public_target` still refuses with "identity graph entry `run` is not backed by a checked API namespace declaration" after this fix. That is the remaining half.

## Docs impact

- [x] No docs changes needed

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions
