### PR TITLE
bugfix - exercise the facade's enum by matching it, not by printing it (#989)

### DIFF
--- a/tests/fixtures/package_boundary_facade/consumer/src/main.incn
+++ b/tests/fixtures/package_boundary_facade/consumer/src/main.incn
@@ -1,8 +1,16 @@
 from pub::facade import build, Item, Mode
 
 
+def describe(mode: Mode) -> str:
+  match mode:
+    case Mode.Fast:
+      return "fast"
+    case Mode.Slow:
+      return "slow"
+
+
 def main() -> None:
   item = Item(label="boundary")
   print(item.label)
   print(build(1))
-  print(Mode.Fast)
+  print(describe(Mode.Fast))

--- a/tests/package_boundary_facade_tests.rs
+++ b/tests/package_boundary_facade_tests.rs
@@ -184,8 +184,8 @@ fn a_consumer_resolves_facade_published_declarations_across_a_dependency() -> Te
     assert_success(&run_output, "consumer run across the package boundary");
     let stdout = String::from_utf8_lossy(&run_output.stdout);
     assert!(
-        stdout.contains("boundary") && stdout.contains('2'),
-        "the consumer must execute the facade's model and function across the boundary, got:\n{stdout}"
+        stdout.contains("boundary") && stdout.contains('2') && stdout.contains("fast"),
+        "the consumer must execute the facade's model, function and enum across the boundary, got:\n{stdout}"
     );
     Ok(())
 }


### PR DESCRIPTION
## Summary

The package-boundary facade fixture I added in #1303 fails on `0.6.0-dev.2`: its consumer calls `print(Mode.Fast)`, and a plain `enum` has no `Display` in the generated Rust, so the consumer never compiles.

```
error[E0277]: `Mode` doesn't implement `std::fmt::Display`
panicked at tests/package_boundary_facade_tests.rs:69
```

This is one of the two remaining `Oven Linux replay` failures on dev.2, and it is my own fixture's bug rather than a compiler defect.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: none. This is test-fixture only.

- **Internals**: the consumer now matches on `Mode` instead of printing it, and the assertion checks the matched result reaches stdout.

  I checked whether printing a bare enum is supposed to work before changing the fixture, rather than assuming. No example and no stdlib enum is printed directly, and none carries a derive that would enable it — so the fixture was asking for a capability the language does not offer here, and one its own purpose never needed.

  Matching is also the stronger proof. The fixture exists to show that a facade re-export carries every declaration kind across a real package boundary; `Display` would only have required the *type* to cross, while a match requires the type **and its variants** to have crossed intact. The match mirrors `examples/intermediate/enums_with_data.incn` — same `match x:` / `case Enum.Variant:` shape, including its payload-free `LoadResult.NotFound` arm and its all-arms-return form on a `-> str` function.

- **Risks**: minimal — a test fixture. The one thing worth noting is that this removes the only place in the tree that printed a bare enum, so it stops being incidental evidence about `Display` on enums. That was never a property this test set out to pin, and nothing else depended on it.

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- The failure and its location were read from the failing CI job rather than inferred: `Mode doesn't implement std::fmt::Display`, raised from the consumer build inside `package_boundary_facade_tests.rs:69`.
- The replacement syntax is copied from a shipped, smoke-tested example (`examples/intermediate/enums_with_data.incn`), which exercises the identical construct including a payload-free variant.
- This test builds a real package pair through Oven, which does not reproduce in my environment — a local run fails first on SDK component preparation, long before reaching the fixture. CI is the judge here, which is why the change is deliberately confined to the fixture and its assertion.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Refs #989.