### PR TITLE
chore - run the expensive Oven and platform suite only where it decides something

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [ main, 0.6.0-dev.2, release/** ]
   pull_request:
     branches: [ main, 0.6.0-dev.2, release/** ]
+  workflow_dispatch:
+    inputs:
+      heavy:
+        description: Run the expensive Oven and platform suite regardless of branch
+        type: boolean
+        default: true
 
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.ref }}
@@ -22,6 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       docs_only: ${{ steps.scope.outputs.docs_only }}
+      heavy: ${{ steps.scope.outputs.heavy }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -32,6 +39,9 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           BASE_REF: ${{ github.base_ref }}
+          REF_NAME: ${{ github.ref_name }}
+          DISPATCH_HEAVY: ${{ inputs.heavy }}
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
         run: |
           set -euo pipefail
 
@@ -66,6 +76,35 @@ jobs:
           fi
 
           echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"
+
+          # The expensive half of this workflow -- four Oven replay shards, the prewarm that feeds them, the platform
+          # ABI matrix, the release-Loaf guard and the shadow-comparison evidence -- costs more than everything else
+          # combined. Spending it on every push to a development line pays release-gate prices for work that is not a
+          # release candidate yet. Run it where it decides something: an integration branch, a slice someone declares
+          # ready, or an explicit request.
+          heavy=false
+          case "$EVENT_NAME" in
+            workflow_dispatch)
+              [ "$DISPATCH_HEAVY" = "true" ] && heavy=true
+              ;;
+            pull_request)
+              # A pull request into `main` or a release branch is a release candidate. One into a `0.6.0-dev.*` line
+              # is not, until it is labelled `full-ci`.
+              case "$BASE_REF" in
+                main|release/*) heavy=true ;;
+              esac
+              case ",$PR_LABELS," in
+                *,full-ci,*) heavy=true ;;
+              esac
+              ;;
+            *)
+              case "$REF_NAME" in
+                main|release/*) heavy=true ;;
+              esac
+              ;;
+          esac
+
+          echo "heavy=$heavy" >> "$GITHUB_OUTPUT"
 
   fmt:
     name: Format Check
@@ -157,7 +196,7 @@ jobs:
     name: Platform C ABI gate (${{ matrix.name }})
     runs-on: ${{ matrix.runner }}
     needs: changes
-    if: ${{ needs.changes.outputs.docs_only != 'true' }}
+    if: ${{ needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.heavy == 'true' }}
     # No explicit budget: a version bump changes Cargo.lock and misses this job's build cache, and the cache only
     # saves when the job completes, so any budget below a full cold workspace build on a 2-core runner means the job
     # can never re-warm. The runner-level 6-hour ceiling still bounds it.
@@ -266,7 +305,7 @@ jobs:
     needs:
       - changes
       - linux-tool-handoff
-    if: ${{ needs.changes.outputs.docs_only != 'true' }}
+    if: ${{ needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.heavy == 'true' }}
     outputs:
       oven_suite_cache_key: ${{ steps.oven-suite-cache-key.outputs.key }}
     steps:
@@ -341,7 +380,7 @@ jobs:
     name: Oven process-containment regressions
     runs-on: ubuntu-latest
     needs: changes
-    if: ${{ needs.changes.outputs.docs_only != 'true' }}
+    if: ${{ needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.heavy == 'true' }}
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master
@@ -374,7 +413,7 @@ jobs:
     needs:
       - changes
       - linux-tool-handoff
-    if: ${{ needs.changes.outputs.docs_only != 'true' }}
+    if: ${{ needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.heavy == 'true' }}
     # No per-job budget, deliberately: the CI contract test forbids one, because a version bump
     # cold-starts every completion-gated cache and any budget below a cold build means the job can
     # never re-warm. The runner-level six-hour ceiling is the only bound, like every other Oven job.
@@ -425,7 +464,7 @@ jobs:
     needs:
       - changes
       - linux-oven-prewarm
-    if: ${{ needs.changes.outputs.docs_only != 'true' }}
+    if: ${{ needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.heavy == 'true' }}
     strategy:
       fail-fast: false
       # `partition` is the 0-based index the Makefile and artifact names consume; `display` exists only because
@@ -521,7 +560,7 @@ jobs:
     needs:
       - changes
       - linux-tool-handoff
-    if: ${{ needs.changes.outputs.docs_only != 'true' }}
+    if: ${{ needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.heavy == 'true' }}
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master
@@ -682,7 +721,7 @@ jobs:
     name: Smoke Release Build
     runs-on: ubuntu-latest
     needs: changes
-    if: ${{ needs.changes.outputs.docs_only != 'true' }}
+    if: ${{ needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.heavy == 'true' }}
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master
@@ -738,12 +777,12 @@ jobs:
   generated-reference:
     name: Generated Reference Up-to-date
     runs-on: ubuntu-latest
+    # Depends only on the job whose artifact it downloads. It previously also waited on the Oven replay, prewarm and
+    # platform jobs, which it never consumed; keeping those would have made this stale-artifact guard skip itself
+    # whenever the expensive suite is gated off, which is exactly when generated output is most likely to drift.
     needs:
       - changes
-      - oven-platform-smoke
-      - oven-linux-replay
       - linux-tool-handoff
-      - linux-oven-prewarm
     if: ${{ needs.changes.outputs.docs_only != 'true' }}
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## Summary

Every push to a development line was paying release-gate prices. The four `Oven Linux replay` shards, the prewarm that feeds them, the platform ABI matrix, the release-Loaf guard, the process-containment regressions and the shadow-comparison evidence together cost more than the rest of the workflow combined — and a change on `0.6.0-dev.*` is not a release candidate. This runs that half only where it decides something, and leaves fast feedback untouched.

Stacked on #1311 (which also edits `ci.yml`); review that first.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [x] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: none for the language or toolchain. For contributors, a `0.6.0-dev.*` pull request gets a fast lane by default and the full suite on request.

- **Internals**: the existing `CI Scope` job already classified each run for `docs_only`; it now also publishes `heavy`. Seven jobs gained `&& needs.changes.outputs.heavy == 'true'`.

  | `heavy` | When |
  | --- | --- |
  | `true` | pull request into `main` or `release/**` |
  | `true` | push to `main` or `release/**` |
  | `true` | `workflow_dispatch` (defaults to on) |
  | `true` | `0.6.0-dev.*` pull request labelled **`full-ci`** |
  | `false` | everything else — i.e. ordinary `0.6.0-dev.*` work |

  Unchanged on every pull request: Format Check, Rustdoc Gate, Clippy, Recoverable emitted symbols, Security Audit, Cargo Deny, Unused Dependencies, Docs Build, Docs Site Build.

  **`Generated Reference Up-to-date` deliberately stays in the fast lane**, and its `needs` are trimmed to `changes` and `linux-tool-handoff` — the one job whose artifact (`test-linux-tools`) it actually downloads. It had also waited on the replay, prewarm and platform jobs without consuming anything from them. Left alone, that would have made a stale-generated-artifact guard skip itself in precisely the runs where generated output is most likely to drift, which is a failure mode this repo has already been bitten by. `linux-tool-handoff` therefore stays ungated, since it produces that artifact.

- **Risks**: the real one is a defect that only the Oven replay can see reaching `main` later, and being discovered at the release gate rather than at the commit that caused it. That is the trade being made deliberately, and there are three escape hatches — the `full-ci` label, `workflow_dispatch`, and the unconditional full run on any PR into `main`.

  A second, smaller risk: `heavy` is computed in shell, so a mistake there silently disables jobs rather than failing loudly. The decision table was extracted and exercised directly (below) rather than trusted by reading.

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- The workflow parses: `yaml.safe_load` on the edited file returns 19 jobs.
- The `heavy` decision was extracted verbatim into a harness and run against every branch it must classify:

  ```
  PR -> 0.6.0-dev.2 (no label)                   false
  PR -> 0.6.0-dev.2 (full-ci label)              true
  PR -> 0.6.0-dev.2 (other labels)               false
  PR -> main                                     true
  PR -> release/0.6                              true
  push 0.6.0-dev.2                               false
  push main                                      true
  push release/0.6                               true
  workflow_dispatch heavy=true                   true
  workflow_dispatch heavy=false                  false
  label 'not-full-ci' must NOT match             false
  ```

  The last row is the one worth having: label matching is delimiter-anchored, so a label that merely contains `full-ci` does not turn the expensive suite on.

- Confirmed by reading the job graph that `generated-reference` downloads only `test-linux-tools`, so trimming its other three dependencies removes ordering, not inputs.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

The gating rule and its escape hatches are documented inline in `ci.yml`, next to the code that implements them, rather than in a separate page that can drift from the workflow.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions