### PR TITLE
chore - make the contributor workflow runnable on native Windows (#1345)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,31 @@
+# Line-ending policy for the whole repository.
+#
+# Git for Windows sets `core.autocrlf=true` in its system configuration, so without this file a stock Windows clone
+# rewrites every checked-out file to CRLF. That is unsafe here: `tests/snapshots/*.snap` and the generated-output
+# fixtures compare compiler output byte for byte, so a converted checkout fails tests in ways that look like compiler
+# defects rather than a checkout artifact. Normalizing to LF everywhere keeps one canonical form in the repository and
+# in every working tree, on every host.
+* text=auto eol=lf
+
+# Files whose bytes must never be rewritten, marked explicitly rather than relying on content detection.
+*.png    binary
+*.webp   binary
+*.ico    binary
+*.jpg    binary
+*.jpeg   binary
+*.gif    binary
+*.pdf    binary
+*.woff   binary
+*.woff2  binary
+*.ttf    binary
+*.otf    binary
+*.vsix   binary
+*.wasm   binary
+*.snap.bin binary
+
+# Snapshots and generated fixtures are compared byte for byte; state the requirement rather than inferring it.
+*.snap   text eol=lf
+*.incn   text eol=lf
+
+# Shell scripts must keep LF regardless of host, or they fail to execute.
+*.sh     text eol=lf

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,38 @@ Thank you for your interest in contributing to the Incan programming language! T
    cargo test
    ```
 
+### Developing on native Windows
+
+Native Windows x64 works. It needs three host tools that Linux and macOS supply by default, and one habit about where you clone.
+
+Run `make` targets from **Git Bash**, not PowerShell or `cmd`. Git for Windows supplies the POSIX tools the Makefile relies on — `sh`, `sed`, `awk`, `grep`, `date` — and GNU Make discovers Git's `sh.exe` automatically, so no extra configuration is required.
+
+**Rust** must use the MSVC toolchain (`x86_64-pc-windows-msvc`), which is rustup's default and which needs Visual Studio Build Tools with the C++ workload. The `--add` argument matters: without it the installer produces an empty shell with no compiler.
+
+```powershell
+winget install Microsoft.VisualStudio.2022.BuildTools --override "--passive --wait --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended"
+```
+
+**MinGW-w64** supplies a C compiler for dependencies that build C sources, and also ships GNU Make itself.
+
+```powershell
+winget install BrechtSanders.WinLibs.POSIX.MSVCRT
+```
+
+It installs Make as `mingw32-make`. Either use that name, or copy it to `make.exe` alongside it so the `make <target>` commands used throughout this repository work verbatim.
+
+**Python** runs the repository check scripts.
+
+```powershell
+winget install Python.Python.3.13
+```
+
+The Makefile resolves the interpreter through `$(PYTHON)`, which defaults to `python` on Windows. This is deliberate: `python3` is not a real command there, and on a default install that name resolves to a Microsoft Store alias stub that prints an advert and exits without running anything. Override with `make PYTHON=<interpreter> <target>` if your host needs a different name.
+
+Finally, **clone to a short path** such as `C:\dev\incan`. Windows limits paths to 260 characters. The `LongPathsEnabled` registry setting lifts that limit only for programs that declare themselves long-path aware, and neither `link.exe` nor libgit2 does, so a deeply nested clone fails at link time with `LNK1104` on a file whose path is simply too long. Pointing `CARGO_TARGET_DIR` at a short directory is an equally good fix, because the paths that overrun are the build outputs rather than the sources.
+
+Line endings need no configuration: the repository's `.gitattributes` normalizes every text file to LF, which matters because the snapshot fixtures compare compiler output byte for byte.
+
 ## Project Structure
 
 The compiler is organized into a **frontend** (lex/parse/typecheck), a **backend** (lowering + Rust emission), plus CLI and tooling.

--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,23 @@ endif
 # INCAN_SKIP_CARGO_BIN_LINK=1.
 ifneq ($(CI),)
 INCAN_LINK_CARGO_BIN ?= 0
+else ifeq ($(OS),Windows_NT)
+# Git for Windows implements `ln -s` as a file copy unless MSYS=winsymlinks:nativestrict is set, so enabling this on
+# native Windows would copy the whole debug binary into ~/.cargo/bin on every build instead of linking to it. Opt in
+# with INCAN_LINK_CARGO_BIN=1 if that tradeoff is wanted.
+INCAN_LINK_CARGO_BIN ?= 0
 else
 INCAN_LINK_CARGO_BIN ?= 1
+endif
+
+# Interpreter for the repository check scripts. `python3` is the right name on Linux and macOS, but native Windows has
+# no such command: python.org installs `python` and the `py` launcher, and the `python3` name there resolves to a
+# Microsoft Store alias stub that prints an install advert and exits without running anything. Override with
+# `make PYTHON=<interpreter>` on a host that needs a different one.
+ifeq ($(OS),Windows_NT)
+PYTHON ?= python
+else
+PYTHON ?= python3
 endif
 
 .PHONY: help
@@ -94,12 +109,14 @@ help: build-quiet  ## Display this help message
 
 .PHONY: _incan_link_debug_to_cargo_bin
 _incan_link_debug_to_cargo_bin:
-	@if [ "$(INCAN_LINK_CARGO_BIN)" != "1" ] || [ "$(INCAN_SKIP_CARGO_BIN_LINK)" = "1" ]; then exit 0; fi
-	@if [ ! -f "$(CURDIR)/target/debug/incan" ]; then echo "incan: expected $(CURDIR)/target/debug/incan after build"; exit 1; fi
-	@mkdir -p "$(HOME)/.cargo/bin"
-	@ln -sf "$(CURDIR)/target/debug/incan" "$(HOME)/.cargo/bin/incan"
-	@echo "\033[32m✓ Linked ~/.cargo/bin/incan -> $(CURDIR)/target/debug/incan\033[0m"
-	@if [ -f "$(CURDIR)/target/debug/incan-lsp" ]; then \
+	@# One shell for the whole recipe: `exit 0` only leaves the line it runs on, so with a line-per-shell recipe the
+	@# opt-out below never skipped anything and the link happened even when it was switched off.
+	@if [ "$(INCAN_LINK_CARGO_BIN)" != "1" ] || [ "$(INCAN_SKIP_CARGO_BIN_LINK)" = "1" ]; then exit 0; fi; \
+	if [ ! -f "$(CURDIR)/target/debug/incan" ]; then echo "incan: expected $(CURDIR)/target/debug/incan after build"; exit 1; fi; \
+	mkdir -p "$(HOME)/.cargo/bin"; \
+	ln -sf "$(CURDIR)/target/debug/incan" "$(HOME)/.cargo/bin/incan"; \
+	echo "\033[32m✓ Linked ~/.cargo/bin/incan -> $(CURDIR)/target/debug/incan\033[0m"; \
+	if [ -f "$(CURDIR)/target/debug/incan-lsp" ]; then \
 		ln -sf "$(CURDIR)/target/debug/incan-lsp" "$(HOME)/.cargo/bin/incan-lsp"; \
 		echo "\033[32m✓ Linked ~/.cargo/bin/incan-lsp -> $(CURDIR)/target/debug/incan-lsp\033[0m"; \
 	fi
@@ -184,24 +201,24 @@ lint-fast-ci:
 .PHONY: rustdoc-gate  ## quality - Require rustdoc on changed Rust functions/methods
 rustdoc-gate:
 	@echo "\033[1mChecking rustdoc coverage for changed Rust functions/methods...\033[0m"
-	@python3 scripts/check_changed_rustdocs.py
+	@$(PYTHON) scripts/check_changed_rustdocs.py
 
 .PHONY: rustdoc-gate-ci
 rustdoc-gate-ci:
-	@python3 scripts/check_changed_rustdocs.py
+	@$(PYTHON) scripts/check_changed_rustdocs.py
 
 .PHONY: version-gate  ## quality - Require hand-written version literals to match the workspace version
 version-gate:
-	@python3 scripts/check_release_version_consistency.py
+	@$(PYTHON) scripts/check_release_version_consistency.py
 
 .PHONY: agents-doc-sync  ## quality - Check AGENTS.md's skill table matches .agents/skills/ (local only, not CI)
 agents-doc-sync:
 	@echo "\033[1mChecking AGENTS.md skill table against .agents/skills/...\033[0m"
-	@python3 scripts/check_agents_doc_sync.py
+	@$(PYTHON) scripts/check_agents_doc_sync.py
 
 .PHONY: agents-doc-sync-ci
 agents-doc-sync-ci:
-	@python3 scripts/check_agents_doc_sync.py
+	@$(PYTHON) scripts/check_agents_doc_sync.py
 
 .PHONY: cargo-deny  ## quality - Run cargo-deny policy checks
 cargo-deny:
@@ -545,7 +562,7 @@ test-rust-inspect:
 generated-rust-audit-gate:
 	@echo "\033[1mRunning generated Rust audit helper checks...\033[0m"
 	@cargo test --test generated_rust_audit_tests
-	@python3 scripts/generated_rust_audit.py --format json --fail-on-missing \
+	@$(PYTHON) scripts/generated_rust_audit.py --format json --fail-on-missing \
 		--artifact program-main=tests/fixtures/generated_rust_audit/main.rs \
 		--artifact stdlib-copy=tests/fixtures/generated_rust_audit/nested >/dev/null
 	@echo "\033[32m✓ Generated Rust audit helper checks passed\033[0m"

--- a/scripts/check_agents_doc_sync.py
+++ b/scripts/check_agents_doc_sync.py
@@ -33,7 +33,7 @@ def actual_skills() -> set[str]:
 
 
 def documented_skills() -> set[str]:
-    text = AGENTS_MD.read_text()
+    text = AGENTS_MD.read_text(encoding="utf-8")
     # Capture everything between "### Skills" and the next heading, so this
     # doesn't stop early at a blank line inside the section (e.g. the intro
     # sentence before the table).

--- a/scripts/check_changed_rustdocs.py
+++ b/scripts/check_changed_rustdocs.py
@@ -219,7 +219,7 @@ def function_end_line(lines: list[str], fn_index: int) -> int:
 
 def missing_docs(path: Path, changed_lines: set[int]) -> list[tuple[int, str]]:
     """Return undocumented non-test function definitions for one Rust source file."""
-    lines = path.read_text().splitlines()
+    lines = path.read_text(encoding="utf-8").splitlines()
     test_lines = test_module_lines(lines)
     quoted_lines = quote_macro_lines(lines)
     trait_impls = trait_impl_lines(lines)


### PR DESCRIPTION
## Summary

A native Windows contributor could not run the workflow `AGENTS.md` designates as canonical. After this change, `make pre-commit-fast` passes on native Windows x64:

```
✓ Pre-commit checks passed (fast)
Phase timing: fmt-check=4s, rustdoc=0s, version-gate=0s, agents-doc-sync=0s, check=51s, total=55s
```

Measuring first shrank the work considerably, and two items in #1345 turned out to be wrong.

**The `SHELL` / POSIX-tools problem does not exist.** GNU Make 4.4.1 auto-discovers Git's `sh.exe`, `uname` answers `MINGW64_NT`, and `sed`/`awk`/`grep`/`date`/`mkdir -p` all resolve through Git for Windows. No `SHELL := bash` declaration is needed and none was added. `make` itself needs no install either — WinLibs, already required for the C compiler, ships `mingw32-make`.

**`ln -s` was worse than filed, not better.** The issue described it as producing copies that "drift later". In fact `INCAN_LINK_CARGO_BIN` defaults to `1` off CI, so on Windows every `make build` was copying the whole ~130 MB debug binary into `~/.cargo/bin`, because Git for Windows implements `ln -s` as a copy.

## Type of change

- [x] Bug fix
- [x] CI / tooling
- [x] Documentation

## Area(s)

- [x] Tooling (CLI/formatter/test runner)
- [x] Documentation

## Key details

### A pre-existing bug: the cargo-bin link switch never worked, on any platform

`_incan_link_debug_to_cargo_bin` opens with an opt-out:

```make
@if [ "$(INCAN_LINK_CARGO_BIN)" != "1" ] || [ "$(INCAN_SKIP_CARGO_BIN_LINK)" = "1" ]; then exit 0; fi
```

`.ONESHELL` is not declared, so every recipe line runs in its own shell and `exit 0` leaves only *that* line. The remaining lines always ran. The switch has never disabled anything — including in CI, where the comment says it is meant to be off.

That is fixed by making the recipe a single shell. Verified in all four states on Windows: default skips, `CI=1` skips, `INCAN_SKIP_CARGO_BIN_LINK=1` skips, and explicit `INCAN_LINK_CARGO_BIN=1` still links.

### `python3` is not a command on Windows

The six check-script invocations now resolve through `$(PYTHON)`, which defaults to `python3` on Linux and macOS and `python` on Windows. This is not a preference: python.org installs `python` and the `py` launcher but not `python3`, and on a default Windows install that name resolves to a Microsoft Store alias stub which prints an install advert and exits without running anything — producing `Error 9009` rather than a recognisable "missing interpreter". Overridable with `make PYTHON=<interpreter>`.

### Two Python UTF-8 bugs, surfaced once the scripts could actually run

With a real interpreter in place, both scripts failed with `UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d`. Python on Windows defaults `open()`/`read_text()` to the locale encoding (cp1252) rather than UTF-8. `check_release_version_consistency.py` and `generated_rust_audit.py` already passed `encoding="utf-8"`; `check_agents_doc_sync.py` and `check_changed_rustdocs.py` did not. This was an inconsistency rather than a design choice, so both were brought in line.

### `.gitattributes`

The repository had none, and Git for Windows sets `core.autocrlf=true` in its system config, so a stock Windows clone converted every file to CRLF — including 190 `.snap` insta snapshots and 400 `.incn` sources, exactly the byte-for-byte output-comparison fixtures where that produces phantom failures that look like compiler defects.

`* text=auto eol=lf` normalizes everything, with explicit `binary` marks for image, font, and archive types rather than relying on content detection.

**This does not renormalize anything.** `git ls-files --eol` reports zero CRLF files in the tree; the 16 non-LF entries are `i/none w/none`, meaning files with no line endings at all (empty files and single-line SVGs). The change is purely protective for future clones.

### Deliberately left out

- **85 `@echo "\033[...]"` lines print escapes literally** under Git's `sh`, because only dash interprets them; `printf '%b'` is the portable spelling. Cosmetic, mechanical, touches most of the file, and orthogonal to making the workflow run. Worth its own issue.
- **`ln -s` producing copies on Windows** is documented and defaulted off rather than reimplemented. Doing it properly means either a real hardlink or an explicit copy with staleness handling, which is a design question rather than a fix.

## Testing / verification

- [x] `make test` / `cargo test` — see note
- [x] Manual verification described below

On native Windows x64, Rust 1.98.1 MSVC, run from Git Bash:

| command | before | after |
| --- | --- | --- |
| `make fmt-check` | passed | passed |
| `make agents-doc-sync` | `Error 9009`, then `UnicodeDecodeError` | **passes** |
| `make pre-commit-fast` | failed | **passes, exit 0** |

Manual verification notes:

- Cargo-bin link switch exercised in all four states listed above.
- `.gitattributes` checked with `git check-attr`: `src/lib.rs` and `tests/snapshots` resolve to `eol: lf`, `*.png` to `binary: set`.
- No Unix behavior change: `PYTHON` still defaults to `python3`, and `INCAN_LINK_CARGO_BIN` still defaults to `1` off CI. The guard fix does change CI behavior, but toward what the existing comment already documents.

### Residual risk

`make pre-commit` (full) and `make test` were **not** run on this host — they need a release build and smoke tests well beyond what has been exercised here, and the full suite still has 65 pre-existing native-Windows failures tracked by #1343. A Linux or macOS run is required before merge, particularly to confirm the recipe-joining change behaves identically there.

## Docs impact

- [x] Docs updated

`CONTRIBUTING.md` gains a "Developing on native Windows" section covering the three host tools, the MSVC toolchain requirement, and the short-clone-path constraint. Every claim in it was executed on this machine rather than inferred.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #1345.
