### PR TITLE
bugfix - project a package's own inherent method while building that package (#1174)

### DIFF
--- a/src/backend/ir/lower/expr/mod.rs
+++ b/src/backend/ir/lower/expr/mod.rs
@@ -120,14 +120,26 @@ impl AstLowering {
     /// Trait dispatch is deliberately excluded rather than caught here. A local type adopting a package's trait
     /// carries that trait's package identity while its wrapper is emitted locally, so the trait cases are decided by
     /// `can_use_source_method_projection` on the trait's own terms.
+    ///
+    /// A package origin names *which library declares the method*, not that the method is foreign to this build. When
+    /// that library is the one this compilation is producing, the wrapper is emitted right here, and suppressing the
+    /// projection would decline to name a slot that does exist. Only another library's inherent method has no wrapper
+    /// this compilation can name.
     fn method_belongs_to_an_imported_type(&self, call_span: ast::Span, dispatch: Option<&IrMethodDispatch>) -> bool {
         if dispatch.is_some() {
             return false;
         }
-        self.type_info
+        let Some(identity) = self
+            .type_info
             .as_ref()
             .and_then(|info| info.resolved_identity(call_span))
-            .is_some_and(|identity| matches!(identity.origin, incan_semantics_core::SymbolOrigin::Package { .. }))
+        else {
+            return false;
+        };
+        let incan_semantics_core::SymbolOrigin::Package { library, .. } = &identity.origin else {
+            return false;
+        };
+        self.produced_library_identity() != Some(library.as_str())
     }
 
     /// Convert a contained checked-C value contract into its private generated-Rust carrier.
@@ -2736,6 +2748,83 @@ mod tests {
             type_args: Vec::new(),
             receiver_is_mutable: false,
         }))
+    }
+
+    /// Build a lowering whose checked facts resolve one method call to a declaration owned by `library`.
+    fn lowering_resolving_a_package_method(
+        library: &str,
+        produced_library: Option<&str>,
+        call_span: ast::Span,
+    ) -> AstLowering {
+        let mut type_info = crate::frontend::typechecker::TypeCheckInfo::default();
+        type_info.record_resolved_identity(
+            call_span,
+            incan_semantics_core::CanonicalSymbolId {
+                namespace: incan_semantics_core::SymbolNamespace::Member,
+                origin: incan_semantics_core::SymbolOrigin::Package {
+                    library: library.to_string(),
+                    module_path: vec!["registry".to_string()],
+                },
+                declaration_name: "entry".to_string(),
+                kind: incan_semantics_core::SemanticSourceTargetKind::Method,
+                scope_discriminant: None,
+                declaration_span: incan_semantics_core::HirSourceSpan::new(0, 0),
+            },
+        );
+        let mut lowering = AstLowering::new_with_type_info(type_info);
+        lowering.set_registry_package_identity(produced_library.map(str::to_string));
+        lowering
+    }
+
+    /// A package's own inherent method keeps its projection while that package is the one being compiled.
+    ///
+    /// Regression for #1174: the suppression rule matched any `SymbolOrigin::Package`, so once a package's modules
+    /// called into each other, the package's own declarations looked foreign to its own build. Building
+    /// `incan_stdlib_core` then emitted a raw `entry` where the checked registry lowering required the projected
+    /// name, and every `Registry.entry` in the component failed to lower.
+    #[test]
+    fn a_package_projects_its_own_inherent_method_while_building_itself() {
+        let call_span = ast::Span { start: 10, end: 20 };
+        let lowering = lowering_resolving_a_package_method("incan_stdlib_core", Some("incan_stdlib_core"), call_span);
+
+        assert!(
+            !lowering.method_belongs_to_an_imported_type(call_span, None),
+            "a package's own declaration is emitted by this build, so its wrapper can be named"
+        );
+    }
+
+    /// Another package's inherent method still has no wrapper this compilation can name.
+    ///
+    /// The other half of #1174, pinned so narrowing the rule does not restore the original defect: a consumer calling
+    /// a method on a dependency's type must reach the dependency's own slot, because no wrapper is emitted here --
+    /// and for a newtype over a `rust::` type none exists anywhere, since Rust forbids a foreign inherent `impl`.
+    #[test]
+    fn another_packages_inherent_method_is_still_not_projected() {
+        let call_span = ast::Span { start: 10, end: 20 };
+        let consumer = lowering_resolving_a_package_method("incan_stdlib_core", Some("my_app"), call_span);
+        assert!(
+            consumer.method_belongs_to_an_imported_type(call_span, None),
+            "a dependency's inherent method has no wrapper in the consumer's compilation"
+        );
+
+        // No project owns an ad-hoc single-file build, and every package identity is then genuinely foreign.
+        let unowned = lowering_resolving_a_package_method("incan_stdlib_core", None, call_span);
+        assert!(
+            unowned.method_belongs_to_an_imported_type(call_span, None),
+            "without a produced library every package identity stays foreign"
+        );
+    }
+
+    /// Trait dispatch stays with `can_use_source_method_projection`, whichever package owns the declaration.
+    #[test]
+    fn trait_dispatch_is_not_decided_by_the_declaring_package() {
+        let call_span = ast::Span { start: 10, end: 20 };
+        let lowering = lowering_resolving_a_package_method("incan_stdlib_core", Some("my_app"), call_span);
+
+        assert!(
+            !lowering.method_belongs_to_an_imported_type(call_span, Some(&trait_dispatch("FallibleIterator"))),
+            "a dispatched call is decided on the trait's own terms, not the declaring package's"
+        );
     }
 
     #[test]

--- a/src/backend/ir/lower/mod.rs
+++ b/src/backend/ir/lower/mod.rs
@@ -240,11 +240,24 @@ pub struct AstLowering {
     /// Canonical package identity supplied by the build or test orchestration layer.
     ///
     /// Explicit `RegistrySubject.package()` entries need this boundary-owned fact so their runtime value agrees with
-    /// the checked package artifact rather than preserving a source placeholder.
+    /// the checked package artifact rather than preserving a source placeholder. It is also the only fact this stage
+    /// has for "which library is this compilation producing", which method projection needs to tell a package's own
+    /// declarations from another package's -- see [`AstLowering::produced_library_identity`]. It is `None` when no
+    /// project owns the compilation, and every package identity is then genuinely foreign.
     pub(super) registry_package_identity: Option<String>,
 }
 
 impl AstLowering {
+    /// The library this compilation is producing, when a project owns it.
+    ///
+    /// A [`SymbolOrigin::Package`](incan_semantics_core::SymbolOrigin::Package) says which library *declares* a
+    /// symbol; it does not say the symbol is foreign. Comparing against this answers the second question, which is
+    /// the one an emission decision usually needs: a package's own declarations are emitted by this build, another
+    /// package's are not.
+    fn produced_library_identity(&self) -> Option<&str> {
+        self.registry_package_identity.as_deref()
+    }
+
     /// Return the compiler-minted identity for a linker-visible source function declaration.
     fn emitted_function_identity(&self, name: &str, span: ast::Span) -> Result<CanonicalSymbolId, LoweringError> {
         let identity = self.type_info.as_ref().and_then(|info| {

--- a/tests/generated_rust_artifact_tests.rs
+++ b/tests/generated_rust_artifact_tests.rs
@@ -534,3 +534,50 @@ def main() -> None:
 
     Ok(())
 }
+
+/// A package that calls between its own modules must project the callee's emitted name.
+///
+/// Regression for #1174. A package origin says which library *declares* a method; it does not say the method is
+/// foreign to this build. Reading it as the latter made a package's own build treat its own declarations as imported
+/// and emit a raw `c.bumped()` where the wrapper it was itself emitting is named `__incan_v1_…`. Building
+/// `stdlib-core` then failed with 67 lowering errors, because the checked registry lowering requires the projected
+/// name.
+///
+/// Deliberately a generated-Rust assertion rather than a build-to-completion one: `incan build --lib` emits the
+/// generated project *before* the dependency check stops it, so this costs about a second and needs no Oven bake.
+/// That matters, because the defect is otherwise reachable only through a cold SDK component build -- minutes of
+/// work that neither a local suite nor a gated development pull request performs.
+#[test]
+fn a_package_projects_a_call_into_its_own_sibling_module() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let root = tmp.path().join("pkgprobe");
+    let src = root.join("src");
+    fs::create_dir_all(&src)?;
+    fs::write(
+        root.join("incan.toml"),
+        "[project]\nname = \"pkgprobe\"\nversion = \"0.1.0\"\n",
+    )?;
+    fs::write(
+        src.join("types.incn"),
+        "pub model Counter:\n    pub value: int\n\n    def bumped(self) -> int:\n        return self.value + 1\n",
+    )?;
+    fs::write(
+        src.join("lib.incn"),
+        "from types import Counter\n\npub def probe() -> int:\n  c = Counter(value=41)\n  return c.bumped()\n",
+    )?;
+
+    // The command stops at the dependency check, which is expected and not what this pins. The generated project is
+    // already written by then, and it is the artifact under test.
+    let _ = run_incan(&root, &["build", "--lib", "src/lib.incn"])?;
+
+    let generated = fs::read_to_string(root.join("target/lib/src/lib.rs"))?;
+    assert!(
+        !generated.contains("c.bumped()"),
+        "a sibling module's method must not be called by its source spelling:\n{generated}"
+    );
+    assert!(
+        generated.contains("__incan_v1_"),
+        "the call must name the projected wrapper this build emits:\n{generated}"
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary

`0.6.0-dev.2` cannot build the `stdlib-core` SDK component from a cold cache. It fails with **67 lowering errors**, every one of them:

> `checked registry entry lowering no longer matches its frontend-approved Registry.entry`

This is a regression from #1323, which is mine.

#1323 stopped projecting an inherent method a package declares — correctly, because a wrapper is emitted beside its declaration and only the compilation that declares the type emits one. The rule it used was too broad:

```rust
matches!(identity.origin, SymbolOrigin::Package { .. })
```

**A package origin says which library *declares* the method. It does not say the method is foreign to this build.** I read the first as the second. Once a package's own modules call into each other, its declarations carry its own library name — so the package's own build treated them as imported and declined to name a wrapper it was itself emitting.

Instrumenting the failure shows it exactly:

```
origin:                    Package { library: "incan_stdlib_core", module_path: ["registry"] }
registry_package_identity: Some("incan_stdlib_core")
```

`registry.entry` resolves to a declaration owned by `incan_stdlib_core`, in the compilation producing `incan_stdlib_core`. The frontend approved the projected `__incan_v1_…` name; lowering emitted a raw `entry`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [x] Compiler (frontend/backend/codegen)

## Key details

- **User-facing behavior**: a package that calls between its own modules builds again. Nothing else changes; the emitted name for every other call is identical.
- **Internals**: compare the declaring library against the library this compilation produces.

  ```rust
  let SymbolOrigin::Package { library, .. } = &identity.origin else { return false };
  self.produced_library_identity() != Some(library.as_str())
  ```

  `registry_package_identity` already carries that fact on every project path (`build.rs` ×2, `test_runner`), and is `None` for an ad-hoc build with no project — where any package identity *is* genuinely foreign, so #1323's original `std.async.sync.MutexGuard` case is unchanged. I added a named accessor and documented the field's second purpose rather than quietly reusing a registry-named field for an emission decision.
- **Risks**: low, and bounded by the tests below. The change only narrows a suppression, so it can restore a projection that was wrongly suppressed; it cannot suppress one that was previously emitted.

### I checked whether the same misreading exists elsewhere

Every other `SymbolOrigin::Package` use in `src` and `crates` either destructures it to *use* the library name, or matches `Module(_) | Package { .. }` together — which asks "does this have a real origin at all", a different and safe question. This was the only place a package origin was read as "foreign to me".

## Testing / verification

- [x] `cargo test --test replacement_backend_execution_tests` — **118 passed from a cold SDK cache** (801s, because the component now genuinely builds instead of failing fast). The same run is 117/1 on `0.6.0-dev.2`.
- [x] `cargo test --lib` — 3242 passed, 28 failed: the same 28 environment-dependent failures this branch line already has.
- [x] `cargo test --test codegen_snapshot_tests` — 257 passed, no churn.
- [x] `cargo test --test parity_corpus_tests` — 31 passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo +nightly fmt`, `scripts/check_changed_rustdocs.py`.

Three tests, which #1323 shipped without — that is the reason this was possible at all:

- `a_package_projects_its_own_inherent_method_while_building_itself` — the case that broke. **Confirmed it fails against the pre-fix rule and passes with the fix**, by temporarily restoring the old condition rather than assuming.
- `another_packages_inherent_method_is_still_not_projected` — #1323's original case, plus the no-project case where the produced library is `None`. Passes both before and after, so the narrowing provably did not restore the original defect.
- `trait_dispatch_is_not_decided_by_the_declaring_package` — pins that a dispatched call stays with `can_use_source_method_projection` on the trait's own terms.

## Why it reached the branch

Two independent gaps, and the second is worth acting on separately.

**Locally**, a warm SDK provider cache hides it — nothing rebuilds the component, so the defective lowering never runs. It surfaced only when a version bump invalidated that cache.

**In CI**, #1323 skipped every heavy lane, including `Oven Linux replay` and `Linux Oven prewarm`. Those are the only lanes that build a package, so a gated development pull request exercises no package build at all. That is the gate working as designed and a real defect walking through the gap it leaves.

## Docs impact

- [x] No docs changes needed

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions