### PR TITLE
bugfix - synchronize publication directories on native Windows (#1340)

### DIFF
--- a/src/cli/commands/common.rs
+++ b/src/cli/commands/common.rs
@@ -638,26 +638,22 @@ fn sync_sdk_provider_tree(path: &Path) -> CliResult<()> {
                 })?;
         }
     }
-    fs::File::open(path)
-        .and_then(|directory| directory.sync_all())
-        .map_err(|error| {
-            CliError::failure(format!(
-                "failed to synchronize staged artifact directory {}: {error}",
-                path.display()
-            ))
-        })
+    crate::durable_publication::sync_directory(path).map_err(|error| {
+        CliError::failure(format!(
+            "failed to synchronize staged artifact directory {}: {error}",
+            path.display()
+        ))
+    })
 }
 
 /// Flush the artifact store after publishing a new immutable artifact directory.
 fn sync_sdk_provider_store(store_root: &Path) -> CliResult<()> {
-    fs::File::open(store_root)
-        .and_then(|directory| directory.sync_all())
-        .map_err(|error| {
-            CliError::failure(format!(
-                "failed to synchronize artifact store {}: {error}",
-                store_root.display()
-            ))
-        })
+    crate::durable_publication::sync_directory(store_root).map_err(|error| {
+        CliError::failure(format!(
+            "failed to synchronize artifact store {}: {error}",
+            store_root.display()
+        ))
+    })
 }
 
 /// Allocate a unique private staging directory for one artifact identity.

--- a/src/durable_publication.rs
+++ b/src/durable_publication.rs
@@ -1,0 +1,132 @@
+//! Parent-directory synchronization for the crash-safe publication recipe.
+//!
+//! RFC 112 separates three properties of a publication: replacement atomicity controls what concurrent readers
+//! observe, synchronization requests durable persistence, and advisory locks coordinate cooperating writers.
+//! Synchronizing the staged file alone does not persist the *directory entry* produced by the replacement, so
+//! the recipe ends with an explicit directory synchronization step. This module owns that one step for compiler-host
+//! code, which runs before any user program exists and therefore cannot call the generated `std.fs` library.
+//!
+//! The boundary exists because the step is spelled differently per host and getting it wrong fails in a way that is
+//! easy to misread. On Unix a plain read handle to the directory is enough. On Windows two separate conditions must
+//! both hold, and missing either produces an identical `ERROR_ACCESS_DENIED` that looks like a permissions problem
+//! rather than a wrong-API problem. Centralizing the call keeps that knowledge in one place and stops each new
+//! durable-write site from rediscovering it.
+
+use std::fs::File;
+use std::io;
+use std::path::Path;
+
+/// Request that a directory's contents be durably persisted, so a completed rename into it survives a crash.
+///
+/// Callers invoke this as the final step of the publication recipe, after the staged file has been synchronized and
+/// atomically renamed over its destination. A failure here means the replacement may not survive a crash; it does not
+/// mean the replacement failed, because the rename has already completed by this point. Callers map the returned
+/// [`io::Error`] into their own error type rather than this module choosing one for them.
+pub(crate) fn sync_directory(directory: &Path) -> io::Result<()> {
+    open_directory_for_sync(directory)?.sync_all()
+}
+
+/// Open a directory handle suitable for synchronization on Unix hosts.
+///
+/// A plain read handle accepts `fsync`, so no extra access mode or flag is required.
+#[cfg(unix)]
+fn open_directory_for_sync(directory: &Path) -> io::Result<File> {
+    File::open(directory)
+}
+
+/// Open a directory handle suitable for synchronization on Windows hosts.
+///
+/// Two conditions must hold together, and each fails with the same `ERROR_ACCESS_DENIED` when missing, which is why
+/// they are documented here rather than left to the reader. `FILE_FLAG_BACKUP_SEMANTICS` is required for `CreateFile`
+/// to return a handle to a directory at all — without it, a directory simply cannot be opened, which is why the
+/// ordinary [`File::open`] used on Unix fails immediately. `GENERIC_WRITE` is then required for `FlushFileBuffers`
+/// to be accepted on that handle; a read-only directory handle opens successfully and only fails at the flush.
+#[cfg(windows)]
+fn open_directory_for_sync(directory: &Path) -> io::Result<File> {
+    use std::fs::OpenOptions;
+    use std::os::windows::fs::OpenOptionsExt;
+
+    /// `FILE_FLAG_BACKUP_SEMANTICS` — permits `CreateFile` to return a directory handle.
+    const FILE_FLAG_BACKUP_SEMANTICS: u32 = 0x0200_0000;
+    /// `GENERIC_WRITE` — the access right `FlushFileBuffers` requires of its handle.
+    const GENERIC_WRITE: u32 = 0x4000_0000;
+
+    OpenOptions::new()
+        .access_mode(GENERIC_WRITE)
+        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
+        .open(directory)
+}
+
+/// Refuse directory synchronization on hosts that cannot express it.
+///
+/// RFC 112 requires that a host unable to honor a requested guarantee return a typed filesystem error rather than
+/// silently weakening the operation, so this arm reports the limitation instead of returning `Ok` and leaving the
+/// caller believing durability was requested.
+#[cfg(not(any(unix, windows)))]
+fn open_directory_for_sync(directory: &Path) -> io::Result<File> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        format!(
+            "this host cannot synchronize a directory, so publication durability cannot be requested for {}",
+            directory.display()
+        ),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::io::Write;
+
+    use super::sync_directory;
+
+    /// Exercise the full recipe tail: stage, synchronize, rename, then synchronize the parent directory.
+    ///
+    /// This is the case that failed on native Windows before the host-specific open was introduced, and it passes on
+    /// every supported host because the step is genuinely available on all of them.
+    #[test]
+    fn synchronizes_a_directory_after_an_atomic_replacement() -> Result<(), Box<dyn std::error::Error>> {
+        let directory = tempfile::tempdir()?;
+        let staged = directory.path().join(".receipt.json.tmp");
+        let published = directory.path().join("receipt.json");
+
+        let mut file = fs::File::create(&staged)?;
+        file.write_all(b"{}\n")?;
+        file.sync_all()?;
+        drop(file);
+        fs::rename(&staged, &published)?;
+
+        sync_directory(directory.path())?;
+
+        assert!(
+            published.exists(),
+            "the published file should remain after synchronization"
+        );
+        Ok(())
+    }
+
+    /// Synchronizing a directory that does not exist reports an error rather than silently succeeding.
+    #[test]
+    fn reports_an_error_for_a_missing_directory() -> Result<(), Box<dyn std::error::Error>> {
+        let directory = tempfile::tempdir()?;
+        let missing = directory.path().join("absent");
+
+        assert!(
+            sync_directory(&missing).is_err(),
+            "a missing directory cannot be synchronized and must not report success"
+        );
+        Ok(())
+    }
+
+    /// A directory holding an unpublished staged file is still synchronizable.
+    ///
+    /// Publication failure paths synchronize before cleaning up a staged sibling, so this shape must not error.
+    #[test]
+    fn synchronizes_a_directory_containing_a_staged_file() -> Result<(), Box<dyn std::error::Error>> {
+        let directory = tempfile::tempdir()?;
+        fs::write(directory.path().join(".partial.tmp"), b"partial")?;
+
+        sync_directory(directory.path())?;
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod cli;
 pub(crate) mod compiled_sdk;
 pub mod compiler_stack;
 pub mod dependency_resolver;
+pub(crate) mod durable_publication;
 pub mod format;
 pub mod frontend;
 #[cfg(feature = "cli")]

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -739,7 +739,7 @@ fn publish_lockfile(path: &Path, content: &[u8], _publication_lock: &Publication
         staged_file.write_all(content)?;
         staged_file.sync_all()?;
         fs::rename(&staged_path, path)?;
-        File::open(parent)?.sync_all()?;
+        crate::durable_publication::sync_directory(parent)?;
         Ok(())
     })();
     drop(staged_file);

--- a/src/oven.rs
+++ b/src/oven.rs
@@ -11,7 +11,7 @@
 //! stages consume portable identities and sealed Loafs rather than project-local build paths.
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::fs::{self, File, OpenOptions};
+use std::fs::{self, OpenOptions};
 use std::io::{self, ErrorKind, Write};
 use std::path::{Path, PathBuf};
 
@@ -1468,7 +1468,7 @@ pub(crate) fn write_receipt_staged(payload: &[u8], staged_path: &Path, path: &Pa
     staged.write_all(b"\n")?;
     staged.sync_all()?;
     fs::rename(staged_path, path)?;
-    File::open(parent)?.sync_all()
+    crate::durable_publication::sync_directory(parent)
 }
 
 /// Canonical receipt fields used only for content-addressed identity serialization.

--- a/src/oven/store.rs
+++ b/src/oven/store.rs
@@ -3241,11 +3241,12 @@ fn write_synced_file(path: &Path, bytes: &[u8], trailing_newline: bool) -> Resul
     })
 }
 
-/// Synchronize a directory entry after atomic store publication where the host supports directory handles.
+/// Synchronize a directory entry after atomic store publication so the published entry survives a crash.
+///
+/// Acquiring a synchronizable directory handle is host-specific and lives in [`crate::durable_publication`]; this
+/// wrapper only maps the failure into the store's error type.
 pub(crate) fn sync_directory(path: PathBuf) -> Result<(), OvenStoreError> {
-    File::open(&path)
-        .and_then(|directory| directory.sync_all())
-        .map_err(|source| OvenStoreError::Io { path, source })
+    crate::durable_publication::sync_directory(&path).map_err(|source| OvenStoreError::Io { path, source })
 }
 
 /// Synchronize nested materialized directories from leaves to root before their entry becomes visible.


### PR DESCRIPTION
## Summary

`incan run` fails on native Windows x64 immediately after `incan new` succeeds, with `failed to publish Oven receipt at <project>\.incan/oven/receipt.json: Access is denied. (os error 5)`.

The cause is the last line of `write_receipt_staged`: `File::open(parent)?.sync_all()`. Opening a parent directory as a file to fsync it is the standard Unix durable-rename idiom, and it is one of the five named steps in the publication recipe RFC 112 defines. Win32 requires `FILE_FLAG_BACKUP_SEMANTICS` before `CreateFile` will return a directory handle at all, and `std::fs::File::open` does not pass it.

The failure mode is unusually bad: the write has **already succeeded** when the barrier fails. `fs::rename` on the preceding line completed, so the receipt exists on disk with correct content and normal attributes, while the command reports failure and exits 1. On-disk state and reported state disagree.

This was systemic rather than a single site — the same idiom appeared unguarded in six places across `oven`, `lockfile`, `oven::store`, and `cli::commands::common`.

## Type of change

- [x] Bug fix

## Area(s)

- [x] Tooling (CLI/formatter/test runner)
- [x] Compiler (frontend/backend/codegen)

## Key details

- **User-facing behavior**: publication paths that request crash durability now work on native Windows instead of failing after a completed write. No behavior change on Unix.
- **Internals**: a new `pub(crate) durable_publication` module owns the one host-specific step; the six call sites delegate to it and keep their own error types, since the helper returns `io::Result<()>`. Consolidating was worth more than six local fixes: the platform assumption now lives in exactly one place, so the next durable-write site cannot silently reintroduce it.
- **Risks**: low. The Unix path is byte-for-byte the previous behavior. The Windows path is newly exercised, which is the point.

### Why the step is honored rather than skipped

The obvious fix — gating the sync away under `cfg(windows)` — would violate the governing spec. RFC 112's core model, point 5:

> **Portability is truthful:** the initial supported hosts are Linux and macOS. A host that cannot honor a requested guarantee must return a typed filesystem error rather than silently weakening the operation.

It is also unnecessary. A probe measured five directory-open variants on native Windows:

| approach | result |
| --- | --- |
| `File::open(parent).sync_all()` (previous code) | `ERROR_ACCESS_DENIED` |
| `read` + `BACKUP_SEMANTICS` + `sync_all()` | `ERROR_ACCESS_DENIED` |
| `read` + `BACKUP_SEMANTICS`, open only | ok |
| `access_mode(GENERIC_WRITE)` + `BACKUP_SEMANTICS` + `sync_all()` | **ok** |
| `access_mode(READ\|WRITE)` + `BACKUP_SEMANTICS` + `sync_all()` | **ok** |

Two conditions must hold together, and each fails with the same error when missing: `FILE_FLAG_BACKUP_SEMANTICS` to obtain the handle, `GENERIC_WRITE` for `FlushFileBuffers` to be accepted on it. Native Windows genuinely provides the guarantee; the codebase was asking for it the Unix way. Conformance is strengthened, not carved out.

A `cfg(not(any(unix, windows)))` arm returns a typed `Unsupported` error, which is what point 5 requires of a host that truly cannot honor the request.

**Scope note:** this proves the directory-synchronization step only. RFC 112's other pillars — same-filesystem atomic replacement and advisory locks — are not exercised here, so this does not by itself make native Windows RFC-112 conformant.

## Testing / verification

- [x] `cargo test`
- [ ] `make test` — **could not run on this host**, see below
- [x] Manual verification described below

Full lib suite, same machine, `x86_64-pc-windows-msvc`, Rust 1.98.1:

| | passed | failed |
| --- | ---: | ---: |
| `main` (baseline worktree) | 2830 | **122** |
| this branch | 2890 | **65** |

Failing test *names* were diffed rather than compared by total, because totals alone cannot distinguish "57 fixed" from "58 fixed and 1 broken":

- **regressions: 0**
- **fixed: 57**
- three new tests added in `durable_publication`

The 57 repairs are the interesting part. `oven::store::sync_directory` was failing on *every* call, so a broad slice of the suite was collapsing behind one broken step; `oven::store::` alone goes from 0/23 passing to 20/23. The remaining 65 failures are all present on `main` and are pre-existing native-Windows gaps, tracked by #1343.

Manual verification notes:

- `incan new hello --yes` then `incan run`: receipt publication now succeeds. The run stops at the designed `run incan oven bake once` message, which is correct behavior and not a failure of this path.
- `cargo clippy --all-targets`: no new warnings attributable to this branch.
- `cargo +nightly fmt`: clean.

### Verification not performed, stated as residual risk

- **`make pre-commit` was not run.** `make` is unavailable on native Windows (#1345), so the local gate — including `make agents-doc-sync` — has not executed. A Linux or macOS run is required before merge.
- **`scripts/check_changed_rustdocs.py` was not run.** It is invoked as `python3`, which on a default Windows host resolves to a non-functional Microsoft Store alias stub (#1345). Rustdoc coverage on changed functions was audited by hand instead; every function in the new module carries rustdoc, including the private per-host helpers.

## Docs impact

- [x] No docs changes needed

`docs/language/how-to/file_io.md` states that native Windows filesystem semantics are not yet covered by the public `std.fs` contract. That statement predates native Windows being a viable target and should be revisited as the Windows track lands, but not from this PR: it describes the public `std.fs` surface, whereas this change is compiler-host infrastructure that mirrors the recipe rather than implementing it. Revisiting belongs with #1344 once replace and lock behavior are proven the same way.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #1340.
