### PR TITLE
feature - execute calls that leave the entry module through the replacement route (#1260)

### DIFF
--- a/src/backend/replacement/execution_preflight.rs
+++ b/src/backend/replacement/execution_preflight.rs
@@ -7,10 +7,11 @@
 
 use std::collections::BTreeSet;
 
-use incan_semantics_core::CompilerNodeId;
 use incan_semantics_core::body_ir::{
-    Body, BodyIrModule, CallableParam, CallableParamDefault, CallableTarget, Callee, Rvalue, Statement, StatementKind,
+    Body, BodyIrModule, CallableParam, CallableParamDefault, CallableTarget, Callee, NamedCallableTarget, Rvalue,
+    Statement, StatementKind,
 };
+use incan_semantics_core::{CompilerNodeId, HirSourceSpan};
 
 use super::{
     ReplacementExecutionError, named_callable_body, provider::ProviderRuntime, unsupported,
@@ -23,11 +24,13 @@ use super::{
 /// worklist breaks recursive call cycles without omitting the rest of a body.
 pub(super) fn validate(
     module: &BodyIrModule,
+    reachable: &[BodyIrModule],
     entry: &Body,
     providers: Option<&ProviderRuntime>,
 ) -> Result<(), ReplacementExecutionError> {
     let mut preflight = ExecutionPreflight {
         module,
+        reachable,
         providers,
         pending: vec![entry],
         visited: BTreeSet::new(),
@@ -45,12 +48,70 @@ pub(super) fn validate(
 /// Borrowed traversal state; visited declaration identities bound recursion without storing runtime evidence.
 struct ExecutionPreflight<'module, 'runtime> {
     module: &'module BodyIrModule,
+    /// Modules other than the entry's that a resolved call may reach.
+    ///
+    /// Preflight has to follow a call across a module edge for the same reason it follows one inside a module: an
+    /// admitted profile is proved before any program effect runs, and a body left unvisited is a body whose refusals
+    /// would surface part-way through execution instead.
+    reachable: &'module [BodyIrModule],
     providers: Option<&'runtime ProviderRuntime>,
     pending: Vec<&'module Body>,
     visited: BTreeSet<&'module CompilerNodeId>,
 }
 
 impl<'module> ExecutionPreflight<'module, '_> {
+    /// Resolve one named callee to the body preflight must also validate.
+    ///
+    /// A same-module call keeps the existing route: `direct_call_id` is a span identity that exists only for a
+    /// declaration physically present in this module, so its presence already proves locality and
+    /// `named_callable_body` applies the checks it always did.
+    ///
+    /// An imported callee has no such span identity and resolves on the canonical identity the typechecker selected,
+    /// never on its spelling. Preflight must follow it: refusing here because the callee is elsewhere would make an
+    /// imported body's refusals surface part-way through execution, which is the property this pass exists to
+    /// prevent.
+    fn resolve_callee(
+        &self,
+        target: &NamedCallableTarget,
+        span: HirSourceSpan,
+    ) -> Result<&'module Body, ReplacementExecutionError> {
+        if target.direct_call_id.is_some() {
+            return named_callable_body(self.module, target, span);
+        }
+        let canonical = target.canonical.as_ref().ok_or_else(|| {
+            unsupported(
+                format!(
+                    "named callable `{}` without a canonical declaration target",
+                    target.name
+                ),
+                span,
+            )
+        })?;
+        let mut resolved = self
+            .reachable
+            .iter()
+            .filter_map(|module| module.body_for_canonical_target(canonical));
+        let body = resolved.next().ok_or_else(|| {
+            unsupported(
+                format!(
+                    "named callable `{}` resolves to a declaration outside this execution graph",
+                    target.name
+                ),
+                span,
+            )
+        })?;
+        if resolved.next().is_some() {
+            return Err(unsupported(
+                format!(
+                    "named callable `{}` resolves to more than one module in this execution graph",
+                    target.name
+                ),
+                span,
+            ));
+        }
+        Ok(body)
+    }
+
     /// Inspect retained source defaults without evaluating them or substituting partial presets.
     fn parameters(&mut self, params: &'module [CallableParam]) -> Result<(), ReplacementExecutionError> {
         for parameter in params {
@@ -84,13 +145,12 @@ impl<'module> ExecutionPreflight<'module, '_> {
                     args,
                     ..
                 } if target.builtin.is_none()
-                    && target.direct_call_id.is_some()
+                    && (target.direct_call_id.is_some() || target.canonical.is_some())
                     && args.iter().all(|argument| argument.as_one().is_some())
                     && validate_argument_binding_profile(&target.binding) =>
                 {
                     // Invalid bindings and spreads belong to the caller's structural gate, not the target's host.
-                    self.pending
-                        .push(named_callable_body(self.module, target, statement.span)?);
+                    self.pending.push(self.resolve_callee(target, statement.span)?);
                 }
                 StatementKind::Assign { rvalue, .. } => self.rvalue(rvalue)?,
                 StatementKind::If {

--- a/src/backend/replacement/mod.rs
+++ b/src/backend/replacement/mod.rs
@@ -1067,6 +1067,28 @@ impl<'module> ReplacementExecutionGraph<'module> {
         std::iter::once(self.primary).chain(self.reachable.iter().copied())
     }
 
+    /// Resolve the declaration a canonical target selects, together with the module that owns it.
+    ///
+    /// This is the cross-module counterpart to [`BodyIrModule::body_for_canonical_target`], which answers only for
+    /// the module it is asked. Each module in the graph is asked in turn, and that method already refuses a target
+    /// whose module path is not its own, so a match means the owning module was found rather than a same-named
+    /// declaration in the wrong place.
+    ///
+    /// Two modules answering for one canonical identity is a contradiction rather than an ambiguity to break by
+    /// order: an identity names exactly one declaration site. `None` is returned instead, because dispatching to
+    /// either would make the choice depend on graph assembly order.
+    #[must_use]
+    pub fn body_for_canonical_target(
+        &self,
+        target: &incan_semantics_core::CanonicalSymbolId,
+    ) -> Option<(&'module BodyIrModule, &'module Body)> {
+        let mut found = self
+            .modules()
+            .filter_map(|module| module.body_for_canonical_target(target).map(|body| (module, body)));
+        let first = found.next()?;
+        found.next().is_none().then_some(first)
+    }
+
     /// Resolve the module owning `module_id`, or `None` when the graph does not contain it.
     ///
     /// A `None` here is a refusal, not a fallback: an unresolvable callee must fail before program effects rather

--- a/src/backend/replacement/mod.rs
+++ b/src/backend/replacement/mod.rs
@@ -1324,6 +1324,25 @@ pub fn prepare_free_function_execution_with_providers<'module, 'args>(
     args: &'args [ReplacementValue],
     providers: Option<&Rc<ProviderRuntime>>,
 ) -> Result<ValidatedFreeFunctionExecution<'module, 'args>, ReplacementExecutionError> {
+    prepare_free_function_execution_in_graph(ReplacementExecutionGraph::single_module(module), name, args, providers)
+}
+
+/// Validate and prepare one Body-IR free function whose reachable calls may leave its own module.
+///
+/// The graph names every module a call may resolve into, entrypoint first. Validation still runs against the
+/// entrypoint's module, because that is where the selected body and its arguments live; what the graph adds is the
+/// ability for a frame to execute against the module its callee was resolved to rather than the module the call was
+/// written in.
+///
+/// A one-node graph is exactly the previous behaviour, which is why
+/// [`prepare_free_function_execution_with_providers`] delegates here rather than duplicating the validation order.
+pub fn prepare_free_function_execution_in_graph<'module, 'args>(
+    graph: ReplacementExecutionGraph<'module>,
+    name: &str,
+    args: &'args [ReplacementValue],
+    providers: Option<&Rc<ProviderRuntime>>,
+) -> Result<ValidatedFreeFunctionExecution<'module, 'args>, ReplacementExecutionError> {
+    let module = graph.primary();
     let body = named_free_function(module, name)?;
     if body.is_generator() {
         return Err(unsupported("generator body", body.span));
@@ -1340,7 +1359,7 @@ pub fn prepare_free_function_execution_with_providers<'module, 'args>(
     validate_reachable_typed_numeric_profile(module, body)?;
     execution_preflight::validate(module, body, providers.map(Rc::as_ref))?;
     Ok(ValidatedFreeFunctionExecution {
-        graph: ReplacementExecutionGraph::single_module(module),
+        graph,
         name: name.to_string(),
         args,
         providers: providers.cloned(),

--- a/src/backend/replacement/mod.rs
+++ b/src/backend/replacement/mod.rs
@@ -3963,6 +3963,9 @@ impl<'run, 'writer> BodyExecutor<'run, 'writer> {
     }
 
     /// Execute an isolated frame against the local-type table owned by that frame's declaration.
+    ///
+    /// The frame runs in this executor's own module, which is correct for every same-module call in the #988 profile.
+    /// A frame whose callee was resolved to another module goes through [`Self::execute_child_in_module`] instead.
     fn execute_child_with_local_types<T>(
         &mut self,
         locals: BTreeMap<LocalId, ReplacementValue>,
@@ -3970,7 +3973,30 @@ impl<'run, 'writer> BodyExecutor<'run, 'writer> {
         steps: usize,
         execute: impl FnOnce(&mut BodyExecutor<'_, 'writer>) -> Result<T, ReplacementExecutionError>,
     ) -> Result<T, ReplacementExecutionError> {
-        let mut child = BodyExecutor::with_locals(&self.module, locals, local_types, steps, self.io);
+        let module = self.module.clone();
+        self.execute_child_in_module(&module, locals, local_types, steps, execute)
+    }
+
+    /// Execute an isolated frame that is owned by `module` rather than by this executor's own module.
+    ///
+    /// Every nested frame -- callable, generator, task, default computation, and adapter -- reaches its executor
+    /// through here, so this is the one place a cross-module call changes what a child frame executes against. The
+    /// caller passes the module the callee was *resolved* to, never the module the call was written in: a frame that
+    /// kept the caller's module would resolve an imported body against the wrong declaration table, which is the
+    /// failure `a_cross_module_call_is_refused_by_the_single_module_executor` exists to prevent.
+    ///
+    /// Evidence merging is unchanged and deliberately module-agnostic. Ownership reads, runtime requirements, body
+    /// snapshots, step count, task identities, and lifecycle events belong to the one receipt-bound execution rather
+    /// than to whichever module a frame happened to run in, so they merge upward the same way across a module edge.
+    fn execute_child_in_module<T>(
+        &mut self,
+        module: &BodyIrModule,
+        locals: BTreeMap<LocalId, ReplacementValue>,
+        local_types: BTreeMap<LocalId, IncanType>,
+        steps: usize,
+        execute: impl FnOnce(&mut BodyExecutor<'_, 'writer>) -> Result<T, ReplacementExecutionError>,
+    ) -> Result<T, ReplacementExecutionError> {
+        let mut child = BodyExecutor::with_locals(module, locals, local_types, steps, self.io);
         child.next_task_id = self.next_task_id;
         child.providers = self.providers.clone();
         let result = execute(&mut child);

--- a/src/backend/replacement/mod.rs
+++ b/src/backend/replacement/mod.rs
@@ -3233,7 +3233,12 @@ fn validate_call_profile(
             true
         }
         Callee::Function(CallableTarget::Named(target)) => {
-            target.direct_call_id.is_some()
+            // `direct_call_id` is a span identity that only exists for a same-module declaration, so requiring it made
+            // locality the admission criterion. #1260 executes calls that leave the entry module, where the frontend
+            // resolves the callee to a canonical identity instead. Resolution is the property this gate actually
+            // needs: an unresolved call carries neither. Whether the execution graph holds that identity's body is
+            // decided at dispatch, which reports its own error rather than being silently admitted here.
+            (target.direct_call_id.is_some() || target.canonical.is_some())
                 && target.builtin.is_none()
                 && validate_argument_binding_profile(&target.binding)
         }

--- a/src/backend/replacement/mod.rs
+++ b/src/backend/replacement/mod.rs
@@ -1378,7 +1378,7 @@ pub fn prepare_free_function_execution_in_graph<'module, 'args>(
     }
     validate_scalar_arguments(args, body.span)?;
     validate_selected_parameter_arguments(&body.params, args)?;
-    validate_reachable_typed_numeric_profile(module, body)?;
+    validate_reachable_typed_numeric_profile(&graph, module, body)?;
     let preflight_reachable: Vec<BodyIrModule> = graph
         .modules()
         .filter(|candidate| candidate.module_id != module.module_id)
@@ -1812,15 +1812,17 @@ impl TypedNumericProfileKind {
 /// lossless widening, direct calls, scalar conversions and Display output, while keeping arithmetic, Debug,
 /// aggregates, methods and other unproved behavior explicitly non-green under #988.
 fn validate_reachable_typed_numeric_profile(
+    graph: &ReplacementExecutionGraph<'_>,
     module: &BodyIrModule,
     root: &Body,
 ) -> Result<(), ReplacementExecutionError> {
     let mut visited = BTreeSet::new();
-    validate_typed_numeric_body_profile(module, root, &mut visited)
+    validate_typed_numeric_body_profile(graph, module, root, &mut visited)
 }
 
 /// Validate one reachable body once, following its source defaults and identity-selected sibling calls.
 fn validate_typed_numeric_body_profile(
+    graph: &ReplacementExecutionGraph<'_>,
     module: &BodyIrModule,
     body: &Body,
     visited: &mut BTreeSet<CompilerNodeId>,
@@ -1831,28 +1833,30 @@ fn validate_typed_numeric_body_profile(
     validate_typed_numeric_types(body)?;
     for parameter in &body.params {
         if let CallableParamDefault::Source(computation) = &parameter.default {
-            validate_typed_numeric_statements(module, body, &computation.stmts, visited)?;
+            validate_typed_numeric_statements(graph, module, body, &computation.stmts, visited)?;
             let _ = typed_numeric_operand_kind(body, &computation.result, computation.span)?;
         }
     }
-    validate_typed_numeric_statements(module, body, &body.block.stmts, visited)
+    validate_typed_numeric_statements(graph, module, body, &body.block.stmts, visited)
 }
 
 /// Validate a statement sequence for typed-numeric carrier movement and explicit operation refusals.
 fn validate_typed_numeric_statements(
+    graph: &ReplacementExecutionGraph<'_>,
     module: &BodyIrModule,
     body: &Body,
     statements: &[Statement],
     visited: &mut BTreeSet<CompilerNodeId>,
 ) -> Result<(), ReplacementExecutionError> {
     for statement in statements {
-        validate_typed_numeric_statement(module, body, statement, visited)?;
+        validate_typed_numeric_statement(graph, module, body, statement, visited)?;
     }
     Ok(())
 }
 
 /// Validate one normalized statement without executing its effects.
 fn validate_typed_numeric_statement(
+    graph: &ReplacementExecutionGraph<'_>,
     module: &BodyIrModule,
     body: &Body,
     statement: &Statement,
@@ -1860,10 +1864,10 @@ fn validate_typed_numeric_statement(
 ) -> Result<(), ReplacementExecutionError> {
     match &statement.kind {
         StatementKind::Assign { rvalue, .. } => {
-            validate_typed_numeric_rvalue(module, body, rvalue, statement.span, visited)
+            validate_typed_numeric_rvalue(graph, module, body, rvalue, statement.span, visited)
         }
         StatementKind::Call { callee, args, .. } => {
-            validate_typed_numeric_call(module, body, callee, args, statement.span, visited)
+            validate_typed_numeric_call(graph, module, body, callee, args, statement.span, visited)
         }
         StatementKind::Drop { .. } | StatementKind::Continue | StatementKind::Unsupported { .. } => Ok(()),
         StatementKind::If {
@@ -1872,14 +1876,14 @@ fn validate_typed_numeric_statement(
             else_block,
         } => {
             refuse_typed_numeric_operand(body, cond, statement.span, "condition")?;
-            validate_typed_numeric_statements(module, body, &then_block.stmts, visited)?;
+            validate_typed_numeric_statements(graph, module, body, &then_block.stmts, visited)?;
             if let Some(else_block) = else_block {
-                validate_typed_numeric_statements(module, body, &else_block.stmts, visited)?;
+                validate_typed_numeric_statements(graph, module, body, &else_block.stmts, visited)?;
             }
             Ok(())
         }
         StatementKind::Loop { body: loop_body } => {
-            validate_typed_numeric_statements(module, body, &loop_body.stmts, visited)
+            validate_typed_numeric_statements(graph, module, body, &loop_body.stmts, visited)
         }
         StatementKind::Break { value } => {
             if let Some(value) = value {
@@ -1926,7 +1930,7 @@ fn validate_typed_numeric_statement(
         StatementKind::Race { arms, .. } => {
             for arm in arms {
                 refuse_typed_numeric_operand(body, &arm.awaitable, statement.span, "race awaitable")?;
-                validate_typed_numeric_statements(module, body, &arm.body.stmts, visited)?;
+                validate_typed_numeric_statements(graph, module, body, &arm.body.stmts, visited)?;
                 let _ = typed_numeric_operand_kind(body, &arm.result, statement.span)?;
             }
             Ok(())
@@ -1936,6 +1940,7 @@ fn validate_typed_numeric_statement(
 
 /// Validate one rvalue, admitting carrier movement and refusing unproved typed-numeric operations.
 fn validate_typed_numeric_rvalue(
+    graph: &ReplacementExecutionGraph<'_>,
     module: &BodyIrModule,
     body: &Body,
     rvalue: &Rvalue,
@@ -2016,11 +2021,11 @@ fn validate_typed_numeric_rvalue(
             }
             for parameter in params {
                 if let CallableParamDefault::Source(computation) = &parameter.default {
-                    validate_typed_numeric_statements(module, body, &computation.stmts, visited)?;
+                    validate_typed_numeric_statements(graph, module, body, &computation.stmts, visited)?;
                     let _ = typed_numeric_operand_kind(body, &computation.result, computation.span)?;
                 }
             }
-            validate_typed_numeric_statements(module, body, &closure.stmts, visited)?;
+            validate_typed_numeric_statements(graph, module, body, &closure.stmts, visited)?;
             let _ = typed_numeric_operand_kind(body, &closure.result, span)?;
             Ok(())
         }
@@ -2033,17 +2038,17 @@ fn validate_typed_numeric_rvalue(
             for operand in captured_operands {
                 let _ = typed_numeric_operand_kind(body, operand, span)?;
             }
-            validate_typed_numeric_statements(module, body, &generator.stmts, visited)
+            validate_typed_numeric_statements(graph, module, body, &generator.stmts, visited)
         }
         Rvalue::Match { scrutinee, arms } => {
             refuse_typed_numeric_operand(body, scrutinee, span, "match")?;
             for arm in arms {
                 validate_typed_numeric_pattern(&arm.pattern, span)?;
-                validate_typed_numeric_statements(module, body, &arm.guard_stmts, visited)?;
+                validate_typed_numeric_statements(graph, module, body, &arm.guard_stmts, visited)?;
                 if let Some(guard) = &arm.guard {
                     refuse_typed_numeric_operand(body, guard, span, "match guard")?;
                 }
-                validate_typed_numeric_statements(module, body, &arm.body_stmts, visited)?;
+                validate_typed_numeric_statements(graph, module, body, &arm.body_stmts, visited)?;
                 let _ = typed_numeric_operand_kind(body, &arm.result, span)?;
             }
             Ok(())
@@ -2054,6 +2059,7 @@ fn validate_typed_numeric_rvalue(
 
 /// Validate one call that receives a typed-numeric operand and follow any retained same-module target.
 fn validate_typed_numeric_call(
+    graph: &ReplacementExecutionGraph<'_>,
     module: &BodyIrModule,
     body: &Body,
     callee: &Callee,
@@ -2068,12 +2074,21 @@ fn validate_typed_numeric_call(
         .flatten()
         .collect::<Vec<_>>();
 
+    // Follow the callee into whichever module declares it. A same-module target is reached by its span identity; one
+    // that left the module carries a canonical identity instead, and the graph owns that resolution. Following both is
+    // what makes admitting a cross-module call below sound: the callee's own operations are validated under the same
+    // contract, in its own module, rather than being trusted because the call site could not see them.
     if let Callee::Function(CallableTarget::Named(target)) = callee
-        && target.direct_call_id.is_some()
         && target.builtin.is_none()
     {
-        let called = named_callable_body(module, target, span)?;
-        validate_typed_numeric_body_profile(module, called, visited)?;
+        if target.direct_call_id.is_some() {
+            let called = named_callable_body(module, target, span)?;
+            validate_typed_numeric_body_profile(graph, module, called, visited)?;
+        } else if let Some(canonical) = target.canonical.as_ref()
+            && let Some((owner, called)) = graph.body_for_canonical_target(canonical)
+        {
+            validate_typed_numeric_body_profile(graph, owner, called, visited)?;
+        }
     }
     let Some(kind) = kinds.first().copied() else {
         return Ok(());
@@ -2088,7 +2103,10 @@ fn validate_typed_numeric_call(
                 format!("`{}` conversion", target.name),
                 span,
             )),
-            None if target.direct_call_id.is_some() => Ok(()),
+            // A direct call is admitted whether the declaration is in this module or another one the graph resolved.
+            // `direct_call_id` alone made locality the criterion; the callee's operations are validated above either
+            // way, so the distinction the profile actually cares about is that the frontend resolved the call at all.
+            None if target.direct_call_id.is_some() || target.canonical.is_some() => Ok(()),
             other => Err(typed_numeric_operation_refusal(
                 kind,
                 format!(

--- a/src/backend/replacement/mod.rs
+++ b/src/backend/replacement/mod.rs
@@ -1379,7 +1379,12 @@ pub fn prepare_free_function_execution_in_graph<'module, 'args>(
     validate_scalar_arguments(args, body.span)?;
     validate_selected_parameter_arguments(&body.params, args)?;
     validate_reachable_typed_numeric_profile(module, body)?;
-    execution_preflight::validate(module, body, providers.map(Rc::as_ref))?;
+    let preflight_reachable: Vec<BodyIrModule> = graph
+        .modules()
+        .filter(|candidate| candidate.module_id != module.module_id)
+        .cloned()
+        .collect();
+    execution_preflight::validate(module, &preflight_reachable, body, providers.map(Rc::as_ref))?;
     Ok(ValidatedFreeFunctionExecution {
         graph,
         name: name.to_string(),
@@ -1599,13 +1604,7 @@ pub fn execute_prevalidated_free_function_with_io(
 ) -> Result<ReplacementExecution, ReplacementExecutionError> {
     let body = named_free_function(execution.graph.primary(), &execution.name)?;
     let checkpoint = io.checkpoint();
-    let mut executor = BodyExecutor::new(
-        execution.graph.primary(),
-        body,
-        execution.args,
-        execution.providers.clone(),
-        io,
-    )?;
+    let mut executor = BodyExecutor::new(&execution.graph, body, execution.args, execution.providers.clone(), io)?;
     let (value, result_span) = if body.is_async {
         let task = executor.construct_task(body.clone(), executor.locals.clone(), body.span)?;
         (executor.drive_task(&task, body.span)?, body.span)
@@ -3878,6 +3877,12 @@ fn validate_write_place(
 /// Mutable interpreter state for one Body-IR execution.
 struct BodyExecutor<'run, 'writer> {
     module: BodyIrModule,
+    /// Modules other than this frame's own that a resolved call may execute against.
+    ///
+    /// Shared rather than cloned per frame: a nested frame inherits the same set, and the graph is immutable for the
+    /// life of one execution. `module` stays owned because a frame executes against exactly one module and every
+    /// existing lookup reads it directly.
+    reachable: Rc<Vec<BodyIrModule>>,
     locals: BTreeMap<LocalId, ReplacementValue>,
     /// Checked local types for the currently selected declaration or its nested source-local frame.
     local_types: BTreeMap<LocalId, IncanType>,
@@ -3909,14 +3914,23 @@ struct BodyExecutor<'run, 'writer> {
 impl<'run, 'writer> BodyExecutor<'run, 'writer> {
     /// Bind the already-typechecked call arguments to their Body-IR parameter locals.
     fn new(
-        module: &BodyIrModule,
+        graph: &ReplacementExecutionGraph<'_>,
         body: &Body,
         args: &[ReplacementValue],
         providers: Option<Rc<ProviderRuntime>>,
         io: &'run mut ProgramIo<'writer>,
     ) -> Result<Self, ReplacementExecutionError> {
+        let module = graph.primary();
+        let reachable = Rc::new(
+            graph
+                .modules()
+                .filter(|candidate| candidate.module_id != module.module_id)
+                .cloned()
+                .collect::<Vec<_>>(),
+        );
         let mut executor = Self {
             module: module.clone(),
+            reachable,
             locals: BTreeMap::new(),
             local_types: BTreeMap::new(),
             ownership_reads: Vec::new(),
@@ -3938,6 +3952,7 @@ impl<'run, 'writer> BodyExecutor<'run, 'writer> {
     /// Build an isolated executor for a nested callable, default computation, or suspended generator frame.
     fn with_locals(
         module: &BodyIrModule,
+        reachable: Rc<Vec<BodyIrModule>>,
         locals: BTreeMap<LocalId, ReplacementValue>,
         local_types: BTreeMap<LocalId, IncanType>,
         steps: usize,
@@ -3945,6 +3960,7 @@ impl<'run, 'writer> BodyExecutor<'run, 'writer> {
     ) -> Self {
         Self {
             module: module.clone(),
+            reachable,
             locals,
             local_types,
             ownership_reads: Vec::new(),
@@ -4037,7 +4053,8 @@ impl<'run, 'writer> BodyExecutor<'run, 'writer> {
         steps: usize,
         execute: impl FnOnce(&mut BodyExecutor<'_, 'writer>) -> Result<T, ReplacementExecutionError>,
     ) -> Result<T, ReplacementExecutionError> {
-        let mut child = BodyExecutor::with_locals(module, locals, local_types, steps, self.io);
+        let mut child =
+            BodyExecutor::with_locals(module, Rc::clone(&self.reachable), locals, local_types, steps, self.io);
         child.next_task_id = self.next_task_id;
         child.providers = self.providers.clone();
         let result = execute(&mut child);
@@ -4826,7 +4843,7 @@ impl<'run, 'writer> BodyExecutor<'run, 'writer> {
         args: &[&Operand],
         span: HirSourceSpan,
     ) -> Result<ReplacementValue, ReplacementExecutionError> {
-        let body = named_callable_body(&self.module, target, span)?.clone();
+        let (callee_module, body) = self.resolve_named_callable(target, span)?;
         validate_direct_body_profile(&body)?;
         if body.is_async && !target.type_args.is_empty() {
             return Err(unsupported("generic async callable target", span));
@@ -4856,7 +4873,9 @@ impl<'run, 'writer> BodyExecutor<'run, 'writer> {
                 )),
             })));
         }
-        self.execute_child(locals, self.steps, |child| {
+        let frame_module = callee_module.unwrap_or_else(|| self.module.clone());
+        let local_types_for_frame = self.local_types.clone();
+        self.execute_child_in_module(&frame_module, locals, local_types_for_frame, self.steps, |child| {
             child.record_body(&body);
             match child.execute_block(&body.block)? {
                 Flow::Return(Some(value), return_span) => {
@@ -4868,6 +4887,59 @@ impl<'run, 'writer> BodyExecutor<'run, 'writer> {
                 }
             }
         })
+    }
+
+    /// Resolve a named call to its declaration, and to the module that owns it when that is not this frame's own.
+    ///
+    /// A same-module call keeps its existing path exactly: `direct_call_id` is a span identity that only exists for a
+    /// declaration physically present here, so its presence already proves the callee is local and
+    /// `named_callable_body` performs the same checks it always did. `None` for the owning module means "this
+    /// frame's module", so nothing about same-module execution changes.
+    ///
+    /// A call whose callee is imported has no such span identity, and this is the only case that consults the wider
+    /// graph. It resolves on the canonical identity the typechecker selected, never on the callee's spelling: an
+    /// import spelling, alias, or source path is not a dispatch key, and a same-named declaration in a reachable
+    /// module must not answer for a different one.
+    fn resolve_named_callable(
+        &self,
+        target: &NamedCallableTarget,
+        span: HirSourceSpan,
+    ) -> Result<(Option<BodyIrModule>, Body), ReplacementExecutionError> {
+        if target.direct_call_id.is_some() {
+            return Ok((None, named_callable_body(&self.module, target, span)?.clone()));
+        }
+        let canonical = target.canonical.as_ref().ok_or_else(|| {
+            unsupported(
+                format!(
+                    "named callable `{}` without a same-module declaration identity or a canonical target",
+                    target.name
+                ),
+                span,
+            )
+        })?;
+        let mut resolved = self
+            .reachable
+            .iter()
+            .filter_map(|module| module.body_for_canonical_target(canonical).map(|body| (module, body)));
+        let (module, body) = resolved.next().ok_or_else(|| {
+            unsupported(
+                format!(
+                    "named callable `{}` resolves to a declaration outside this execution graph",
+                    target.name
+                ),
+                span,
+            )
+        })?;
+        if resolved.next().is_some() {
+            return Err(unsupported(
+                format!(
+                    "named callable `{}` resolves to more than one module in this execution graph",
+                    target.name
+                ),
+                span,
+            ));
+        }
+        Ok((Some(module.clone()), body.clone()))
     }
 
     /// Capture one admitted map or filter adapter without polling its source or callback.
@@ -7818,8 +7890,14 @@ mod tests {
         let mut stdout = std::io::sink();
         let mut stderr = std::io::sink();
         let mut io = ProgramIo::new(&mut stdout, &mut stderr);
-        let mut executor =
-            BodyExecutor::with_locals(&module, BTreeMap::new(), BTreeMap::new(), MAX_EXECUTION_STEPS, &mut io);
+        let mut executor = BodyExecutor::with_locals(
+            &module,
+            Rc::new(Vec::new()),
+            BTreeMap::new(),
+            BTreeMap::new(),
+            MAX_EXECUTION_STEPS,
+            &mut io,
+        );
         let mut generator = ReplacementGenerator {
             frame: GeneratorFrame::new(
                 BTreeMap::new(),
@@ -7905,7 +7983,7 @@ mod tests {
         let mut stdout = std::io::sink();
         let mut stderr = std::io::sink();
         let mut io = ProgramIo::new(&mut stdout, &mut stderr);
-        let mut executor = BodyExecutor::with_locals(&module, locals, BTreeMap::new(), 0, &mut io);
+        let mut executor = BodyExecutor::with_locals(&module, Rc::new(Vec::new()), locals, BTreeMap::new(), 0, &mut io);
         let arms = [
             RaceArm {
                 awaitable: Operand::place(Place::from_local(winner_local), OwnershipFact::Borrow, false),

--- a/src/backend/replacement/mod.rs
+++ b/src/backend/replacement/mod.rs
@@ -994,8 +994,97 @@ pub struct ReplacementExecution {
 /// The capability retains the exact typed Body IR, source-level function name, and concrete arguments that were
 /// validated. It lets selection/receipt code decide whether direct execution may proceed without rerunning profile
 /// validation or allowing an unvalidated Body IR body to reach the executor.
+/// The set of Body-IR modules one replacement execution may resolve a call into.
+///
+/// The executor previously held a single `&BodyIrModule`, which is exactly right for the bounded #988 profile where
+/// every reachable call is same-module: an imported callable deliberately carries no same-module `direct_call_id`,
+/// so there was nothing to resolve elsewhere. #1260 widens that to a call graph crossing one source-local module
+/// edge or one direct public path-package edge, which needs somewhere to look the callee's owning module up.
+///
+/// Resolution is by compiler-owned module identity. A module is never selected from a source spelling, an import
+/// spelling, a source path, a generated Rust name, or declaration order, which is the property that lets the same
+/// graph serve a local module edge and a package edge without the executor knowing which it crossed.
+///
+/// The single-module case remains a one-node graph, so the existing #988 behaviour is unchanged and its tests keep
+/// proving the same thing.
+#[derive(Debug, Clone)]
+pub struct ReplacementExecutionGraph<'module> {
+    primary: &'module BodyIrModule,
+    reachable: Vec<&'module BodyIrModule>,
+}
+
+impl<'module> ReplacementExecutionGraph<'module> {
+    /// Build the one-node graph that represents today's single-module execution.
+    #[must_use]
+    pub fn single_module(primary: &'module BodyIrModule) -> Self {
+        Self {
+            primary,
+            reachable: Vec::new(),
+        }
+    }
+
+    /// Build a graph whose entrypoint is `primary` and whose reachable callees may live in `reachable`.
+    ///
+    /// Duplicate module identities are rejected rather than silently de-duplicated: two modules claiming one identity
+    /// means the caller assembled the graph from disagreeing analyses, and picking either one would make dispatch
+    /// depend on assembly order.
+    pub fn new(
+        primary: &'module BodyIrModule,
+        reachable: impl IntoIterator<Item = &'module BodyIrModule>,
+    ) -> Result<Self, ReplacementExecutionError> {
+        let mut modules: Vec<&'module BodyIrModule> = Vec::new();
+        for module in reachable {
+            if module.module_id == primary.module_id || modules.iter().any(|seen| seen.module_id == module.module_id) {
+                // Anchor the refusal at the entrypoint module's first body, which is the only span this graph owns.
+                // A graph-assembly fault has no single source construct to point at, and inventing a synthetic span
+                // would put a location in a diagnostic that no source position backs.
+                let span = primary
+                    .bodies
+                    .first()
+                    .map(|body| body.span)
+                    .unwrap_or(incan_semantics_core::HirSourceSpan { start: 0, end: 0 });
+                return Err(unsupported(
+                    "duplicate module identity in the replacement execution graph",
+                    span,
+                ));
+            }
+            modules.push(module);
+        }
+        Ok(Self {
+            primary,
+            reachable: modules,
+        })
+    }
+
+    /// Return the module owning the entrypoint this execution was prepared for.
+    #[must_use]
+    pub fn primary(&self) -> &'module BodyIrModule {
+        self.primary
+    }
+
+    /// Return every module this execution may resolve into, entrypoint first.
+    pub fn modules(&self) -> impl Iterator<Item = &'module BodyIrModule> + '_ {
+        std::iter::once(self.primary).chain(self.reachable.iter().copied())
+    }
+
+    /// Resolve the module owning `module_id`, or `None` when the graph does not contain it.
+    ///
+    /// A `None` here is a refusal, not a fallback: an unresolvable callee must fail before program effects rather
+    /// than resolve against the caller's own module, which is the invariant
+    /// `a_cross_module_call_is_refused_by_the_single_module_executor` pins.
+    #[must_use]
+    pub fn module_for(&self, module_id: &CompilerNodeId) -> Option<&'module BodyIrModule> {
+        self.modules().find(|module| module.module_id == *module_id)
+    }
+}
+
 pub struct ValidatedFreeFunctionExecution<'module, 'args> {
-    module: &'module BodyIrModule,
+    /// Every module this execution may resolve a call into, entrypoint first.
+    ///
+    /// Held as a graph rather than a single module so #1260 can widen dispatch without changing this type again. The
+    /// single-module profile is a one-node graph, so today's resolution is unchanged: `graph.primary()` is the same
+    /// module the executor used before.
+    graph: ReplacementExecutionGraph<'module>,
     name: String,
     args: &'args [ReplacementValue],
     /// The provider runtime this execution's admitted provider operations were validated against.
@@ -1251,7 +1340,7 @@ pub fn prepare_free_function_execution_with_providers<'module, 'args>(
     validate_reachable_typed_numeric_profile(module, body)?;
     execution_preflight::validate(module, body, providers.map(Rc::as_ref))?;
     Ok(ValidatedFreeFunctionExecution {
-        module,
+        graph: ReplacementExecutionGraph::single_module(module),
         name: name.to_string(),
         args,
         providers: providers.cloned(),
@@ -1467,9 +1556,15 @@ pub fn execute_prevalidated_free_function_with_io(
     execution: ValidatedFreeFunctionExecution<'_, '_>,
     io: &mut ProgramIo<'_>,
 ) -> Result<ReplacementExecution, ReplacementExecutionError> {
-    let body = named_free_function(execution.module, &execution.name)?;
+    let body = named_free_function(execution.graph.primary(), &execution.name)?;
     let checkpoint = io.checkpoint();
-    let mut executor = BodyExecutor::new(execution.module, body, execution.args, execution.providers.clone(), io)?;
+    let mut executor = BodyExecutor::new(
+        execution.graph.primary(),
+        body,
+        execution.args,
+        execution.providers.clone(),
+        io,
+    )?;
     let (value, result_span) = if body.is_async {
         let task = executor.construct_task(body.clone(), executor.locals.clone(), body.span)?;
         (executor.drive_task(&task, body.span)?, body.span)

--- a/src/cli/commands/build.rs
+++ b/src/cli/commands/build.rs
@@ -2514,6 +2514,25 @@ fn replacement_profile_cli_error(error: ReplacementExecutionError, entrypoint: &
     }
 }
 
+/// Whether one import names another module of the project currently being built.
+///
+/// #1260 executes a call that leaves the entry module, so an import naming a sibling of that module is now inside the
+/// profile: the session analyzes the whole source graph at once, and the execution graph resolves the callee's
+/// canonical identity to the module that declares it. Everything reaching outside that graph stays refused -- the
+/// standard library, a `pub::` package dependency, and every Rust or Python interop form each bring a boundary the
+/// source-only profile has no evidence for, and each is owned by a separate child of #989.
+fn replacement_local_module_import(import: &crate::frontend::ast::ImportDecl) -> bool {
+    let path = match &import.kind {
+        ImportKind::Module(path) | ImportKind::From { module: path, .. } => path,
+        // `pub::` dependencies, Rust crates and Python modules are other packages by construction.
+        _ => return false,
+    };
+    let Some(first) = path.segments.first() else {
+        return false;
+    };
+    first.as_str() != incan_core::lang::stdlib::STDLIB_ROOT
+}
+
 /// Return the first unsupported source-module boundary with its original Incan source span.
 fn replacement_module_profile_error(program: &crate::frontend::ast::Program) -> Option<ReplacementExecutionError> {
     if let Some(rust_module) = &program.rust_module_path {
@@ -2541,6 +2560,9 @@ fn replacement_module_profile_error(program: &crate::frontend::ast::Program) -> 
             );
             if exact_async_activation && !async_activation_seen {
                 async_activation_seen = true;
+                continue;
+            }
+            if !exact_async_activation && replacement_local_module_import(import) {
                 continue;
             }
             let description = if exact_async_activation {
@@ -2730,7 +2752,27 @@ fn build_replacement_file_report(
         session_inputs.semantic_module.source_identity(),
         options.backend.fallback_policy,
     );
-    if let Some(error) = replacement_module_profile_error(&session_inputs.program) {
+    // Every module the call can reach has to satisfy the profile, not only the entrypoint. Allowing a local import
+    // means an unsupported declaration is now reachable from a file the entry never names, and refusing it here keeps
+    // the boundary a property of the executed graph rather than of whichever file happened to be the entrypoint.
+    let profile_error = replacement_module_profile_error(&session_inputs.program).or_else(|| {
+        session_inputs
+            .reachable_modules
+            .iter()
+            // The one analysis also checks the standard-library modules the graph pulled in, which arrive under the
+            // generated `__incan_std` namespace rather than the source `std` spelling. Those are not project source
+            // and were never meant to satisfy a source-only profile -- `import std.async` legitimately reaches stdlib
+            // modules full of classes and imports. Only the project's own modules are executed here, so only they are
+            // held to the profile.
+            .filter(|module| {
+                !matches!(
+                    module.module_path.first().map(String::as_str),
+                    Some(incan_core::lang::stdlib::STDLIB_ROOT | incan_core::lang::stdlib::INCAN_STD_NAMESPACE)
+                )
+            })
+            .find_map(|module| replacement_module_profile_error(&module.program))
+    });
+    if let Some(error) = profile_error {
         return refuse_replacement_profile(&selection, error, &entrypoint);
     }
     let body_ir = build_body_ir_module_v0(

--- a/src/cli/commands/build.rs
+++ b/src/cli/commands/build.rs
@@ -21,7 +21,8 @@ use serde::{Deserialize, Serialize};
 use crate::backend::project::generator::GENERATED_CARGO_TARGET_DIR_ENV;
 use crate::backend::project::runner::resolved_cargo_executable;
 use crate::backend::replacement::{
-    ReplacementExecutionError, execute_prevalidated_free_function, prepare_free_function_execution,
+    ReplacementExecutionError, ReplacementExecutionGraph, execute_prevalidated_free_function,
+    prepare_free_function_execution_in_graph,
 };
 use crate::backend::selection::{
     BackendExecutionReceipt, BackendKind, BackendSelection, FallbackOutcome, FallbackPolicy, SemanticModuleProvenance,
@@ -2599,6 +2600,24 @@ struct ReplacementSessionInputs {
     module_path: Vec<String>,
     type_info: typechecker::TypeCheckInfo,
     semantic_module: SemanticModuleProvenance,
+    /// Every non-entry module the one analysis already checked, in collection order.
+    ///
+    /// The session collects and analyzes the whole root source graph and previously kept only the entrypoint, which
+    /// is all the same-module #988 profile can execute. #1260 executes a call that leaves the entry module, so the
+    /// modules that call may reach have to survive the same analysis rather than be re-collected or re-checked
+    /// later: re-analysis would produce a second checker authority, and identities minted by two analyses cannot be
+    /// compared.
+    ///
+    /// The entrypoint is deliberately not repeated here. It stays in the fields above so existing readers keep
+    /// working unchanged, and the execution graph is assembled with the entry module as its primary.
+    reachable_modules: Vec<ReplacementModuleInputs>,
+}
+
+/// One checked non-entry module retained from the replacement session's single analysis.
+struct ReplacementModuleInputs {
+    program: crate::frontend::ast::Program,
+    module_path: Vec<String>,
+    type_info: typechecker::TypeCheckInfo,
 }
 
 /// Collect and analyze the replacement entrypoint once through the project-selected compilation session.
@@ -2640,10 +2659,25 @@ fn replacement_session_inputs(
     let semantic_snapshot_rendering = semantic_snapshot.render_snapshot();
     let source_identity = digest_output(&[entry_module.source.as_str()]);
 
+    let reachable_modules = modules
+        .iter()
+        .filter(|module| module.file_path != entry_module.file_path)
+        .filter_map(|module| {
+            analysis
+                .module_analysis_for_path(&module.file_path)
+                .map(|checked| ReplacementModuleInputs {
+                    program: module.ast.clone(),
+                    module_path: module.path_segments.clone(),
+                    type_info: checked.type_info().clone(),
+                })
+        })
+        .collect();
+
     Ok(ReplacementSessionInputs {
         program: entry_module.ast.clone(),
         module_path: entry_module.path_segments.clone(),
         type_info: entry_analysis.type_info().clone(),
+        reachable_modules,
         semantic_module: SemanticModuleProvenance::new(
             semantic_snapshot.hir.id.to_string(),
             semantic_snapshot.hir.path.clone(),
@@ -2704,7 +2738,19 @@ fn build_replacement_file_report(
         &session_inputs.module_path,
         &session_inputs.type_info,
     );
-    let execution_plan = match prepare_free_function_execution(&body_ir, "main", &[]) {
+    // Lower every module the one analysis checked, not just the entrypoint. A call that leaves the entry module can
+    // only resolve if its callee's module was lowered from that same analysis; lowering it later, or from a second
+    // analysis, would mint identities that cannot be compared with the ones the entry module carries.
+    let reachable_body_ir: Vec<_> = session_inputs
+        .reachable_modules
+        .iter()
+        .map(|module| build_body_ir_module_v0(&module.program, &module.module_path, &module.type_info))
+        .collect();
+    let execution_graph = match ReplacementExecutionGraph::new(&body_ir, reachable_body_ir.iter()) {
+        Ok(graph) => graph,
+        Err(error) => return refuse_replacement_profile(&selection, error, &entrypoint),
+    };
+    let execution_plan = match prepare_free_function_execution_in_graph(execution_graph, "main", &[], None) {
         Ok(plan) => plan,
         Err(error) => return refuse_replacement_profile(&selection, error, &entrypoint),
     };

--- a/tests/replacement_backend_execution_tests.rs
+++ b/tests/replacement_backend_execution_tests.rs
@@ -4,7 +4,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 
-use incan::backend::replacement::{ReplacementValue, execute_free_function};
+use incan::backend::replacement::{ReplacementExecutionGraph, ReplacementValue, execute_free_function};
 use incan::backend::selection::{
     BackendKind, FallbackOutcome, FallbackPolicy, ShadowComparisonState, digest_output, finalize_receipt,
     select_backend,
@@ -83,6 +83,68 @@ fn a_cross_module_call_is_refused_by_the_single_module_executor() -> Result<(), 
         executed.is_err(),
         "executing a cross-module call against only the caller's module must refuse until #1260 supplies the \
          execution graph, got: {executed:?}"
+    );
+    Ok(())
+}
+
+/// A canonical target owned by another module resolves through the execution graph, not through the caller.
+///
+/// This is the mechanism #1260 dispatches on. `direct_call_id` is a span identity and exists only for a declaration
+/// physically present in the calling module, which is why an imported callable has none. The canonical identity
+/// answers the different question of *which declaration was selected*, and survives the module boundary, so the
+/// graph resolves it by asking each module in turn rather than by matching a name.
+///
+/// The negative half matters as much as the positive: asking the consumer's own module for the same target must
+/// still return nothing. A resolution that succeeded locally would mean the executor could dispatch to a same-named
+/// declaration in the wrong module, which is exactly the failure the canonical identity exists to prevent.
+#[test]
+fn a_canonical_target_resolves_to_its_owning_module_through_the_graph() -> Result<(), Box<dyn std::error::Error>> {
+    let provider = lower_named_body_ir(
+        "pub def provide() -> int:\n  return 7\n",
+        &["graph_resolution_provider"],
+    )?;
+    let consumer = lower_named_body_ir("def main() -> int:\n  return 1\n", &["graph_resolution_consumer"])?;
+
+    let provided = provider
+        .bodies
+        .iter()
+        .find(|body| body.name == "provide")
+        .ok_or("the provider module must retain its callable body")?;
+    let target = provided
+        .canonical
+        .as_ref()
+        .ok_or("the provider body must carry a canonical identity")?;
+
+    // The consumer alone cannot resolve it: the identity is owned by another module.
+    assert!(
+        consumer.body_for_canonical_target(target).is_none(),
+        "a canonical target owned by another module must not resolve against the caller's own module"
+    );
+
+    let graph = ReplacementExecutionGraph::new(&consumer, std::iter::once(&provider))?;
+    let (owner, body) = graph
+        .body_for_canonical_target(target)
+        .ok_or("the graph must resolve a canonical target owned by a reachable module")?;
+    assert_eq!(
+        owner.module_id, provider.module_id,
+        "resolution must report the module that owns the declaration"
+    );
+    assert_eq!(body.name, "provide", "resolution must return the selected declaration");
+    Ok(())
+}
+
+/// A graph refuses to be built from two modules claiming one identity.
+///
+/// Assembling a graph from disagreeing analyses is a caller fault, and accepting it would make dispatch depend on
+/// assembly order. Refusing at construction keeps that fault at the boundary that produced it rather than surfacing
+/// later as a call resolving to whichever module happened to be first.
+#[test]
+fn a_graph_refuses_duplicate_module_identities() -> Result<(), Box<dyn std::error::Error>> {
+    let module = lower_named_body_ir("def main() -> int:\n  return 1\n", &["duplicate_identity"])?;
+    let twin = lower_named_body_ir("def main() -> int:\n  return 2\n", &["duplicate_identity"])?;
+    assert!(
+        ReplacementExecutionGraph::new(&module, std::iter::once(&twin)).is_err(),
+        "two modules claiming one identity must refuse rather than resolve by assembly order"
     );
     Ok(())
 }

--- a/tests/replacement_backend_execution_tests.rs
+++ b/tests/replacement_backend_execution_tests.rs
@@ -4,10 +4,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 
-use incan::backend::replacement::{
-    ReplacementExecutionGraph, ReplacementValue, execute_free_function, execute_prevalidated_free_function,
-    prepare_free_function_execution_in_graph,
-};
+use incan::backend::replacement::{ReplacementExecutionGraph, ReplacementValue, execute_free_function};
 use incan::backend::selection::{
     BackendKind, FallbackOutcome, FallbackPolicy, ShadowComparisonState, digest_output, finalize_receipt,
     select_backend,
@@ -2760,6 +2757,121 @@ fn replacement_cli_executes_typed_body_ir_and_persists_a_replacement_receipt() -
         receipt["identity"]
             .as_str()
             .is_some_and(|identity| identity.starts_with("sha256:"))
+    );
+    Ok(())
+}
+
+/// Execute a call that leaves the entry module through the replacement route, with a #986 receipt.
+///
+/// This is #1260's local-module positive fixture. Everything before it executed inside one module, where a callee
+/// carries a same-module `direct_call_id`. Here `main` calls a function declared in a sibling module, so the frontend
+/// resolves the callee to a canonical identity instead and the execution graph has to find the module that declares
+/// it. The result is asserted from the report rather than the receipt, because the receipt stays receipt-only.
+#[test]
+fn replacement_cli_executes_a_call_into_a_sibling_module_with_a_replacement_receipt()
+-> Result<(), Box<dyn std::error::Error>> {
+    let temporary = tempfile::tempdir()?;
+    fs::write(
+        temporary.path().join("helper.incn"),
+        "pub def bump(value: int) -> int:\n  return value + 1\n",
+    )?;
+    let entrypoint = temporary.path().join("main.incn");
+    fs::write(
+        &entrypoint,
+        "from helper import bump\n\ndef main() -> int:\n  return bump(41)\n",
+    )?;
+
+    let output = Command::new(incan_binary())
+        .args([
+            "build",
+            entrypoint.to_string_lossy().as_ref(),
+            "--backend",
+            "replacement",
+            "--backend-fallback",
+            "refuse",
+        ])
+        .args([
+            "--report",
+            "json",
+            "--report-output",
+            temporary
+                .path()
+                .join("cross-module-report.json")
+                .to_string_lossy()
+                .as_ref(),
+        ])
+        .output()?;
+    assert!(
+        output.status.success(),
+        "a call into a sibling module must execute through the replacement route. stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let report: serde_json::Value =
+        serde_json::from_slice(&fs::read(temporary.path().join("cross-module-report.json"))?)?;
+    assert_eq!(
+        report["replacement_execution"]["result"], "42",
+        "the sibling module's declaration must produce the source-observable result"
+    );
+    assert!(
+        !temporary.path().join("target/incan").exists(),
+        "direct replacement execution must not create a legacy generated-project directory"
+    );
+
+    let receipt: serde_json::Value = serde_json::from_str(&fs::read_to_string(
+        temporary.path().join(".incan/backend/receipt.json"),
+    )?)?;
+    assert_eq!(receipt["executed_backend"], "replacement");
+    assert_eq!(receipt["selection"]["selected_backend"], "replacement");
+    assert_eq!(receipt["fallback_outcome"], serde_json::json!("not_needed"));
+    Ok(())
+}
+
+/// A sibling module is held to the same source-only profile as the entrypoint.
+///
+/// Allowing a local import means an unsupported declaration becomes reachable from a file the entrypoint never names.
+/// The refusal must still happen, so the boundary is a property of the executed graph rather than of whichever file
+/// happened to be the entrypoint.
+#[test]
+fn replacement_cli_refuses_an_unsupported_declaration_in_a_sibling_module() -> Result<(), Box<dyn std::error::Error>> {
+    let temporary = tempfile::tempdir()?;
+    fs::write(
+        temporary.path().join("helper.incn"),
+        "pub class Holder:\n  value: int\n\npub def bump(value: int) -> int:\n  return value + 1\n",
+    )?;
+    let entrypoint = temporary.path().join("main.incn");
+    fs::write(
+        &entrypoint,
+        "from helper import bump\n\ndef main() -> int:\n  return bump(41)\n",
+    )?;
+
+    let output = Command::new(incan_binary())
+        .args([
+            "build",
+            entrypoint.to_string_lossy().as_ref(),
+            "--backend",
+            "replacement",
+            "--backend-fallback",
+            "refuse",
+        ])
+        .output()?;
+    assert!(
+        !output.status.success(),
+        "an unsupported declaration in a reachable module must be refused"
+    );
+    let combined = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("INCAN-R988-UNSUPPORTED") && combined.contains("non-function top-level declaration"),
+        "missing typed refusal for the sibling module's declaration: {combined}"
+    );
+    assert!(
+        !temporary.path().join(".incan/backend/receipt.json").exists(),
+        "a refused profile must not publish a replacement receipt"
     );
     Ok(())
 }

--- a/tests/replacement_backend_execution_tests.rs
+++ b/tests/replacement_backend_execution_tests.rs
@@ -2828,6 +2828,90 @@ fn replacement_cli_executes_a_call_into_a_sibling_module_with_a_replacement_rece
     Ok(())
 }
 
+/// A typed-numeric carrier crosses a module boundary, and the callee's own operations are still validated.
+///
+/// The typed-numeric walk previously followed only same-module calls, because it selected the callee by its
+/// same-module span identity. A cross-module callee was therefore refused outright. Admitting one is only sound if
+/// its operations are validated too, so both directions are pinned here: the admitted call executes, and an
+/// operation the profile does not admit is still refused when it lives in the *callee's* module rather than the
+/// entrypoint's.
+#[test]
+fn replacement_cli_follows_a_typed_numeric_call_into_the_module_that_declares_it()
+-> Result<(), Box<dyn std::error::Error>> {
+    let admitted = tempfile::tempdir()?;
+    fs::write(
+        admitted.path().join("helper.incn"),
+        "pub def widen(value: u8) -> u8:\n  return value\n",
+    )?;
+    let entrypoint = admitted.path().join("main.incn");
+    fs::write(
+        &entrypoint,
+        "from helper import widen\n\ndef main() -> u8:\n  start: u8 = 41\n  return widen(start)\n",
+    )?;
+    let report_path = admitted.path().join("typed-numeric-report.json");
+    let output = Command::new(incan_binary())
+        .args([
+            "build",
+            entrypoint.to_string_lossy().as_ref(),
+            "--backend",
+            "replacement",
+            "--backend-fallback",
+            "refuse",
+        ])
+        .args([
+            "--report",
+            "json",
+            "--report-output",
+            report_path.to_string_lossy().as_ref(),
+        ])
+        .output()?;
+    assert!(
+        output.status.success(),
+        "an admitted typed-numeric call must cross the module boundary. stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: serde_json::Value = serde_json::from_slice(&fs::read(&report_path)?)?;
+    assert_eq!(report["replacement_execution"]["result"], "41");
+
+    // The same shape, with an operation the carrier profile does not admit moved into the callee's module. A refusal
+    // here is the evidence that the walk actually entered `helper.incn` rather than trusting the call.
+    let refused = tempfile::tempdir()?;
+    fs::write(
+        refused.path().join("helper.incn"),
+        "pub def widen(value: u8) -> u8:\n  values: List[u8] = [value]\n  return values[0]\n",
+    )?;
+    let refused_entrypoint = refused.path().join("main.incn");
+    fs::write(
+        &refused_entrypoint,
+        "from helper import widen\n\ndef main() -> u8:\n  start: u8 = 41\n  return widen(start)\n",
+    )?;
+    let refusal = Command::new(incan_binary())
+        .args([
+            "build",
+            refused_entrypoint.to_string_lossy().as_ref(),
+            "--backend",
+            "replacement",
+            "--backend-fallback",
+            "refuse",
+        ])
+        .output()?;
+    assert!(
+        !refusal.status.success(),
+        "an unadmitted typed-numeric operation in the callee's module must still be refused"
+    );
+    let combined = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&refusal.stdout),
+        String::from_utf8_lossy(&refusal.stderr)
+    );
+    assert!(
+        combined.contains("INCAN-R988-UNSUPPORTED") && combined.contains("aggregate construction"),
+        "the callee module's unadmitted operation must be named: {combined}"
+    );
+    Ok(())
+}
+
 /// A sibling module is held to the same source-only profile as the entrypoint.
 ///
 /// Allowing a local import means an unsupported declaration becomes reachable from a file the entrypoint never names.

--- a/tests/replacement_backend_execution_tests.rs
+++ b/tests/replacement_backend_execution_tests.rs
@@ -30,6 +30,63 @@ fn lower_typed_body_ir(source: &str) -> Result<BodyIrModule, Box<dyn std::error:
     Ok(build_body_ir_module_v0(&program, &module_path, checker.type_info()))
 }
 
+/// Lower one named module against a shared checker so two modules can be produced for cross-module tests.
+///
+/// `lower_typed_body_ir` fixes the module path, which is right for the single-module #988 profile but cannot express
+/// a call that crosses a module edge. #1260 needs two Body-IR modules whose canonical identities were minted under
+/// their own module paths, which is what this produces.
+fn lower_named_body_ir(source: &str, module_path: &[&str]) -> Result<BodyIrModule, Box<dyn std::error::Error>> {
+    let tokens = lexer::lex(source).map_err(|errors| std::io::Error::other(format!("{errors:?}")))?;
+    let program = parser::parse(&tokens).map_err(|errors| std::io::Error::other(format!("{errors:?}")))?;
+    let module_path: Vec<String> = module_path.iter().map(|part| (*part).to_string()).collect();
+    let mut checker = TypeChecker::new();
+    checker.set_current_module_path(Some(module_path.clone()));
+    checker
+        .check_program(&program)
+        .map_err(|errors| std::io::Error::other(format!("{errors:?}")))?;
+    Ok(build_body_ir_module_v0(&program, &module_path, checker.type_info()))
+}
+
+/// Characterize the module boundary #1260 replaces: a cross-module call cannot resolve through one module.
+///
+/// `prepare_free_function_execution` and `execute_free_function` take one `&BodyIrModule`, so a body whose reachable
+/// call graph leaves that module has no way to reach its callee: an imported callable deliberately carries no
+/// same-module `direct_call_id`, and #1260 must resolve it from the compiler-owned canonical target rather than
+/// manufacture one. This pins the current boundary so the `ReplacementExecutionGraph` that replaces it has a failing
+/// test to satisfy, and so the refusal stays a refusal rather than silently executing the wrong body.
+///
+/// This passes today, so it is a characterization test rather than a failing one. Its value is the invariant it
+/// pins: a cross-module call must never resolve against the caller's own module. When #1260 makes such a call
+/// execute, this test inverts to assert the value it produces, and until then it stops a partial implementation from
+/// silently resolving the wrong body.
+#[test]
+fn a_cross_module_call_is_refused_by_the_single_module_executor() -> Result<(), Box<dyn std::error::Error>> {
+    let provider = lower_named_body_ir("pub def provide() -> int:\n  return 7\n", &["cross_module_provider"])?;
+    let consumer = lower_named_body_ir(
+        "from cross_module_provider import provide\n\ndef main() -> int:\n  return provide()\n",
+        &["cross_module_consumer"],
+    )?;
+
+    // The provider's body exists, but it exists in the *other* module.
+    assert!(
+        provider.bodies.iter().any(|body| body.name == "provide"),
+        "the provider module must retain its own callable body"
+    );
+    assert!(
+        !consumer.bodies.iter().any(|body| body.name == "provide"),
+        "the consumer module must not contain the imported callee's body; a cross-module call has to be resolved \
+         through the module graph rather than found locally"
+    );
+
+    let executed = execute_free_function(&consumer, "main", &[]);
+    assert!(
+        executed.is_err(),
+        "executing a cross-module call against only the caller's module must refuse until #1260 supplies the \
+         execution graph, got: {executed:?}"
+    );
+    Ok(())
+}
+
 /// Legal source used to isolate malformed retained constructor facts after checked lowering.
 const PAIR_CONSTRUCTION_SOURCE: &str = r#"
 model Pair:

--- a/tests/replacement_backend_execution_tests.rs
+++ b/tests/replacement_backend_execution_tests.rs
@@ -4,7 +4,10 @@ use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 
-use incan::backend::replacement::{ReplacementExecutionGraph, ReplacementValue, execute_free_function};
+use incan::backend::replacement::{
+    ReplacementExecutionGraph, ReplacementValue, execute_free_function, execute_prevalidated_free_function,
+    prepare_free_function_execution_in_graph,
+};
 use incan::backend::selection::{
     BackendKind, FallbackOutcome, FallbackPolicy, ShadowComparisonState, digest_output, finalize_receipt,
     select_backend,
@@ -146,6 +149,47 @@ fn a_graph_refuses_duplicate_module_identities() -> Result<(), Box<dyn std::erro
         ReplacementExecutionGraph::new(&module, std::iter::once(&twin)).is_err(),
         "two modules claiming one identity must refuse rather than resolve by assembly order"
     );
+    Ok(())
+}
+
+/// Two independently checked modules cannot express a resolved cross-module call.
+///
+/// This records why #1260's executable proof lives in a session-backed integration fixture rather than here. Each
+/// module below is checked by its own `TypeChecker`, so the consumer's checker never sees the provider and the call
+/// stays unresolved: `direct_call_id`, `binding`, and `canonical` are all absent. There is nothing for the execution
+/// graph to resolve, and a test that lowered two modules separately and expected a cross-module call to execute
+/// would be asserting against a call the frontend never resolved.
+///
+/// `CompilationSession::analyze_modules` is the only checker authority for a source graph, which is what makes a
+/// call across a module edge carry the canonical identity dispatch resolves on.
+#[test]
+fn independently_checked_modules_do_not_resolve_a_cross_module_call() -> Result<(), Box<dyn std::error::Error>> {
+    let consumer = lower_named_body_ir(
+        "from unseen_provider import provide\n\ndef main() -> int:\n  return provide()\n",
+        &["unresolved_consumer"],
+    )?;
+    let unresolved =
+        consumer
+            .bodies
+            .iter()
+            .flat_map(|body| body.block.stmts.iter())
+            .filter_map(|statement| match &statement.kind {
+                StatementKind::Call {
+                    callee:
+                        incan_semantics_core::body_ir::Callee::Function(
+                            incan_semantics_core::body_ir::CallableTarget::Named(target),
+                        ),
+                    ..
+                } => Some(target),
+                _ => None,
+            })
+            .find(|target| target.name == "provide");
+    if let Some(target) = unresolved {
+        assert!(
+            target.direct_call_id.is_none() && target.canonical.is_none(),
+            "a call the frontend never resolved must carry neither identity, got: {target:?}"
+        );
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Everything the replacement backend executed until now lived inside one module. #1260 executes a call that leaves it: `main` calls a function declared in a sibling module, resolved through the compiler-owned module graph and the callee's canonical identity, and produces a source-observable result with a #986 receipt.

The **local-module** half of #1260's acceptance criteria is delivered here. The **package-consumer** half is blocked on a design decision that the issue does not settle — see the last section, which is the part that needs your call.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: `incan build --backend replacement` now executes a project whose entrypoint imports a sibling module, instead of refusing the import. Everything reaching outside the project's own source graph is still refused, with the same typed diagnostic.

- **Internals**, in the order the eight commits build it:

  1. Characterize the module boundary being replaced.
  2. Introduce `ReplacementExecutionGraph` without changing dispatch.
  3. Route every nested frame through one cross-module-capable seam.
  4. Retain and lower the whole checked module graph — one analysis, not one per module, so identities stay comparable.
  5. Resolve a canonical call target to its owning module through the graph.
  6. Dispatch and preflight a call through the module its callee resolves to.
  7. Open the two gates that still refused the call before it reached any of that.
  8. Follow a typed-numeric call into the module that declares it.

  The last two are where the behavior changes, and both come down to the same thing: **`direct_call_id` was standing in for "is this call admissible", when it actually answers "is this call local".** It is a span identity that only exists for a same-module declaration. A cross-module callee carries a canonical identity instead, and a call the frontend never resolved carries neither — so resolution, not locality, is the property these gates need.

  The source-only profile also refused every import, so a second module never reached execution at all. A local import is now inside the profile, and the profile now applies to every project module the call can reach rather than only the entrypoint — otherwise an unsupported declaration would become reachable from a file the entrypoint never names. Standard-library modules the same analysis checked are excluded: they arrive under the generated `__incan_std` namespace, are not project source, and were never meant to satisfy a source-only profile.

- **Risks**: the typed-numeric change is the one to look at. Admitting a cross-module call is only sound if the callee's operations are validated under the same contract, and the walk previously had no way to reach them — the driver held the graph but passed only the primary module. Both gates therefore move together; widening admission alone would have trusted operations precisely because the call site could not see them. The test below pins that by putting an unadmitted operation in the *callee's* module and requiring the refusal.

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

- `cargo test --test replacement_backend_execution_tests` — 113 passed
- `cargo test --lib backend::replacement` — 45 passed
- `replacement_abs_sum_profile_tests` (4), `replacement_compatibility_registry_tests` (6), `replacement_enumerate_zip_tests` (15), `replacement_bool_truthiness_tests` (6), `replacement_collection_len_tests` (4), `replacement_example_coverage` (1) — all passed
- `cargo clippy --all-targets --all-features` clean; `scripts/check_changed_rustdocs.py` passes

Manual verification notes:

- Three tests are added, each pinning a direction rather than only the happy path:
  - a call into a sibling module executes, asserted through the report's `replacement_execution.result` and a receipt showing `executed_backend: replacement`;
  - an unsupported declaration in that sibling module is still refused, and publishes no receipt;
  - a typed-numeric `u8` call crosses the boundary **and** the same shape with an aggregate construction moved into the callee's module is refused — that refusal is the evidence the walk entered the other module rather than trusting the call.
- Extending the profile across the graph initially broke three async tests. The cause was worth finding rather than patching around: stdlib modules the same analysis checks arrive as `["__incan_std", …]`, not `["std", …]`, so a filter written against the source spelling silently held them to a source-only profile they were never meant to satisfy.
- Also drops two imports an earlier commit in this branch left unused, which `-D warnings` would have failed on.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

No user-facing documentation describes the replacement backend's admitted profile; it is reported through the typed `INCAN-R988-UNSUPPORTED` diagnostic, which continues to name its boundary.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

## Flagged, not fixed

A refusal raised in a non-entry module prints the **entrypoint's** path beside the **callee module's** span, because `ReplacementExecutionError::Unsupported` carries a span and no owning file. This was unreachable while every import was refused; this change makes it reachable. Repairing it means giving the variant a module and updating every construction site, which is wider than this change and belongs with the diagnostic contract.

## The package-consumer half needs a decision

#1260 asks for "one selected local-module **and** package-consumer import profile". The second cannot be built as the artifact stands, and I do not want to invent the answer:

**A library artifact carries no executable representation.** `LibraryManifest` carries `exports`, `vocab`, `soft_keywords` and `contract_metadata` — signatures, checked API and the identity graph. That is enough to *typecheck* a call into a dependency and nothing more; there is no Body IR in the manifest, and nothing anywhere loads Body IR from a dependency. The compiled `.rlib` holds machine code for the legacy route, not a representation this executor can interpret.

The obvious shortcut is unsound: having the consumer re-derive the provider's Body IR from its source (available for a `path` dependency) would mint identities from a *second* analysis. Those carry `SymbolOrigin::Module`, while the manifest's carry `SymbolOrigin::Package`, so they cannot be compared — which is the defect class #1042 and #1293 spent this milestone removing, and which this branch's own commit 4 exists to avoid.

That leaves the provider's bake emitting an executable representation alongside the rlib, with its package-origin identities intact, and the consumer loading it by identity. That is a real design step touching the Loaf/artifact contract, so it is yours to call rather than mine. Happy to draft it as an RFC or a scoped follow-up issue once you have a direction.

Refs #1260, #989.