### PR TITLE
bugfix - resolve an alias re-exported under a new name through its declaration (#989)

### DIFF
--- a/src/cli/commands/build.rs
+++ b/src/cli/commands/build.rs
@@ -2987,7 +2987,15 @@ fn rename_checked_export(export: &CheckedNamedExport, exported_name: &str) -> Ch
     match &mut renamed.kind {
         CheckedExportKind::Function(function_export) => function_export.name = exported_name.to_string(),
         CheckedExportKind::Partial(partial_export) => partial_export.name = exported_name.to_string(),
-        CheckedExportKind::Alias(alias_export) => alias_export.name = exported_name.to_string(),
+        CheckedExportKind::Alias(alias_export) => {
+            alias_export.name = exported_name.to_string();
+            // Rename the callable the alias projects along with the alias itself. The projection describes the
+            // binding a consumer resolves under this public name, so a renaming re-export must carry the new name
+            // here too; only `emitted_name` stays put, because the declaration behind the rename is unchanged.
+            if let Some(projected_function) = alias_export.projected_function.as_mut() {
+                projected_function.name = exported_name.to_string();
+            }
+        }
         CheckedExportKind::TypeAlias(type_alias_export) => type_alias_export.name = exported_name.to_string(),
         CheckedExportKind::Model(model_export) => model_export.name = exported_name.to_string(),
         CheckedExportKind::Class(class_export) => class_export.name = exported_name.to_string(),
@@ -17577,6 +17585,73 @@ impl ChildId {
             ),
             "the package-root export must retain the checked entrypoint re-export projection"
         );
+        Ok(())
+    }
+
+    /// A renamed re-export of a callable alias must republish the callable under the new public name.
+    ///
+    /// The manifest's callable projection describes the binding a consumer resolves at this public name, so leaving
+    /// the inner hop's name on it makes the manifest advertise `run` for an export named `public_target`.
+    #[test]
+    fn resolve_library_reexports_renames_the_callable_an_alias_projects() -> Result<(), Box<dyn std::error::Error>> {
+        let source = "pub from provider import run as public_target\n";
+        let tokens = lexer::lex(source).map_err(|errs| format!("lex errors: {errs:?}"))?;
+        let ast = parser::parse_with_module_path(&tokens, Some("project/src/lib.incn"))
+            .map_err(|errs| format!("parse errors: {errs:?}"))?;
+        let lib_module = ParsedModule {
+            name: "main".to_string(),
+            path_segments: vec!["main".to_string()],
+            file_path: PathBuf::from("project/src/lib.incn"),
+            source: source.to_string(),
+            ast,
+        };
+
+        let callable = crate::frontend::library_exports::CheckedFunctionExport {
+            name: "run".to_string(),
+            emitted_name: None,
+            type_params: Vec::new(),
+            params: Vec::new(),
+            param_defaults: Vec::new(),
+            return_type: ResolvedType::Int,
+            is_async: false,
+        };
+        let run_export = CheckedNamedExport {
+            name: "run".to_string(),
+            identity: CheckedExportIdentity::alias(
+                vec!["provider".to_string(), "run".to_string()],
+                vec!["provider".to_string(), "helper".to_string()],
+            ),
+            kind: CheckedExportKind::Alias(crate::frontend::library_exports::CheckedAliasExport {
+                name: "run".to_string(),
+                target_path: vec!["provider".to_string(), "helper".to_string()],
+                projected_function: Some(callable),
+            }),
+        };
+        let mut module_exports: HashMap<String, HashMap<String, Vec<CheckedNamedExport>>> = HashMap::new();
+        module_exports.insert(
+            "provider".to_string(),
+            HashMap::from([("run".to_string(), vec![run_export])]),
+        );
+
+        let resolved = LibraryReexportResolver::new(&module_exports)
+            .resolve(&lib_module)
+            .map_err(|errs| format!("{errs:?}"))?;
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].name, "public_target");
+        match &resolved[0].kind {
+            CheckedExportKind::Alias(alias) => {
+                assert_eq!(alias.name, "public_target");
+                let projected = alias
+                    .projected_function
+                    .as_ref()
+                    .ok_or("the renamed re-export must keep the callable the alias projects")?;
+                assert_eq!(
+                    projected.name, "public_target",
+                    "the projected callable must carry the name the re-export published it under"
+                );
+            }
+            other => panic!("expected an alias export, got {other:?}"),
+        }
         Ok(())
     }
 

--- a/src/library_manifest/tests.rs
+++ b/src/library_manifest/tests.rs
@@ -3996,3 +3996,158 @@ fn crate_qualified_reexport_passes_identity_graph_validation() -> Result<(), Box
         .map_err(|error| format!("a `crate`-qualified re-export must pass identity-graph validation, got: {error}"))?;
     Ok(())
 }
+
+/// A same-module alias re-exported under a new name must survive identity validation end to end.
+///
+/// This is the shape `pub run = alias helper` in `provider` plus `pub from provider import run as public_target` in
+/// the entrypoint. It exercises three places where a spelling used to stand in for a resolved identity: the checked
+/// alias records its target as the source wrote it (`["helper"]`) while the graph entry records the resolved
+/// declaration (`["provider", "helper"]`); the alias's materialized callable projection carries the resolved path
+/// where the alias carries the spelling; and the re-export's authoritative path ends at the alias's own public name
+/// rather than at the declaration the identity names.
+#[test]
+fn same_module_alias_reexported_under_a_new_name_passes_identity_validation() -> Result<(), Box<dyn std::error::Error>>
+{
+    let anchor = |id: &str, start: usize, end: usize| SourceAnchor {
+        id: id.to_string(),
+        span: SourceSpan { start, end },
+    };
+    let mut modules = vec![
+        CheckedApiMetadata {
+            schema_version: CHECKED_API_METADATA_SCHEMA_VERSION,
+            module_path: vec!["provider".to_string()],
+            declarations: vec![
+                ApiDeclaration::Function(ApiFunction {
+                    name: "helper".to_string(),
+                    anchor: anchor("provider.helper", 59, 116),
+                    docstring: None,
+                    docstring_sections: None,
+                    decorators: Vec::new(),
+                    type_params: Vec::new(),
+                    params: Vec::new(),
+                    return_type: TypeRef::Named {
+                        name: "int".to_string(),
+                    },
+                    is_async: false,
+                }),
+                ApiDeclaration::Alias(ApiAlias {
+                    name: "run".to_string(),
+                    anchor: anchor("provider.run", 130, 150),
+                    // Spelled the way the source wrote it, not the way it resolves.
+                    target_path: vec!["helper".to_string()],
+                    is_public: true,
+                    projected_function: None,
+                }),
+            ],
+        },
+        CheckedApiMetadata {
+            schema_version: CHECKED_API_METADATA_SCHEMA_VERSION,
+            module_path: vec!["main".to_string()],
+            declarations: vec![ApiDeclaration::Alias(ApiAlias {
+                name: "public_target".to_string(),
+                anchor: anchor("main.public_target", 0, 45),
+                // The entrypoint spells the hop it re-exports; the projection below resolves past it.
+                target_path: vec!["provider".to_string(), "run".to_string()],
+                is_public: true,
+                projected_function: Some(crate::frontend::api_metadata::ApiProjectedFunction {
+                    source_path: vec!["provider".to_string(), "helper".to_string()],
+                    callable: crate::frontend::api_metadata::ApiCallableMetadata {
+                        name: "public_target".to_string(),
+                        anchor: anchor("main.public_target", 0, 45),
+                        type_params: Vec::new(),
+                        receiver: None,
+                        params: Vec::new(),
+                        return_type: TypeRef::Named {
+                            name: "int".to_string(),
+                        },
+                        is_async: false,
+                    },
+                    decorators: Vec::new(),
+                }),
+            })],
+        },
+    ];
+    materialize_api_alias_projections(&mut modules);
+    let mut api = CheckedApiMetadataPackage {
+        schema_version: CHECKED_API_METADATA_SCHEMA_VERSION,
+        package: None,
+        modules,
+        public_namespaces: Vec::new(),
+    };
+    materialize_checked_api_public_namespaces(&mut api)?;
+
+    let identity = published_declaration_identity(
+        "aliasrepro",
+        &["provider"],
+        "helper",
+        incan_semantics_core::SemanticSourceTargetKind::Function,
+        59,
+        116,
+    );
+    let canonical = CanonicalIdentityExport::from_canonical("aliasrepro", &identity);
+
+    let mut manifest = LibraryManifest::from_checked_exports("aliasrepro", "0.1.0", &[]);
+    manifest.exports.aliases.push(AliasExport {
+        name: "public_target".to_string(),
+        target_path: vec!["provider".to_string(), "helper".to_string()],
+        projected_function: Some(FunctionExport {
+            // The renamed re-export republishes the callable under its new public name.
+            name: "public_target".to_string(),
+            emitted_name: None,
+            type_params: Vec::new(),
+            params: Vec::new(),
+            return_type: TypeRef::Named {
+                name: "int".to_string(),
+            },
+            is_async: false,
+        }),
+    });
+    let graph = &mut manifest.contract_metadata.identity_graph;
+    graph.exports.push(ExportIdentity {
+        public_name: "helper".to_string(),
+        public_path: vec!["aliasrepro".to_string(), "provider".to_string(), "helper".to_string()],
+        source_path: vec!["provider".to_string(), "helper".to_string()],
+        kind: ExportIdentityKind::Function,
+        projection: ExportIdentityProjection::Direct,
+        canonical: canonical.clone(),
+    });
+    graph.exports.push(ExportIdentity {
+        public_name: "run".to_string(),
+        public_path: vec!["aliasrepro".to_string(), "provider".to_string(), "run".to_string()],
+        source_path: vec!["provider".to_string(), "run".to_string()],
+        kind: ExportIdentityKind::Alias,
+        projection: ExportIdentityProjection::Alias {
+            target_path: vec!["provider".to_string(), "helper".to_string()],
+        },
+        canonical: canonical.clone(),
+    });
+    graph.exports.push(ExportIdentity {
+        public_name: "public_target".to_string(),
+        public_path: vec!["aliasrepro".to_string(), "public_target".to_string()],
+        source_path: vec!["provider".to_string(), "run".to_string()],
+        kind: ExportIdentityKind::Alias,
+        projection: ExportIdentityProjection::Reexport {
+            target_path: vec!["provider".to_string(), "run".to_string()],
+        },
+        canonical: canonical.clone(),
+    });
+    manifest.contract_metadata.api = Some(api);
+
+    let tmp = tempfile::tempdir()?;
+    let path = tmp.path().join("alias-reexport.incnlib");
+    manifest.write_to_path(&path).map_err(|error| {
+        format!("a renamed re-export of a same-module alias must pass identity-graph validation, got: {error}")
+    })?;
+
+    let loaded = LibraryManifest::read_from_path(&path)?;
+    let published = loaded
+        .contract_metadata
+        .identity_graph
+        .canonical_for_public_path(&["aliasrepro".to_string(), "public_target".to_string()])
+        .ok_or("the renamed re-export must publish a canonical identity")?;
+    assert_eq!(
+        published.declaration_name, "helper",
+        "renaming a declaration twice must still resolve to the declaration, not to either local name"
+    );
+    Ok(())
+}

--- a/src/library_manifest/validation.rs
+++ b/src/library_manifest/validation.rs
@@ -85,7 +85,7 @@ fn validate_identity_graph(raw: &RawLibraryManifest) -> Result<(), LibraryManife
         }
         if let Some(identity) = &entry.canonical {
             validate_canonical_identity(identity, &format!("export `{}`", entry.public_name), false)?;
-            validate_export_identity_binding(raw, entry, identity)?;
+            validate_export_identity_binding(raw, &graph.exports, entry, identity)?;
             if graph.schema_version == LIBRARY_IDENTITY_GRAPH_SCHEMA_VERSION {
                 if entry.public_path.len() == 2 {
                     validate_root_identity_graph_backing(raw, entry, identity)?;
@@ -330,6 +330,7 @@ fn validate_current_identity_graph_coverage(raw: &RawLibraryManifest) -> Result<
 /// Bind one graph entry's canonical identity to the exact source/projection path the entry publishes.
 fn validate_export_identity_binding(
     raw: &RawLibraryManifest,
+    siblings: &[super::ExportIdentity],
     entry: &super::ExportIdentity,
     identity: &CanonicalIdentityExport,
 ) -> Result<(), LibraryManifestError> {
@@ -443,7 +444,7 @@ fn validate_export_identity_binding(
             &entry.source_path
         }
     };
-    if authoritative_path.is_empty() || !canonical_identity_matches_path(raw, identity, authoritative_path) {
+    if authoritative_path.is_empty() || !canonical_identity_matches_path(siblings, identity, authoritative_path) {
         return Err(LibraryManifestError::Invalid(format!(
             "identity graph entry `{}` canonical identity disagrees with its authoritative source/projection path",
             entry.public_name
@@ -614,16 +615,24 @@ fn api_declaration_backs_identity_entry(
 ) -> bool {
     match declaration {
         ApiDeclaration::Alias(alias) if alias.name == declaration_name && alias.is_public => {
+            // The two records name the same target at different qualifications, and for a chain at different hops:
+            // a same-module alias records `["helper"]` where the graph entry records `["provider", "helper"]`, and a
+            // facade records the hop it was written on where the entry carries the entrypoint's. Compare what they
+            // can honestly agree on -- the declaration each names -- and let the identity carry the rest.
             let target_matches = match &entry.projection {
                 ExportIdentityProjection::Alias { target_path }
-                | ExportIdentityProjection::Reexport { target_path } => target_path == &alias.target_path,
+                | ExportIdentityProjection::Reexport { target_path } => target_path.last() == alias.target_path.last(),
                 ExportIdentityProjection::Direct | ExportIdentityProjection::Partial { .. } => false,
             };
             if !target_matches || !matches!(entry.kind, ExportIdentityKind::Alias | ExportIdentityKind::Function) {
                 return false;
             }
+            // `source_path` is the target's resolved declaration path; `target_path` is how the alias spelled it.
+            // Resolution only prepends the owning module, so the spelling must be a suffix of the resolution rather
+            // than equal to it -- an unqualified `helper` resolves to `["provider", "helper"]` and still names the
+            // same declaration.
             if let Some(projected) = &alias.projected_function
-                && projected.source_path != alias.target_path
+                && !projected.source_path.ends_with(&alias.target_path)
             {
                 return false;
             }
@@ -776,15 +785,31 @@ fn api_declaration_export_kind(declaration: &ApiDeclaration) -> Option<ExportIde
 ///
 /// Every one of those is a correct program, and asserting prefix equality rejected all of them. That is the same
 /// spelling-is-not-identity mistake the identity model exists to remove, so this compares only what a path can
-/// honestly prove: that it names the declaration the identity names. Structural agreement between the identity graph
-/// and the raw exports is enforced separately by the per-projection checks in `validate_export_identity_binding` and
-/// by the API-declaration backing checks, and consumers resolve by identity rather than by these strings.
+/// honestly prove: that it names the declaration the identity names, or that it names another export of this package
+/// that carries the very same identity. The second case is a projection over a projection -- re-exporting an alias
+/// publishes the alias's path, whose last segment is the local name the alias chose, not the declaration it renames.
+/// Structural agreement between the identity graph and the raw exports is enforced separately by the per-projection
+/// checks in `validate_export_identity_binding` and by the API-declaration backing checks, and consumers resolve by
+/// identity rather than by these strings.
 fn canonical_identity_matches_path(
-    _raw: &RawLibraryManifest,
+    siblings: &[super::ExportIdentity],
     identity: &CanonicalIdentityExport,
     path: &[String],
 ) -> bool {
-    path.last() == Some(&identity.declaration_name)
+    if path.last() == Some(&identity.declaration_name) {
+        return true;
+    }
+    // The path may name a projection hop rather than the declaration. A re-export of an alias publishes the alias's
+    // path -- `["provider", "run"]` -- while the identity behind it is the declaration the alias renames, `helper`.
+    // That is the intended model: a local name for a declaration does not become a second declaration. Accept the
+    // path when this package publishes it as an export carrying this same identity; that hop's own graph entry
+    // proves its binding, so the chain stays validated one hop at a time instead of demanding that the last hop
+    // spell a name it deliberately replaced.
+    siblings.iter().any(|sibling| {
+        sibling.public_path.len() > 1
+            && &sibling.public_path[1..] == path
+            && sibling.canonical.as_ref() == Some(identity)
+    })
 }
 
 /// Validate all canonical field identities exported for one nominal declaration.


### PR DESCRIPTION
## Summary

A module-level alias re-exported under a new name — `pub run = alias helper` in `provider`, then `pub from provider import run as public_target` in the entrypoint — failed library-manifest validation with `identity graph entry \`run\` is not backed by a checked API namespace declaration`. Four sites compared a *spelling* where a resolved identity was the only thing the two records could honestly agree on, which is the same defect class as #1306, #1307 and #1293's own validator work. This makes an alias and a re-export behave as one concept across the whole chain: a local name for a declaration does not become a second declaration.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: `pub from <module> import <alias> as <name>` now builds. Before this, any package whose entrypoint renamed a re-exported alias failed at manifest write, so the library could not be produced at all. Consumers resolve the renamed export to the original declaration, and the callable they resolve is advertised under the name they imported.

- **Internals**: four spelling-for-identity comparisons, in `src/library_manifest/validation.rs` and `src/cli/commands/build.rs`.

  | Site | Was | Now |
  | --- | --- | --- |
  | `api_declaration_backs_identity_entry` | whole target paths equal | the declaration each path names |
  | same arm, callable projection | `projected.source_path == alias.target_path` | the spelling is a **suffix** of the resolution |
  | `canonical_identity_matches_path` | path must end at the declaration name | …or name another export of this package carrying the same identity |
  | `rename_checked_export` | renamed the alias only | also renames the callable the alias projects |

  The third is the substantive one. Re-exporting an alias publishes the *alias's* path, whose last segment is the local name the alias chose, not the declaration behind it. The alias's own graph entry already proves that hop, so requiring the last hop to spell a name it deliberately replaced double-counts a chain that is validated hop by hop. `validate_export_identity_binding` now receives the sibling entries so it can resolve that one extra hop.

- **Risks**: three of the four changes *relax* a validator, so the risk is accepting a manifest that should be rejected. Each relaxation still requires identity agreement rather than dropping the check: the suffix rule only tolerates the module qualification resolution adds, and the sibling rule only accepts a path this same package publishes under the identical canonical identity. The fourth change alters a manifest field (`projected_function.name`) that consumers read; `emitted_name` is deliberately left alone, because the declaration behind a rename is unchanged.

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Targeted rather than full-suite, per the slice convention that workers run focused tests and the full suite runs at slice level:

- `cargo test --lib library_manifest` — 94 passed, 0 failed
- `cargo test --lib cli::commands::build` — 93 passed, 3 failed; the three are the known `CARGO_BIN_EXE_incan` environment gap and fail identically on the unmodified base
- `cargo clippy --lib --all-features` — clean
- `make fmt` and `scripts/check_changed_rustdocs.py` — clean

Manual verification notes:

- Built a real producer/consumer pair (`[dependencies]` path dependency, consumed over `pub::`) rather than a unit fixture, because the failure only appears when a manifest is actually written. Producer declares `helper`, aliases it as `run`, and the entrypoint re-exports `run as public_target`; the same chain is repeated for a model via `Gadget = alias Widget`. The consumer prints `public_target(41) = 42` and `gadget = 3`, so both the function and the model resolve and execute through declaration → alias → renamed re-export → cross-package use.
- Both regression tests were confirmed red before their fix. `same_module_alias_reexported_under_a_new_name_passes_identity_validation` fails with the exact production error quoted above; `resolve_library_reexports_renames_the_callable_an_alias_projects` fails with `left: "run"`, `right: "public_target"`.

**Deliberately not changed.** `api_declaration_backs_identity_entry` keeps its `Alias | Function` kind whitelist. I removed it earlier reasoning that a re-export republishes its target's kind, then tested that reasoning: a model alias, a renamed model re-export and a nested model re-export all pass *with* the whitelist in place, because a re-export's graph kind is `Alias`. No shape I could construct needs the relaxation, so it stays.

**Known-red, not caused here.** `0.6.0-dev.2` is red on `Oven Linux replay` for reasons this PR does not touch — `unresolved import crate::io_facade::BytesIO` (addressed by #1302), a union-wrapper assertion (addressed by #1308), and an unowned `no method named __incan_v1_…` on `RawMutexGuard<T>`. The same job fails on dev.2 itself ([run 33856252697](https://github.com/encero-systems/incan/actions/runs/33856252697)).

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

Rustdoc on the four changed functions was updated in place and passes the changed-rustdoc gate. No user-facing documentation described the broken behavior, so nothing on the docs site becomes stale.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Refs #989. Does not close it — the children #1260, #1261 and #1262 remain.