### PR TITLE
bugfix - report a refusal against the module its span was measured in (#1260)

### DIFF
--- a/src/backend/replacement/execution_preflight.rs
+++ b/src/backend/replacement/execution_preflight.rs
@@ -32,14 +32,22 @@ pub(super) fn validate(
         module,
         reachable,
         providers,
-        pending: vec![entry],
+        pending: vec![(module, entry)],
         visited: BTreeSet::new(),
     };
-    while let Some(body) = preflight.pending.pop() {
+    while let Some((owner, body)) = preflight.pending.pop() {
         if preflight.visited.insert(&body.direct_call_id) {
-            validate_direct_body_profile(body)?;
-            preflight.parameters(&body.params)?;
-            preflight.statements(&body.block.stmts)?;
+            // A refusal raised here carries a span measured in `owner`, which is not always the entrypoint's module
+            // once a call can leave it. Recording the module keeps the reported location and the reported span
+            // describing the same file.
+            let owner_id = owner.module_id.path();
+            validate_direct_body_profile(body).map_err(|error| error.measured_in_module(owner_id))?;
+            preflight
+                .parameters(&body.params)
+                .map_err(|error| error.measured_in_module(owner_id))?;
+            preflight
+                .statements(&body.block.stmts)
+                .map_err(|error| error.measured_in_module(owner_id))?;
         }
     }
     Ok(())
@@ -55,7 +63,7 @@ struct ExecutionPreflight<'module, 'runtime> {
     /// would surface part-way through execution instead.
     reachable: &'module [BodyIrModule],
     providers: Option<&'runtime ProviderRuntime>,
-    pending: Vec<&'module Body>,
+    pending: Vec<(&'module BodyIrModule, &'module Body)>,
     visited: BTreeSet<&'module CompilerNodeId>,
 }
 
@@ -74,9 +82,9 @@ impl<'module> ExecutionPreflight<'module, '_> {
         &self,
         target: &NamedCallableTarget,
         span: HirSourceSpan,
-    ) -> Result<&'module Body, ReplacementExecutionError> {
+    ) -> Result<(&'module BodyIrModule, &'module Body), ReplacementExecutionError> {
         if target.direct_call_id.is_some() {
-            return named_callable_body(self.module, target, span);
+            return named_callable_body(self.module, target, span).map(|body| (self.module, body));
         }
         let canonical = target.canonical.as_ref().ok_or_else(|| {
             unsupported(
@@ -90,8 +98,8 @@ impl<'module> ExecutionPreflight<'module, '_> {
         let mut resolved = self
             .reachable
             .iter()
-            .filter_map(|module| module.body_for_canonical_target(canonical));
-        let body = resolved.next().ok_or_else(|| {
+            .filter_map(|module| module.body_for_canonical_target(canonical).map(|body| (module, body)));
+        let resolved_body = resolved.next().ok_or_else(|| {
             unsupported(
                 format!(
                     "named callable `{}` resolves to a declaration outside this execution graph",
@@ -109,7 +117,7 @@ impl<'module> ExecutionPreflight<'module, '_> {
                 span,
             ));
         }
-        Ok(body)
+        Ok(resolved_body)
     }
 
     /// Inspect retained source defaults without evaluating them or substituting partial presets.

--- a/src/backend/replacement/mod.rs
+++ b/src/backend/replacement/mod.rs
@@ -4119,7 +4119,9 @@ impl<'run, 'writer> BodyExecutor<'run, 'writer> {
             BodyExecutor::with_locals(module, Rc::clone(&self.reachable), locals, local_types, steps, self.io);
         child.next_task_id = self.next_task_id;
         child.providers = self.providers.clone();
-        let result = execute(&mut child);
+        // A frame running in another module raises refusals measured in that module's source, so record it here
+        // rather than letting the failure inherit the entrypoint's file on its way out.
+        let result = execute(&mut child).map_err(|error| error.measured_in_module(module.module_id.path()));
         let BodyExecutor {
             ownership_reads,
             runtime_requirements,

--- a/src/backend/replacement/mod.rs
+++ b/src/backend/replacement/mod.rs
@@ -1189,6 +1189,12 @@ pub enum ReplacementExecutionError {
         span_start: usize,
         /// End byte offset duplicated for typed error formatting.
         span_end: usize,
+        /// Module identity the span was measured in, when it is not the executed entrypoint's.
+        ///
+        /// A span is a byte range and means nothing without the file it was measured in. While only the entrypoint
+        /// could raise a refusal this was implicit; once a call can leave that module, a refusal raised in another
+        /// one has to say so or the diagnostic points at the wrong file.
+        module_id: Option<String>,
     },
     /// A selected operation reached a source-observable runtime failure.
     #[error("replacement backend runtime failure at original Incan source span {span_start}..{span_end}: {detail}")]
@@ -1264,6 +1270,38 @@ pub enum ReplacementExecutionError {
 }
 
 impl ReplacementExecutionError {
+    /// Record the module a refusal's span was measured in, when it is not the executed entrypoint's.
+    ///
+    /// Applied where a walk crosses into another module, so every refusal raised beyond that point carries its own
+    /// source rather than inheriting the entrypoint's. An error that already names a module keeps it: the innermost
+    /// module that refused is the one that owns the span.
+    pub(crate) fn measured_in_module(self, module: &str) -> Self {
+        match self {
+            Self::Unsupported {
+                description,
+                span,
+                span_start,
+                span_end,
+                module_id,
+            } => Self::Unsupported {
+                description,
+                span,
+                span_start,
+                span_end,
+                module_id: module_id.or_else(|| Some(module.to_string())),
+            },
+            other => other,
+        }
+    }
+
+    /// Return the module identity a refusal's span was measured in, when it is not the entrypoint's.
+    pub(crate) fn measured_module(&self) -> Option<&str> {
+        match self {
+            Self::Unsupported { module_id, .. } => module_id.as_deref(),
+            _ => None,
+        }
+    }
+
     /// Construct a typed, source-span-preserving refusal for an unsupported source-profile boundary.
     #[must_use]
     pub fn unsupported_profile(description: impl Into<String>, span: HirSourceSpan) -> Self {
@@ -1830,7 +1868,7 @@ fn validate_typed_numeric_body_profile(
     if !visited.insert(body.direct_call_id.clone()) {
         return Ok(());
     }
-    validate_typed_numeric_types(body)?;
+    validate_typed_numeric_types(body).map_err(|error| error.measured_in_module(module.module_id.path()))?;
     for parameter in &body.params {
         if let CallableParamDefault::Source(computation) = &parameter.default {
             validate_typed_numeric_statements(graph, module, body, &computation.stmts, visited)?;
@@ -1838,6 +1876,7 @@ fn validate_typed_numeric_body_profile(
         }
     }
     validate_typed_numeric_statements(graph, module, body, &body.block.stmts, visited)
+        .map_err(|error| error.measured_in_module(module.module_id.path()))
 }
 
 /// Validate a statement sequence for typed-numeric carrier movement and explicit operation refusals.
@@ -7325,6 +7364,7 @@ fn unsupported(description: impl Into<String>, span: HirSourceSpan) -> Replaceme
         span,
         span_start: span.start,
         span_end: span.end,
+        module_id: None,
     }
 }
 

--- a/src/cli/commands/build.rs
+++ b/src/cli/commands/build.rs
@@ -2514,6 +2514,24 @@ fn replacement_profile_cli_error(error: ReplacementExecutionError, entrypoint: &
     }
 }
 
+/// Return the file a refusal's span was measured in, falling back to the executed entrypoint.
+///
+/// A refusal raised while walking a module the entrypoint merely reaches carries that module's identity. Resolving it
+/// back to a file keeps the reported location and the reported span describing the same source.
+fn replacement_refusal_source<'a>(
+    error: &ReplacementExecutionError,
+    entrypoint: &'a Path,
+    reachable: &'a [ReplacementModuleInputs],
+) -> &'a Path {
+    let Some(module_id) = error.measured_module() else {
+        return entrypoint;
+    };
+    reachable
+        .iter()
+        .find(|module| incan_semantics_core::module_identity_for_path(&module.module_path) == module_id)
+        .map_or(entrypoint, |module| module.file_path.as_path())
+}
+
 /// Whether one import names another module of the project currently being built.
 ///
 /// #1260 executes a call that leaves the entry module, so an import naming a sibling of that module is now inside the
@@ -2646,6 +2664,8 @@ struct ReplacementModuleInputs {
     program: crate::frontend::ast::Program,
     module_path: Vec<String>,
     type_info: typechecker::TypeCheckInfo,
+    /// The file this module was collected from, so a refusal raised in it can name its own source.
+    file_path: PathBuf,
 }
 
 /// Collect and analyze the replacement entrypoint once through the project-selected compilation session.
@@ -2697,6 +2717,7 @@ fn replacement_session_inputs(
                     program: module.ast.clone(),
                     module_path: module.path_segments.clone(),
                     type_info: checked.type_info().clone(),
+                    file_path: module.file_path.clone(),
                 })
         })
         .collect();
@@ -2761,25 +2782,32 @@ fn build_replacement_file_report(
     // Every module the call can reach has to satisfy the profile, not only the entrypoint. Allowing a local import
     // means an unsupported declaration is now reachable from a file the entry never names, and refusing it here keeps
     // the boundary a property of the executed graph rather than of whichever file happened to be the entrypoint.
-    let profile_error = replacement_module_profile_error(&session_inputs.program).or_else(|| {
-        session_inputs
-            .reachable_modules
-            .iter()
-            // The one analysis also checks the standard-library modules the graph pulled in, which arrive under the
-            // generated `__incan_std` namespace rather than the source `std` spelling. Those are not project source
-            // and were never meant to satisfy a source-only profile -- `import std.async` legitimately reaches stdlib
-            // modules full of classes and imports. Only the project's own modules are executed here, so only they are
-            // held to the profile.
-            .filter(|module| {
-                !matches!(
-                    module.module_path.first().map(String::as_str),
-                    Some(incan_core::lang::stdlib::STDLIB_ROOT | incan_core::lang::stdlib::INCAN_STD_NAMESPACE)
-                )
-            })
-            .find_map(|module| replacement_module_profile_error(&module.program))
-    });
-    if let Some(error) = profile_error {
-        return refuse_replacement_profile(&selection, error, &entrypoint);
+    // A refusal carries a span, and a span only means something beside the file it was measured in. Reporting every
+    // refusal against the entrypoint was harmless while only the entrypoint could raise one; now that a reachable
+    // module can, the pair has to travel together or the diagnostic points at the wrong file.
+    let profile_error = replacement_module_profile_error(&session_inputs.program)
+        .map(|error| (error, entrypoint.clone()))
+        .or_else(|| {
+            session_inputs
+                .reachable_modules
+                .iter()
+                // The one analysis also checks the standard-library modules the graph pulled in, which arrive under the
+                // generated `__incan_std` namespace rather than the source `std` spelling. Those are not project source
+                // and were never meant to satisfy a source-only profile -- `import std.async` legitimately reaches
+                // stdlib modules full of classes and imports. Only the project's own modules are
+                // executed here, so only they are held to the profile.
+                .filter(|module| {
+                    !matches!(
+                        module.module_path.first().map(String::as_str),
+                        Some(incan_core::lang::stdlib::STDLIB_ROOT | incan_core::lang::stdlib::INCAN_STD_NAMESPACE)
+                    )
+                })
+                .find_map(|module| {
+                    replacement_module_profile_error(&module.program).map(|error| (error, module.file_path.clone()))
+                })
+        });
+    if let Some((error, source_path)) = profile_error {
+        return refuse_replacement_profile(&selection, error, &source_path);
     }
     let body_ir = build_body_ir_module_v0(
         &session_inputs.program,
@@ -2800,11 +2828,17 @@ fn build_replacement_file_report(
     };
     let execution_plan = match prepare_free_function_execution_in_graph(execution_graph, "main", &[], None) {
         Ok(plan) => plan,
-        Err(error) => return refuse_replacement_profile(&selection, error, &entrypoint),
+        Err(error) => {
+            let source =
+                replacement_refusal_source(&error, &entrypoint, &session_inputs.reachable_modules).to_path_buf();
+            return refuse_replacement_profile(&selection, error, &source);
+        }
     };
     let executed = resolve_available_replacement_execution(&selection)?;
-    let execution = execute_prevalidated_free_function(execution_plan)
-        .map_err(|error| replacement_profile_cli_error(error, &entrypoint))?;
+    let execution = execute_prevalidated_free_function(execution_plan).map_err(|error| {
+        let source = replacement_refusal_source(&error, &entrypoint, &session_inputs.reachable_modules);
+        replacement_profile_cli_error(error, source)
+    })?;
     let result_type = execution.value.scalar_type_name().ok_or_else(|| {
         CliError::failure("replacement execution produced a non-scalar value after scalar-result validation")
     })?;

--- a/tests/replacement_backend_execution_tests.rs
+++ b/tests/replacement_backend_execution_tests.rs
@@ -2910,6 +2910,10 @@ fn replacement_cli_follows_a_typed_numeric_call_into_the_module_that_declares_it
         combined.contains("INCAN-R988-UNSUPPORTED") && combined.contains("aggregate construction"),
         "the callee module's unadmitted operation must be named: {combined}"
     );
+    assert!(
+        combined.contains("helper.incn:") && !combined.contains("main.incn:"),
+        "a refusal measured in the callee's module must report that module's source: {combined}"
+    );
     Ok(())
 }
 
@@ -3069,6 +3073,12 @@ fn replacement_cli_refuses_an_unsupported_declaration_in_a_sibling_module() -> R
     assert!(
         combined.contains("INCAN-R988-UNSUPPORTED") && combined.contains("non-function top-level declaration"),
         "missing typed refusal for the sibling module's declaration: {combined}"
+    );
+    // The span was measured in `helper.incn`, so the reported location has to be `helper.incn`. Reporting the
+    // entrypoint alongside another file's offsets points a reader at unrelated source.
+    assert!(
+        combined.contains("helper.incn:") && !combined.contains("main.incn:"),
+        "a refusal raised in a sibling module must report that module's source: {combined}"
     );
     assert!(
         !temporary.path().join(".incan/backend/receipt.json").exists(),


### PR DESCRIPTION
## Summary

A span is a byte range and means nothing without the file it was measured in. Every replacement refusal was reported against the executed entrypoint — harmless while only the entrypoint could raise one. #1318 lets a call leave that module, so a refusal raised in a module the entrypoint merely *reaches* printed the entrypoint's path beside another file's offsets.

This is the item I flagged rather than fixed on #1318. It is my own change that made it reachable, so it belongs with that work rather than in someone else's backlog.

Third in the stack: #1318 → #1320 → this. Review those first.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: a refusal now names the file that contains the construct it refused. Before:

  ```
  … typed numeric `u8` aggregate construction … at original Incan source span 53..60
  primary Incan source location: …/src/main.incn:53..60      ← the aggregate is in helper.incn
  ```

  Offsets from one file printed against another are worse than no location: `53..60` in `main.incn` is unrelated source, and for a short entrypoint the range may not exist at all.

- **Internals**: two paths can raise a cross-module refusal, and they are fixed differently because they know different things.

  The **profile check** already knew which module it was checking and discarded it. It now carries that module's file alongside the error, so the reporting call receives the right source directly.

  The **typed-numeric walk** is deeper — the error surfaces through the executor, far from any file. `ReplacementExecutionError::Unsupported` gained an optional module identity that the walk stamps as it enters each module, and the CLI resolves it back to a file through the reachable-module set it already holds. The innermost module wins: an error that already names one keeps it, because that is the module that actually refused.

- **Risks**: adding a field to a public error variant. It is contained — the variant has two direct constructions and one `unsupported()` helper behind 279 call sites, so those call sites are untouched, and existing destructuring in the test suites already uses `..`. The field is `Option`, and `None` preserves exactly the previous behavior, so any construction path I did not tag degrades to the old reporting rather than to something wrong.

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

- `cargo test --test replacement_backend_execution_tests` — 114 passed
- `cargo test --lib backend::replacement` — 45 passed
- `cargo clippy --all-targets --all-features` clean; `scripts/check_changed_rustdocs.py` passes

Manual verification notes:

- Three fixtures, covering both directions:

  | Case | Construct lives in | Reported |
  | --- | --- | --- |
  | profile refusal, sibling module | `helper.incn` | `helper.incn:0..32` ✓ |
  | typed-numeric refusal, callee module | `helper.incn` | `helper.incn:53..60` ✓ |
  | refusal in the entrypoint itself | `main.incn` | `main.incn:0..28` ✓ (unchanged) |

- Rather than adding new tests, the two cross-module refusal tests introduced on #1318 now also assert the reported file — and assert the entrypoint is *not* named. Binding the assertion to the tests that already exercise those paths means the diagnostic cannot drift back without failing the test that proved the behavior in the first place.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Refs #1260.