### PR TITLE
chore - stop rebuilding the whole compiler on every development pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
     outputs:
       docs_only: ${{ steps.scope.outputs.docs_only }}
       heavy: ${{ steps.scope.outputs.heavy }}
+      reference: ${{ steps.scope.outputs.reference }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -105,6 +106,25 @@ jobs:
           esac
 
           echo "heavy=$heavy" >> "$GITHUB_OUTPUT"
+
+          # `Linux compiler and reference handoff` is a cold workspace build plus an SDK prewarm, and it typechecks the
+          # committed documentation examples. Once the expensive suite is gated off, its only remaining consumer is
+          # `Generated Reference Up-to-date`. Paying half an hour on every development pull request to re-derive a
+          # reference that can only change when the language registries, the generators, the committed reference pages
+          # or the verified examples change is the wrong trade -- so run the pair when one of those actually moved.
+          reference="$heavy"
+          if [ "$reference" != "true" ] && [ "$EVENT_NAME" = "pull_request" ]; then
+            while IFS= read -r -d '' file; do
+              case "$file" in
+                crates/incan_core/*) reference=true; break ;;
+                workspaces/docs-site/docs/language/reference/language.md) reference=true; break ;;
+                workspaces/docs-site/docs/language/reference/feature_inventory.md) reference=true; break ;;
+                workspaces/docs-site/docs/_snippets/language/examples/*) reference=true; break ;;
+              esac
+            done < <(git diff --name-only -z "$base_ref" HEAD)
+          fi
+
+          echo "reference=$reference" >> "$GITHUB_OUTPUT"
 
   fmt:
     name: Format Check
@@ -255,7 +275,7 @@ jobs:
     name: Linux compiler and reference handoff
     runs-on: ubuntu-latest
     needs: changes
-    if: ${{ needs.changes.outputs.docs_only != 'true' }}
+    if: ${{ needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.reference == 'true' }}
     # No explicit budget, like oven-platform-smoke: the completion-gated cache must be able to save after a cold
     # workspace build. The runner-level 6-hour ceiling still bounds it.
     steps:
@@ -783,7 +803,7 @@ jobs:
     needs:
       - changes
       - linux-tool-handoff
-    if: ${{ needs.changes.outputs.docs_only != 'true' }}
+    if: ${{ needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.reference == 'true' }}
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master


### PR DESCRIPTION
## Summary

`Linux compiler and reference handoff` still runs on every pull request and takes 30-37 minutes. It is a cold `cargo build --locked --features lsp --bins` — it caches Cargo *sources* but not build output, unlike Clippy, which restores a shared `rust-cache` and finishes in under three minutes — followed by an SDK prewarm to typecheck the committed documentation examples.

Now that #1314 gated the expensive suite, this job's only remaining consumer is `Generated Reference Up-to-date`. So a development pull request pays half an hour to re-derive a reference that can only change when the language registries, the two generators, the committed reference pages, or the verified examples change.

This is the follow-up commit to #1314; it missed that merge, so it needs its own pull request.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [x] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: none. For contributors, a development pull request that cannot affect the generated reference no longer waits on a cold compiler build.

- **Internals**: `CI Scope` publishes a third scope, `reference`, alongside `docs_only` and `heavy`. It gates `Linux compiler and reference handoff` and `Generated Reference Up-to-date` together, since the second consumes the first's `test-linux-tools` artifact.

  `reference` is true when the run is already `heavy`, or when a pull request touches something that can actually change the result:

  | Path | Why |
  | --- | --- |
  | `crates/incan_core/**` | the language registries and both generators |
  | `…/language/reference/language.md` | the committed generated page |
  | `…/language/reference/feature_inventory.md` | the committed generated page |
  | `…/_snippets/language/examples/**` | the verified examples `check-docs-examples` typechecks |

  A change confined to the backend, the CLI or the test suite cannot alter either output.

- **Risks**: a compiler change that breaks a documentation example without touching `crates/incan_core/**` now surfaces at the slice gate rather than on the pull request. That is the same trade #1314 made for the Oven replay, applied to a cheaper guard, and the same escape hatches apply — the `full-ci` label, `workflow_dispatch`, and the unconditional full run on any pull request into `main`.

  The scope is computed in shell, so a mistake silently disables jobs rather than failing loudly. The decision table was extracted and exercised directly rather than trusted by reading.

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- The workflow parses: `yaml.safe_load` returns 19 jobs.
- The `reference` decision was extracted verbatim into a harness and run against the paths it must and must not react to:

  ```
  dev PR touching src/backend only                         false
  dev PR touching crates/incan_core                        true
  dev PR touching language.md                              true
  dev PR touching feature_inventory.md                     true
  dev PR touching a verified example                       true
  dev PR touching unrelated docs                           false
  dev PR touching tests only                               false
  PR into main (heavy)                                     true
  push to dev.2                                            false
  push to main (heavy)                                     true
  near-miss: crates/incan_core_extra/                      false
  ```

  The last row is the one worth having: the pattern is slash-anchored, so a sibling crate whose name merely starts with `incan_core` does not pull in a half-hour job.

- This pull request is its own evidence: it touches only `.github/workflows/ci.yml`, so `reference` is false and both gated jobs should report **skipping** on it.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

The gating rule and its escape hatches are documented inline in `ci.yml`, next to the code that implements them.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

## Deliberately not done

Adding sccache to this job, which would be the obvious way to make its cold build fast. `RUSTC_WRAPPER` participates in Oven's compiler identity, and this job uploads the `incan` binary the Oven jobs consume — not something to change as a cost optimization. Giving it Clippy's shared `rust-cache` is the safer version of that idea and remains available if the job's remaining runs are still too slow.

Follow-up to #1314.