### PR TITLE
feature - execute the RFC 120 identity matrix through the replacement route (#1260, #1261)

### DIFF
--- a/tests/parity_corpus_tests.rs
+++ b/tests/parity_corpus_tests.rs
@@ -102,9 +102,10 @@ const ISINSTANCE_TARGETS_SOURCE: &str = include_str!("fixtures/replacement/isins
 
 use parity_corpus::{
     BehaviorCategory, CheckedIdentityGraph, ComparisonOutcome, Disposition, EvidenceLane, IdentityAssertions,
-    IdentityBindingForm, IdentityConformancePlan, IdentityConformanceSubject, IdentityCoverageCell, IdentityNamespace,
-    IdentityReplacementPlan, IdentityScope, IdentitySourceModule, OverallState, ParityCase, ReceiptRef,
-    ReleaseArtifactAssertions, SourceIdentityConformancePlan, behavior_observation_identity, exact_rust_identifier,
+    IdentityBindingForm, IdentityConformancePlan, IdentityConformanceSubject, IdentityCoverageCell,
+    IdentityGraphDeferral, IdentityGraphEntrypoint, IdentityNamespace, IdentityReplacementPlan, IdentityScope,
+    IdentitySourceModule, OverallState, ParityCase, ReceiptRef, ReleaseArtifactAssertions,
+    SourceIdentityConformancePlan, behavior_observation_identity, exact_rust_identifier,
     identity_conformance_evidence_identity, validate_corpus, validate_identity_coverage,
 };
 
@@ -1924,6 +1925,109 @@ def aliased_path_block_scope() -> int:
     return 0
 
 "#;
+
+/// Every matrix cell the replacement route executes across the module boundary, with the value it must return.
+///
+/// The returned values are deliberately distinct so a call that reached the wrong declaration is a wrong number
+/// rather than a coincidence: were `lexical_alias` resolved to `imported_lexical`, this row would return 3 where 5
+/// is required, and both are real declarations that execute.
+///
+/// Member cells are absent on purpose and are declared in [`IDENTITY_MATRIX_DEFERRED`] instead.
+const IDENTITY_MATRIX_ENTRYPOINTS: &[IdentityGraphEntrypoint] = &[
+    IdentityGraphEntrypoint {
+        function: "local_lexical_function_scope",
+        expected: 1,
+    },
+    IdentityGraphEntrypoint {
+        function: "local_lexical_block_scope",
+        expected: 1,
+    },
+    IdentityGraphEntrypoint {
+        function: "imported_lexical_function_scope",
+        expected: 3,
+    },
+    IdentityGraphEntrypoint {
+        function: "imported_lexical_block_scope",
+        expected: 3,
+    },
+    IdentityGraphEntrypoint {
+        function: "aliased_lexical_function_scope",
+        expected: 5,
+    },
+    IdentityGraphEntrypoint {
+        function: "aliased_lexical_block_scope",
+        expected: 5,
+    },
+    IdentityGraphEntrypoint {
+        function: "reexported_lexical_function_scope",
+        expected: 7,
+    },
+    IdentityGraphEntrypoint {
+        function: "reexported_lexical_block_scope",
+        expected: 7,
+    },
+    IdentityGraphEntrypoint {
+        function: "imported_path_function_scope",
+        expected: 17,
+    },
+    IdentityGraphEntrypoint {
+        function: "imported_path_block_scope",
+        expected: 17,
+    },
+    IdentityGraphEntrypoint {
+        function: "aliased_path_function_scope",
+        expected: 19,
+    },
+    IdentityGraphEntrypoint {
+        function: "aliased_path_block_scope",
+        expected: 19,
+    },
+];
+
+/// Matrix cells the replacement route refuses today, each bound to the issue that owns closing the gap.
+///
+/// Every member cell in the matrix reads a field through a model method, and the direct profile retains a model
+/// declaration only when it has no methods (`is_direct_replacement_plain_model`), so the constructor is refused
+/// before the method is ever reached. That is a language-matrix gap owned by #1291, not an import one: the same
+/// refusal occurs for `LocalMember`, which crosses no module boundary at all. #1260 and #1261 supply what these
+/// cells still need after that lands -- the imported, aliased, and re-exported identities they construct through.
+///
+/// The runner requires each of these to actually be refused. A deferral that quietly starts working fails this row
+/// rather than passing unnoticed, so the day #1291 lands, someone has to come back and promote these cells.
+const IDENTITY_MATRIX_DEFERRED: &[IdentityGraphDeferral] = &[
+    IdentityGraphDeferral {
+        function: "local_member_function_scope",
+        owning_issue: 1291,
+    },
+    IdentityGraphDeferral {
+        function: "local_member_block_scope",
+        owning_issue: 1291,
+    },
+    IdentityGraphDeferral {
+        function: "imported_member_function_scope",
+        owning_issue: 1291,
+    },
+    IdentityGraphDeferral {
+        function: "imported_member_block_scope",
+        owning_issue: 1291,
+    },
+    IdentityGraphDeferral {
+        function: "aliased_member_function_scope",
+        owning_issue: 1291,
+    },
+    IdentityGraphDeferral {
+        function: "aliased_member_block_scope",
+        owning_issue: 1291,
+    },
+    IdentityGraphDeferral {
+        function: "reexported_member_function_scope",
+        owning_issue: 1291,
+    },
+    IdentityGraphDeferral {
+        function: "reexported_member_block_scope",
+        owning_issue: 1291,
+    },
+];
 
 const IDENTITY_MATRIX_MODULES: &[IdentitySourceModule] = &[
     IdentitySourceModule {
@@ -3842,11 +3946,12 @@ fn seed_corpus() -> Vec<ParityCase> {
                 modules: IDENTITY_MATRIX_MODULES,
                 root_module: "identity_matrix",
                 verify: verify_identity_matrix,
-                replacement: IdentityReplacementPlan::Unavailable {
-                    owning_issue: 989,
-                    reason: "#989 owns cross-package/import/re-export replacement execution; this row executes the checked graph, HIR, Body IR, and generated canonical projections only",
+                replacement: IdentityReplacementPlan::Graph {
+                    root_module: "identity_matrix",
+                    entrypoints: IDENTITY_MATRIX_ENTRYPOINTS,
+                    deferred: IDENTITY_MATRIX_DEFERRED,
                 },
-                comparison_reason: "#989 owns cross-package/import/re-export replacement execution, so no paired source-observable comparison was available",
+                comparison_reason: "the checked graph and the cross-module replacement route both executed, but no independent legacy execution was run for a source-observable comparison",
             })),
             replacement_execution: None,
         },
@@ -4193,7 +4298,8 @@ fn rfc_120_rows_publish_real_conformance_evidence_without_fabricating_legacy_exe
         );
         if matches!(
             row.id,
-            "parity-987-120-02-let-shadow"
+            "parity-987-120-01-identity-matrix"
+                | "parity-987-120-02-let-shadow"
                 | "parity-987-120-03-mut-shadow"
                 | "parity-987-120-04-generic-binder"
                 | "parity-987-120-05-builtin-rebinding"
@@ -4216,7 +4322,9 @@ fn rfc_120_rows_publish_real_conformance_evidence_without_fabricating_legacy_exe
         .and_then(|row| row.identity_conformance.as_ref())
         .ok_or("RFC 120 identity matrix evidence is missing")?;
     assert_eq!(matrix.coverage_cells.len(), 26);
-    assert_eq!(matrix.replacement_unavailable_issue, Some(989));
+    // The matrix used to record #989 as owning an unavailable replacement route. #1260 and #1261 made cross-module
+    // execution real, so the row now carries an executed output identity instead of an owner for its absence.
+    assert_eq!(matrix.replacement_unavailable_issue, None);
 
     let artifact = rows
         .iter()

--- a/tests/support/parity_corpus.rs
+++ b/tests/support/parity_corpus.rs
@@ -43,8 +43,9 @@
 
 use incan::backend::IrCodegen;
 use incan::backend::replacement::{
-    OwnershipReadProjection, ReplacementValue, RuntimeRequirementProjection, TaskLifecycleProjection,
-    execute_prevalidated_free_function, prepare_free_function_execution,
+    OwnershipReadProjection, ReplacementExecutionGraph, ReplacementValue, RuntimeRequirementProjection,
+    TaskLifecycleProjection, execute_prevalidated_free_function, prepare_free_function_execution,
+    prepare_free_function_execution_in_graph,
 };
 use incan::backend::selection::{
     BackendKind, BackendSelection, BackendSelectionError, FallbackPolicy, ShadowComparisonState, digest_output,
@@ -1194,8 +1195,45 @@ pub(crate) enum IdentityReplacementPlan {
         arguments: fn() -> Vec<ReplacementValue>,
         expected: fn() -> ReplacementValue,
     },
+    /// Execute every declared entrypoint against a replacement graph spanning the checked modules.
+    ///
+    /// This is the cross-module form of [`IdentityReplacementPlan::Direct`]. A row uses it when its entrypoints
+    /// call across the module boundary rather than staying inside one module's Body IR, which is exactly the
+    /// surface #1260 and #1261 made executable: the callee's identity is resolved through the graph rather than
+    /// through the caller module's own bodies.
+    Graph {
+        root_module: &'static str,
+        entrypoints: &'static [IdentityGraphEntrypoint],
+        deferred: &'static [IdentityGraphDeferral],
+    },
     /// The checked graph is executable through its compiler carriers, but replacement package execution is not.
     Unavailable { owning_issue: u32, reason: &'static str },
+}
+
+/// One entrypoint a graph replacement plan executes, with the integer result the checked route must produce.
+///
+/// Entrypoints are scalar and argument-free on purpose. The claim under test is that a call reaching another
+/// module resolves to one declaration and returns that declaration's result; parameter passing and richer value
+/// shapes are already covered by the single-module rows and would only add noise here.
+#[derive(Clone, Copy)]
+pub(crate) struct IdentityGraphEntrypoint {
+    /// Free function in the plan's root module.
+    pub(crate) function: &'static str,
+    /// Value the entrypoint must return.
+    pub(crate) expected: i64,
+}
+
+/// One entrypoint a graph replacement plan cannot execute yet, bound to the issue that owns closing the gap.
+///
+/// The runner requires the refusal to be real: it prepares the entrypoint and fails the row if preparation
+/// succeeds. A gap that closes without anyone noticing would otherwise leave a stale deferral behind, which is the
+/// same "unavailable counted as fine" failure the corpus exists to prevent.
+#[derive(Clone, Copy)]
+pub(crate) struct IdentityGraphDeferral {
+    /// Free function in the plan's root module.
+    pub(crate) function: &'static str,
+    /// Issue that owns making this entrypoint executable.
+    pub(crate) owning_issue: u32,
 }
 
 /// Data-driven multi-module identity-conformance evaluation.
@@ -1540,6 +1578,113 @@ fn try_execute_identity_conformance_plan(
                             None,
                             behavior_outcome,
                         )
+                    }
+                    IdentityReplacementPlan::Graph {
+                        root_module,
+                        entrypoints,
+                        deferred,
+                    } => {
+                        if entrypoints.is_empty() {
+                            return Err("a graph replacement plan must declare at least one entrypoint".to_string());
+                        }
+                        let root = graph.module(root_module)?;
+                        let selection = select_backend(
+                            BackendKind::Replacement,
+                            true,
+                            true,
+                            graph.source_graph_identity.clone(),
+                            FallbackPolicy::Refuse,
+                        );
+                        let executed_backend = resolve_execution(&selection, true)
+                            .map_err(|error| format!("identity replacement selection failed: {error}"))?;
+
+                        // Each entrypoint is executed against a graph rebuilt over the same modules. Building it per
+                        // entrypoint rather than once keeps every execution independent, so one row cannot observe
+                        // state another left behind -- the property a cross-module claim most needs to be free of.
+                        let mut per_entrypoint_identities: Vec<String> = Vec::new();
+                        let mut behavior_outcome = ComparisonOutcome::Match;
+                        for entrypoint in entrypoints {
+                            let reachable = graph
+                                .modules
+                                .iter()
+                                .filter(|module| module.name != root_module)
+                                .map(|module| &module.body_ir);
+                            let execution_graph = ReplacementExecutionGraph::new(&root.body_ir, reachable)
+                                .map_err(|error| format!("identity replacement graph assembly failed: {error}"))?;
+                            let execution_plan = prepare_free_function_execution_in_graph(
+                                execution_graph,
+                                entrypoint.function,
+                                &[],
+                                None,
+                            )
+                            .map_err(|error| {
+                                format!(
+                                    "identity replacement execution refused `{}`: {error}",
+                                    entrypoint.function
+                                )
+                            })?;
+                            let execution = execute_prevalidated_free_function(execution_plan).map_err(|error| {
+                                format!(
+                                    "identity replacement execution failed `{}`: {error}",
+                                    entrypoint.function
+                                )
+                            })?;
+                            if execution.value != ReplacementValue::Int(entrypoint.expected) {
+                                behavior_outcome = ComparisonOutcome::Mismatch {
+                                    detail: format!(
+                                        "identity replacement `{}` returned {:?}, expected Int({})",
+                                        entrypoint.function, execution.value, entrypoint.expected
+                                    ),
+                                };
+                                break;
+                            }
+                            per_entrypoint_identities.push(execution.output_identity);
+                        }
+
+                        // Prove every deferral is still real. A cell that starts executing must fail this row so it
+                        // gets promoted, rather than sitting in the deferred list claiming a gap that closed.
+                        for deferral in deferred {
+                            if deferral.owning_issue == 0 {
+                                return Err(format!(
+                                    "deferred entrypoint `{}` must name the issue that owns closing the gap",
+                                    deferral.function
+                                ));
+                            }
+                            let reachable = graph
+                                .modules
+                                .iter()
+                                .filter(|module| module.name != root_module)
+                                .map(|module| &module.body_ir);
+                            let execution_graph = ReplacementExecutionGraph::new(&root.body_ir, reachable)
+                                .map_err(|error| format!("identity replacement graph assembly failed: {error}"))?;
+                            if prepare_free_function_execution_in_graph(execution_graph, deferral.function, &[], None)
+                                .is_ok()
+                            {
+                                return Err(format!(
+                                    "deferred entrypoint `{}` now prepares successfully; #{} closed, so promote it \
+                                     into the executed entrypoints",
+                                    deferral.function, deferral.owning_issue
+                                ));
+                            }
+                        }
+
+                        // The row's output identity covers every entrypoint it executed, so dropping one changes it.
+                        // A single entrypoint's identity would let the others silently disappear.
+                        let borrowed: Vec<&str> = per_entrypoint_identities.iter().map(String::as_str).collect();
+                        let output_identity = digest_output(&borrowed);
+                        let shadow = unavailable_shadow_comparison(selection.shadow_requested, plan.comparison_reason);
+                        let receipt = finalize_receipt(
+                            &selection,
+                            executed_backend,
+                            output_identity.clone(),
+                            shadow,
+                            DIAGNOSTIC_SCHEMA_VERSION,
+                        )
+                        .map_err(|error| format!("identity replacement receipt failed: {error}"))?;
+                        receipt
+                            .verify_identity()
+                            .map_err(|error| format!("identity replacement receipt verification failed: {error}"))?;
+                        (Some(output_identity), Some(receipt.identity), None, behavior_outcome)
                     }
                     IdentityReplacementPlan::Unavailable { owning_issue, reason } => {
                         if owning_issue == 0 || !reason.contains(&format!("#{owning_issue}")) {


### PR DESCRIPTION
## Summary

The RFC 120 identity matrix — 26 coverage cells over local, imported, aliased and re-exported bindings in module, function and block scope — recorded this about its replacement route:

```rust
replacement: IdentityReplacementPlan::Unavailable {
    owning_issue: 989,
    reason: "#989 owns cross-package/import/re-export replacement execution; this row \
             executes the checked graph, HIR, Body IR, and generated canonical projections only",
},
```

That was true when it was written. #1260 and #1261 made cross-module execution real, so the row can now run what it had only checked. It does.

`parity-987-120-01-identity-matrix` is the corpus row that has been carrying the largest gap between "the compiler resolves this correctly" and "the route executes it". Closing it is the executable evidence #1260 and #1261 each ask for under *"Stable #987 corpus IDs and dispositions distinguish matched, diverged, unavailable, migrated, and unsupported cases."*

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [x] Compiler (frontend/backend/codegen)

## Key details

**`IdentityReplacementPlan::Graph`** is the cross-module form of the existing `Direct` plan. `Direct` prepares an entrypoint against one module's Body IR, which is all a single-module row needs; these entrypoints call across the boundary, so the callee is resolved through a `ReplacementExecutionGraph` spanning the checked modules instead.

The graph is rebuilt per entrypoint rather than once. Twelve independent executions is the property a cross-module claim most needs to be free of shared state, and rebuilding costs nothing at this size.

**Twelve cells execute.** Local, imported, aliased and re-exported lexical calls in function and block scope, plus module-qualified and alias-qualified path calls in both scopes. Their expected values are deliberately distinct, so a call that reached the wrong declaration is a wrong number rather than a coincidence: were `lexical_alias` resolved to `imported_lexical`, the row would return 3 where 5 is required, and both are real declarations that execute.

The row's output identity is a digest over every entrypoint it executed, so dropping one changes it. A single entrypoint's identity would let the other eleven disappear silently.

**Eight cells stay deferred, and move owner from #989 to #1291.** Every member cell reads a field through a model method, and the direct profile retains a model declaration only when it has no methods (`is_direct_replacement_plain_model`), so the *constructor* is refused before the method is ever reached:

> `replacement backend does not support constructor `LocalMember` without a source-local declaration identity`

That is a language-matrix gap, not an import one. The identical refusal occurs for `LocalMember`, which crosses no module boundary at all, and the imported, aliased and re-exported spellings of the same shape fail for the same reason. Recorded on #1291 as a residual direct-execution row it should own.

**A deferral now has to be real.** The runner prepares each deferred entrypoint and fails the row if preparation *succeeds*. The day #1291 lands, this row fails until someone promotes those cells — they are already written and already carry their expected values, so promoting them is a table edit. Without that check a stale deferral would sit there claiming a gap that had closed, which is the same "unavailable quietly counted as fine" failure the corpus exists to prevent.

**Risks.** Test-only. The one assertion that changes is `matrix.replacement_unavailable_issue`, which went from `Some(989)` to `None` because the row now carries an executed output identity instead of an owner for its absence, and the matrix joins the rows required to publish a real receipt identity.

## Testing / verification

- [x] `cargo test --test parity_corpus_tests` — 31 passed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo +nightly fmt`
- [x] `scripts/check_changed_rustdocs.py`

The row remains **non-green**, correctly: no independent legacy execution ran, so there is no paired source-observable comparison. Its `comparison_reason` says exactly that instead of naming #989 as the reason nothing ran. Reaching green needs #1146's receipt-bound comparison, as with every other executing row.

## Docs impact

- [x] No docs changes needed

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

## Stack

Stacked on #1330 — the four path cells do not execute without it. Full chain: #1318 → #1320 → #1321 → #1328 → #1330 → this.

Advances #1260 and #1261.
