### PR TITLE
chore - move Cargo's own JSON shapes out of the legacy publisher (#1299)

### DIFF
--- a/src/oven/legacy_cargo.rs
+++ b/src/oven/legacy_cargo.rs
@@ -5,6 +5,12 @@
 //! publishes receipt-bound compiler-suite plans into the bounded Oven store, then removes every private Cargo target
 //! before returning. Normal Oven build, run, and test code neither calls this module nor receives a Cargo target path.
 
+mod cargo_json;
+
+// Cargo's own JSON shapes live beside this file rather than inside it. They are deserialization targets with no
+// publisher behavior, and every path stays where callers expect it through this re-export, so this is a move.
+use cargo_json::*;
+
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs::{self, File, OpenOptions};
 use std::io;
@@ -2787,138 +2793,6 @@ fn collect_materialized_directory_files(
     Ok(())
 }
 
-/// Minimal Cargo JSON message shape used to map publisher-built dependency artifacts back to unit-graph edges.
-#[derive(Clone, Deserialize)]
-struct CargoCompilerArtifact {
-    reason: String,
-    package_id: String,
-    target: CargoCompilerArtifactTarget,
-    #[serde(default)]
-    features: Vec<String>,
-    #[serde(default)]
-    filenames: Vec<PathBuf>,
-    #[serde(default)]
-    profile: CargoCompilerArtifactProfile,
-}
-
-#[derive(Clone, Default, Deserialize)]
-struct CargoCompilerArtifactProfile {
-    #[serde(default)]
-    test: bool,
-}
-
-/// Target identity emitted by Cargo's stable JSON message stream.
-#[derive(Clone, Deserialize)]
-struct CargoCompilerArtifactTarget {
-    name: String,
-    #[serde(default)]
-    src_path: PathBuf,
-}
-
-/// Cargo's unstable-but-structured unit graph, read only at the named publisher boundary.
-///
-/// The graph is not retained as an execution dependency. Oven converts its workspace test roots, resolved features,
-/// and direct dependency edges into a receipt-bound target plan before the transient Cargo target is reclaimed.
-#[derive(Deserialize)]
-struct CargoUnitGraph {
-    version: u32,
-    units: Vec<CargoUnitGraphUnit>,
-    roots: Vec<usize>,
-}
-
-#[derive(Clone, Deserialize)]
-struct CargoUnitGraphUnit {
-    pkg_id: String,
-    target: CargoUnitGraphTarget,
-    mode: String,
-    #[serde(default)]
-    platform: Option<String>,
-    #[serde(default)]
-    features: Vec<String>,
-    #[serde(default)]
-    dependencies: Vec<CargoUnitGraphDependency>,
-}
-
-#[derive(Clone, Deserialize)]
-struct CargoUnitGraphTarget {
-    kind: Vec<String>,
-    #[serde(default)]
-    crate_types: Vec<String>,
-    name: String,
-    src_path: PathBuf,
-    edition: String,
-}
-
-#[derive(Clone, Deserialize)]
-struct CargoUnitGraphDependency {
-    index: usize,
-    extern_crate_name: Option<String>,
-}
-
-/// Minimal publisher-only Cargo metadata needed to name a sealed third-party foundation manifest.
-///
-/// The unit graph is authoritative for the resolved feature set and dependency edges; Cargo metadata supplies the
-/// stable package name/version for a synthetic legacy publisher manifest. Neither record reaches an Oven consumer.
-#[derive(Clone, Deserialize)]
-struct CargoMetadata {
-    packages: Vec<CargoMetadataPackage>,
-    #[serde(default)]
-    resolve: Option<CargoMetadataResolve>,
-}
-
-/// Feature selections resolved by the explicit publisher's locked Cargo metadata call.
-#[derive(Clone, Deserialize)]
-struct CargoMetadataResolve {
-    #[serde(default)]
-    root: Option<String>,
-    #[serde(default)]
-    nodes: Vec<CargoMetadataResolveNode>,
-}
-
-/// One exact package ID and its unified features in publisher metadata.
-#[derive(Clone, Deserialize)]
-struct CargoMetadataResolveNode {
-    id: String,
-    #[serde(default)]
-    features: Vec<String>,
-    #[serde(default)]
-    dependencies: Vec<String>,
-    /// Direct dependency edges with the Cargo name used by the root package and the exact resolved package ID.
-    ///
-    /// `dependencies` is sufficient for source-closure walking, but it discards the alias-to-package relationship
-    /// needed to select a direct Rustc artifact when the lock contains multiple versions of the same crate.
-    #[serde(default)]
-    deps: Vec<CargoMetadataResolveDependency>,
-}
-
-/// One resolved Cargo dependency edge retained only while the explicit baker is publishing a Loaf.
-#[derive(Clone, Deserialize)]
-struct CargoMetadataResolveDependency {
-    name: String,
-    pkg: String,
-}
-
-/// One declared `rustc --extern` name bound to the exact Cargo package instance that owns its artifact.
-///
-/// Package names are not sufficient: a valid lock can contain two versions of one crate name. The resolved Cargo
-/// package ID is therefore consumed at the explicit baker boundary and never guessed by a normal Oven command.
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct ResolvedDirectDependency {
-    package: String,
-    package_id: String,
-}
-
-/// One Cargo package identity used while creating the explicit third-party foundation publisher input.
-#[derive(Clone, Deserialize)]
-struct CargoMetadataPackage {
-    id: String,
-    name: String,
-    version: String,
-    manifest_path: PathBuf,
-    #[serde(default)]
-    source: Option<String>,
-}
-
 /// Metadata search boundary used while resolving one explicit Rust-inspection surface.
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum InspectionPackageScope {
@@ -3032,24 +2906,6 @@ fn inspection_package_closure_ids(
         }
     }
     Ok(selected)
-}
-
-/// Exact registry checksum records decoded from the publisher's already-resolved Cargo lock.
-#[derive(Deserialize)]
-struct CargoChecksumLock {
-    #[serde(default)]
-    package: Vec<CargoChecksumLockPackage>,
-}
-
-/// One package identity whose checksum must agree with the source retained in a Loaf.
-#[derive(Deserialize)]
-struct CargoChecksumLockPackage {
-    name: String,
-    version: String,
-    #[serde(default)]
-    source: Option<String>,
-    #[serde(default)]
-    checksum: Option<String>,
 }
 
 /// Typed source handoff used only by children of the explicit `legacy_cargo` baker.

--- a/src/oven/legacy_cargo/cargo_json.rs
+++ b/src/oven/legacy_cargo/cargo_json.rs
@@ -1,0 +1,159 @@
+//! Cargo's own JSON shapes, as this publisher reads them.
+//!
+//! These mirror what `cargo` emits -- its build-artifact messages, unit graph, metadata resolve, and the
+//! registry checksum lock. They are deserialization targets and carry no publisher behavior, so they are
+//! grouped here to keep the publisher's own logic legible beside them.
+
+use std::path::PathBuf;
+
+use serde::Deserialize;
+
+/// Minimal Cargo JSON message shape used to map publisher-built dependency artifacts back to unit-graph edges.
+#[derive(Clone, Deserialize)]
+pub(super) struct CargoCompilerArtifact {
+    pub(super) reason: String,
+    pub(super) package_id: String,
+    pub(super) target: CargoCompilerArtifactTarget,
+    #[serde(default)]
+    pub(super) features: Vec<String>,
+    #[serde(default)]
+    pub(super) filenames: Vec<PathBuf>,
+    #[serde(default)]
+    pub(super) profile: CargoCompilerArtifactProfile,
+}
+
+#[derive(Clone, Default, Deserialize)]
+pub(super) struct CargoCompilerArtifactProfile {
+    #[serde(default)]
+    pub(super) test: bool,
+}
+
+/// Target identity emitted by Cargo's stable JSON message stream.
+#[derive(Clone, Deserialize)]
+pub(super) struct CargoCompilerArtifactTarget {
+    pub(super) name: String,
+    #[serde(default)]
+    pub(super) src_path: PathBuf,
+}
+
+/// Cargo's unstable-but-structured unit graph, read only at the named publisher boundary.
+///
+/// The graph is not retained as an execution dependency. Oven converts its workspace test roots, resolved features,
+/// and direct dependency edges into a receipt-bound target plan before the transient Cargo target is reclaimed.
+#[derive(Deserialize)]
+pub(super) struct CargoUnitGraph {
+    pub(super) version: u32,
+    pub(super) units: Vec<CargoUnitGraphUnit>,
+    pub(super) roots: Vec<usize>,
+}
+
+#[derive(Clone, Deserialize)]
+pub(super) struct CargoUnitGraphUnit {
+    pub(super) pkg_id: String,
+    pub(super) target: CargoUnitGraphTarget,
+    pub(super) mode: String,
+    #[serde(default)]
+    pub(super) platform: Option<String>,
+    #[serde(default)]
+    pub(super) features: Vec<String>,
+    #[serde(default)]
+    pub(super) dependencies: Vec<CargoUnitGraphDependency>,
+}
+
+#[derive(Clone, Deserialize)]
+pub(super) struct CargoUnitGraphTarget {
+    pub(super) kind: Vec<String>,
+    #[serde(default)]
+    pub(super) crate_types: Vec<String>,
+    pub(super) name: String,
+    pub(super) src_path: PathBuf,
+    pub(super) edition: String,
+}
+
+#[derive(Clone, Deserialize)]
+pub(super) struct CargoUnitGraphDependency {
+    pub(super) index: usize,
+    pub(super) extern_crate_name: Option<String>,
+}
+
+/// Minimal publisher-only Cargo metadata needed to name a sealed third-party foundation manifest.
+///
+/// The unit graph is authoritative for the resolved feature set and dependency edges; Cargo metadata supplies the
+/// stable package name/version for a synthetic legacy publisher manifest. Neither record reaches an Oven consumer.
+#[derive(Clone, Deserialize)]
+pub(super) struct CargoMetadata {
+    pub(super) packages: Vec<CargoMetadataPackage>,
+    #[serde(default)]
+    pub(super) resolve: Option<CargoMetadataResolve>,
+}
+
+/// Feature selections resolved by the explicit publisher's locked Cargo metadata call.
+#[derive(Clone, Deserialize)]
+pub(super) struct CargoMetadataResolve {
+    #[serde(default)]
+    pub(super) root: Option<String>,
+    #[serde(default)]
+    pub(super) nodes: Vec<CargoMetadataResolveNode>,
+}
+
+/// One exact package ID and its unified features in publisher metadata.
+#[derive(Clone, Deserialize)]
+pub(super) struct CargoMetadataResolveNode {
+    pub(super) id: String,
+    #[serde(default)]
+    pub(super) features: Vec<String>,
+    #[serde(default)]
+    pub(super) dependencies: Vec<String>,
+    /// Direct dependency edges with the Cargo name used by the root package and the exact resolved package ID.
+    ///
+    /// `dependencies` is sufficient for source-closure walking, but it discards the alias-to-package relationship
+    /// needed to select a direct Rustc artifact when the lock contains multiple versions of the same crate.
+    #[serde(default)]
+    pub(super) deps: Vec<CargoMetadataResolveDependency>,
+}
+
+/// One resolved Cargo dependency edge retained only while the explicit baker is publishing a Loaf.
+#[derive(Clone, Deserialize)]
+pub(super) struct CargoMetadataResolveDependency {
+    pub(super) name: String,
+    pub(super) pkg: String,
+}
+
+/// One declared `rustc --extern` name bound to the exact Cargo package instance that owns its artifact.
+///
+/// Package names are not sufficient: a valid lock can contain two versions of one crate name. The resolved Cargo
+/// package ID is therefore consumed at the explicit baker boundary and never guessed by a normal Oven command.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ResolvedDirectDependency {
+    pub(super) package: String,
+    pub(super) package_id: String,
+}
+
+/// One Cargo package identity used while creating the explicit third-party foundation publisher input.
+#[derive(Clone, Deserialize)]
+pub(super) struct CargoMetadataPackage {
+    pub(super) id: String,
+    pub(super) name: String,
+    pub(super) version: String,
+    pub(super) manifest_path: PathBuf,
+    #[serde(default)]
+    pub(super) source: Option<String>,
+}
+
+/// Exact registry checksum records decoded from the publisher's already-resolved Cargo lock.
+#[derive(Deserialize)]
+pub(super) struct CargoChecksumLock {
+    #[serde(default)]
+    pub(super) package: Vec<CargoChecksumLockPackage>,
+}
+
+/// One package identity whose checksum must agree with the source retained in a Loaf.
+#[derive(Deserialize)]
+pub(super) struct CargoChecksumLockPackage {
+    pub(super) name: String,
+    pub(super) version: String,
+    #[serde(default)]
+    pub(super) source: Option<String>,
+    #[serde(default)]
+    pub(super) checksum: Option<String>,
+}


### PR DESCRIPTION
## Summary

`src/oven/legacy_cargo.rs` carries ~9,100 production lines. The clearest seam it already has is the set of types that are **not the publisher's at all**: they mirror what `cargo` emits — build-artifact messages, the unit graph, the metadata resolve, and the registry checksum lock — and exist only to deserialize it.

Second of #1299's per-file splits. It **moves only**; no logic is edited.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: none. This is a move.

- **Internals**: 150 lines of Cargo wire shapes move to `src/oven/legacy_cargo/cargo_json.rs`. They sat in two contiguous runs in the original file and are taken as they were. What remains beside the boundary is the publisher's own logic, no longer interleaved with a hundred lines of deserialization targets.

  The items were module-private and are now `pub(super)` — exactly the reach they had when they shared a file with their only readers. Nothing became visible outside this module, and nothing was added to the crate's public surface.

- **Risks**: bounded. A move of `#[derive(Deserialize)]` shapes cannot change behavior unless a field's serde attributes or visibility change, and neither did. The evidence below is aimed at showing that, rather than at showing the publisher works.

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes, chosen to test *that it is a move*:

- **The exported surface is identical**: 49 `pub`/`pub(crate)` items before and after, none lost, none gained.
- **The test result is identical**: `cargo test --lib` reports **3234 passed / 28 failed** here and on the unmodified branch. Those 28 are the known `CARGO_BIN_EXE_incan` gap every plain `--lib` run hits.
- `cargo clippy --all-targets --all-features` clean, with no unused imports left by the move; `make fmt`; `scripts/check_changed_rustdocs.py` passes.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

## Please run this one with `full-ci`

Same reasoning as #1325: #1299 asks for the Oven-heavy lanes rather than unit tests alone, and #1314 gates those off development pull requests. The surface and test-result evidence is the right evidence for a move, but it is not the Oven replay, and this is the subsystem whose failures do not look like compile errors.

## Why one seam and not the whole file

The remaining clusters in this file — lock handling, publisher staging, compiler-suite planning — **carry behavior**. The wire shapes do not, which is what makes this move provable by the surface-and-results check above. Moving the behavioral clusters deserves its own change and its own evidence rather than riding along with types that cannot misbehave.

`cli/commands/oven.rs` (~5,900 production lines) is the remaining file in #1299's list.

Refs #1299.