### PR TITLE
feature - execute a module-qualified call by the declaration it resolved to (#1260)

### DIFF
--- a/src/frontend/body_ir/calls.rs
+++ b/src/frontend/body_ir/calls.rs
@@ -824,6 +824,81 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
         ))
     }
 
+    /// Lower `module.function(args)` as a direct call to the declaration its receiver qualifies.
+    ///
+    /// A module binding is a namespace, not a value. `identity_provider.imported_path(17)` reaches the AST as a
+    /// method call, but there is no receiver to read, and treating the qualifier as a place refuses at a name that
+    /// never named one. The typechecker has already resolved this call to exactly one declaration; consuming that
+    /// identity keeps the call on the direct path instead of re-deriving a target from the two spellings the source
+    /// happens to join with a dot. The receiver's own identity decides whether this applies, so a local variable
+    /// that happens to share a module's name still lowers as an ordinary method call.
+    ///
+    /// Returns `None` when the receiver is not a module, leaving every other receiver shape untouched.
+    #[allow(clippy::too_many_arguments)]
+    fn lower_module_qualified_call(
+        &mut self,
+        recv: &ast::Spanned<ast::Expr>,
+        name: &str,
+        type_args: &[ast::Spanned<ast::Type>],
+        args: &[ast::CallArg],
+        span: ast::Span,
+        scope: bir::ScopeId,
+        out: &mut Vec<bir::Statement>,
+    ) -> Option<bir::Operand> {
+        if !self
+            .type_info
+            .resolved_identity(recv.span)
+            .is_some_and(|identity| identity.kind == SemanticSourceTargetKind::Module)
+        {
+            return None;
+        }
+        let hir_span_value = hir_span(span);
+
+        // Without the call's own resolved identity there is no target: the module qualifier names where to look,
+        // not what was found. Refusing here rather than falling through to the method path reports the construct
+        // the source actually wrote.
+        let Some(canonical) = self.type_info.resolved_identity(span).cloned() else {
+            return Some(self.unsupported_operand(
+                format!("module-qualified call `{name}` without a resolved canonical declaration"),
+                scope,
+                hir_span_value,
+                out,
+            ));
+        };
+        let resolved_type_args = match self.call_site_type_arguments(span, type_args) {
+            Ok(resolved_type_args) => resolved_type_args,
+            Err(description) => return Some(self.unsupported_operand(description, scope, hir_span_value, out)),
+        };
+        let declared: Option<Vec<DeclaredSlot>> = self
+            .type_info
+            .call_site_callable_params(span)
+            .map(|params| params.iter().map(DeclaredSlot::from_checked_param).collect());
+        let (operands, binding) =
+            match self.bind_declared_args(&format!("function `{name}`"), declared, args, scope, out) {
+                Ok(bound) => bound,
+                Err(description) => return Some(self.unsupported_operand(description, scope, hir_span_value, out)),
+            };
+        let ty = self.resolve_ty(span);
+        Some(self.push_call_temp(
+            // The declaration lives in another module, so it has no span identity in this one. `canonical` is the
+            // fact that survives the boundary, and it is the only one a consumer may dispatch on here.
+            bir::Callee::Function(bir::CallableTarget::Named(bir::NamedCallableTarget {
+                name: name.to_string(),
+                direct_call_id: None,
+                canonical: Some(canonical),
+                builtin: None,
+                type_args: resolved_type_args,
+                binding,
+            })),
+            operands,
+            ty,
+            scope,
+            hir_span_value,
+            false,
+            out,
+        ))
+    }
+
     /// Lower a method call `recv.name(args)` to a [`bir::Callee::Method`] call, with the receiver prepended to
     /// `args[0]` as a [`bir::OwnershipFact::Borrow`] operand (see the inline comment on the receiver-borrow decision
     /// below).
@@ -852,6 +927,9 @@ impl<'type_info, 'source> BodyBuilder<'type_info, 'source> {
             return self.lower_checked_isinstance_call(type_args, args, span, scope, out);
         }
         if let Some(lowered) = self.lower_checked_builtin_method_call(type_args, args, span, scope, out) {
+            return lowered;
+        }
+        if let Some(lowered) = self.lower_module_qualified_call(recv, name, type_args, args, span, scope, out) {
             return lowered;
         }
         if self.type_info.resolved_identity(recv.span).is_some_and(|identity| {

--- a/src/frontend/typechecker/check_expr/access.rs
+++ b/src/frontend/typechecker/check_expr/access.rs
@@ -4549,6 +4549,13 @@ impl TypeChecker {
                 return match (kind, public_library) {
                     (SymbolKind::Function(info), _) => {
                         self.record_source_target(span, source_module_path, source_name, "function");
+                        // Resolution has just selected one concrete declaration in another module, and its declared
+                        // parameters are the only place a later stage can learn how this call's arguments bind:
+                        // the callee's name is not in scope here, so no by-name lookup can recover them. Recording
+                        // them at the point of resolution is what keeps a cross-module call bindable without
+                        // re-deriving a target from the qualifier and member spellings.
+                        self.type_info
+                            .record_call_site_callable_params_exact(span, &info.params);
                         self.validate_stdlib_module_function_call(
                             callable.as_str(),
                             &info,

--- a/tests/replacement_backend_execution_tests.rs
+++ b/tests/replacement_backend_execution_tests.rs
@@ -2829,6 +2829,120 @@ fn replacement_cli_executes_a_call_into_a_sibling_module_with_a_replacement_rece
     Ok(())
 }
 
+/// Execute a module-qualified call, written and aliased, through the replacement route.
+///
+/// `helper.bump(41)` reaches the AST as a method call, but `helper` is a namespace, not a value. Lowering it as a
+/// receiver refused at a name that never named a place: "resolved reference `helper` has no Body IR place
+/// representation". The qualifier says where to look; the typechecker has already resolved what was found, and this
+/// executes that declaration.
+///
+/// Both spellings are pinned because they differ only in the qualifier's own binding, and an alias is the case where
+/// a name-derived target would go wrong: `provider.bump` and `helper.bump` are one declaration reached two ways.
+#[test]
+fn replacement_cli_executes_a_module_qualified_call() -> Result<(), Box<dyn std::error::Error>> {
+    let cases = [
+        (
+            "plain",
+            "import helper\n\ndef main() -> int:\n  return helper.bump(41)\n",
+        ),
+        (
+            "aliased",
+            "import helper as provider\n\ndef main() -> int:\n  return provider.bump(41)\n",
+        ),
+    ];
+    for (name, entry_source) in cases {
+        let temporary = tempfile::tempdir()?;
+        fs::write(
+            temporary.path().join("helper.incn"),
+            "pub def bump(value: int) -> int:\n  return value + 1\n",
+        )?;
+        let entrypoint = temporary.path().join("main.incn");
+        fs::write(&entrypoint, entry_source)?;
+
+        let report_path = temporary.path().join("module-qualified-report.json");
+        let output = Command::new(incan_binary())
+            .args([
+                "build",
+                entrypoint.to_string_lossy().as_ref(),
+                "--backend",
+                "replacement",
+                "--backend-fallback",
+                "refuse",
+            ])
+            .args([
+                "--report",
+                "json",
+                "--report-output",
+                report_path.to_string_lossy().as_ref(),
+            ])
+            .output()?;
+        assert!(
+            output.status.success(),
+            "the {name} module-qualified call must execute through the replacement route. stdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let report: serde_json::Value = serde_json::from_slice(&fs::read(&report_path)?)?;
+        assert_eq!(
+            report["replacement_execution"]["result"], "42",
+            "the {name} module-qualified call must produce the qualified declaration's result"
+        );
+
+        let receipt: serde_json::Value = serde_json::from_str(&fs::read_to_string(
+            temporary.path().join(".incan/backend/receipt.json"),
+        )?)?;
+        assert_eq!(receipt["executed_backend"], "replacement");
+        assert_eq!(receipt["fallback_outcome"], serde_json::json!("not_needed"));
+    }
+    Ok(())
+}
+
+/// A receiver that merely shares a module's name is still an ordinary method call.
+///
+/// The module-qualified path keys off the receiver's resolved identity rather than its spelling, so a local bound to
+/// a value keeps its own meaning even when an imported module has the same name. Getting this wrong would silently
+/// redirect a method call to a free function in another module, which is the exact failure the identity-over-spelling
+/// rule exists to prevent -- so it is pinned rather than assumed.
+#[test]
+fn a_local_sharing_a_module_name_is_not_treated_as_a_module_qualifier() -> Result<(), Box<dyn std::error::Error>> {
+    let temporary = tempfile::tempdir()?;
+    fs::write(
+        temporary.path().join("helper.incn"),
+        "pub def bump(value: int) -> int:\n  return value + 1\n",
+    )?;
+    let entrypoint = temporary.path().join("main.incn");
+    fs::write(
+        &entrypoint,
+        "import helper\n\ndef main() -> int:\n  helper = 41\n  return helper.bump()\n",
+    )?;
+
+    let output = Command::new(incan_binary())
+        .args([
+            "build",
+            entrypoint.to_string_lossy().as_ref(),
+            "--backend",
+            "replacement",
+            "--backend-fallback",
+            "refuse",
+        ])
+        .output()?;
+    let combined = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !output.status.success(),
+        "an int has no `bump` method, so this must not execute: {combined}"
+    );
+    assert!(
+        !combined.contains("42"),
+        "the shadowing local must not be redirected to the module's declaration: {combined}"
+    );
+    Ok(())
+}
+
 /// A typed-numeric carrier crosses a module boundary, and the callee's own operations are still validated.
 ///
 /// The typed-numeric walk previously followed only same-module calls, because it selected the callee by its


### PR DESCRIPTION
## Summary

`helper.bump(41)` did not execute on the replacement route. It refused with:

> `replacement backend does not support resolved reference `helper` has no Body IR place representation`

`helper` is a namespace, not a value. Lowering it as a method receiver asks for a place at a name that never named one, and the diagnostic points at the qualifier rather than at anything a reader can act on. The qualifier says *where to look*; it is not the thing found.

The typechecker had already found it. The RFC 120 conformance matrix asserts today that `identity_provider.imported_path(17)` resolves to exactly one declaration in `identity_provider`, and that the Body IR records that identity. Two facts were missing between there and execution, one on each side of the boundary.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [x] Compiler (frontend/backend/codegen)

## Key details

**Lowering.** `lower_method_call` now recognises a receiver whose *resolved identity* is a module and lowers the call as a direct call to the identity the call itself resolved to — `Callee::Function(CallableTarget::Named { canonical, .. })` with no `direct_call_id`, because the declaration lives in another module and has no span identity in this one. `canonical` is the fact that survives the boundary, and #1260 already made it the admission criterion in `validate_call_profile`.

This follows the precedent immediately above it in the same file. `std.builtins.len(value)` reaches the AST as a method call too, and `lower_checked_builtin_method_call` already exists because "the namespace is not a runtime receiver". A user module is the same shape; it just had no equivalent.

The receiver's own identity is what decides, never its spelling — so a local bound to a value keeps its ordinary meaning even when an imported module shares its name. That case is pinned by a test rather than assumed, because getting it wrong would silently redirect a method call to a free function in another module.

**Checked facts.** The typechecker now records the callee's declared parameters at the call span when module-member resolution selects a concrete function.

`record_call_site_callable_params` deliberately keeps only unusual parameter shapes — anything non-`Normal` or needing a boundary snapshot. Every ordinary consumer recovers the rest by looking the callee up by name in `declarations.function_bindings`. That cannot work here: the callee's name is not in scope, only the module's is. So `bump(value: int)` recorded nothing, the arguments bound as `UnresolvedPositional`, and `validate_argument_binding_profile` refused the call the frontend had just resolved.

`record_call_site_callable_params_exact` is the existing hook for precisely this — "record exact callable metadata when overload/source-method resolution selected a concrete callable" — and module-member resolution is that. Recording happens where the selection is made, which is the only place the callee's signature is in hand.

**Risks.** The recording site is shared with stdlib module calls (`validate_stdlib_module_function_call` serves both), so it widens what is retained for those too. That is why the codegen snapshots are called out below: all 257 pass unchanged, so no emission path re-derived a different binding from the newly present fact. The lowering change is gated on a receiver the checker itself calls a module, so no other receiver shape is reachable.

## Testing / verification

- [x] `cargo test --test replacement_backend_execution_tests` — includes the two new tests
- [x] `cargo test --test codegen_snapshot_tests` — 257 passed, no snapshot churn from the widened recording
- [x] `cargo test --lib`
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo +nightly fmt`
- [x] `scripts/check_changed_rustdocs.py`

New tests:

- `replacement_cli_executes_a_module_qualified_call` — `helper.bump(41)` and `provider.bump(41)` under `import helper as provider`, each producing `42` with a `#986` receipt recording `executed_backend: replacement` and `fallback_outcome: not_needed`. Both spellings are pinned because they differ only in the qualifier's binding, and an alias is exactly where a name-derived target would go wrong: `provider.bump` and `helper.bump` are one declaration reached two ways.
- `a_local_sharing_a_module_name_is_not_treated_as_a_module_qualifier` — a local shadowing an imported module's name still refuses, and never produces the module declaration's result.

## Docs impact

- [x] No docs changes needed

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

## Stack

Stacked on #1328. Full chain: #1318 → #1320 → #1321 → #1328 → this. It needs #1318's cross-module execution graph to have anything to dispatch into.

Advances #1260.
