### PR TITLE
bugfix - restore the prewarm dependency the generated-reference guard consumes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,7 +325,7 @@ jobs:
     needs:
       - changes
       - linux-tool-handoff
-    if: ${{ needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.heavy == 'true' }}
+    if: ${{ needs.changes.outputs.docs_only != 'true' && (needs.changes.outputs.heavy == 'true' || needs.changes.outputs.reference == 'true') }}
     outputs:
       oven_suite_cache_key: ${{ steps.oven-suite-cache-key.outputs.key }}
     steps:
@@ -797,12 +797,13 @@ jobs:
   generated-reference:
     name: Generated Reference Up-to-date
     runs-on: ubuntu-latest
-    # Depends only on the job whose artifact it downloads. It previously also waited on the Oven replay, prewarm and
-    # platform jobs, which it never consumed; keeping those would have made this stale-artifact guard skip itself
-    # whenever the expensive suite is gated off, which is exactly when generated output is most likely to drift.
+    # Depends on the two jobs whose artifacts it downloads: `test-linux-tools` from the handoff, and
+    # `test-linux-sdk-provider-store` from the prewarm, which it seeds from whenever its provider cache misses. It no
+    # longer waits on the Oven replay or the platform matrix, which it never consumed.
     needs:
       - changes
       - linux-tool-handoff
+      - linux-oven-prewarm
     if: ${{ needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.reference == 'true' }}
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## Summary

`Generated Reference Up-to-date` fails on a full run at **"Seed checked feature inventory providers"**:

```
Unable to download artifact test-linux-sdk-provider-store
```

I introduced this in #1315, and it disables the stale-generated-artifact guard — the one job that change went out of its way to keep alive.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [x] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **What I got wrong**: #1315 trimmed `generated-reference`'s `needs` on the reasoning that it downloads only `test-linux-tools` from `linux-tool-handoff`. It downloads that — **and** `test-linux-sdk-provider-store` from `linux-oven-prewarm`, whenever its provider cache misses. I read the first `download-artifact` step and did not look for a second one in the same job.

  Without the dependency edge the job starts immediately, races the prewarm, and fails on any cache miss. The cache key includes the compiler hash, `Cargo.lock` and the stdlib tree revision, so a miss is the normal case on an active branch — this was going to fail almost every time it ran.

- **The fix**: the guard genuinely needs the prewarm, so if the guard runs the prewarm must too. The `needs` edge is restored, and `linux-oven-prewarm` now runs on `heavy` **or** `reference` rather than `heavy` alone.

  Because `reference` is `heavy || <path match>`, `heavy` implies `reference`, so the gates stay mutually satisfiable:

  | Job | Gate | Needs |
  | --- | --- | --- |
  | `linux-tool-handoff` | `reference` | `changes` |
  | `linux-oven-prewarm` | `heavy \|\| reference` | `changes`, `linux-tool-handoff` |
  | `generated-reference` | `reference` | `changes`, `linux-tool-handoff`, `linux-oven-prewarm` |
  | `oven-linux-replay` | `heavy` | `changes`, `linux-oven-prewarm` |

  Every job's gate implies each of its dependencies' gates, in both directions.

- **Risks**: the cost is real and deliberate. A pull request touching `crates/incan_core/**` or the committed reference pages now pays the prewarm, which is the expensive job. That is the price of the guard being able to run at all, and it is exactly the case where generated output can drift. Ordinary work — backend, CLI, tests — is unaffected and still skips both.

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- The failure was traced to a specific step rather than inferred: `gh run view --json jobs` reports the failing step as `Seed checked feature inventory providers`, which is an `actions/download-artifact` of `test-linux-sdk-provider-store`.
- Located the producer mechanically rather than by reading: both occurrences of that artifact name were mapped back to their owning job, giving `linux-oven-prewarm` (upload, line 394) and `generated-reference` (download, line 851).
- The workflow parses (`yaml.safe_load`, 19 jobs), and the dependency/gate table above was derived from the parsed graph rather than written by hand, so it reflects the file rather than my intent.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Follow-up to #1315.