### PR TITLE
bugfix - select one coherent inspection authority across source-current project outputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1436,7 +1436,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.6.0-dev.1.3"
+version = "0.6.0-dev.1.4"
 dependencies = [
  "blake2",
  "blake3",
@@ -1493,7 +1493,7 @@ dependencies = [
 
 [[package]]
 name = "incan_codegraph"
-version = "0.6.0-dev.1.3"
+version = "0.6.0-dev.1.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -1501,14 +1501,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.6.0-dev.1.3"
+version = "0.6.0-dev.1.4"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.6.0-dev.1.3"
+version = "0.6.0-dev.1.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1517,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.6.0-dev.1.3"
+version = "0.6.0-dev.1.4"
 dependencies = [
  "incan_core",
  "serde",
@@ -1526,7 +1526,7 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.6.0-dev.1.3"
+version = "0.6.0-dev.1.4"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1534,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.6.0-dev.1.3"
+version = "0.6.0-dev.1.4"
 dependencies = [
  "axum",
  "incan_core",
@@ -1548,7 +1548,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.6.0-dev.1.3"
+version = "0.6.0-dev.1.4"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1570,7 +1570,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.6.0-dev.1.3"
+version = "0.6.0-dev.1.4"
 dependencies = [
  "axum",
  "incan_stdlib",
@@ -3138,7 +3138,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.6.0-dev.1.3"
+version = "0.6.0-dev.1.4"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.6.0-dev.1.3"
+version = "0.6.0-dev.1.4"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.93"

--- a/crates/incan_stdlib/stdlib/sdk-components.toml
+++ b/crates/incan_stdlib/stdlib/sdk-components.toml
@@ -1,7 +1,7 @@
 [sdk]
 id = "incan"
-version = "0.6.0-dev.1.3"
-compiler-requirement = ">=0.6.0-dev.1.3,<0.7.0"
+version = "0.6.0-dev.1.4"
+compiler-requirement = ">=0.6.0-dev.1.4,<0.7.0"
 
 [profiles]
 minimal = ["stdlib-core", "stdlib-interop"]

--- a/src/cli/commands/build.rs
+++ b/src/cli/commands/build.rs
@@ -8569,7 +8569,7 @@ fn select_current_debug_project_outputs(
         }
     }
 
-    let mut outputs = Vec::with_capacity(expected.len());
+    let mut groups = Vec::with_capacity(expected.len());
     for (expected, mut candidates) in expected.into_iter().zip(grouped) {
         if candidates.is_empty() {
             return Ok(None);
@@ -8612,18 +8612,62 @@ fn select_current_debug_project_outputs(
             }
         }
         exact.sort_by(|left, right| left.identity.cmp(&right.identity));
-        let selected = if let Some(selected) = exact.into_iter().next() {
-            selected
-        } else if let Some(error) = rejected.into_iter().next() {
-            return Err(error);
-        } else {
-            return Err(CliError::failure(
-                "exact debug project-output lineage disappeared during in-memory selection",
-            ));
-        };
-        outputs.push((expected.target, selected));
+        if exact.is_empty() {
+            return Err(rejected.into_iter().next().unwrap_or_else(|| {
+                CliError::failure("exact debug project-output lineage disappeared during in-memory selection")
+            }));
+        }
+        groups.push((expected.target, exact));
     }
-    Ok(Some(outputs))
+    select_coherent_project_outputs(groups).map(Some)
+}
+
+/// Choose one source-current output per target so that every target names the same project inspection authority.
+///
+/// A bake that re-seals the project inspection authority for unchanged sources (for example after the store came
+/// back from a cache and the generated build-script outputs were discovered again) leaves two exact generations of
+/// every output behind. Each generation is coherent on its own, but the identity-smallest output per target can
+/// belong to different generations, and `incan test` then refuses the mixed set as a disagreement. Prefer an
+/// authority that every target's exact outputs share; when there is none, keep the identity-smallest output per
+/// target so the caller reports the disagreement exactly as before.
+fn select_coherent_project_outputs(
+    groups: Vec<(OvenBakeProjectTarget, Vec<OvenStoredProjectOutput>)>,
+) -> CliResult<Vec<(OvenBakeProjectTarget, OvenStoredProjectOutput)>> {
+    let shared_authority = groups.first().and_then(|(_, outputs)| {
+        outputs
+            .iter()
+            .filter_map(|output| output.payload.inspection_authority.as_ref())
+            .find(|authority| {
+                groups.iter().all(|(_, candidates)| {
+                    candidates
+                        .iter()
+                        .any(|candidate| candidate.payload.inspection_authority.as_ref() == Some(*authority))
+                })
+            })
+            .cloned()
+    });
+    groups
+        .into_iter()
+        .map(|(target, outputs)| {
+            // Each group is sorted by identity and nonempty; the shared authority, when there is one, names the
+            // generation to take from every group.
+            let position = shared_authority
+                .as_ref()
+                .and_then(|authority| {
+                    outputs
+                        .iter()
+                        .position(|output| output.payload.inspection_authority.as_ref() == Some(authority))
+                })
+                .unwrap_or(0);
+            outputs
+                .into_iter()
+                .nth(position)
+                .map(|selected| (target, selected))
+                .ok_or_else(|| {
+                    CliError::failure("exact debug project-output lineage disappeared during in-memory selection")
+                })
+        })
+        .collect()
 }
 
 /// Load immutable Rust-inspection lineage from all source-current baked debug outputs.
@@ -15752,7 +15796,39 @@ headers = ["interop/include/bridge.h"]
         ),
         Box<dyn std::error::Error>,
     > {
-        let entrypoint = project_root.join("src/main.incn");
+        fixture_project_output_publication_for(
+            project_root,
+            profile,
+            label,
+            OvenBakeProjectTarget::Executable,
+            OvenProjectInspectionAuthorityRef {
+                identity: "sha256:fixture-project-authority".to_string(),
+                receipt_identity: "sha256:fixture-authority-receipt".to_string(),
+                build_unit_identity: "sha256:fixture-authority-build-unit".to_string(),
+            },
+        )
+    }
+
+    /// Publish-ready receipt, payload, and files for one bake target of the fixture project.
+    ///
+    /// The receipt derives from the generated source and the label, so two calls with the same label and target
+    /// share one receipt lineage; only the payload differs when `inspection_authority` does, which is exactly what a
+    /// bake that re-seals the project authority for unchanged sources leaves in the store.
+    fn fixture_project_output_publication_for(
+        project_root: &Path,
+        profile: &str,
+        label: &str,
+        target: OvenBakeProjectTarget,
+        inspection_authority: OvenProjectInspectionAuthorityRef,
+    ) -> Result<
+        (
+            crate::oven::OvenReceipt,
+            OvenProjectOutputPayload,
+            Vec<OvenProjectOutputBakeFile>,
+        ),
+        Box<dyn std::error::Error>,
+    > {
+        let entrypoint = project_root.join(target.source_relative_path());
         let generated_source = project_root.join(format!("target/fixture/generated-{label}.rs"));
         let native_output = project_root.join(format!("target/fixture/native-{label}"));
         fs::create_dir_all(generated_source.parent().ok_or("generated source has no parent")?)?;
@@ -15794,18 +15870,14 @@ headers = ["interop/include/bridge.h"]
         let payload = project_output_payload_for_bake(OvenProjectOutputBakeRequest {
             project_root,
             entrypoint: &entrypoint,
-            target: OvenBakeProjectTarget::Executable,
+            target,
             receipt: &receipt,
             plan_identity: format!("fixture-plan-{label}"),
             profile,
             source_authority_digest: &digest_baked_project_source_authority(project_root)?,
             lock_dependencies_fingerprint: baked_project_lock_dependencies_fingerprint(project_root)?,
             files: files.clone(),
-            inspection_authority: OvenProjectInspectionAuthorityRef {
-                identity: "sha256:fixture-project-authority".to_string(),
-                receipt_identity: "sha256:fixture-authority-receipt".to_string(),
-                build_unit_identity: "sha256:fixture-authority-build-unit".to_string(),
-            },
+            inspection_authority,
             required_project_loafs: Vec::new(),
             package_loaf_store_relative_path: None,
             backend_receipt,
@@ -16087,6 +16159,109 @@ headers = ["interop/include/bridge.h"]
             return Err("a same-receipt cohort with no source-current output did not fail closed".into());
         };
         assert!(error.message.contains("disagrees with its source-current lineage"));
+        Ok(())
+    }
+
+    #[test]
+    fn current_debug_output_scan_prefers_the_authority_every_target_shares() -> Result<(), Box<dyn std::error::Error>> {
+        // A store restored from a cache can hold two exact generations of every output for unchanged sources, each
+        // naming the project inspection authority its own bake sealed. Picking per target by identity alone can mix
+        // the generations; the scan must pick the one authority every target can satisfy.
+        let project = tempfile::tempdir()?;
+        fs::create_dir(project.path().join("src"))?;
+        fs::write(project.path().join("incan.toml"), "[project]\nname = \"fixture\"\n")?;
+        fs::write(project.path().join("src/lib.incn"), "def helper() -> None:\n    pass\n")?;
+        fs::write(project.path().join("src/main.incn"), "def main() -> None:\n    pass\n")?;
+        let authority = |identity: &str| OvenProjectInspectionAuthorityRef {
+            identity: identity.to_string(),
+            receipt_identity: format!("{identity}-receipt"),
+            build_unit_identity: format!("{identity}-build-unit"),
+        };
+        let store_root = tempfile::tempdir()?;
+        let store = OvenStore::new(
+            store_root.path(),
+            crate::oven::store::OvenStoreLimits::new(1024 * 1024, 1024 * 1024, 1024 * 1024),
+        );
+        let library_entrypoint = project
+            .path()
+            .join(OvenBakeProjectTarget::Library.source_relative_path());
+        let mut library_generations = Vec::new();
+        for identity in ["sha256:authority-a", "sha256:authority-b"] {
+            let (receipt, payload, files) = fixture_project_output_publication_for(
+                project.path(),
+                "debug",
+                "library",
+                OvenBakeProjectTarget::Library,
+                authority(identity),
+            )?;
+            write_receipt(
+                &receipt,
+                project_bake_receipt_path(
+                    project.path(),
+                    OvenBakeProjectTarget::Library,
+                    &library_entrypoint,
+                    "debug",
+                )?,
+            )?;
+            let published = publish_project_output_loaf(&store, &receipt, &payload, &files)?;
+            library_generations.push((published.identity.clone(), identity));
+            drop(published);
+        }
+        assert_ne!(
+            library_generations[0].0, library_generations[1].0,
+            "two generations with different authorities must publish as distinct Loafs"
+        );
+        // An identity-ordered pick would take the smallest library output; give the executable only the generation
+        // that names the other authority, so the targets agree only when the scan prefers the shared lineage.
+        library_generations.sort();
+        let shared = library_generations
+            .last()
+            .map(|(_, identity)| *identity)
+            .ok_or("no library generation was published")?;
+        let executable_entrypoint = project
+            .path()
+            .join(OvenBakeProjectTarget::Executable.source_relative_path());
+        let (receipt, payload, files) = fixture_project_output_publication_for(
+            project.path(),
+            "debug",
+            "executable",
+            OvenBakeProjectTarget::Executable,
+            authority(shared),
+        )?;
+        write_receipt(
+            &receipt,
+            project_bake_receipt_path(
+                project.path(),
+                OvenBakeProjectTarget::Executable,
+                &executable_entrypoint,
+                "debug",
+            )?,
+        )?;
+        drop(publish_project_output_loaf(&store, &receipt, &payload, &files)?);
+
+        let targets = discover_oven_bake_project_targets(project.path())?;
+        let selected = select_current_debug_project_outputs(
+            &store,
+            project.path(),
+            &targets,
+            &digest_baked_project_source_authority(project.path())?,
+            &receipt.intent.target,
+            &receipt.intent.toolchain,
+        )?
+        .ok_or("the two-target project with exact outputs was not selected")?;
+        assert_eq!(selected.len(), 2);
+        for (target, output) in &selected {
+            assert_eq!(
+                output
+                    .payload
+                    .inspection_authority
+                    .as_ref()
+                    .map(|authority| authority.identity.as_str()),
+                Some(shared),
+                "{} output must name the authority every target shares",
+                target.as_str()
+            );
+        }
         Ok(())
     }
 

--- a/workspaces/release/npm/package.json
+++ b/workspaces/release/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@incan/toolchain",
-  "version": "0.6.0-dev.1.3",
+  "version": "0.6.0-dev.1.4",
   "description": "Command shims for the Incan toolchain",
   "license": "Apache-2.0",
   "homepage": "https://incan.io",

--- a/workspaces/release/pip/pyproject.toml
+++ b/workspaces/release/pip/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "incan"
-version = "0.6.0.dev1+3"
+version = "0.6.0.dev1+4"
 description = "Thin installer package for the Incan toolchain"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/workspaces/release/pip/src/incan_toolchain/__init__.py
+++ b/workspaces/release/pip/src/incan_toolchain/__init__.py
@@ -5,5 +5,5 @@ __all__ = ["__release_version__", "__version__"]
 # Python packages require PEP 440 versions, while toolchain release assets retain the
 # workspace's Cargo version spelling. Keep both identities explicit so an installer
 # never derives a GitHub release URL from a normalized distribution version.
-__release_version__ = "0.6.0-dev.1.3"
-__version__ = "0.6.0.dev1+3"
+__release_version__ = "0.6.0-dev.1.4"
+__version__ = "0.6.0.dev1+4"


### PR DESCRIPTION
## Summary

This PR is the `0.6.0-dev.1.4` line: one `incan test` fix surfaced by IncQL's CI on encero-systems/IncQL#95, plus the version mirror. When the Oven store comes back from a CI cache and the bake re-seals the project inspection authority for unchanged sources (the generated build-script outputs are discovered again), the store holds two exact generations of every project output. `incan test` selected the identity-smallest output per target, which can pick different generations for the library and an executable, and then refused the set with `source-current debug project outputs disagree on their singular Rust inspection authority; rerun incan oven bake --project .`. Whether a run failed was a coin flip on Loaf identities: the macOS leg of that IncQL run failed while the same tree passed locally against the same kind of store. Selection now keeps every exact output per target and prefers the authority all targets share, falling back to the previous pick only when no shared authority exists so the disagreement is still reported. No Incan issue tracks this; the failing run is IncQL run 33923301536.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: `incan test` no longer fails with the disagreement error on a store that holds two generations of the same source-current outputs; it runs against the generation every target shares.
- **Internals**: `select_current_debug_project_outputs` in `src/cli/commands/build.rs` collects all exact outputs per target and hands them to the new `select_coherent_project_outputs`, which picks the first inspection authority (in identity order) present in every target's exact outputs. The test fixture `fixture_project_output_publication_for` takes the bake target and the authority reference so a test can publish two generations of one lineage. The release literals are mirrored to `0.6.0-dev.1.4`.
- **Risks**: the fallback keeps the old identity-smallest pick, so a store with genuinely disagreeing generations still fails closed with the same message. Why a bake re-seals the authority for unchanged sources on a restored store is not changed here; the two generations differ in the number of sealed files (45 versus 58 in the failing run), which is worth its own look.

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [x] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- Per the maintainer's instruction the full `make test` gate was not run on this line. `current_debug_output_scan_prefers_the_authority_every_target_shares` publishes two library generations with different authorities and one executable generation naming the authority the identity-smallest pick would skip; it fails on the previous selection and passes with this one. `current_debug_output_scan_selects_exact_lineage_and_rejects_a_stale_only_cohort` still passes.
- `cargo test -p incan --lib --all-features -- cli::commands::build::tests`: 93 pass; the four that fail (`run_entrypoint_omits_unused_manifest_rust_dependencies`, `unprojected_provider_collection_rejects_unknown_features_in_inactive_modules`, `build_library_canonicalizes_explicit_and_implicit_nested_module_imports`, `build_library_publishes_public_registry_metadata_and_facade_projections`) need the `incan` executable or a baked project in the environment and fail the same way without this change.
- `cargo clippy -p incan --lib --all-features --all-targets -- -D warnings` and `cargo fmt --check` are clean; `scripts/check_release_version_consistency.py` agrees on `0.6.0-dev.1.4`.
- End to end on IncQL's governed-evidence branch (encero-systems/IncQL#95 at 4a0d125) with a toolchain packaged from this tip by `workspaces/release/toolchain/package_archive.sh` (`v0.6.0-dev.1.4`, aarch64-apple-darwin), in CI's shape: bake, `incan oven store prune --max-physical-bytes 1`, a second bake, `make build`, `incan test` 300 passed, and the pub-consumer smoke check.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions
