### PR TITLE
bugfix - resolve a trait's declaration name before the Rust-native slot lookup (#1174)

### DIFF
--- a/src/backend/ir/lower/expr/mod.rs
+++ b/src/backend/ir/lower/expr/mod.rs
@@ -42,6 +42,15 @@ use incan_core::lang::types::collections::{self as collection_types, CollectionT
 use incan_core::lang::{stdlib, trait_bounds};
 use incan_semantics_core::SurfaceExprLoweringAction;
 
+/// Return the trait's declaration name from however the call site's module spelled it.
+///
+/// A trait imported directly is spelled `Serialize`; the same declaration reached through its owning module is
+/// spelled `json.Serialize`. Registries keyed on the declaration name must see one string for both.
+fn trait_declaration_name(dispatch: &IrTraitDispatch) -> &str {
+    let name = dispatch.trait_source_name.as_str();
+    name.rsplit('.').next().unwrap_or(name)
+}
+
 /// Whether a call receiver has a statically nameable source-owned method projection.
 ///
 /// Bare generic and trait-object receivers must keep trait dispatch because no inherent owner is statically nameable.
@@ -55,7 +64,7 @@ fn can_use_source_method_projection(receiver: &TypedExpr, dispatch: Option<&IrMe
     let dispatch_uses_rust_native_trait_slot = matches!(
         dispatch,
         Some(IrMethodDispatch::Trait(trait_dispatch))
-            if trait_bounds::incan_to_rust(&trait_dispatch.trait_source_name).is_some()
+            if trait_bounds::incan_to_rust(trait_declaration_name(trait_dispatch)).is_some()
     );
 
     !dispatch_uses_rust_native_trait_slot

--- a/tests/codegen_snapshot_tests.rs
+++ b/tests/codegen_snapshot_tests.rs
@@ -5433,8 +5433,8 @@ def main() -> str:
     let rust_code = generate_rust(source);
     let compact = rust_code.chars().filter(|ch| !ch.is_whitespace()).collect::<String>();
     assert!(
-        compact.contains("self.to_json()"),
-        "expected the recoverable source projection to reuse the method's borrowed self receiver; generated:\n{rust_code}"
+        compact.contains("json::Serialize::to_json(self)"),
+        "expected the Rust-native trait slot to reuse the method's borrowed self receiver; generated:\n{rust_code}"
     );
     assert!(
         !compact.contains("returnSerialize::to_json(&self)") && !compact.contains("returnself.to_json(&self)"),
@@ -5478,8 +5478,8 @@ from crate.models import Item
     let compact = rust_code.chars().filter(|ch| !ch.is_whitespace()).collect::<String>();
 
     assert!(
-        compact.contains("item.to_json()"),
-        "directly imported source traits must retain their recoverable member projection in each generated module:\n{rust_code}"
+        compact.contains("crate::__incan_std::serde::json::Serialize::to_json(&item)"),
+        "the encoder module must reach the trait through its canonical owner:\n{rust_code}"
     );
     assert!(
         !compact.contains("returnjson::Serialize::to_json(&item)"),

--- a/tests/snapshots/codegen_snapshot_tests__std_serde_json_import.snap
+++ b/tests/snapshots/codegen_snapshot_tests__std_serde_json_import.snap
@@ -114,7 +114,7 @@ fn main() {
         }),
     );
     let _ = println!(
-        "{}", (Config { host : "localhost".to_string(), port : 8080, debug : true })
-        .to_json()
+        "{}", crate ::__incan_std::serde::json::Serialize::to_json(& Config { host :
+        "localhost".to_string(), port : 8080, debug : true },)
     );
 }


### PR DESCRIPTION
## Summary

`0.6.0-dev.2` fails `Oven Linux replay` with generated Rust that does not compile:

```
error[E0599]: no method named `__incan_v1_…to_json…` found for struct `Item`
```

One trait, spelled two ways, took two different code paths — and one of them emitted a call to a method no implementation defines. Comparing the declaration each spelling names, rather than the spelling itself, makes them agree.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: a project that reaches a stdlib trait through its owning module — `from std.serde import json` with `@derive(json)` — now compiles. Before this, its generated Rust called a method that was never emitted.

- **Internals**: `can_use_source_method_projection` asks `trait_bounds::incan_to_rust` whether the selected trait keeps a Rust ABI slot, and hands it the trait as *the call site's module spelled it*:

  | Import | `trait_source_name` | `incan_to_rust` | Route taken |
  | --- | --- | --- | --- |
  | `from std.serde.json import Serialize` | `Serialize` | `Some("serde::Serialize")` | keeps the Rust slot ✓ |
  | `from std.serde import json` | `json.Serialize` | `None` | projects an inherent wrapper ✗ |

  `std.serde.json.Serialize` is `@rust.derive("serde::Serialize")` in the stdlib **and** registered in `trait_bounds` as `Serialize -> serde::Serialize`. It is Rust-native by both declarations, so its slot must keep the Rust spelling and no inherent projection should exist for it under *either* spelling. Emission already agrees: for a derived adoption it synthesizes the trait slot alone (`emit/decls/impls.rs`), which is why the projected call named a method no impl defines.

  The fix takes the declaration name from the dispatch before the registry lookup. The registry is keyed on declaration names, so it should never have been asked about a qualified spelling.

- **Risks**: this changes generated Rust for the qualified spelling — from a projected inherent call to the canonical trait call. That is the same form the bare spelling already produced, so the change moves one path onto the other rather than inventing a third. Generated Rust is explicitly not a stable ABI, and the previous form did not compile.

  The reason to look closely is the three snapshot tests below: I updated them, and a reviewer should agree they were pinning a defect rather than a contract.

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

- `cargo test --test codegen_snapshot_tests` — 257 passed
- `cargo test --test stdlib_generated_rust_snapshot_tests` — 13 passed
- `cargo test --lib backend` — 735 passed
- `cargo test --lib frontend::typechecker` — 1067 passed
- `cargo clippy --all-targets --all-features` clean; `scripts/check_changed_rustdocs.py` passes

Manual verification notes:

- **Measured with one variable.** Two real library projects, identical except the import spelling — same `@derive` adoption, same model, same call. Before: the qualified spelling emitted the projected call that fails to compile, the bare spelling emitted the trait call. After: both emit the identical `incan_stdlib_data::__incan_std::serde::json::Serialize::to_json(&item)`. My first attempt at this bug conflated spelling with adoption mechanism, and isolating them is what identified the actual cause.
- The `--lib` build path and the in-process snapshot path disagreed for the same source, because the first gives stdlib symbols `SymbolOrigin::Package` and the second `SymbolOrigin::Module`. That is why 257 snapshots passed while CI failed. After this change they agree.

**On the three updated tests.** All three use `from std.serde import json`, and all three now match what the bare spelling already produced.

- `test_qualified_source_trait_dispatch_does_not_double_borrow_self` asserted `self.to_json()`. Its name states the property — the receiver must not be double-borrowed — and that assertion was satisfied incidentally by a wrapper body rather than the call site. It now asserts `json::Serialize::to_json(self)`: the receiver passed once, not `&self`. Its existing negative assertions are unchanged and still pass.
- `test_direct_json_trait_import_keeps_canonical_owner_across_modules_issue946` asserted `item.to_json()` under the message "must retain their recoverable member projection". For a Rust-native trait there correctly *is* no projection, so both the assertion and its stated reason were wrong. It now asserts the canonical owner the test is named for. Its second assertion — that the encoder does not reach the trait through the source `json` module — is unchanged and still passes.
- `test_std_serde_json_import_codegen` is a stored snapshot; the two changed lines are the same call-site move.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Refs #1174. Together with #1313 this should clear the remaining `Oven Linux replay` failures on `0.6.0-dev.2`.