### PR TITLE
bugfix - do not project an inherent method a package declares (#1174)

### DIFF
--- a/src/backend/ir/lower/expr/mod.rs
+++ b/src/backend/ir/lower/expr/mod.rs
@@ -90,7 +90,9 @@ impl AstLowering {
         receiver: &TypedExpr,
         dispatch: Option<IrMethodDispatch>,
     ) -> (String, Option<IrMethodDispatch>) {
-        if !can_use_source_method_projection(receiver, dispatch.as_ref()) {
+        if !can_use_source_method_projection(receiver, dispatch.as_ref())
+            || self.method_belongs_to_an_imported_type(call_span, dispatch.as_ref())
+        {
             return (source_method.to_string(), dispatch);
         }
         let rebase_source_stdlib = !matches!(dispatch, Some(IrMethodDispatch::Trait(_)));
@@ -105,6 +107,27 @@ impl AstLowering {
             other => other,
         };
         (projection, dispatch)
+    }
+
+    /// Whether this call reaches an inherent method declared by a package rather than by this compilation.
+    ///
+    /// A recoverable projection is a wrapper emitted beside a declaration, and only the compilation that declares the
+    /// type emits one. A package's inherent method therefore has no wrapper this compilation can name -- and when the
+    /// package's type is itself a newtype over a Rust type, as `std.async.sync.MutexGuard` is over
+    /// `incan_stdlib`'s `MutexGuard`, no wrapper exists at all, because Rust forbids an inherent `impl` on a foreign
+    /// type. Those methods are facades over the Rust ones and the call has to reach the Rust slot.
+    ///
+    /// Trait dispatch is deliberately excluded rather than caught here. A local type adopting a package's trait
+    /// carries that trait's package identity while its wrapper is emitted locally, so the trait cases are decided by
+    /// `can_use_source_method_projection` on the trait's own terms.
+    fn method_belongs_to_an_imported_type(&self, call_span: ast::Span, dispatch: Option<&IrMethodDispatch>) -> bool {
+        if dispatch.is_some() {
+            return false;
+        }
+        self.type_info
+            .as_ref()
+            .and_then(|info| info.resolved_identity(call_span))
+            .is_some_and(|identity| matches!(identity.origin, incan_semantics_core::SymbolOrigin::Package { .. }))
     }
 
     /// Convert a contained checked-C value contract into its private generated-Rust carrier.


### PR DESCRIPTION
## Summary

The last `Oven Linux replay` failure on `0.6.0-dev.2`, confirmed by a full `workflow_dispatch` run after #1313 and #1319 cleared the other two:

```
error[E0599]: no method named `__incan_v1_…incan_stdlib_async…async.sync…get…`
              found for struct `RawMutexGuard<T>`
```

A consumer projected an inherent method that a package declares. The wrapper that name refers to is emitted beside the declaration, by the compilation that owns it — and in this case cannot exist at all.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: a program calling a method on a stdlib type backed by Rust — `Mutex`, `MutexGuard`, `RwLock` and friends — now compiles. Before this, the generated Rust called a method nothing defines.

- **Why the wrapper cannot exist.** `std.async.sync` declares

  ```incan
  from rust::incan_stdlib::async::sync import RawMutexGuard, mutex_guard_get as rust_mutex_guard_get

  pub type MutexGuard[T with Clone] = newtype RawMutexGuard[T]:
      def get(self) -> T:
          return rust_mutex_guard_get(self.0)
  ```

  and the Rust side already provides it:

  ```rust
  impl<T> MutexGuard<T> { pub fn get(&self) -> T; pub fn set(&self, value: T); }
  ```

  So the Incan `get` is a facade over the Rust one. The newtype is transparent to the foreign struct in generated Rust, and Rust forbids an inherent `impl` on a foreign type — no compilation can emit that wrapper.

- **The rule**: a recoverable projection is a wrapper emitted beside a declaration, and only the compilation that declares the type emits one. A consumer projecting a package's inherent method names a wrapper it never emitted and cannot see.

  **Trait dispatch is deliberately excluded rather than folded in.** A local type adopting a package's trait carries that trait's *package* identity while its wrapper is emitted *locally* — so origin alone would be wrong for traits. Those cases stay with `can_use_source_method_projection`, which #1319 corrected on their own terms. What reaches this new check is what remains: an inherent method, no trait, declared elsewhere.

- **Risks**: this narrows projection for package-declared inherent methods, so the risk is losing a recoverable symbol somewhere it was legitimately emitted. The trait carve-out above is the case that would have been wrong, and it is excluded explicitly. Nothing else in the tree changes: the full snapshot surface is unmoved.

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

- `cargo test --test codegen_snapshot_tests` — 257 passed, **no snapshot moved**
- `cargo test --test stdlib_generated_rust_snapshot_tests` — 13 passed
- `cargo test --test emitted_symbol_projection_tests` — 4 passed
- `cargo test --lib backend` — 735 passed; `cargo test --lib frontend` — 1437 passed
- `cargo clippy --all-targets --all-features` clean; `scripts/check_changed_rustdocs.py` passes

Manual verification notes, through **real Oven bakes** rather than generated text alone:

- An async program using `Mutex`, `guard.get()` and `guard.set()` prints `counter=42`. Before the change its generated Rust did not compile.
- Both `@derive(json)` examples still serialize correctly (`Serialized: {"status":200,…}`), so #1319's case is unaffected by the additional gate.

## Why the rule is phrased this way

Three other routes to the same fact were tried and do not reach the consumer, which is worth recording because each looks plausible:

- The declaring package **does** know its newtype is Rust-backed and records it in the checked API as `underlying: {"RustPath": …}` — but the consumer never receives it.
- `TypeInfo.declarations.newtype_construction` holds only *local* newtypes; it is empty for `MutexGuard` in a consumer.
- Imported stdlib types do not arrive as `Newtype` symbols at all, so a symbol-table walk finds nothing to key on either.

The canonical identity's origin is the one fact that survives the package boundary, which is why the check is written against it.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Refs #1174. With #1313 and #1319 this should close the `Oven Linux replay` failures on `0.6.0-dev.2`; I will confirm with a full run rather than a light green.