### PR TITLE
bugfix - resolve field assignment on imported Rust values through rust-inspect metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1436,7 +1436,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.6.0-dev.1.2"
+version = "0.6.0-dev.1.3"
 dependencies = [
  "blake2",
  "blake3",
@@ -1493,7 +1493,7 @@ dependencies = [
 
 [[package]]
 name = "incan_codegraph"
-version = "0.6.0-dev.1.2"
+version = "0.6.0-dev.1.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -1501,14 +1501,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.6.0-dev.1.2"
+version = "0.6.0-dev.1.3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.6.0-dev.1.2"
+version = "0.6.0-dev.1.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1517,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.6.0-dev.1.2"
+version = "0.6.0-dev.1.3"
 dependencies = [
  "incan_core",
  "serde",
@@ -1526,7 +1526,7 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.6.0-dev.1.2"
+version = "0.6.0-dev.1.3"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1534,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.6.0-dev.1.2"
+version = "0.6.0-dev.1.3"
 dependencies = [
  "axum",
  "incan_core",
@@ -1548,7 +1548,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.6.0-dev.1.2"
+version = "0.6.0-dev.1.3"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1570,7 +1570,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.6.0-dev.1.2"
+version = "0.6.0-dev.1.3"
 dependencies = [
  "axum",
  "incan_stdlib",
@@ -3138,7 +3138,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.6.0-dev.1.2"
+version = "0.6.0-dev.1.3"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.6.0-dev.1.2"
+version = "0.6.0-dev.1.3"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.93"

--- a/crates/incan_stdlib/stdlib/sdk-components.toml
+++ b/crates/incan_stdlib/stdlib/sdk-components.toml
@@ -1,7 +1,7 @@
 [sdk]
 id = "incan"
-version = "0.6.0-dev.1.2"
-compiler-requirement = ">=0.6.0-dev.1.2,<0.7.0"
+version = "0.6.0-dev.1.3"
+compiler-requirement = ">=0.6.0-dev.1.3,<0.7.0"
 
 [profiles]
 minimal = ["stdlib-core", "stdlib-interop"]

--- a/src/frontend/typechecker/check_expr/access.rs
+++ b/src/frontend/typechecker/check_expr/access.rs
@@ -136,6 +136,26 @@ impl TypeChecker {
         fields.iter().find(|field| field.name == source_name)
     }
 
+    /// Resolve the type of one field on a value typed by a Rust path, as the field is written in Incan source.
+    ///
+    /// The path is the value's own `RustPath` spelling; the metadata lookup normalises the `rust::` prefix and any
+    /// type arguments, exactly as a field read does. Field access and field assignment resolve through this one
+    /// lookup, so a field that can be read can also be assigned.
+    pub(in crate::frontend::typechecker) fn rust_path_field_type(
+        &self,
+        path: &str,
+        field: &str,
+    ) -> Option<ResolvedType> {
+        // Field reads pass the value's path straight to the metadata lookup, which owns the `rust::` and generic
+        // normalisation; a bare `demo::Holder` has no `<...>` to strip and must resolve exactly like a read does.
+        let metadata = self.rust_item_metadata_for_path(path)?;
+        let RustItemKind::Type(info) = &metadata.kind else {
+            return None;
+        };
+        let rust_field = Self::rust_field_for_source_name(&info.fields, field)?;
+        Some(self.resolved_rust_field_type(path, rust_field))
+    }
+
     /// Resolve a Rust field type from its display string against the owning Rust type.
     ///
     /// Rust field metadata carries both a structural shape and the source display. Field access should use the display

--- a/src/frontend/typechecker/check_stmt.rs
+++ b/src/frontend/typechecker/check_stmt.rs
@@ -525,6 +525,27 @@ impl TypeChecker {
                     }
                 }
             }
+            // A value typed by a Rust path (`mut plan = empty_plan()` where the helper returns
+            // `rust::substrait::proto::Plan`) assigns a field through the same metadata that answers a read of it,
+            // and the expected field type drives the value's boundary coercions exactly as a constructor argument
+            // would.
+            ResolvedType::RustPath(path) => match self.rust_path_field_type(path, field) {
+                Some(expected_ty) => {
+                    let value_ty = self.check_expr_with_expected(&field_assign.value, Some(&expected_ty));
+                    if !self.types_compatible(&value_ty, &expected_ty) {
+                        self.errors.push(errors::field_type_mismatch(
+                            field,
+                            &expected_ty.to_string(),
+                            &value_ty.to_string(),
+                            field_assign.value.span,
+                        ));
+                    }
+                }
+                None => {
+                    self.errors
+                        .push(errors::missing_field(&obj_ty.to_string(), field, span));
+                }
+            },
             ResolvedType::Unknown => {
                 // Don't report additional errors on unknown types
             }

--- a/src/frontend/typechecker/tests.rs
+++ b/src/frontend/typechecker/tests.rs
@@ -6137,6 +6137,104 @@ def f() -> None:
 
 #[cfg(feature = "rust_inspect")]
 #[test]
+fn test_imported_rust_field_assignment_resolves_through_rust_metadata() -> Result<(), Box<dyn std::error::Error>> {
+    // `mut plan = empty_plan()` followed by `plan.relations = [...]` is how a test mutates a prost struct. The value
+    // is typed by its Rust path, so the assignment must resolve the field through the same metadata a read uses,
+    // reject a field the struct does not have, and hold the value to the field's type.
+    let source = r#"
+from rust::demo import Holder, Item
+def f(holder: Holder, item: Item) -> None:
+  mut current = holder
+  current.items = [item]
+
+def g(holder: Holder, item: Item) -> None:
+  mut current = holder
+  current.missing = [item]
+
+def h(holder: Holder) -> None:
+  mut current = holder
+  current.items = 1
+"#;
+    let tokens = lexer::lex(source).map_err(|errs| std::io::Error::other(format!("lex failed: {errs:?}")))?;
+    let ast = parser::parse(&tokens).map_err(|errs| std::io::Error::other(format!("parse failed: {errs:?}")))?;
+    let mut checker = TypeChecker::new();
+    let tmp = seeded_rust_inspect_workspace()?;
+    let manifest_dir = tmp.path().to_path_buf();
+    checker.set_rust_inspect_manifest_dir(manifest_dir.clone());
+    for (path, fields) in [
+        (
+            "demo::Holder",
+            vec![RustFieldInfo {
+                name: "items".to_string(),
+                type_display: "Vec<demo::Item>".to_string(),
+                type_shape: RustTypeShape::RustPath {
+                    path: "Vec".to_string(),
+                    args: vec![RustTypeShape::RustPath {
+                        path: "demo::Item".to_string(),
+                        args: vec![],
+                    }],
+                },
+            }],
+        ),
+        ("demo::Item", vec![]),
+    ] {
+        checker
+            .rust_inspect_cache
+            .insert_test_item(
+                &manifest_dir,
+                RustItemMetadata {
+                    canonical_path: path.to_string(),
+                    definition_path: Some(path.to_string()),
+                    visibility: RustVisibility::Public,
+                    kind: RustItemKind::Type(RustTypeInfo {
+                        type_params: Vec::new(),
+                        type_param_defaults: Vec::new(),
+                        mutable_reference_type_params: Vec::new(),
+                        expanded_derive_traits: Vec::new(),
+                        has_const_params: false,
+                        alias_target: None,
+                        metadata_completeness: Default::default(),
+                        methods: vec![],
+                        implemented_traits: Vec::new(),
+                        fields,
+                        variants: vec![],
+                    }),
+                },
+            )
+            .map_err(|e| std::io::Error::other(format!("seed rust-inspect {path}: {e}")))?;
+    }
+    let messages = checker
+        .check_program(&ast)
+        .err()
+        .unwrap_or_default()
+        .iter()
+        .map(|error| error.message.clone())
+        .collect::<Vec<_>>();
+    assert!(
+        !messages.iter().any(|message| message.contains("has no field 'items'")),
+        "assigning an existing Rust field must typecheck: {messages:?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|message| message.contains("has no field 'missing'")),
+        "assigning a field the Rust struct lacks must be rejected: {messages:?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|message| message.contains("Cannot assign 'int' to field 'items' of type 'List[rust::demo::Item]'")),
+        "assigning an int to a Vec field must be rejected with the field's type: {messages:?}"
+    );
+    assert_eq!(
+        messages.len(),
+        2,
+        "only the two invalid assignments may be reported: {messages:?}"
+    );
+    Ok(())
+}
+
+#[test]
 fn test_imported_rust_vec_field_indexes_with_element_type() -> Result<(), Box<dyn std::error::Error>> {
     let source = r#"
 from rust::demo import Holder, accept_item

--- a/workspaces/release/npm/package.json
+++ b/workspaces/release/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@incan/toolchain",
-  "version": "0.6.0-dev.1.2",
+  "version": "0.6.0-dev.1.3",
   "description": "Command shims for the Incan toolchain",
   "license": "Apache-2.0",
   "homepage": "https://incan.io",

--- a/workspaces/release/pip/pyproject.toml
+++ b/workspaces/release/pip/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "incan"
-version = "0.6.0.dev1+2"
+version = "0.6.0.dev1+3"
 description = "Thin installer package for the Incan toolchain"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/workspaces/release/pip/src/incan_toolchain/__init__.py
+++ b/workspaces/release/pip/src/incan_toolchain/__init__.py
@@ -5,5 +5,5 @@ __all__ = ["__release_version__", "__version__"]
 # Python packages require PEP 440 versions, while toolchain release assets retain the
 # workspace's Cargo version spelling. Keep both identities explicit so an installer
 # never derives a GitHub release URL from a normalized distribution version.
-__release_version__ = "0.6.0-dev.1.2"
-__version__ = "0.6.0.dev1+2"
+__release_version__ = "0.6.0-dev.1.3"
+__version__ = "0.6.0.dev1+3"


### PR DESCRIPTION
## Summary

This PR is the `0.6.0-dev.1.3` line: one typechecker fix surfaced by IncQL's CI on encero-systems/IncQL#100, plus the version mirror. A value typed by its Rust path, such as `mut plan = empty_plan()` followed by `plan.relations = [...]` on a prost struct, failed with `Type 'rust::…::Plan' has no field 'relations'` because `check_field_assignment` only resolved fields of Incan-declared types and fell through to the generic error for every `RustPath` receiver. Field assignment now resolves the field through the same rust-inspect lookup a field read uses: an existing field typechecks its value against the field's resolved type, a field the struct does not have is rejected, and a mismatched value reports the field's type. No Incan issue tracks this; the failing site is IncQL's `tests/plan_validation` work on that branch.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: Assigning to a field of an imported Rust struct value typechecks when the field exists, and reports `Cannot assign '<value>' to field '<name>' of type '<field type>'` or `has no field` otherwise, matching what a field read already resolved.
- **Internals**: `rust_path_field_type` in `check_expr/access.rs` looks the field up through `rust_item_metadata_for_path` and `resolved_rust_field_type`; `check_field_assignment` gains a `ResolvedType::RustPath` arm ahead of the permissive `Unknown` arm. The release literals are mirrored to `0.6.0-dev.1.3`.
- **Risks**: A Rust receiver whose metadata is unavailable still returns `None` from the lookup and now reports `has no field` instead of passing silently; that matches the read path's module-membership behaviour but is stricter than before for metadata-free receivers.

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- Per the maintainer's instruction the full `make test` gate was not run on this line. `cargo test -p incan --lib --all-features -- frontend::typechecker` passes (964 tests) including the new `test_imported_rust_field_assignment_resolves_through_rust_metadata`, which covers the valid assignment, the missing field, and the type mismatch.
- `cargo clippy -p incan --lib --all-features --all-targets -- -D warnings` and `cargo fmt --check` are clean; `scripts/check_release_version_consistency.py` agrees on `0.6.0-dev.1.3`.
- End to end on IncQL with a toolchain packaged from this tip by `workspaces/release/toolchain/package_archive.sh` (`v0.6.0-dev.1.3`, aarch64-apple-darwin), as IncQL's CI builds it: on the portable-plan-backend branch (encero-systems/IncQL#100) bake, a second bake without Cargo, `incan test` 275 passed, and the pub-consumer smoke check; on the governed-evidence branch (encero-systems/IncQL#95) the same sequence with 300 passed. On the `0.6.0-dev.1.2` compiler both branches failed every test with `Type 'rust::substrait::proto::Plan' has no field 'relations'`.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions
