### PR TITLE
feature - execute a facade chain and prove its bindings name one declaration (#1261)

### DIFF
--- a/src/cli/commands/build.rs
+++ b/src/cli/commands/build.rs
@@ -2543,8 +2543,14 @@ fn replacement_module_profile_error(program: &crate::frontend::ast::Program) -> 
     }
     let mut async_activation_seen = false;
     for declaration in &program.declarations {
-        if matches!(declaration.node, Declaration::Function(_) | Declaration::Docstring(_))
-            || matches!(&declaration.node, Declaration::Model(model) if is_direct_replacement_plain_model(model))
+        // An alias is a binding to a declaration, not a declaration of its own: it introduces a second name for a
+        // symbol that already exists and is admitted, or refused, on its own terms wherever it is declared. Refusing
+        // the binding would refuse a name rather than any behavior, and the target is reached through the same
+        // canonical identity either way -- which is the property #1261 exists to prove.
+        if matches!(
+            declaration.node,
+            Declaration::Function(_) | Declaration::Docstring(_) | Declaration::Alias(_)
+        ) || matches!(&declaration.node, Declaration::Model(model) if is_direct_replacement_plain_model(model))
             || matches!(&declaration.node, Declaration::Enum(enum_decl) if is_direct_replacement_fieldless_enum(enum_decl))
             || matches!(&declaration.node, Declaration::Enum(enum_decl) if is_direct_replacement_value_enum(enum_decl))
         {

--- a/tests/replacement_backend_execution_tests.rs
+++ b/tests/replacement_backend_execution_tests.rs
@@ -1,5 +1,6 @@
 //! End-to-end proof for the bounded #988 Body-IR replacement executor.
 
+use std::collections::BTreeSet;
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
@@ -2908,6 +2909,122 @@ fn replacement_cli_follows_a_typed_numeric_call_into_the_module_that_declares_it
     assert!(
         combined.contains("INCAN-R988-UNSUPPORTED") && combined.contains("aggregate construction"),
         "the callee module's unadmitted operation must be named: {combined}"
+    );
+    Ok(())
+}
+
+/// A facade chain executes, and its direct, re-exported and aliased bindings name one canonical declaration.
+///
+/// This is #1261's facade fixture. `provider` declares `compute`; `facade` re-exports it and aliases it as `renamed`;
+/// the entrypoint reaches it all three ways in a single expression. The arithmetic is chosen so the total only
+/// balances when every binding actually reaches `compute` -- 2 + 11 + 29 -- rather than asserting three separate
+/// calls that could each be satisfied differently.
+///
+/// Execution alone would not show that the three bindings are the *same* declaration, so identity is asserted
+/// separately through `incan inspect codegraph`. That is a public projection: it reports declaration ids and call
+/// targets without exposing compiler-session state, Body IR, or generated Rust names, which is the boundary #1261
+/// requires its metadata evidence to respect.
+#[test]
+fn replacement_cli_executes_a_facade_chain_whose_bindings_share_one_declaration()
+-> Result<(), Box<dyn std::error::Error>> {
+    let temporary = tempfile::tempdir()?;
+    let source_dir = temporary.path().join("src");
+    fs::create_dir_all(&source_dir)?;
+    fs::write(
+        temporary.path().join("incan.toml"),
+        "[project]\nname = \"facade_chain\"\nversion = \"0.1.0\"\n",
+    )?;
+    fs::write(
+        source_dir.join("provider.incn"),
+        "pub def compute(value: int) -> int:\n  return value + 1\n",
+    )?;
+    fs::write(
+        source_dir.join("facade.incn"),
+        "pub from provider import compute\n\npub renamed = alias compute\n",
+    )?;
+    let entrypoint = source_dir.join("main.incn");
+    fs::write(
+        &entrypoint,
+        "from provider import compute\nfrom facade import compute as reexported, renamed\n\ndef main() -> int:\n  return compute(1) + reexported(10) + renamed(28)\n",
+    )?;
+
+    let report_path = temporary.path().join("facade-report.json");
+    let output = Command::new(incan_binary())
+        .args([
+            "build",
+            entrypoint.to_string_lossy().as_ref(),
+            "--backend",
+            "replacement",
+            "--backend-fallback",
+            "refuse",
+        ])
+        .args([
+            "--report",
+            "json",
+            "--report-output",
+            report_path.to_string_lossy().as_ref(),
+        ])
+        .output()?;
+    assert!(
+        output.status.success(),
+        "the facade chain must execute through the replacement route. stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: serde_json::Value = serde_json::from_slice(&fs::read(&report_path)?)?;
+    assert_eq!(
+        report["replacement_execution"]["result"], "42",
+        "the total only balances when the direct, re-exported and aliased bindings all reach `compute`"
+    );
+    let receipt: serde_json::Value = serde_json::from_str(&fs::read_to_string(
+        temporary.path().join(".incan/backend/receipt.json"),
+    )?)?;
+    assert_eq!(receipt["executed_backend"], "replacement");
+    assert_eq!(receipt["fallback_outcome"], serde_json::json!("not_needed"));
+
+    // The same chain, inspected: every call must name the one declaration in `provider`.
+    let codegraph = Command::new(incan_binary())
+        .args(["inspect", "codegraph", "src", "--format", "jsonl"])
+        .current_dir(temporary.path())
+        .env("CARGO_NET_OFFLINE", "true")
+        .env("INCAN_NO_BANNER", "1")
+        .output()?;
+    assert!(
+        codegraph.status.success(),
+        "codegraph inspection must succeed. stderr:\n{}",
+        String::from_utf8_lossy(&codegraph.stderr)
+    );
+    let mut call_targets: Vec<(String, String)> = Vec::new();
+    for line in String::from_utf8_lossy(&codegraph.stdout).lines() {
+        let record: serde_json::Value = match serde_json::from_str(line) {
+            Ok(record) => record,
+            Err(_) => continue,
+        };
+        if record["record"] != serde_json::json!("call") {
+            continue;
+        }
+        let (Some(callee), Some(target)) = (record["callee"].as_str(), record["target_id"].as_str()) else {
+            continue;
+        };
+        call_targets.push((callee.to_string(), target.to_string()));
+    }
+    call_targets.sort();
+    let observed: Vec<&str> = call_targets.iter().map(|(callee, _)| callee.as_str()).collect();
+    assert_eq!(
+        observed,
+        ["compute", "reexported", "renamed"],
+        "the fixture must record one call through each binding, got {call_targets:?}"
+    );
+    let distinct: BTreeSet<&str> = call_targets.iter().map(|(_, target)| target.as_str()).collect();
+    assert_eq!(
+        distinct.len(),
+        1,
+        "a direct import, a re-export and an alias must name one declaration, got {distinct:?}"
+    );
+    let target = distinct.iter().next().ok_or("expected one resolved declaration")?;
+    assert!(
+        target.contains("provider.incn") && target.ends_with(":compute"),
+        "the shared declaration must be `compute` in the provider module, got {target}"
     );
     Ok(())
 }


### PR DESCRIPTION
## Summary

#989 needs proof that a direct import, an alias, and a re-export resolve to **one** canonical declaration and execute as one. #1260 made a call that leaves the entry module executable; this admits the remaining binding form and adds the evidence.

Stacked on #1318 — review that first; this PR's own diff is one profile line and one test.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: `incan build --backend replacement` now accepts a module that aliases a binding, so a facade module — the common `pub from … import …` plus `pub x = alias y` shape — executes.

- **Internals**: an alias declaration was refused by the source-only profile as a `non-function top-level declaration`. That treats a *binding* as if it were a *declaration*. An alias introduces a second name for a symbol that already exists, and that symbol is admitted or refused on its own terms wherever it is declared — which #1260's graph-wide profile check now covers. Refusing the binding refused a name rather than any behavior. The issue says the same thing in its rejected alternatives: *"these are bindings to a canonical source symbol, not new declarations."*

- **Risks**: the profile now admits a declaration form it previously refused, so the question is whether an alias can smuggle in something unadmitted. It cannot: an alias can only bind a symbol already in the module graph, every module in that graph is profile-checked (#1260), and an alias whose target is refused never resolves. The refusal moves to the target, which is where it belongs.

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

- `cargo test --test replacement_backend_execution_tests` — 114 passed, in 8s
- `cargo clippy --all-targets --all-features` clean; `scripts/check_changed_rustdocs.py` passes

Manual verification notes:

- The fixture is a three-module chain. `provider` declares `compute`; `facade` re-exports it **and** aliases it as `renamed`; the entrypoint reaches it all three ways in a single expression:

  ```incan
  from provider import compute
  from facade import compute as reexported, renamed

  def main() -> int:
    return compute(1) + reexported(10) + renamed(28)
  ```

  The arithmetic is deliberate: `2 + 11 + 29` only totals 42 when every binding actually reaches `compute`. Three separate assertions could each have been satisfied differently.

- **Execution alone does not prove the three bindings are the same declaration**, so identity is asserted separately through `incan inspect codegraph`, which reports all three calls resolving to one target:

  ```
  compute     -> decl:…/src/provider.incn:0:compute
  reexported  -> decl:…/src/provider.incn:0:compute
  renamed     -> decl:…/src/provider.incn:0:compute
  ```

  That projection is public — declaration ids and call targets, with no compiler-session state, Body IR, or generated Rust names — which is the boundary #1261 requires its metadata evidence to respect.

- The test asserts the *set* of distinct targets has size one, rather than comparing against a hardcoded id, so it keeps proving the property if paths or spans change.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

## What this deliberately does not close

#1261 also asks for the chain to execute on **both** the replacement and a reference route, and for the checked public **package/caller** contract to be projected. Neither is delivered here, for reasons that are structural rather than effort:

- **Two-route parity** lives in the #987 corpus, whose `ParityCase` carries a single `source: &str` and executes one named function in it. A three-module facade chain does not fit that shape, and extending the corpus to multi-module cases is a design step of its own.
- **The package/caller contract** hits exactly the blocker recorded on #1318: a library artifact carries signatures, checked API and the identity graph, but no executable representation, so a facade that crosses a *package* boundary cannot execute on the replacement route at all yet.

So this delivers the local-module half of #1261, the same way #1318 delivers the local-module half of #1260. Both remaining halves wait on the same artifact-contract decision.

Refs #1261, #989.