### PR TITLE
feature - refuse a Rust interop boundary as a missing host, not an unreached construct (#1262)

### DIFF
--- a/src/cli/commands/build.rs
+++ b/src/cli/commands/build.rs
@@ -2551,6 +2551,31 @@ fn replacement_local_module_import(import: &crate::frontend::ast::ImportDecl) ->
     first.as_str() != incan_core::lang::stdlib::STDLIB_ROOT
 }
 
+/// Describe a Rust-interop import in terms of the boundary it crosses, when it is one.
+///
+/// A `rust::` import is refused for a different reason than an ordinary one, and #1262 requires the difference to be
+/// visible: a reader has to be able to tell a construct this profile has not reached yet from a boundary that needs a
+/// host it does not have. Reporting both as "import declaration" told them neither, and named the wrong thing to go
+/// looking for.
+///
+/// The crate is named because it is the actionable part. Which crate a call would have entered is what a reader needs
+/// to know, and it is the identity the eventual interop plan is selected against.
+fn replacement_rust_interop_boundary(import: &crate::frontend::ast::ImportDecl) -> Option<String> {
+    let (crate_name, form) = match &import.kind {
+        ImportKind::RustCrate { crate_name, .. } => (crate_name, "module import"),
+        ImportKind::RustFrom { crate_name, .. } => (crate_name, "item import"),
+        ImportKind::Python(module) => {
+            return Some(format!(
+                "Python interop import of `{module}`, which this backend has no host for"
+            ));
+        }
+        _ => return None,
+    };
+    Some(format!(
+        "Rust interop {form} of crate `{crate_name}`: executing it needs a Rust interop host, and this route has none"
+    ))
+}
+
 /// Return the first unsupported source-module boundary with its original Incan source span.
 fn replacement_module_profile_error(program: &crate::frontend::ast::Program) -> Option<ReplacementExecutionError> {
     if let Some(rust_module) = &program.rust_module_path {
@@ -2590,9 +2615,11 @@ fn replacement_module_profile_error(program: &crate::frontend::ast::Program) -> 
                 continue;
             }
             let description = if exact_async_activation {
-                "duplicate `import std.async` replacement activation"
+                "duplicate `import std.async` replacement activation".to_string()
+            } else if let Some(boundary) = replacement_rust_interop_boundary(import) {
+                boundary
             } else {
-                "import declaration"
+                "import declaration".to_string()
             };
             return Some(ReplacementExecutionError::unsupported_profile(
                 description,

--- a/tests/replacement_backend_execution_tests.rs
+++ b/tests/replacement_backend_execution_tests.rs
@@ -4206,6 +4206,157 @@ fn replacement_cli_refuses_module_boundaries_with_primary_spans() -> Result<(), 
     Ok(())
 }
 
+/// A Rust or Python interop boundary must refuse as a missing host, not as a construct the profile has not reached.
+///
+/// #1262 requires public diagnostics to distinguish host-capability failures from the other reasons a program is
+/// refused. Before this, `import rust::serde_json` and `import std.io` both reported "import declaration", which told
+/// a reader that the replacement route had not got round to imports yet. The truth is narrower and more useful: the
+/// route reached this import and found that executing it needs a Rust interop host it does not have.
+///
+/// The crate is named because it is the actionable identity -- it is what an eventual interop plan is selected
+/// against -- and the refusal is addressed to the file that crosses the boundary, which is not always the entry
+/// module.
+#[test]
+fn a_rust_interop_boundary_refuses_as_a_missing_host() -> Result<(), Box<dyn std::error::Error>> {
+    let cases = [
+        (
+            "rust-crate-import",
+            "import rust::serde_json\n\ndef main() -> int:\n  return 42\n",
+            "Rust interop module import of crate `serde_json`",
+        ),
+        (
+            "rust-item-import",
+            "from rust::incan_stdlib::text import normalize\n\ndef main() -> int:\n  return 42\n",
+            "Rust interop item import of crate `incan_stdlib`",
+        ),
+        (
+            "python-import",
+            "import python \"os\"\n\ndef main() -> int:\n  return 42\n",
+            "Python interop import of `os`",
+        ),
+    ];
+    for (name, source, expected_boundary) in cases {
+        let temporary = tempfile::tempdir()?;
+        let entrypoint = temporary.path().join(format!("{name}.incn"));
+        fs::write(&entrypoint, source)?;
+        let output = Command::new(incan_binary())
+            .args([
+                "build",
+                entrypoint.to_string_lossy().as_ref(),
+                "--backend",
+                "replacement",
+                "--backend-fallback",
+                "refuse",
+            ])
+            .output()?;
+        assert!(
+            !output.status.success(),
+            "{name} must be refused by the source-only profile"
+        );
+        let combined = format!(
+            "{}\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            combined.contains("INCAN-R988-UNSUPPORTED"),
+            "{name} must be refused through the typed profile diagnostic: {combined}"
+        );
+        assert!(
+            combined.contains(expected_boundary),
+            "{name} must name the interop boundary it crosses: {combined}"
+        );
+        assert!(
+            !combined.contains("does not support import declaration"),
+            "{name} must not report an interop boundary as an unreached construct: {combined}"
+        );
+    }
+
+    // The pair that makes the distinction real: an ordinary import is still refused as a construct this profile has
+    // not reached, and never claims a missing interop host.
+    let temporary = tempfile::tempdir()?;
+    let ordinary = temporary.path().join("ordinary.incn");
+    fs::write(&ordinary, "import std.io\n\ndef main() -> int:\n  return 42\n")?;
+    let output = Command::new(incan_binary())
+        .args([
+            "build",
+            ordinary.to_string_lossy().as_ref(),
+            "--backend",
+            "replacement",
+            "--backend-fallback",
+            "refuse",
+        ])
+        .output()?;
+    let combined = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("does not support import declaration"),
+        "a standard-library import must still refuse as an unreached construct: {combined}"
+    );
+    assert!(
+        !combined.contains("interop host"),
+        "a standard-library import must not claim a missing interop host: {combined}"
+    );
+    Ok(())
+}
+
+/// An interop refusal is addressed to the module that crosses the boundary, not to the entry module.
+///
+/// #1318 admitted local module imports into the profile, so the first Rust boundary a program reaches is now often in
+/// a module the entry file merely imported. A refusal that pointed at the entry module would send a reader to a file
+/// containing nothing to fix.
+#[test]
+fn a_rust_interop_refusal_names_the_module_that_crosses_the_boundary() -> Result<(), Box<dyn std::error::Error>> {
+    let temporary = tempfile::tempdir()?;
+    let helpers = temporary.path().join("helpers.incn");
+    fs::write(
+        &helpers,
+        "from rust::incan_stdlib::text import normalize\n\npub def helper() -> int:\n  return 1\n",
+    )?;
+    let entrypoint = temporary.path().join("main.incn");
+    fs::write(
+        &entrypoint,
+        "from helpers import helper\n\ndef main() -> int:\n  return helper()\n",
+    )?;
+
+    let output = Command::new(incan_binary())
+        .args([
+            "build",
+            entrypoint.to_string_lossy().as_ref(),
+            "--backend",
+            "replacement",
+            "--backend-fallback",
+            "refuse",
+        ])
+        .output()?;
+    assert!(
+        !output.status.success(),
+        "a Rust interop boundary must be refused wherever it is declared"
+    );
+    let combined = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("Rust interop item import of crate `incan_stdlib`"),
+        "an imported module's interop boundary must be named: {combined}"
+    );
+    assert!(
+        combined.contains(&format!("primary Incan source location: {}", helpers.display()))
+            || combined.contains("helpers.incn:"),
+        "the refusal must address the module that crosses the boundary: {combined}"
+    );
+    assert!(
+        !combined.contains("main.incn:0.."),
+        "the refusal must not be addressed to the entry module: {combined}"
+    );
+    Ok(())
+}
+
 /// Duplicate standard-library activation is a canonical binding error before backend selection begins.
 #[test]
 fn duplicate_async_activation_fails_during_typechecking() -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
## Summary

`import rust::serde_json` and `import std.io` were refused by the replacement route with the same words: *"does not support import declaration"*. That reads as "the route has not got round to imports yet", and sends the reader looking for the wrong thing. It had got round to this import. What it found was a boundary into Rust that needs an interop host, and this route has none.

#1262 asks for exactly that distinction — *"public diagnostics ... distinguish Incan domain, boundary projection, host-capability, version, linkage, panic/runtime, and backend failures"*, and *"missing host/linkage ... [has] pre-effect refusal coverage"*. This PR delivers that half. It does not deliver the invocation half; see **Scope** below.

Before and after, on the same three programs:

| Program | Before | After |
| --- | --- | --- |
| `import rust::serde_json` | import declaration | Rust interop **module** import of crate `serde_json`: executing it needs a Rust interop host, and this route has none |
| `from rust::incan_stdlib::text import normalize` | import declaration | Rust interop **item** import of crate `incan_stdlib`: executing it needs a Rust interop host, and this route has none |
| `import std.io` | import declaration | import declaration *(unchanged — it really is an unreached construct)* |

The crate is named because it is the actionable identity. Which crate a call would have entered is what the reader needs, and it is the identity an eventual interop plan is selected against. A Python interop import gets the same treatment for the same reason.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)

## Key details

- **User-facing behavior**: the refusal text for a `rust::`, `from rust::`, or `import python` declaration on the replacement route. Every other refusal is byte-identical, including `import std.io`, the aliased and `from`-form `std.async` cases, and `rust.module(...)` — which already named itself correctly.
- **Internals**: one new classifier, `replacement_rust_interop_boundary`, sits beside `replacement_local_module_import` in `src/cli/commands/build.rs` and answers *which boundary is this* for an import the profile did not admit. `replacement_module_profile_error` consults it before falling back to the generic description. The refusal type, code (`INCAN-R988-UNSUPPORTED`), span, and selection path are untouched.
- **Risks**: low. The change is confined to the description string of an already-refusing path; nothing that previously executed can now refuse, and nothing that previously refused can now execute. The one behavioural surface with a real edge is ordering — a module carrying both a Rust import and another unsupported declaration reports whichever comes first in declaration order, exactly as before.

### Where the refusal is addressed

#1318 admitted local module imports into the profile, so the first Rust boundary a program reaches is now frequently in a module the entry file merely imported. A refusal pointing at the entry module would send the reader to a file with nothing in it to fix. #1321 carries the file identity that lets it point at the right one, and this PR has a test that holds it to that:

```
main.incn:     from helpers import helper
helpers.incn:  from rust::incan_stdlib::text import normalize

→ INCAN-R988-UNSUPPORTED: ... Rust interop item import of crate `incan_stdlib` ...
  primary Incan source location: /.../helpers.incn:0..46
```

## Scope

This is #1262's **pre-effect refusal** half, and #1262 stays open.

The issue's positive matrix — the free call, the borrowed `&str` coercion, the owned callable, and the Rust-hosted caller — needs the replacement route to actually invoke Rust behaviour through a declared host. No production `ProviderOperationHost` exists today; the only implementation in the tree is `LedgerHost`, a test double. Building one is a separate packet, not something to smuggle into a diagnostics change, and a refusal that named a host it could not use would be worse than the generic text it replaces.

What the issue asks for that needs no invocation is the part delivered here: a missing host is refused *before* any effect, and a reader can tell it apart from a construct the route has not reached.

## Testing / verification

- [x] `cargo test --test replacement_backend_execution_tests` — the two new tests plus the existing `replacement_cli_refuses_module_boundaries_with_primary_spans`, which pins the unchanged refusals. 3 passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo +nightly fmt`
- [x] `scripts/check_changed_rustdocs.py` — passed.
- [x] Manual verification described below

New tests:

- `a_rust_interop_boundary_refuses_as_a_missing_host` — the three interop forms each name their boundary and crate, none of them reports "import declaration", **and** `import std.io` still reports "import declaration" and never claims a missing interop host. The pair is what makes the distinction real; asserting only the first half would pass on a change that relabelled every import.
- `a_rust_interop_refusal_names_the_module_that_crosses_the_boundary` — the two-module case above, asserting the refusal is addressed to `helpers.incn` and not to the entry module.

Manual verification notes:

- Built each program through `incan build --backend replacement --backend-fallback refuse` and read the emitted diagnostic; the table at the top of this description is that output.
- Checked that `type X = rusttype Y` is not separately reachable: it needs the crate in scope, and the `rust::` import that brings it there is refused first in declaration order. There is nothing to classify there that this PR does not already catch upstream.

## Docs impact

- [x] No docs changes needed

The refusal text is the user-facing surface and it is exercised by the tests above; no reference page documents these strings.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

## Stack

Stacked on #1321 (`bugfix/1260-refusal-source-paths`), which supplies the refusal file identity the cross-module test asserts. Full chain: #1318 → #1320 → #1321 → this.

Closes nothing. Advances #1262.