### PR TITLE
chore - run the expensive CI suite only where it decides something

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [ main, 0.6.0-dev.2, release/** ]
   pull_request:
     branches: [ main, 0.6.0-dev.2, release/** ]
+  workflow_dispatch:
+    inputs:
+      heavy:
+        description: Run the expensive Oven and platform suite regardless of branch
+        type: boolean
+        default: true
 
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.ref }}
@@ -22,6 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       docs_only: ${{ steps.scope.outputs.docs_only }}
+      heavy: ${{ steps.scope.outputs.heavy }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -32,6 +39,9 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           BASE_REF: ${{ github.base_ref }}
+          REF_NAME: ${{ github.ref_name }}
+          DISPATCH_HEAVY: ${{ inputs.heavy }}
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
         run: |
           set -euo pipefail
 
@@ -66,6 +76,35 @@ jobs:
           fi
 
           echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"
+
+          # The expensive half of this workflow -- four Oven replay shards, the prewarm that feeds them, the platform
+          # ABI matrix, the release-Loaf guard and the shadow-comparison evidence -- costs more than everything else
+          # combined. Spending it on every push to a development line pays release-gate prices for work that is not a
+          # release candidate yet. Run it where it decides something: an integration branch, a slice someone declares
+          # ready, or an explicit request.
+          heavy=false
+          case "$EVENT_NAME" in
+            workflow_dispatch)
+              [ "$DISPATCH_HEAVY" = "true" ] && heavy=true
+              ;;
+            pull_request)
+              # A pull request into `main` or a release branch is a release candidate. One into a `0.6.0-dev.*` line
+              # is not, until it is labelled `full-ci`.
+              case "$BASE_REF" in
+                main|release/*) heavy=true ;;
+              esac
+              case ",$PR_LABELS," in
+                *,full-ci,*) heavy=true ;;
+              esac
+              ;;
+            *)
+              case "$REF_NAME" in
+                main|release/*) heavy=true ;;
+              esac
+              ;;
+          esac
+
+          echo "heavy=$heavy" >> "$GITHUB_OUTPUT"
 
   fmt:
     name: Format Check
@@ -157,7 +196,7 @@ jobs:
     name: Platform C ABI gate (${{ matrix.name }})
     runs-on: ${{ matrix.runner }}
     needs: changes
-    if: ${{ needs.changes.outputs.docs_only != 'true' }}
+    if: ${{ needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.heavy == 'true' }}
     # No explicit budget: a version bump changes Cargo.lock and misses this job's build cache, and the cache only
     # saves when the job completes, so any budget below a full cold workspace build on a 2-core runner means the job
     # can never re-warm. The runner-level 6-hour ceiling still bounds it.
@@ -266,7 +305,7 @@ jobs:
     needs:
       - changes
       - linux-tool-handoff
-    if: ${{ needs.changes.outputs.docs_only != 'true' }}
+    if: ${{ needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.heavy == 'true' }}
     outputs:
       oven_suite_cache_key: ${{ steps.oven-suite-cache-key.outputs.key }}
     steps:
@@ -341,7 +380,7 @@ jobs:
     name: Oven process-containment regressions
     runs-on: ubuntu-latest
     needs: changes
-    if: ${{ needs.changes.outputs.docs_only != 'true' }}
+    if: ${{ needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.heavy == 'true' }}
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master
@@ -374,7 +413,7 @@ jobs:
     needs:
       - changes
       - linux-tool-handoff
-    if: ${{ needs.changes.outputs.docs_only != 'true' }}
+    if: ${{ needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.heavy == 'true' }}
     # No per-job budget, deliberately: the CI contract test forbids one, because a version bump
     # cold-starts every completion-gated cache and any budget below a cold build means the job can
     # never re-warm. The runner-level six-hour ceiling is the only bound, like every other Oven job.
@@ -425,7 +464,7 @@ jobs:
     needs:
       - changes
       - linux-oven-prewarm
-    if: ${{ needs.changes.outputs.docs_only != 'true' }}
+    if: ${{ needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.heavy == 'true' }}
     strategy:
       fail-fast: false
       # `partition` is the 0-based index the Makefile and artifact names consume; `display` exists only because
@@ -521,7 +560,7 @@ jobs:
     needs:
       - changes
       - linux-tool-handoff
-    if: ${{ needs.changes.outputs.docs_only != 'true' }}
+    if: ${{ needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.heavy == 'true' }}
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master
@@ -682,7 +721,7 @@ jobs:
     name: Smoke Release Build
     runs-on: ubuntu-latest
     needs: changes
-    if: ${{ needs.changes.outputs.docs_only != 'true' }}
+    if: ${{ needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.heavy == 'true' }}
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master
@@ -738,12 +777,12 @@ jobs:
   generated-reference:
     name: Generated Reference Up-to-date
     runs-on: ubuntu-latest
+    # Depends only on the job whose artifact it downloads. It previously also waited on the Oven replay, prewarm and
+    # platform jobs, which it never consumed; keeping those would have made this stale-artifact guard skip itself
+    # whenever the expensive suite is gated off, which is exactly when generated output is most likely to drift.
     needs:
       - changes
-      - oven-platform-smoke
-      - oven-linux-replay
       - linux-tool-handoff
-      - linux-oven-prewarm
     if: ${{ needs.changes.outputs.docs_only != 'true' }}
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## Summary

Two changes, both aimed at what CI costs on a development line.

**1. The expensive suite.** The four `Oven Linux replay` shards, the prewarm that feeds them, the platform ABI matrix, the release-Loaf guard, the process-containment regressions and the shadow-comparison evidence together cost more than the rest of the workflow combined — and a change on `0.6.0-dev.*` is not a release candidate. (This half re-opens #1312, whose content never reached `0.6.0-dev.2`: it targeted `chore/dev2-main-sync` and merged into it at 14:45, one minute *after* that branch had already merged into dev.2 as #1311 at 14:44, so it landed on a branch that was already spent.)

**2. `Linux compiler and reference handoff`.** It ran on every pull request at 30-37 minutes. It is a cold `cargo build --locked --features lsp --bins` — it caches Cargo *sources* but not build output, unlike Clippy, which restores a shared `rust-cache` and finishes in under three minutes — followed by an SDK prewarm to typecheck the committed documentation examples. Once the suite above is gated, its only remaining consumer is `Generated Reference Up-to-date`.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [x] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: none for the language or toolchain. For contributors, a `0.6.0-dev.*` pull request gets a fast lane by default and the full suite on request.

- **Internals**: the existing `CI Scope` job already classified each run for `docs_only`; it now also publishes `heavy` and `reference`.

  `heavy` gates seven jobs:

  | `heavy` | When |
  | --- | --- |
  | `true` | pull request into `main` or `release/**` |
  | `true` | push to `main` or `release/**` |
  | `true` | `workflow_dispatch` (defaults to on) |
  | `true` | `0.6.0-dev.*` pull request labelled **`full-ci`** |
  | `false` | everything else — i.e. ordinary `0.6.0-dev.*` work |

  `reference` gates `Linux compiler and reference handoff` and `Generated Reference Up-to-date` together. It is `heavy`, or a pull request touching something that can actually change their result: `crates/incan_core/**` (the language registries and both generators), the two committed reference pages, or the verified example snippets. A change confined to the backend, the CLI or the test suite cannot alter either output, so it no longer waits half an hour on this pair.

  Unchanged on every pull request: Format Check, Rustdoc Gate, Clippy, Recoverable emitted symbols, Security Audit, Cargo Deny, Unused Dependencies, Docs Build, Docs Site Build.

  `Generated Reference Up-to-date` also has its `needs` trimmed to the one job whose artifact (`test-linux-tools`) it downloads. It had additionally waited on the replay, prewarm and platform jobs without consuming anything from them; left alone, that would have made a stale-generated-artifact guard skip itself whenever the expensive suite is gated off.

- **Risks**: the real one is a defect only the Oven replay can see reaching `main` later, and surfacing at the release gate rather than at the commit that caused it. That is the trade being made deliberately, with three escape hatches — the `full-ci` label, `workflow_dispatch`, and the unconditional full run on any PR into `main`.

  For `reference`, the narrower risk is a compiler change that breaks a documentation example without touching `crates/incan_core/**`. That now surfaces at the slice gate rather than on the pull request. It is the same trade, applied to a cheaper guard.

  Both scopes are computed in shell, so a mistake silently disables jobs rather than failing loudly. Both decision tables were extracted and exercised directly rather than trusted by reading.

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- The workflow parses: `yaml.safe_load` returns 19 jobs after both edits.
- `heavy`, exercised against every branch it must classify:

  ```
  PR -> 0.6.0-dev.2 (no label)                   false
  PR -> 0.6.0-dev.2 (full-ci label)              true
  PR -> 0.6.0-dev.2 (other labels)               false
  PR -> main                                     true
  PR -> release/0.6                              true
  push 0.6.0-dev.2                               false
  push main                                      true
  push release/0.6                               true
  workflow_dispatch heavy=true                   true
  workflow_dispatch heavy=false                  false
  label 'not-full-ci' must NOT match             false
  ```

- `reference`, exercised against the paths it must and must not react to:

  ```
  dev PR touching src/backend only                         false
  dev PR touching crates/incan_core                        true
  dev PR touching language.md                              true
  dev PR touching feature_inventory.md                     true
  dev PR touching a verified example                       true
  dev PR touching unrelated docs                           false
  dev PR touching tests only                               false
  PR into main (heavy)                                     true
  push to dev.2                                            false
  push to main (heavy)                                     true
  near-miss: crates/incan_core_extra/                      false
  ```

  The two near-miss rows are the ones worth having: label matching is delimiter-anchored so a label merely containing `full-ci` does not turn the suite on, and the path pattern is slash-anchored so a sibling crate whose name starts with `incan_core` does not match.

- This pull request is its own evidence for the first half: the gate applies to itself, and `Platform C ABI gate`, `Smoke Release Build` and `Oven process-containment regressions` report **skipping** while Clippy, Cargo Deny, Security Audit and both docs builds still run.
- Confirmed by reading the job graph that `generated-reference` downloads only `test-linux-tools`.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

Both gating rules and their escape hatches are documented inline in `ci.yml`, next to the code that implements them, rather than in a separate page that can drift from the workflow.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

## Deliberately not done

Adding sccache to `Linux compiler and reference handoff`, which would be the obvious way to make its cold build fast. `RUSTC_WRAPPER` participates in Oven's compiler identity, and this job uploads the `incan` binary the Oven jobs consume — not something to change as a cost optimization. Giving it Clippy's shared `rust-cache` is the safer version of that idea and remains available if the job's remaining runs are still too slow.

Supersedes #1312.