### PR TITLE
chore - emit Makefile colour codes portably (#1351)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,15 @@ endif
 # blank spacer lines, which carry no escapes.
 ECHO := printf '%b\n'
 
+# Status glyphs, spelled as octal escapes rather than written literally. GNU Make on Windows re-encodes non-ASCII
+# recipe text on its way to the shell — it reads the file's UTF-8 as the ANSI codepage and re-emits that as UTF-8, so
+# a literal check mark arrives as mojibake no matter which emitter prints it. Keeping the bytes as escapes leaves the
+# recipe pure ASCII, which Make passes through untouched, and `printf %b` reconstructs the exact character at runtime.
+# Identical output on every host.
+SYM_CHECK := \0342\0234\0223
+SYM_WARN := \0342\0232\0240
+SYM_INFO := \0342\0204\0271
+
 # Interpreter for the repository check scripts. `python3` is the right name on Linux and macOS, but native Windows has
 # no such command: python.org installs `python` and the `py` launcher, and the `python3` name there resolves to a
 # Microsoft Store alias stub that prints an install advert and exits without running anything. Override with
@@ -121,10 +130,10 @@ _incan_link_debug_to_cargo_bin:
 	if [ ! -f "$(CURDIR)/target/debug/incan" ]; then echo "incan: expected $(CURDIR)/target/debug/incan after build"; exit 1; fi; \
 	mkdir -p "$(HOME)/.cargo/bin"; \
 	ln -sf "$(CURDIR)/target/debug/incan" "$(HOME)/.cargo/bin/incan"; \
-	$(ECHO) "\033[32m✓ Linked ~/.cargo/bin/incan -> $(CURDIR)/target/debug/incan\033[0m"; \
+	$(ECHO) "\033[32m$(SYM_CHECK) Linked ~/.cargo/bin/incan -> $(CURDIR)/target/debug/incan\033[0m"; \
 	if [ -f "$(CURDIR)/target/debug/incan-lsp" ]; then \
 		ln -sf "$(CURDIR)/target/debug/incan-lsp" "$(HOME)/.cargo/bin/incan-lsp"; \
-		$(ECHO) "\033[32m✓ Linked ~/.cargo/bin/incan-lsp -> $(CURDIR)/target/debug/incan-lsp\033[0m"; \
+		$(ECHO) "\033[32m$(SYM_CHECK) Linked ~/.cargo/bin/incan-lsp -> $(CURDIR)/target/debug/incan-lsp\033[0m"; \
 	fi
 
 .PHONY: build  ## build - Debug build (compiler + LSP); links ~/.cargo/bin/incan + incan-lsp locally
@@ -152,7 +161,7 @@ release:
 install:
 	@$(ECHO) "\033[1mInstalling incan...\033[0m"
 	@cargo install --path .
-	@$(ECHO) "\033[32m✓ Installed to ~/.cargo/bin/incan\033[0m"
+	@$(ECHO) "\033[32m$(SYM_CHECK) Installed to ~/.cargo/bin/incan\033[0m"
 
 # =============================================================================
 # Code Quality
@@ -162,18 +171,18 @@ install:
 fmt:
 	@$(ECHO) "\033[1mFormatting code...\033[0m"
 	@cargo +nightly fmt --version >/dev/null 2>&1 || ( \
-		$(ECHO) "\033[33m⚠ nightly rustfmt is required for this project formatting config.\033[0m"; \
+		$(ECHO) "\033[33m$(SYM_WARN) nightly rustfmt is required for this project formatting config.\033[0m"; \
 		$(ECHO) "\033[33m  Install it via: rustup toolchain install nightly --component rustfmt\033[0m"; \
 		exit 1; \
 	)
 	@cargo +nightly fmt --all
-	@$(ECHO) "\033[32m✓ Code formatted\033[0m"
+	@$(ECHO) "\033[32m$(SYM_CHECK) Code formatted\033[0m"
 
 .PHONY: fmt-check  ## quality - Check formatting without changes
 fmt-check:
 	@$(ECHO) "\033[1mChecking formatting...\033[0m"
 	@cargo +nightly fmt --version >/dev/null 2>&1 || ( \
-		$(ECHO) "\033[33m⚠ nightly rustfmt is required for this project formatting config.\033[0m"; \
+		$(ECHO) "\033[33m$(SYM_WARN) nightly rustfmt is required for this project formatting config.\033[0m"; \
 		$(ECHO) "\033[33m  Install it via: rustup toolchain install nightly --component rustfmt\033[0m"; \
 		exit 1; \
 	)
@@ -192,7 +201,7 @@ lint-fast:
 .PHONY: fmt-check-ci
 fmt-check-ci:
 	@cargo +nightly fmt --version >/dev/null 2>&1 || ( \
-		$(ECHO) "\033[33m⚠ nightly rustfmt is required for this project formatting config.\033[0m"; \
+		$(ECHO) "\033[33m$(SYM_WARN) nightly rustfmt is required for this project formatting config.\033[0m"; \
 		$(ECHO) "\033[33m  Install it via: rustup toolchain install nightly --component rustfmt\033[0m"; \
 		exit 1; \
 	)
@@ -241,12 +250,12 @@ check-fast-ci:
 
 .PHONY: check  ## quality - Run all quality checks (fmt + lint)
 check: fmt-check lint
-	@$(ECHO) "\033[32m✓ All checks passed\033[0m"
+	@$(ECHO) "\033[32m$(SYM_CHECK) All checks passed\033[0m"
 
 .PHONY: udeps  ## quality - Check for unused dependencies (requires nightly + cargo-udeps)
 udeps:
 	@$(ECHO) "\033[1mChecking for unused dependencies...\033[0m"
-	@cargo +nightly udeps --quiet 2>/dev/null || $(ECHO) "\033[33m⚠ cargo-udeps skipped (requires cargo-udeps + nightly rustc 1.85+. Run `rustup update nightly` if needed.)\033[0m"
+	@cargo +nightly udeps --quiet 2>/dev/null || $(ECHO) "\033[33m$(SYM_WARN) cargo-udeps skipped (requires cargo-udeps + nightly rustc 1.85+. Run `rustup update nightly` if needed.)\033[0m"
 
 .PHONY: pre-commit-fast  ## quality - Fast local gate: fmt-check + cargo check with phase timing
 pre-commit-fast:
@@ -272,7 +281,7 @@ pre-commit-fast:
 	$(MAKE) -s check-fast-ci; \
 	$(ECHO) "\033[32mDONE\033[0m"; \
 	t3=$$(date +%s); \
-	$(ECHO) "\033[32m✓ Pre-commit checks passed (fast)\033[0m"; \
+	$(ECHO) "\033[32m$(SYM_CHECK) Pre-commit checks passed (fast)\033[0m"; \
 	$(ECHO) "\033[36mPhase timing:\033[0m fmt-check=$$((t1-start))s, rustdoc=$$((t2-t1))s, version-gate=$$((t2a-t2))s, agents-doc-sync=$$((t2b-t2a))s, check=$$((t3-t2b))s, total=$$((t3-start))s"
 
 .PHONY: pre-commit-full-gate  ## quality - Full local gate core: fmt-check + tests + clippy + cargo-deny with phase timing
@@ -303,7 +312,7 @@ pre-commit-full-gate:
 	$(MAKE) -s cargo-deny-ci; \
 	$(ECHO) "\033[32mDONE\033[0m"; \
 	t5=$$(date +%s); \
-	$(ECHO) "\033[32m✓ Pre-commit checks passed (full)\033[0m"; \
+	$(ECHO) "\033[32m$(SYM_CHECK) Pre-commit checks passed (full)\033[0m"; \
 	$(ECHO) "\033[36mPhase timing:\033[0m fmt-check=$$((t1-start))s, rustdoc=$$((t2-t1))s, agents-doc-sync=$$((t2b-t2))s, tests=$$((t3-t2b))s, lint=$$((t4-t3))s, deny=$$((t5-t4))s, total=$$((t5-start))s"
 
 .PHONY: pre-commit  ## quality - Full local gate: pre-commit-full-gate + smoke-test-fast
@@ -311,7 +320,7 @@ pre-commit:
 	@$(ECHO) "\033[1mRunning pre-commit (full local gate)...\033[0m"
 	@$(MAKE) pre-commit-full-gate
 	@$(MAKE) smoke-test-fast
-	@$(ECHO) "\033[32m✓ Pre-commit passed\033[0m"
+	@$(ECHO) "\033[32m$(SYM_CHECK) Pre-commit passed\033[0m"
 
 .PHONY: ci-full  ## quality - Full CI check: fmt, lint, udeps, test, and release build
 ci-full: fmt lint udeps
@@ -319,7 +328,7 @@ ci-full: fmt lint udeps
 	@$(MAKE) -s test-oven
 	@$(ECHO) "\033[1mBuilding release...\033[0m"
 	@cargo build --release --quiet
-	@$(ECHO) "\033[32m✓ Full CI checks passed\033[0m"
+	@$(ECHO) "\033[32m$(SYM_CHECK) Full CI checks passed\033[0m"
 
 # =============================================================================
 # Testing
@@ -441,7 +450,7 @@ shadow-comparison-evidence:
 		test -f "$$receipt" || { echo "Oven bake did not publish an executable debug receipt" >&2; exit 1; }; \
 		$(SHADOW_TEST_ENV) INCAN_SHADOW_OVEN_RECEIPT="$$receipt" \
 			cargo test --test shadow_comparison_tests --test parity_corpus_tests
-	@$(ECHO) "\033[32m✓ the #1146 comparison ran under Oven authority and its corpus row is green\033[0m"
+	@$(ECHO) "\033[32m$(SYM_CHECK) the #1146 comparison ran under Oven authority and its corpus row is green\033[0m"
 
 # Oven home the staged comparison publishes its direct-rustc plan into, kept out of the developer's own store.
 INCAN_SHADOW_OVEN_HOME ?= $(CURDIR)/target/incan_shadow_oven_home
@@ -571,7 +580,7 @@ generated-rust-audit-gate:
 	@$(PYTHON) scripts/generated_rust_audit.py --format json --fail-on-missing \
 		--artifact program-main=tests/fixtures/generated_rust_audit/main.rs \
 		--artifact stdlib-copy=tests/fixtures/generated_rust_audit/nested >/dev/null
-	@$(ECHO) "\033[32m✓ Generated Rust audit helper checks passed\033[0m"
+	@$(ECHO) "\033[32m$(SYM_CHECK) Generated Rust audit helper checks passed\033[0m"
 
 .PHONY: examples  ## test - Smoke test examples (check all, run entrypoints with timeout)
 examples: release
@@ -610,7 +619,7 @@ smoke-test-canary:
 	@$(ECHO) "\033[1mRunning Incan assertion canary...\033[0m"
 	@$(TEST_RUNTIME_ENV) RUSTUP_TOOLCHAIN="$(INCAN_TEST_SUITE_TOOLCHAIN)" INCAN_NO_BANNER=1 \
 		./target/release/incan test tests/fixtures/test_assert_canary.incn
-	@$(ECHO) "\033[32m✓ Incan assertion canary passed\033[0m"
+	@$(ECHO) "\033[32m$(SYM_CHECK) Incan assertion canary passed\033[0m"
 
 .PHONY: smoke-test-web-example
 smoke-test-web-example:
@@ -618,7 +627,7 @@ smoke-test-web-example:
 	@$(ECHO) "\033[1mBuilding web example (build-only)...\033[0m"
 	@$(TEST_RUNTIME_ENV) RUSTUP_TOOLCHAIN="$(INCAN_TEST_SUITE_TOOLCHAIN)" INCAN_NO_BANNER=1 \
 		./target/release/incan build examples/web/hello_web.incn
-	@$(ECHO) "\033[32m✓ Web example built\033[0m"
+	@$(ECHO) "\033[32m$(SYM_CHECK) Web example built\033[0m"
 
 .PHONY: smoke-test-nested-project-example
 smoke-test-nested-project-example:
@@ -626,7 +635,7 @@ smoke-test-nested-project-example:
 	@$(ECHO) "\033[1mBuilding nested_project example (build-only)...\033[0m"
 	@$(TEST_RUNTIME_ENV) RUSTUP_TOOLCHAIN="$(INCAN_TEST_SUITE_TOOLCHAIN)" INCAN_NO_BANNER=1 \
 		./target/release/incan build examples/advanced/nested_project/src/main.incn
-	@$(ECHO) "\033[32m✓ Nested project example built\033[0m"
+	@$(ECHO) "\033[32m$(SYM_CHECK) Nested project example built\033[0m"
 
 .PHONY: smoke-test-examples
 smoke-test-examples:
@@ -679,13 +688,13 @@ smoke-test:
 	@$(ECHO) "\033[1mRunning smoke-test...\033[0m"
 	@$(MAKE) test
 	@$(MAKE) smoke-test-core
-	@$(ECHO) "\033[32m✓ Smoke-test passed\033[0m"
+	@$(ECHO) "\033[32m$(SYM_CHECK) Smoke-test passed\033[0m"
 
 .PHONY: smoke-test-fast  ## test - Fast smoke test for after pre-commit (skips duplicate unit test suite)
 smoke-test-fast:
 	@$(ECHO) "\033[1mRunning smoke-test-fast...\033[0m"
 	@$(MAKE) smoke-test-core
-	@$(ECHO) "\033[32m✓ Smoke-test-fast passed\033[0m"
+	@$(ECHO) "\033[32m$(SYM_CHECK) Smoke-test-fast passed\033[0m"
 
 .PHONY: verify  ## test - Compatibility alias to pre-commit
 verify:
@@ -693,17 +702,17 @@ verify:
 
 .PHONY: test-verbose  ## test - Run the complete compiler suite through Oven
 test-verbose: test-oven
-	@$(ECHO) "\033[32m✓ Oven reports each root and retains the runner transcript on failure\033[0m"
+	@$(ECHO) "\033[32m$(SYM_CHECK) Oven reports each root and retains the runner transcript on failure\033[0m"
 
 .PHONY: test-diagnose  ## test - Run the complete compiler suite through Oven and retain failure evidence
 test-diagnose: test-oven
-	@$(ECHO) "\033[32m✓ Oven diagnostics are retained in the caller output only when a root fails\033[0m"
+	@$(ECHO) "\033[32m$(SYM_CHECK) Oven diagnostics are retained in the caller output only when a root fails\033[0m"
 
 .PHONY: test-timings  ## test - Generate cargo compile-timing report (target/cargo-timings)
 test-timings:
 	@$(ECHO) "\033[1mGenerating cargo timing report for test build...\033[0m"
 	@cargo test --all --no-run --timings
-	@$(ECHO) "\033[32m✓ Timing report generated in target/cargo-timings\033[0m"
+	@$(ECHO) "\033[32m$(SYM_CHECK) Timing report generated in target/cargo-timings\033[0m"
 
 # Keep single-root diagnostics on the same short, invocation-owned scratch policy as full suite replay.
 .PHONY: test-one  ## test - Run one receipt-bound compiler-suite source root (optional TEST_EXACT=module::case)
@@ -751,32 +760,32 @@ test-one: test-prewarm-oven-loafs
 lsp:
 	@$(ECHO) "\033[1mBuilding LSP server...\033[0m"
 	@cargo build --release --features lsp --bin incan-lsp
-	@$(ECHO) "\033[32m✓ LSP server built: target/release/incan-lsp\033[0m"
+	@$(ECHO) "\033[32m$(SYM_CHECK) LSP server built: target/release/incan-lsp\033[0m"
 
 .PHONY: install-lsp  ## tool - Install incan-lsp to ~/.cargo/bin
 install-lsp:
 	@$(ECHO) "\033[1mInstalling incan-lsp...\033[0m"
 	@cargo install --path . --features lsp --bin incan-lsp --force
-	@$(ECHO) "\033[32m✓ Installed to ~/.cargo/bin/incan-lsp\033[0m"
-	@$(ECHO) "\033[33mℹ Ensure ~/.cargo/bin is on your PATH\033[0m"
+	@$(ECHO) "\033[32m$(SYM_CHECK) Installed to ~/.cargo/bin/incan-lsp\033[0m"
+	@$(ECHO) "\033[33m$(SYM_INFO) Ensure ~/.cargo/bin is on your PATH\033[0m"
 
 .PHONY: test-incan-canary  ## test - End-to-end Incan test canary (assertion codegen)
 test-incan-canary: release
 	@$(ECHO) "\033[1mRunning Incan assertion canary...\033[0m"
 	@INCAN_NO_BANNER=1 ./target/release/incan test tests/fixtures/test_assert_canary.incn
-	@$(ECHO) "\033[32m✓ Incan assertion canary passed\033[0m"
+	@$(ECHO) "\033[32m$(SYM_CHECK) Incan assertion canary passed\033[0m"
 
 .PHONY: examples-web-build  ## test - Build-only web example (no run)
 examples-web-build: release
 	@$(ECHO) "\033[1mBuilding web example (build-only)...\033[0m"
 	@INCAN_NO_BANNER=1 ./target/release/incan build examples/web/hello_web.incn
-	@$(ECHO) "\033[32m✓ Web example built\033[0m"
+	@$(ECHO) "\033[32m$(SYM_CHECK) Web example built\033[0m"
 
 .PHONY: examples-nested-project-build  ## test - Build-only nested_project example (multi-module imports)
 examples-nested-project-build: release
 	@$(ECHO) "\033[1mBuilding nested_project example (build-only)...\033[0m"
 	@INCAN_NO_BANNER=1 ./target/release/incan build examples/advanced/nested_project/src/main.incn
-	@$(ECHO) "\033[32m✓ Nested project example built\033[0m"
+	@$(ECHO) "\033[32m$(SYM_CHECK) Nested project example built\033[0m"
 
 .PHONY: vscode-package  ## tool - Package VS Code extension
 vscode-package:
@@ -784,13 +793,13 @@ vscode-package:
 	@cd workspaces/ide/vscode && npm ci
 	@cd workspaces/ide/vscode && npm run compile
 	@cd workspaces/ide/vscode && npx @vscode/vsce package
-	@$(ECHO) "\033[32m✓ Extension packaged\033[0m"
+	@$(ECHO) "\033[32m$(SYM_CHECK) Extension packaged\033[0m"
 
 .PHONY: toolchain-release-build  ## tool - Build toolchain release binaries (compiler + LSP)
 toolchain-release-build:
 	@$(ECHO) "\033[1mBuilding toolchain release binaries...\033[0m"
 	@cargo build --locked --release --features lsp --bin incan --bin incan-lsp
-	@$(ECHO) "\033[32m✓ toolchain release binaries built\033[0m"
+	@$(ECHO) "\033[32m$(SYM_CHECK) toolchain release binaries built\033[0m"
 
 .PHONY: toolchain-release-package  ## tool - Package local toolchain archive (TOOLCHAIN_DIST=/private/tmp/incan-local-test)
 toolchain-release-package: toolchain-release-build
@@ -846,7 +855,7 @@ bench-build-times:
 gate-release:
 	@$(MAKE) gate-incql
 	@$(MAKE) gate-cleanroom
-	@$(ECHO) "\033[32m✓ Release gates passed\033[0m"
+	@$(ECHO) "\033[32m$(SYM_CHECK) Release gates passed\033[0m"
 
 .PHONY: watch  ## tool - Watch for changes and rebuild (requires cargo-watch)
 watch:
@@ -871,7 +880,7 @@ clean:
 	@$(ECHO) "\033[1mCleaning...\033[0m"
 	@cargo clean
 	@rm -rf target/incan/
-	@$(ECHO) "\033[32m✓ Clean\033[0m"
+	@$(ECHO) "\033[32m$(SYM_CHECK) Clean\033[0m"
 
 .PHONY: docs  ## docs - Build and serve the documentation site locally
 docs:

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,12 @@ else
 INCAN_LINK_CARGO_BIN ?= 1
 endif
 
+# Emitter for coloured status lines. Whether `echo` interprets backslash escapes is not portable: dash, which is
+# /bin/sh on most Linux distributions, does, while bash and the sh that Git for Windows supplies do not, so the escape
+# sequences print literally on those hosts. `printf %b` interprets them everywhere. Plain `echo` is still fine for
+# blank spacer lines, which carry no escapes.
+ECHO := printf '%b\n'
+
 # Interpreter for the repository check scripts. `python3` is the right name on Linux and macOS, but native Windows has
 # no such command: python.org installs `python` and the `py` launcher, and the `python3` name there resolves to a
 # Microsoft Store alias stub that prints an install advert and exits without running anything. Override with
@@ -81,25 +87,25 @@ endif
 help: build-quiet  ## Display this help message
 	@INCAN_NO_BANNER=1 ./target/debug/incan --version
 	@echo ""
-	@echo "\033[1mBuild:\033[0m"
+	@$(ECHO) "\033[1mBuild:\033[0m"
 	@grep -E '^.PHONY: .*?## build - .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ".PHONY: |## build - "}; {printf "  \033[36m%-18s\033[0m %s\n", $$2, $$3}'
 	@echo ""
-	@echo "\033[1mCode Quality:\033[0m"
+	@$(ECHO) "\033[1mCode Quality:\033[0m"
 	@grep -E '^.PHONY: .*?## quality - .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ".PHONY: |## quality - "}; {printf "  \033[36m%-18s\033[0m %s\n", $$2, $$3}'
 	@echo ""
-	@echo "\033[1mTesting:\033[0m"
+	@$(ECHO) "\033[1mTesting:\033[0m"
 	@grep -E '^.PHONY: .*?## test - .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ".PHONY: |## test - "}; {printf "  \033[36m%-18s\033[0m %s\n", $$2, $$3}'
 	@echo ""
-	@echo "\033[1mRelease gates (local only):\033[0m"
+	@$(ECHO) "\033[1mRelease gates (local only):\033[0m"
 	@grep -E '^.PHONY: .*?## gate - .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ".PHONY: |## gate - "}; {printf "  \033[36m%-18s\033[0m %s\n", $$2, $$3}'
 	@echo ""
-	@echo "\033[1mDocs:\033[0m"
+	@$(ECHO) "\033[1mDocs:\033[0m"
 	@grep -E '^.PHONY: .*?## docs - .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ".PHONY: |## docs - "}; {printf "  \033[36m%-18s\033[0m %s\n", $$2, $$3}'
 	@echo ""
-	@echo "\033[1mTooling:\033[0m"
+	@$(ECHO) "\033[1mTooling:\033[0m"
 	@grep -E '^.PHONY: .*?## tool - .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ".PHONY: |## tool - "}; {printf "  \033[36m%-18s\033[0m %s\n", $$2, $$3}'
 	@echo ""
-	@echo "\033[1mMiscellaneous:\033[0m"
+	@$(ECHO) "\033[1mMiscellaneous:\033[0m"
 	@grep -E '^.PHONY: .*?## misc - .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ".PHONY: |## misc - "}; {printf "  \033[36m%-18s\033[0m %s\n", $$2, $$3}'
 	@echo ""
 
@@ -115,21 +121,21 @@ _incan_link_debug_to_cargo_bin:
 	if [ ! -f "$(CURDIR)/target/debug/incan" ]; then echo "incan: expected $(CURDIR)/target/debug/incan after build"; exit 1; fi; \
 	mkdir -p "$(HOME)/.cargo/bin"; \
 	ln -sf "$(CURDIR)/target/debug/incan" "$(HOME)/.cargo/bin/incan"; \
-	echo "\033[32m✓ Linked ~/.cargo/bin/incan -> $(CURDIR)/target/debug/incan\033[0m"; \
+	$(ECHO) "\033[32m✓ Linked ~/.cargo/bin/incan -> $(CURDIR)/target/debug/incan\033[0m"; \
 	if [ -f "$(CURDIR)/target/debug/incan-lsp" ]; then \
 		ln -sf "$(CURDIR)/target/debug/incan-lsp" "$(HOME)/.cargo/bin/incan-lsp"; \
-		echo "\033[32m✓ Linked ~/.cargo/bin/incan-lsp -> $(CURDIR)/target/debug/incan-lsp\033[0m"; \
+		$(ECHO) "\033[32m✓ Linked ~/.cargo/bin/incan-lsp -> $(CURDIR)/target/debug/incan-lsp\033[0m"; \
 	fi
 
 .PHONY: build  ## build - Debug build (compiler + LSP); links ~/.cargo/bin/incan + incan-lsp locally
 build:
-	@echo "\033[1mBuilding (debug)...\033[0m"
+	@$(ECHO) "\033[1mBuilding (debug)...\033[0m"
 	@cargo build --features lsp
 	@$(MAKE) _incan_link_debug_to_cargo_bin
 
 .PHONY: build-fast  ## build - Debug build (compiler only); links ~/.cargo/bin/incan locally
 build-fast:
-	@echo "\033[1mBuilding compiler only (debug)...\033[0m"
+	@$(ECHO) "\033[1mBuilding compiler only (debug)...\033[0m"
 	@cargo build
 	@$(MAKE) _incan_link_debug_to_cargo_bin
 
@@ -139,14 +145,14 @@ build-quiet:
 
 .PHONY: release  ## build - Release build (optimized)
 release:
-	@echo "\033[1mBuilding (release)...\033[0m"
+	@$(ECHO) "\033[1mBuilding (release)...\033[0m"
 	@cargo build --release
 
 .PHONY: install  ## build - Install to ~/.cargo/bin
 install:
-	@echo "\033[1mInstalling incan...\033[0m"
+	@$(ECHO) "\033[1mInstalling incan...\033[0m"
 	@cargo install --path .
-	@echo "\033[32m✓ Installed to ~/.cargo/bin/incan\033[0m"
+	@$(ECHO) "\033[32m✓ Installed to ~/.cargo/bin/incan\033[0m"
 
 # =============================================================================
 # Code Quality
@@ -154,40 +160,40 @@ install:
 
 .PHONY: fmt  ## quality - Format Rust code
 fmt:
-	@echo "\033[1mFormatting code...\033[0m"
+	@$(ECHO) "\033[1mFormatting code...\033[0m"
 	@cargo +nightly fmt --version >/dev/null 2>&1 || ( \
-		echo "\033[33m⚠ nightly rustfmt is required for this project formatting config.\033[0m"; \
-		echo "\033[33m  Install it via: rustup toolchain install nightly --component rustfmt\033[0m"; \
+		$(ECHO) "\033[33m⚠ nightly rustfmt is required for this project formatting config.\033[0m"; \
+		$(ECHO) "\033[33m  Install it via: rustup toolchain install nightly --component rustfmt\033[0m"; \
 		exit 1; \
 	)
 	@cargo +nightly fmt --all
-	@echo "\033[32m✓ Code formatted\033[0m"
+	@$(ECHO) "\033[32m✓ Code formatted\033[0m"
 
 .PHONY: fmt-check  ## quality - Check formatting without changes
 fmt-check:
-	@echo "\033[1mChecking formatting...\033[0m"
+	@$(ECHO) "\033[1mChecking formatting...\033[0m"
 	@cargo +nightly fmt --version >/dev/null 2>&1 || ( \
-		echo "\033[33m⚠ nightly rustfmt is required for this project formatting config.\033[0m"; \
-		echo "\033[33m  Install it via: rustup toolchain install nightly --component rustfmt\033[0m"; \
+		$(ECHO) "\033[33m⚠ nightly rustfmt is required for this project formatting config.\033[0m"; \
+		$(ECHO) "\033[33m  Install it via: rustup toolchain install nightly --component rustfmt\033[0m"; \
 		exit 1; \
 	)
 	@cargo +nightly fmt --all -- --check
 
 .PHONY: lint  ## quality - Run clippy linter
 lint:
-	@echo "\033[1mRunning clippy...\033[0m"
+	@$(ECHO) "\033[1mRunning clippy...\033[0m"
 	@cargo clippy --all-targets --all-features -- -D warnings
 
 .PHONY: lint-fast  ## quality - Run faster clippy profile (workspace + all targets + all-features)
 lint-fast:
-	@echo "\033[1mRunning clippy (fast profile)...\033[0m"
+	@$(ECHO) "\033[1mRunning clippy (fast profile)...\033[0m"
 	@cargo clippy --workspace --all-targets --all-features -- -D warnings
 
 .PHONY: fmt-check-ci
 fmt-check-ci:
 	@cargo +nightly fmt --version >/dev/null 2>&1 || ( \
-		echo "\033[33m⚠ nightly rustfmt is required for this project formatting config.\033[0m"; \
-		echo "\033[33m  Install it via: rustup toolchain install nightly --component rustfmt\033[0m"; \
+		$(ECHO) "\033[33m⚠ nightly rustfmt is required for this project formatting config.\033[0m"; \
+		$(ECHO) "\033[33m  Install it via: rustup toolchain install nightly --component rustfmt\033[0m"; \
 		exit 1; \
 	)
 	@cargo +nightly fmt --all -- --check
@@ -200,7 +206,7 @@ lint-fast-ci:
 
 .PHONY: rustdoc-gate  ## quality - Require rustdoc on changed Rust functions/methods
 rustdoc-gate:
-	@echo "\033[1mChecking rustdoc coverage for changed Rust functions/methods...\033[0m"
+	@$(ECHO) "\033[1mChecking rustdoc coverage for changed Rust functions/methods...\033[0m"
 	@$(PYTHON) scripts/check_changed_rustdocs.py
 
 .PHONY: rustdoc-gate-ci
@@ -213,7 +219,7 @@ version-gate:
 
 .PHONY: agents-doc-sync  ## quality - Check AGENTS.md's skill table matches .agents/skills/ (local only, not CI)
 agents-doc-sync:
-	@echo "\033[1mChecking AGENTS.md skill table against .agents/skills/...\033[0m"
+	@$(ECHO) "\033[1mChecking AGENTS.md skill table against .agents/skills/...\033[0m"
 	@$(PYTHON) scripts/check_agents_doc_sync.py
 
 .PHONY: agents-doc-sync-ci
@@ -222,7 +228,7 @@ agents-doc-sync-ci:
 
 .PHONY: cargo-deny  ## quality - Run cargo-deny policy checks
 cargo-deny:
-	@echo "\033[1mRunning cargo-deny...\033[0m"
+	@$(ECHO) "\033[1mRunning cargo-deny...\033[0m"
 	@cargo deny check
 
 .PHONY: cargo-deny-ci
@@ -235,12 +241,12 @@ check-fast-ci:
 
 .PHONY: check  ## quality - Run all quality checks (fmt + lint)
 check: fmt-check lint
-	@echo "\033[32m✓ All checks passed\033[0m"
+	@$(ECHO) "\033[32m✓ All checks passed\033[0m"
 
 .PHONY: udeps  ## quality - Check for unused dependencies (requires nightly + cargo-udeps)
 udeps:
-	@echo "\033[1mChecking for unused dependencies...\033[0m"
-	@cargo +nightly udeps --quiet 2>/dev/null || echo "\033[33m⚠ cargo-udeps skipped (requires cargo-udeps + nightly rustc 1.85+. Run `rustup update nightly` if needed.)\033[0m"
+	@$(ECHO) "\033[1mChecking for unused dependencies...\033[0m"
+	@cargo +nightly udeps --quiet 2>/dev/null || $(ECHO) "\033[33m⚠ cargo-udeps skipped (requires cargo-udeps + nightly rustc 1.85+. Run `rustup update nightly` if needed.)\033[0m"
 
 .PHONY: pre-commit-fast  ## quality - Fast local gate: fmt-check + cargo check with phase timing
 pre-commit-fast:
@@ -248,26 +254,26 @@ pre-commit-fast:
 	start=$$(date +%s); \
 	printf "\033[1mChecking formatting...\033[0m "; \
 	$(MAKE) -s fmt-check-ci; \
-	echo "\033[32mDONE\033[0m"; \
+	$(ECHO) "\033[32mDONE\033[0m"; \
 	t1=$$(date +%s); \
 	printf "\033[1mChecking rustdoc coverage...\033[0m "; \
 	$(MAKE) -s rustdoc-gate-ci; \
-	echo "\033[32mDONE\033[0m"; \
+	$(ECHO) "\033[32mDONE\033[0m"; \
 	t2=$$(date +%s); \
 	printf "\033[1mChecking version consistency...\033[0m "; \
 	$(MAKE) -s version-gate; \
-	echo "\033[32mDONE\033[0m"; \
+	$(ECHO) "\033[32mDONE\033[0m"; \
 	t2a=$$(date +%s); \
 	printf "\033[1mChecking AGENTS.md skill table...\033[0m "; \
 	$(MAKE) -s agents-doc-sync-ci; \
-	echo "\033[32mDONE\033[0m"; \
+	$(ECHO) "\033[32mDONE\033[0m"; \
 	t2b=$$(date +%s); \
-	echo "\033[1mRunning cargo check (fast gate)...\033[0m"; \
+	$(ECHO) "\033[1mRunning cargo check (fast gate)...\033[0m"; \
 	$(MAKE) -s check-fast-ci; \
-	echo "\033[32mDONE\033[0m"; \
+	$(ECHO) "\033[32mDONE\033[0m"; \
 	t3=$$(date +%s); \
-	echo "\033[32m✓ Pre-commit checks passed (fast)\033[0m"; \
-	echo "\033[36mPhase timing:\033[0m fmt-check=$$((t1-start))s, rustdoc=$$((t2-t1))s, version-gate=$$((t2a-t2))s, agents-doc-sync=$$((t2b-t2a))s, check=$$((t3-t2b))s, total=$$((t3-start))s"
+	$(ECHO) "\033[32m✓ Pre-commit checks passed (fast)\033[0m"; \
+	$(ECHO) "\033[36mPhase timing:\033[0m fmt-check=$$((t1-start))s, rustdoc=$$((t2-t1))s, version-gate=$$((t2a-t2))s, agents-doc-sync=$$((t2b-t2a))s, check=$$((t3-t2b))s, total=$$((t3-start))s"
 
 .PHONY: pre-commit-full-gate  ## quality - Full local gate core: fmt-check + tests + clippy + cargo-deny with phase timing
 pre-commit-full-gate:
@@ -275,45 +281,45 @@ pre-commit-full-gate:
 	start=$$(date +%s); \
 	printf "\033[1mChecking formatting...\033[0m "; \
 	$(MAKE) -s fmt-check-ci; \
-	echo "\033[32mDONE\033[0m"; \
+	$(ECHO) "\033[32mDONE\033[0m"; \
 	t1=$$(date +%s); \
 	printf "\033[1mChecking rustdoc coverage...\033[0m "; \
 	$(MAKE) -s rustdoc-gate-ci; \
-	echo "\033[32mDONE\033[0m"; \
+	$(ECHO) "\033[32mDONE\033[0m"; \
 	t2=$$(date +%s); \
 	printf "\033[1mChecking AGENTS.md skill table...\033[0m "; \
 	$(MAKE) -s agents-doc-sync-ci; \
-	echo "\033[32mDONE\033[0m"; \
+	$(ECHO) "\033[32mDONE\033[0m"; \
 	t2b=$$(date +%s); \
-	echo "\033[1mRunning tests...\033[0m"; \
+	$(ECHO) "\033[1mRunning tests...\033[0m"; \
 	$(MAKE) -s test-oven; \
-	echo "\033[32mDONE\033[0m"; \
+	$(ECHO) "\033[32mDONE\033[0m"; \
 	t3=$$(date +%s); \
-	echo "\033[1mRunning clippy...\033[0m"; \
+	$(ECHO) "\033[1mRunning clippy...\033[0m"; \
 	$(MAKE) -s lint-fast-ci; \
-	echo "\033[32mDONE\033[0m"; \
+	$(ECHO) "\033[32mDONE\033[0m"; \
 	t4=$$(date +%s); \
-	echo "\033[1mRunning cargo-deny...\033[0m"; \
+	$(ECHO) "\033[1mRunning cargo-deny...\033[0m"; \
 	$(MAKE) -s cargo-deny-ci; \
-	echo "\033[32mDONE\033[0m"; \
+	$(ECHO) "\033[32mDONE\033[0m"; \
 	t5=$$(date +%s); \
-	echo "\033[32m✓ Pre-commit checks passed (full)\033[0m"; \
-	echo "\033[36mPhase timing:\033[0m fmt-check=$$((t1-start))s, rustdoc=$$((t2-t1))s, agents-doc-sync=$$((t2b-t2))s, tests=$$((t3-t2b))s, lint=$$((t4-t3))s, deny=$$((t5-t4))s, total=$$((t5-start))s"
+	$(ECHO) "\033[32m✓ Pre-commit checks passed (full)\033[0m"; \
+	$(ECHO) "\033[36mPhase timing:\033[0m fmt-check=$$((t1-start))s, rustdoc=$$((t2-t1))s, agents-doc-sync=$$((t2b-t2))s, tests=$$((t3-t2b))s, lint=$$((t4-t3))s, deny=$$((t5-t4))s, total=$$((t5-start))s"
 
 .PHONY: pre-commit  ## quality - Full local gate: pre-commit-full-gate + smoke-test-fast
 pre-commit:
-	@echo "\033[1mRunning pre-commit (full local gate)...\033[0m"
+	@$(ECHO) "\033[1mRunning pre-commit (full local gate)...\033[0m"
 	@$(MAKE) pre-commit-full-gate
 	@$(MAKE) smoke-test-fast
-	@echo "\033[32m✓ Pre-commit passed\033[0m"
+	@$(ECHO) "\033[32m✓ Pre-commit passed\033[0m"
 
 .PHONY: ci-full  ## quality - Full CI check: fmt, lint, udeps, test, and release build
 ci-full: fmt lint udeps
-	@echo "\033[1mRunning tests...\033[0m"
+	@$(ECHO) "\033[1mRunning tests...\033[0m"
 	@$(MAKE) -s test-oven
-	@echo "\033[1mBuilding release...\033[0m"
+	@$(ECHO) "\033[1mBuilding release...\033[0m"
 	@cargo build --release --quiet
-	@echo "\033[32m✓ Full CI checks passed\033[0m"
+	@$(ECHO) "\033[32m✓ Full CI checks passed\033[0m"
 
 # =============================================================================
 # Testing
@@ -343,7 +349,7 @@ test-oven-partition:
 	@test -n "$(INCAN_TEST_OVEN_PARTITION_INDEX)" || { echo "INCAN_TEST_OVEN_PARTITION_INDEX is required" >&2; exit 2; }
 	@test -n "$(INCAN_TEST_OVEN_PARTITION_COUNT)" || { echo "INCAN_TEST_OVEN_PARTITION_COUNT is required" >&2; exit 2; }
 	@partition_display=$$(( $(INCAN_TEST_OVEN_PARTITION_INDEX) + 1 )); \
-		echo "\033[1mRunning prepared Oven compiler-suite partition $$partition_display/$(INCAN_TEST_OVEN_PARTITION_COUNT)...\033[0m"
+		$(ECHO) "\033[1mRunning prepared Oven compiler-suite partition $$partition_display/$(INCAN_TEST_OVEN_PARTITION_COUNT)...\033[0m"
 	@$(MAKE) --no-print-directory test-oven-replay \
 		INCAN_TEST_OVEN_COMPILER_SUITE_PARTITION_ARGS='--partition-index $(INCAN_TEST_OVEN_PARTITION_INDEX) --partition-count $(INCAN_TEST_OVEN_PARTITION_COUNT)'
 
@@ -351,7 +357,7 @@ test-oven-partition:
 # short `/tmp` scratch directory instead of inheriting an arbitrarily deep worktree `TMPDIR`.
 .PHONY: test-oven-replay
 test-oven-replay:
-	@echo "\033[1mRunning prepared compiler-suite replay through Oven...\033[0m"
+	@$(ECHO) "\033[1mRunning prepared compiler-suite replay through Oven...\033[0m"
 	@set -e; \
 		mkdir -p "$(INCAN_TEST_OVEN_COMPILER_SUITE_OUTPUT_ROOT)"; \
 		suite_output="$$(mktemp -d "$(INCAN_TEST_OVEN_COMPILER_SUITE_OUTPUT_ROOT)/oven-compiler-suite-output.XXXXXX")"; \
@@ -398,7 +404,7 @@ test: test-oven
 
 .PHONY: test-prewarm-sdk
 test-prewarm-sdk:
-	@echo "\033[1mPrewarming compiled SDK providers...\033[0m"
+	@$(ECHO) "\033[1mPrewarming compiled SDK providers...\033[0m"
 	@if [ "$(INCAN_TEST_COMPILER_ALREADY_BUILT)" = "1" ]; then \
 		test -x "$(CURDIR)/target/debug/incan"; \
 	else \
@@ -419,7 +425,7 @@ test-prewarm-sdk:
 # two relevant suites with INCAN_SHADOW_REQUIRE_LEGACY_ROUTE=1 so an unstaged or failing comparison is a hard
 # failure rather than a reported skip. It is the only place that can prove the intended green corpus row.
 shadow-comparison-evidence:
-	@echo "\033[1mStaging Oven and proving the #1146 source-observable comparison...\033[0m"
+	@$(ECHO) "\033[1mStaging Oven and proving the #1146 source-observable comparison...\033[0m"
 	@set -e; \
 		if [ "$(INCAN_TEST_COMPILER_ALREADY_BUILT)" = "1" ]; then \
 			test -x "$(CURDIR)/target/debug/incan"; \
@@ -435,7 +441,7 @@ shadow-comparison-evidence:
 		test -f "$$receipt" || { echo "Oven bake did not publish an executable debug receipt" >&2; exit 1; }; \
 		$(SHADOW_TEST_ENV) INCAN_SHADOW_OVEN_RECEIPT="$$receipt" \
 			cargo test --test shadow_comparison_tests --test parity_corpus_tests
-	@echo "\033[32m✓ the #1146 comparison ran under Oven authority and its corpus row is green\033[0m"
+	@$(ECHO) "\033[32m✓ the #1146 comparison ran under Oven authority and its corpus row is green\033[0m"
 
 # Oven home the staged comparison publishes its direct-rustc plan into, kept out of the developer's own store.
 INCAN_SHADOW_OVEN_HOME ?= $(CURDIR)/target/incan_shadow_oven_home
@@ -449,7 +455,7 @@ SHADOW_TEST_ENV = $(TEST_ENV) CARGO_NET_OFFLINE=true \
 
 .PHONY: test-prewarm-oven-loafs
 test-prewarm-oven-loafs: test-prewarm-sdk
-	@echo "\033[1mBaking or reusing the compiler-suite standard-library Loaf family...\033[0m" >&2
+	@$(ECHO) "\033[1mBaking or reusing the compiler-suite standard-library Loaf family...\033[0m" >&2
 	@$(TEST_ENV) RUSTUP_TOOLCHAIN="$(INCAN_TEST_LOAF_TOOLCHAIN)" CARGO_NET_OFFLINE=true INCAN_NO_BANNER=1 \
 		INCAN_STDLIB="$(CURDIR)/crates/incan_stdlib/stdlib" \
 		INCAN_STDLIB_DIR="$(CURDIR)/crates/incan_stdlib/stdlib" \
@@ -465,7 +471,7 @@ test-prewarm-oven-loafs: test-prewarm-sdk
 
 .PHONY: test-prewarm-oven-release-loafs
 test-prewarm-oven-release-loafs: test-prewarm-sdk
-	@echo "\033[1mBaking or reusing the release standard-library Loaf family...\033[0m"
+	@$(ECHO) "\033[1mBaking or reusing the release standard-library Loaf family...\033[0m"
 	@test -x "$(INCAN_TEST_OVEN_RELEASE_COMPILER_BIN)"
 	@mkdir -p "$(INCAN_TEST_OVEN_RELEASE_TOOLCHAIN_ROOT)/bin"
 	@cp "$(INCAN_TEST_OVEN_RELEASE_COMPILER_BIN)" "$(INCAN_TEST_OVEN_RELEASE_TOOLCHAIN_ROOT)/bin/incan"
@@ -485,7 +491,7 @@ test-prewarm-oven-release-loafs: test-prewarm-sdk
 
 .PHONY: test-oven-focused
 test-oven-focused:
-	@echo "\033[1mRunning focused Oven and Loaf regression tests...\033[0m"
+	@$(ECHO) "\033[1mRunning focused Oven and Loaf regression tests...\033[0m"
 	@CARGO_PROFILE_TEST_DEBUG=0 cargo test --locked --lib oven::
 	@CARGO_PROFILE_TEST_DEBUG=0 cargo test --locked --test cli_integration \
 		lock_records_oven_interop_requirements_and_detects_input_drift -- --exact
@@ -496,12 +502,12 @@ test-oven-focused:
 
 .PHONY: test-oven-pr-regressions
 test-oven-pr-regressions:
-	@echo "\033[1mRunning bounded Oven process-containment regressions...\033[0m"
+	@$(ECHO) "\033[1mRunning bounded Oven process-containment regressions...\033[0m"
 	@CARGO_PROFILE_TEST_DEBUG=0 CARGO_BUILD_JOBS=2 cargo test --locked --features lsp --test oven_pr_regressions
 
 .PHONY: test-oven-release-smoke
 test-oven-release-smoke: test-prewarm-oven-release-loafs
-	@echo "\033[1mRunning Cargo-guarded Oven release-envelope smoke...\033[0m"
+	@$(ECHO) "\033[1mRunning Cargo-guarded Oven release-envelope smoke...\033[0m"
 	@set -e; \
 		smoke_root="$$(mktemp -d "$(INCAN_TEST_OVEN_COMPILER_SUITE_OUTPUT_ROOT)/oven-release-smoke.XXXXXX")"; \
 		cleanup_smoke_root() { rm -rf -- "$$smoke_root"; }; \
@@ -554,37 +560,37 @@ test-oven-release-smoke: test-prewarm-oven-release-loafs
 
 .PHONY: test-rust-inspect  ## test - Run focused rust-inspect regression tests
 test-rust-inspect:
-	@echo "\033[1mRunning rust-inspect focused tests...\033[0m"
+	@$(ECHO) "\033[1mRunning rust-inspect focused tests...\033[0m"
 	@cargo test --lib --features rust_inspect frontend::typechecker::tests::test_rust_inspect_unavailable_stays_permissive_for_method_calls
 	@cargo test --lib --features rust_inspect frontend::typechecker::tests::test_rusttype_return_coercion_recorded_for_generic_newtype_method_call
 
 .PHONY: generated-rust-audit-gate  ## test - Run deterministic generated Rust audit helper checks
 generated-rust-audit-gate:
-	@echo "\033[1mRunning generated Rust audit helper checks...\033[0m"
+	@$(ECHO) "\033[1mRunning generated Rust audit helper checks...\033[0m"
 	@cargo test --test generated_rust_audit_tests
 	@$(PYTHON) scripts/generated_rust_audit.py --format json --fail-on-missing \
 		--artifact program-main=tests/fixtures/generated_rust_audit/main.rs \
 		--artifact stdlib-copy=tests/fixtures/generated_rust_audit/nested >/dev/null
-	@echo "\033[32m✓ Generated Rust audit helper checks passed\033[0m"
+	@$(ECHO) "\033[32m✓ Generated Rust audit helper checks passed\033[0m"
 
 .PHONY: examples  ## test - Smoke test examples (check all, run entrypoints with timeout)
 examples: release
-	@echo "\033[1mRunning examples...\033[0m"
+	@$(ECHO) "\033[1mRunning examples...\033[0m"
 	@INCAN_NO_BANNER=1 INCAN_EXAMPLES_TIMEOUT=$${INCAN_EXAMPLES_TIMEOUT:-30} bash scripts/run_examples.sh
 
 .PHONY: benchmarks  ## test - Run benchmark suite (requires hyperfine)
 benchmarks: release
-	@echo "\033[1mRunning benchmarks...\033[0m"
+	@$(ECHO) "\033[1mRunning benchmarks...\033[0m"
 	@INCAN_NO_BANNER=1 bash workspaces/benchmarks/run_all.sh
 
 .PHONY: benchmarks-rust  ## test - Run benchmarks (Incan vs Rust only; no Python)
 benchmarks-rust: release
-	@echo "\033[1mRunning benchmarks (Incan vs Rust; no Python)...\033[0m"
+	@$(ECHO) "\033[1mRunning benchmarks (Incan vs Rust; no Python)...\033[0m"
 	@INCAN_NO_BANNER=1 SKIP_PYTHON=true bash workspaces/benchmarks/run_all.sh
 
 .PHONY: benchmarks-incan  ## test - Smoke-check benchmark .incn files (build only; no Python/Rust runs)
 benchmarks-incan: release
-	@echo "\033[1mChecking benchmarks (Incan build only)...\033[0m"
+	@$(ECHO) "\033[1mChecking benchmarks (Incan build only)...\033[0m"
 	@INCAN_NO_BANNER=1 bash workspaces/benchmarks/check_incan.sh
 
 .PHONY: smoke-test-release
@@ -601,47 +607,47 @@ smoke-test-require-release-bin:
 .PHONY: smoke-test-canary
 smoke-test-canary:
 	@$(MAKE) -s smoke-test-require-release-bin
-	@echo "\033[1mRunning Incan assertion canary...\033[0m"
+	@$(ECHO) "\033[1mRunning Incan assertion canary...\033[0m"
 	@$(TEST_RUNTIME_ENV) RUSTUP_TOOLCHAIN="$(INCAN_TEST_SUITE_TOOLCHAIN)" INCAN_NO_BANNER=1 \
 		./target/release/incan test tests/fixtures/test_assert_canary.incn
-	@echo "\033[32m✓ Incan assertion canary passed\033[0m"
+	@$(ECHO) "\033[32m✓ Incan assertion canary passed\033[0m"
 
 .PHONY: smoke-test-web-example
 smoke-test-web-example:
 	@$(MAKE) -s smoke-test-require-release-bin
-	@echo "\033[1mBuilding web example (build-only)...\033[0m"
+	@$(ECHO) "\033[1mBuilding web example (build-only)...\033[0m"
 	@$(TEST_RUNTIME_ENV) RUSTUP_TOOLCHAIN="$(INCAN_TEST_SUITE_TOOLCHAIN)" INCAN_NO_BANNER=1 \
 		./target/release/incan build examples/web/hello_web.incn
-	@echo "\033[32m✓ Web example built\033[0m"
+	@$(ECHO) "\033[32m✓ Web example built\033[0m"
 
 .PHONY: smoke-test-nested-project-example
 smoke-test-nested-project-example:
 	@$(MAKE) -s smoke-test-require-release-bin
-	@echo "\033[1mBuilding nested_project example (build-only)...\033[0m"
+	@$(ECHO) "\033[1mBuilding nested_project example (build-only)...\033[0m"
 	@$(TEST_RUNTIME_ENV) RUSTUP_TOOLCHAIN="$(INCAN_TEST_SUITE_TOOLCHAIN)" INCAN_NO_BANNER=1 \
 		./target/release/incan build examples/advanced/nested_project/src/main.incn
-	@echo "\033[32m✓ Nested project example built\033[0m"
+	@$(ECHO) "\033[32m✓ Nested project example built\033[0m"
 
 .PHONY: smoke-test-examples
 smoke-test-examples:
 	@$(MAKE) -s smoke-test-require-release-bin
-	@echo "\033[1mRunning examples...\033[0m"
+	@$(ECHO) "\033[1mRunning examples...\033[0m"
 	@$(TEST_RUNTIME_ENV) RUSTUP_TOOLCHAIN="$(INCAN_TEST_SUITE_TOOLCHAIN)" INCAN_NO_BANNER=1 \
 		INCAN_EXAMPLES_TIMEOUT=$${INCAN_EXAMPLES_TIMEOUT:-30} bash scripts/run_examples.sh
-	@echo "\033[1mChecking documentation examples...\033[0m"
+	@$(ECHO) "\033[1mChecking documentation examples...\033[0m"
 	@$(TEST_RUNTIME_ENV) RUSTUP_TOOLCHAIN="$(INCAN_TEST_SUITE_TOOLCHAIN)" INCAN_NO_BANNER=1 \
 		INCAN_BIN=./target/release/incan bash scripts/check_docs_examples.sh
 
 .PHONY: check-docs-examples  ## test - Typecheck committed verified documentation examples
 check-docs-examples: test-prewarm-sdk
-	@echo "\033[1mChecking verified documentation examples...\033[0m"
+	@$(ECHO) "\033[1mChecking verified documentation examples...\033[0m"
 	@$(TEST_RUNTIME_ENV) RUSTUP_TOOLCHAIN="$(INCAN_TEST_SUITE_TOOLCHAIN)" INCAN_NO_BANNER=1 \
 		INCAN_BIN=./target/debug/incan bash scripts/check_docs_examples.sh
 
 .PHONY: smoke-test-rust-interop-examples
 smoke-test-rust-interop-examples: test-prewarm-oven-loafs
 	@$(MAKE) -s smoke-test-require-release-bin
-	@echo "\033[1mRunning receipt-compatible Rust-interop smoke examples...\033[0m"
+	@$(ECHO) "\033[1mRunning receipt-compatible Rust-interop smoke examples...\033[0m"
 	@$(TEST_RUNTIME_ENV) RUSTUP_TOOLCHAIN="$(INCAN_TEST_SUITE_TOOLCHAIN)" INCAN_NO_BANNER=1 \
 		INCAN_EXAMPLES_ONLY="examples/advanced/using_rust_crates.incn:examples/pro/rust_interop_pro.incn" \
 		INCAN_EXAMPLES_TIMEOUT=30 INCAN_EXAMPLES_TIMEOUT_MODE=fail INCAN_EXAMPLES_REQUIRE_CARGO_FREE=1 \
@@ -650,7 +656,7 @@ smoke-test-rust-interop-examples: test-prewarm-oven-loafs
 .PHONY: smoke-test-benchmarks-incan
 smoke-test-benchmarks-incan:
 	@$(MAKE) -s smoke-test-require-release-bin
-	@echo "\033[1mChecking benchmarks (Incan build only)...\033[0m"
+	@$(ECHO) "\033[1mChecking benchmarks (Incan build only)...\033[0m"
 	@$(TEST_RUNTIME_ENV) RUSTUP_TOOLCHAIN="$(INCAN_TEST_SUITE_TOOLCHAIN)" INCAN_NO_BANNER=1 \
 		bash workspaces/benchmarks/check_incan.sh
 
@@ -670,16 +676,16 @@ smoke-test-core: test-prewarm-oven-loafs test-prewarm-oven-release-loafs
 
 .PHONY: smoke-test  ## test - Full smoke test: tests + release canary + examples + benchmarks-incan
 smoke-test:
-	@echo "\033[1mRunning smoke-test...\033[0m"
+	@$(ECHO) "\033[1mRunning smoke-test...\033[0m"
 	@$(MAKE) test
 	@$(MAKE) smoke-test-core
-	@echo "\033[32m✓ Smoke-test passed\033[0m"
+	@$(ECHO) "\033[32m✓ Smoke-test passed\033[0m"
 
 .PHONY: smoke-test-fast  ## test - Fast smoke test for after pre-commit (skips duplicate unit test suite)
 smoke-test-fast:
-	@echo "\033[1mRunning smoke-test-fast...\033[0m"
+	@$(ECHO) "\033[1mRunning smoke-test-fast...\033[0m"
 	@$(MAKE) smoke-test-core
-	@echo "\033[32m✓ Smoke-test-fast passed\033[0m"
+	@$(ECHO) "\033[32m✓ Smoke-test-fast passed\033[0m"
 
 .PHONY: verify  ## test - Compatibility alias to pre-commit
 verify:
@@ -687,23 +693,23 @@ verify:
 
 .PHONY: test-verbose  ## test - Run the complete compiler suite through Oven
 test-verbose: test-oven
-	@echo "\033[32m✓ Oven reports each root and retains the runner transcript on failure\033[0m"
+	@$(ECHO) "\033[32m✓ Oven reports each root and retains the runner transcript on failure\033[0m"
 
 .PHONY: test-diagnose  ## test - Run the complete compiler suite through Oven and retain failure evidence
 test-diagnose: test-oven
-	@echo "\033[32m✓ Oven diagnostics are retained in the caller output only when a root fails\033[0m"
+	@$(ECHO) "\033[32m✓ Oven diagnostics are retained in the caller output only when a root fails\033[0m"
 
 .PHONY: test-timings  ## test - Generate cargo compile-timing report (target/cargo-timings)
 test-timings:
-	@echo "\033[1mGenerating cargo timing report for test build...\033[0m"
+	@$(ECHO) "\033[1mGenerating cargo timing report for test build...\033[0m"
 	@cargo test --all --no-run --timings
-	@echo "\033[32m✓ Timing report generated in target/cargo-timings\033[0m"
+	@$(ECHO) "\033[32m✓ Timing report generated in target/cargo-timings\033[0m"
 
 # Keep single-root diagnostics on the same short, invocation-owned scratch policy as full suite replay.
 .PHONY: test-one  ## test - Run one receipt-bound compiler-suite source root (optional TEST_EXACT=module::case)
 test-one: test-prewarm-oven-loafs
 	@test -n "$(TEST_ROOT)" || { echo "usage: make test-one TEST_ROOT=tests/cli_integration.rs" >&2; exit 2; }
-	@echo "\033[1mRunning $(TEST_ROOT)$(if $(TEST_EXACT), ($(TEST_EXACT)),) through Oven...\033[0m"
+	@$(ECHO) "\033[1mRunning $(TEST_ROOT)$(if $(TEST_EXACT), ($(TEST_EXACT)),) through Oven...\033[0m"
 	@set -e; \
 		mkdir -p "$(INCAN_TEST_OVEN_COMPILER_SUITE_OUTPUT_ROOT)"; \
 		root_output="$$(mktemp -d "$(INCAN_TEST_OVEN_COMPILER_SUITE_OUTPUT_ROOT)/oven-test-one.XXXXXX")"; \
@@ -743,48 +749,48 @@ test-one: test-prewarm-oven-loafs
 
 .PHONY: lsp  ## tool - Build the LSP server
 lsp:
-	@echo "\033[1mBuilding LSP server...\033[0m"
+	@$(ECHO) "\033[1mBuilding LSP server...\033[0m"
 	@cargo build --release --features lsp --bin incan-lsp
-	@echo "\033[32m✓ LSP server built: target/release/incan-lsp\033[0m"
+	@$(ECHO) "\033[32m✓ LSP server built: target/release/incan-lsp\033[0m"
 
 .PHONY: install-lsp  ## tool - Install incan-lsp to ~/.cargo/bin
 install-lsp:
-	@echo "\033[1mInstalling incan-lsp...\033[0m"
+	@$(ECHO) "\033[1mInstalling incan-lsp...\033[0m"
 	@cargo install --path . --features lsp --bin incan-lsp --force
-	@echo "\033[32m✓ Installed to ~/.cargo/bin/incan-lsp\033[0m"
-	@echo "\033[33mℹ Ensure ~/.cargo/bin is on your PATH\033[0m"
+	@$(ECHO) "\033[32m✓ Installed to ~/.cargo/bin/incan-lsp\033[0m"
+	@$(ECHO) "\033[33mℹ Ensure ~/.cargo/bin is on your PATH\033[0m"
 
 .PHONY: test-incan-canary  ## test - End-to-end Incan test canary (assertion codegen)
 test-incan-canary: release
-	@echo "\033[1mRunning Incan assertion canary...\033[0m"
+	@$(ECHO) "\033[1mRunning Incan assertion canary...\033[0m"
 	@INCAN_NO_BANNER=1 ./target/release/incan test tests/fixtures/test_assert_canary.incn
-	@echo "\033[32m✓ Incan assertion canary passed\033[0m"
+	@$(ECHO) "\033[32m✓ Incan assertion canary passed\033[0m"
 
 .PHONY: examples-web-build  ## test - Build-only web example (no run)
 examples-web-build: release
-	@echo "\033[1mBuilding web example (build-only)...\033[0m"
+	@$(ECHO) "\033[1mBuilding web example (build-only)...\033[0m"
 	@INCAN_NO_BANNER=1 ./target/release/incan build examples/web/hello_web.incn
-	@echo "\033[32m✓ Web example built\033[0m"
+	@$(ECHO) "\033[32m✓ Web example built\033[0m"
 
 .PHONY: examples-nested-project-build  ## test - Build-only nested_project example (multi-module imports)
 examples-nested-project-build: release
-	@echo "\033[1mBuilding nested_project example (build-only)...\033[0m"
+	@$(ECHO) "\033[1mBuilding nested_project example (build-only)...\033[0m"
 	@INCAN_NO_BANNER=1 ./target/release/incan build examples/advanced/nested_project/src/main.incn
-	@echo "\033[32m✓ Nested project example built\033[0m"
+	@$(ECHO) "\033[32m✓ Nested project example built\033[0m"
 
 .PHONY: vscode-package  ## tool - Package VS Code extension
 vscode-package:
-	@echo "\033[1mPackaging VS Code extension...\033[0m"
+	@$(ECHO) "\033[1mPackaging VS Code extension...\033[0m"
 	@cd workspaces/ide/vscode && npm ci
 	@cd workspaces/ide/vscode && npm run compile
 	@cd workspaces/ide/vscode && npx @vscode/vsce package
-	@echo "\033[32m✓ Extension packaged\033[0m"
+	@$(ECHO) "\033[32m✓ Extension packaged\033[0m"
 
 .PHONY: toolchain-release-build  ## tool - Build toolchain release binaries (compiler + LSP)
 toolchain-release-build:
-	@echo "\033[1mBuilding toolchain release binaries...\033[0m"
+	@$(ECHO) "\033[1mBuilding toolchain release binaries...\033[0m"
 	@cargo build --locked --release --features lsp --bin incan --bin incan-lsp
-	@echo "\033[32m✓ toolchain release binaries built\033[0m"
+	@$(ECHO) "\033[32m✓ toolchain release binaries built\033[0m"
 
 .PHONY: toolchain-release-package  ## tool - Package local toolchain archive (TOOLCHAIN_DIST=/private/tmp/incan-local-test)
 toolchain-release-package: toolchain-release-build
@@ -840,11 +846,11 @@ bench-build-times:
 gate-release:
 	@$(MAKE) gate-incql
 	@$(MAKE) gate-cleanroom
-	@echo "\033[32m✓ Release gates passed\033[0m"
+	@$(ECHO) "\033[32m✓ Release gates passed\033[0m"
 
 .PHONY: watch  ## tool - Watch for changes and rebuild (requires cargo-watch)
 watch:
-	@echo "\033[1mWatching for changes...\033[0m"
+	@$(ECHO) "\033[1mWatching for changes...\033[0m"
 	@cargo watch -x build
 
 # =============================================================================
@@ -862,10 +868,10 @@ zen:
 
 .PHONY: clean  ## misc - Clean build artifacts
 clean:
-	@echo "\033[1mCleaning...\033[0m"
+	@$(ECHO) "\033[1mCleaning...\033[0m"
 	@cargo clean
 	@rm -rf target/incan/
-	@echo "\033[32m✓ Clean\033[0m"
+	@$(ECHO) "\033[32m✓ Clean\033[0m"
 
 .PHONY: docs  ## docs - Build and serve the documentation site locally
 docs:
@@ -897,8 +903,8 @@ docs-lint:
 
 .PHONY: version  ## misc - Show version info
 version:
-	@echo "\033[1mIncan version:\033[0m"
+	@$(ECHO) "\033[1mIncan version:\033[0m"
 	@cargo pkgid | cut -d# -f2
 	@echo ""
-	@echo "\033[1mRust version:\033[0m"
+	@$(ECHO) "\033[1mRust version:\033[0m"
 	@rustc --version


### PR DESCRIPTION
## Summary

Makefile status output was wrong on native Windows in two independent ways. Both are fixed here, and the second is only fixable because of the first.

**Escape sequences printed literally.** 85 recipe lines emitted colour with `@echo "\033[...]"`. Whether `echo` interprets backslash escapes is not portable — dash does, bash and Git for Windows' `sh` do not:

```
\033[1mChecking formatting...\033[0m
\033[32m✓ Pre-commit checks passed (fast)\033[0m
```

**Non-ASCII glyphs arrived as mojibake.** The `✓` and `⚠` characters rendered as `âœ“` regardless of emitter.

## Type of change

- [x] Bug fix
- [x] CI / tooling

## Area(s)

- [x] Tooling (CLI/formatter/test runner)

## Key details

### Colour escapes

One new variable, `ECHO := printf '%b\n'`, and **113 converted call sites**. That is more than the 85 the issue cited, because the original count missed `echo` calls nested inside multi-line shell blocks.

Only lines carrying escapes were converted; plain `@echo ""` spacers behave identically on every shell and were left alone. The `awk`-internal `printf "...\033..."` lines in the `help` target were correctly not touched — that is awk's own printf, which already interprets escapes. The single `>&2` redirect works unchanged. No `%` appears in any converted string, so there is no format-specifier hazard.

### Mojibake

The cause was measured rather than guessed. The Makefile source holds correct UTF-8 (`e2 9c 93`), the emitted bytes were `c3 a2 c5 93 e2 80 9c`, and **both `echo` and `printf` produced that identically** — so the conversion happens before either emitter runs. GNU Make on Windows reads the file's UTF-8 as the ANSI codepage and re-emits it as UTF-8 on the way to the shell.

Because the corruption happens inside Make, no choice of emitter can fix it. The fix is to leave Make nothing to convert — keep recipe text pure ASCII and reconstruct the character at runtime:

```make
SYM_CHECK := \0342\0234\0223
SYM_WARN := \0342\0232\0240
SYM_INFO := \0342\0204\0271
```

33 emitted glyphs across three characters were converted. The one remaining literal (`→`) sits in a comment, which is never emitted.

These two fixes compose rather than merely coexisting: octal escapes only work because the `$(ECHO)` change routes the lines through `printf %b`, which interprets `\0nnn`. Under the previous `echo` they would have printed literally.

## Testing / verification

- [x] Manual verification described below

`make pre-commit-fast` on native Windows x64, before and after:

| | before | after |
| --- | --- | --- |
| literal `\033` in output | present | **0** |
| real ESC (`0x1b`) bytes | 0 | **10** |
| check-mark bytes | `c3 a2 c5 93 e2 80 9c` | **`e2 9c 93`** |
| rendered success line | `\033[32mâœ“ Pre-commit…` | **`✓ Pre-commit checks passed (fast)`** |
| exit code | 0 | 0 |

### Unix output is unchanged — measured, not assumed

`dash` is `/bin/sh` on most Linux distributions and is the shell this has to stay identical on. Run directly against it:

| form | bytes |
| --- | --- |
| old, `echo "\033[32mX\033[0m"` | `1b5b 3332 6d58 1b5b 306d 0a` |
| new, `printf '%b\n' "\033[32mX\033[0m"` | `1b5b 3332 6d58 1b5b 306d 0a` |
| old, `echo "✓"` | `e29c 930a` |
| new, `printf '%b\n' "\0342\0234\0223"` | `e29c 930a` |

Byte-for-byte identical, trailing newline included. `\033` resolves correctly under `%b` because POSIX defines the escape as `\0ddd` with a one-to-three-digit octal number, so it parses as `\0` followed by `33` — octal 33, which is `ESC`.

**On bash the change is an improvement rather than a no-op.** bash's builtin `echo` does not interpret `\033` without `-e`, emitting the literal bytes `5c 30 33 33`. Any host where `/bin/sh` is bash was therefore already printing escape sequences literally, and now renders colour correctly.

Structural safety was checked separately: no converted line passes multiple arguments (which would make `printf` repeat its format), none sits inside `$(shell …)` or a command substitution, and none is nested within existing single quotes.

### Residual risk

`make pre-commit` (full) and `make test` were not run on this host; see #1345. Those need a Linux or macOS run regardless. The emission change itself is now measured rather than reasoned.

## Docs impact

- [x] No docs changes needed

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #1351.

Stacked on #1350; base retargets to `0.6.0-dev.windows` automatically when that merges.
