### PR TITLE
chore - classify the public package boundary in the parity corpus (#989)

### DIFF
--- a/tests/parity_corpus_tests.rs
+++ b/tests/parity_corpus_tests.rs
@@ -224,6 +224,41 @@ fn body_ir_snapshot(src: &str, expect_desc: &str) -> Result<String, ComparisonOu
     Ok(build_body_ir_module_v0(&program, &module_path, checker.type_info()).render_snapshot())
 }
 
+/// Run one module through the direct route's source-profile gate and classify the refusal it produces.
+///
+/// This observes admission, not execution: the profile decides which source modules the direct route will run at
+/// all, and a boundary it declines never reaches Body IR. `None` means the module was admitted.
+fn outcome_from_source_profile(
+    src: &str,
+    expect: impl FnOnce(Option<&str>) -> bool,
+    expect_desc: &str,
+) -> ComparisonOutcome {
+    let tokens = match lexer::lex(src) {
+        Ok(tokens) => tokens,
+        Err(errors) => {
+            return ComparisonOutcome::Incompatible {
+                reason: format!("lex failed before the profile could run: {errors:?}"),
+            };
+        }
+    };
+    let program = match parser::parse(&tokens) {
+        Ok(program) => program,
+        Err(errors) => {
+            return ComparisonOutcome::Incompatible {
+                reason: format!("parse failed before the profile could run: {errors:?}"),
+            };
+        }
+    };
+    let refusal = incan::backend::replacement::source_profile::source_profile_refusal(&program).map(|e| e.to_string());
+    if expect(refusal.as_deref()) {
+        ComparisonOutcome::Match
+    } else {
+        ComparisonOutcome::Mismatch {
+            detail: format!("expected {expect_desc}, got profile refusal: {refusal:?}"),
+        }
+    }
+}
+
 fn outcome_from_typecheck(src: &str, expect: impl FnOnce(&[String]) -> bool, expect_desc: &str) -> ComparisonOutcome {
     match typecheck_err_messages(src) {
         Err(errs) => ComparisonOutcome::Incompatible {
@@ -283,6 +318,41 @@ def main() -> None:
     if a < b < c:
         println("chained")
 "#;
+
+/// One package consumer: a call into a dependency through the public `pub::` surface.
+const PACKAGE_CONSUMER_SRC: &str = r#"
+from pub::widgets import build
+
+def f() -> int:
+    return build()
+"#;
+
+/// Confirm that a package consumer is still refused before the direct route reaches execution.
+///
+/// This row exists to keep the #989 package boundary counted rather than absent. It confirms current behavior, so
+/// it flips the day #1339 ships an executable representation -- at which point the row must be promoted to a real
+/// execution rather than quietly left recording a refusal that no longer happens.
+fn case_package_consumer_call_is_refused() -> ComparisonOutcome {
+    outcome_from_source_profile(
+        PACKAGE_CONSUMER_SRC,
+        |refusal| refusal.is_some(),
+        "the direct route refuses a `pub::` package consumer",
+    )
+}
+
+/// Confirm that the refusal is still reported as an unreached construct rather than in packaging terms.
+///
+/// RFC 123 requires a consumer that cannot obtain a usable representation to name the package, the version and the
+/// unmet requirement, and never to report the condition as an unsupported language construct. Today it reports
+/// `import declaration` -- the same misdiagnosis #1262 fixed for `rust::`. Pinning the current wording keeps the gap
+/// visible and makes the row fail when #1339 corrects it.
+fn case_package_representation_refusal_is_not_a_language_refusal() -> ComparisonOutcome {
+    outcome_from_source_profile(
+        PACKAGE_CONSUMER_SRC,
+        |refusal| refusal.is_some_and(|text| text.contains("import declaration")),
+        "the package boundary still refuses as an unreached construct rather than in packaging terms",
+    )
+}
 
 fn case_diagnostic_chained_comparison_rejected() -> ComparisonOutcome {
     outcome_from_typecheck(
@@ -3933,6 +4003,53 @@ fn seed_corpus() -> Vec<ParityCase> {
             identity_conformance: None,
             replacement_execution: None,
         },
+        // ---- #989 public-boundary rows the replacement route cannot yet reach ----
+        //
+        // These are declared rather than evaluated on purpose. A package consumer needs a baked dependency and an
+        // executable representation of its public surface, and neither exists yet; declaring the rows keeps the
+        // boundary counted and owned instead of absent, which is what #989's disposition model asks for. Each names
+        // the issue that makes it executable, so the row fails review the day that issue closes and nothing here
+        // changes.
+        ParityCase {
+            id: "parity-987-989-package-consumer-call",
+            title: "A call into a package dependency executes on a route that does not link Rust",
+            category: BehaviorCategory::SupportedLanguageContract,
+            lane: EvidenceLane::PackageImportBoundary,
+            evidence: "#989; RFC 123; #1339 owns the executable representation this row needs",
+            disposition: Disposition::Unsupported {
+                owning_issue: 1339,
+                migration_note: "A package publishes signatures, checked API and canonical identities -- enough to \
+                                  typecheck a call into it, and nothing a non-linking route can execute. The direct \
+                                  route therefore refuses every `pub::` import, so moving a declaration into a \
+                                  package removes execution routes it had as a local module. RFC 123 is Planned and \
+                                  #1339 implements the representation that closes this. Until then the boundary is \
+                                  unavailable rather than passing, and no result may claim package parity.",
+            },
+            source: PACKAGE_CONSUMER_SRC,
+            evaluate: Some(case_package_consumer_call_is_refused),
+            identity_conformance: None,
+            replacement_execution: None,
+        },
+        ParityCase {
+            id: "parity-987-989-package-representation-refusal",
+            title: "A missing or uninterpretable package representation refuses in packaging terms, before any result",
+            category: BehaviorCategory::DiagnosticBehavior,
+            lane: EvidenceLane::PackageImportBoundary,
+            evidence: "#989; RFC 123 reference-level rules; #1339",
+            disposition: Disposition::Unsupported {
+                owning_issue: 1339,
+                migration_note: "RFC 123 requires a consumer that cannot obtain a usable representation to refuse \
+                                  before producing any result, naming the package, the version and the requirement \
+                                  it did not meet -- and never to report the condition as an unsupported language \
+                                  construct. Today a `pub::` import reports `import declaration`, which is the same \
+                                  misdiagnosis #1262 fixed for `rust::`: it sends a reader to the language when the \
+                                  problem is packaging. Owned by #1339.",
+            },
+            source: PACKAGE_CONSUMER_SRC,
+            evaluate: Some(case_package_representation_refusal_is_not_a_language_refusal),
+            identity_conformance: None,
+            replacement_execution: None,
+        },
         ParityCase {
             id: "parity-987-120-01-identity-matrix",
             title: "RFC 120 identities survive every semantically valid binding, namespace, and scope cell",
@@ -4081,8 +4198,8 @@ fn rfc_120_member_coverage_rejects_a_consistent_wrong_owner_selection() {
             root_module: "identity_matrix",
             verify: verify_wrong_owner_member_selection,
             replacement: IdentityReplacementPlan::Unavailable {
-                owning_issue: 989,
-                reason: "#989 owns cross-package replacement execution",
+                owning_issue: 1332,
+                reason: "a negative fixture is rejected during conformance, so no route runs it; #1332 owns the paired reference route these rows would need if they ever did",
             },
             comparison_reason: "negative conformance fixture must fail before execution",
         })),
@@ -4116,8 +4233,8 @@ fn rfc_120_module_path_coverage_rejects_a_consistent_wrong_target_selection() {
             root_module: "identity_matrix",
             verify: verify_wrong_path_target_selection,
             replacement: IdentityReplacementPlan::Unavailable {
-                owning_issue: 989,
-                reason: "#989 owns cross-package replacement execution",
+                owning_issue: 1332,
+                reason: "a negative fixture is rejected during conformance, so no route runs it; #1332 owns the paired reference route these rows would need if they ever did",
             },
             comparison_reason: "negative conformance fixture must fail before execution",
         })),


### PR DESCRIPTION
## Summary

#989 exits when the public-boundary corpus *"passes or is explicitly classified under the #652 disposition model."* I checked, and the package rows were **neither** — they were absent. A boundary nobody wrote down isn't classified, it's invisible, and #989 can't honestly close over a gap the corpus doesn't record.

This adds the classification so it can.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [x] Compiler (frontend/backend/codegen)

## Key details

**Two rows for the package consumer, both owned by #1339:**

| row | records |
| --- | --- |
| `parity-987-989-package-consumer-call` | a call into a `pub::` dependency is refused, because a package publishes nothing a non-linking route can execute |
| `parity-987-989-package-representation-refusal` | that refusal reports `import declaration` rather than naming the package and the unmet requirement |

The second is worth its own row because it's a *diagnostic* gap, not an execution one. RFC 123 requires a consumer that cannot obtain a usable representation to name the package, the version and the requirement it did not meet, and never to report the condition as an unsupported language construct. Today it does exactly that — the same misdiagnosis #1262 fixed for `rust::`, which sends a reader to the language when the problem is packaging.

**Both confirm current behavior rather than declaring it.** My first attempt used declaration-only rows and the corpus validator rejected them:

```
case must declare exactly one execution shape, found 0
```

That's the right guardrail, and the rejection improved the change. A declared-only row records an opinion; these record an observation, through a new `outcome_from_source_profile` helper that runs a module through the direct route's admission gate. They flip the day #1339 ships a representation — so whoever closes that issue has to come back and promote them rather than leaving a stale claim behind. Same discipline as the deferred-entrypoint check in #1331.

**Also fixes two mislabelled rows.** The RFC 120 negative fixtures `parity-987-120-negative-wrong-owner` and `-wrong-path-target` recorded `Unavailable { owning_issue: 989, reason: "#989 owns cross-package replacement execution" }`. They're negative fixtures — rejected *during conformance*, so no route ever runs them and the route was never the reason they don't execute. They now point at #1332, which owns the paired reference route they'd need if they ever did.

- **User-facing behavior**: none. Test-only.
- **Risks**: none beyond the corpus itself.

## Testing / verification

- [x] `cargo test --test parity_corpus_tests` — 31 passed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo +nightly fmt`, `scripts/check_changed_rustdocs.py`

## Docs impact

- [x] No docs changes needed

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Last piece of #989's exit condition. Advances #1138.