### PR TITLE
bugfix - decode projections in the two remaining failing generated-Rust assertions (#1174)

### DIFF
--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -7012,7 +7012,7 @@ pub def main() -> None:
         "incan build for union widening generated wrapper conversion",
     );
 
-    let generated_main = fs::read_to_string(tmp.path().join("target/incan/union_widening_conversion/src/main.rs"))?;
+    let generated_main = read_generated_rust(&tmp.path().join("target/incan/union_widening_conversion/src/main.rs"))?;
     assert!(
         generated_main.contains("match make_base()"),
         "expected generated Rust to convert call-result union wrappers through a match, got:\n{generated_main}"
@@ -10081,7 +10081,7 @@ def main() -> None:
     )?;
     assert_success(&build_output, "public alias of imported item build");
 
-    let generated_main = fs::read_to_string(output_dir.join("src/main.rs"))?;
+    let generated_main = read_generated_rust(&output_dir.join("src/main.rs"))?;
     assert!(
         !generated_main.contains("pub use target_builder as public_target;"),
         "public alias should not re-export the private local import binding, got:\n{generated_main}"


### PR DESCRIPTION
## Summary

Two tests fail on `0.6.0-dev.2` by asserting source spellings that RFC 120 now projects:

- `build_public_alias_of_imported_item_reexports_original_path_issue617` expects `pub use crate::helper::target as public_target;`, where the emitter writes the encoded name aliased to the same public name.
- `build_union_widening_converts_generated_wrappers_issue741` expects `match make_base()`, where the callee is projected.

`read_generated_rust` was added to this file for exactly this during #1293 and applied to one of eight reads. These are the two whose assertions actually fail.

## Type of change

- [x] Bug fix

## Area(s)

- [x] Tooling (CLI/formatter/test runner)

## Key details

- **User-facing behavior**: none. Test-only.
- **Internals**: two reads switch from `fs::read_to_string` to the existing `read_generated_rust`, which decodes projections before matching.
- **Risks**: low. The remaining six reads are **deliberately left alone** — a read whose assertions pass is not evidence of anything needing to change, and converting them speculatively would be a bulk edit I cannot verify.

## Testing / verification

- [x] `make test` / `cargo test` (compiles; see note)
- [ ] `make examples` (not relevant)
- [ ] `incan fmt --check .` (not relevant)
- [x] Manual verification described below

Manual verification notes:

- **Not verified locally, and I want that explicit.** Both tests shell out to `incan build` against temp projects, which fails on this machine's Oven environment *before reaching the changed assertions*. The change compiles, clippy and the changed-rustdoc gate pass, and the decode helper is the one already proven on `generated_rust_artifact_tests` and the snapshot suites — but CI is what proves these two.

## Docs impact

- [x] No docs changes needed

## Additional context

These are red on `0.6.0-dev.2`, not caused by any open PR. They arrived with #1293, where I catalogued them as stale assertions and applied the remedy to one read while noting the others needed the harness to verify. This closes the two that actually fail.

Together with #1306 (sibling-import identity) and #1307 (same-module alias callable metadata), this addresses the third of the three defect classes currently red on the integration branch.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions
