### PR TITLE
bugfix - report uncontained descendants instead of claiming containment (#1355)

### DIFF
--- a/src/oven/interop.rs
+++ b/src/oven/interop.rs
@@ -1623,8 +1623,12 @@ fn run_interop_tool(mut command: Command, executable: &Path, label: &str) -> Res
             Some(status) => break status,
             None if Instant::now() >= deadline => {
                 timed_out = true;
-                break terminate_process_group(&mut child)
+                let termination = terminate_process_group(&mut child)
                     .map_err(|error| format!("could not terminate timed-out {label}: {error}"))?;
+                if let Some(note) = termination.uncontained_note() {
+                    tracing::warn!("timed-out {label} was terminated, but {note}");
+                }
+                break termination.status;
             }
             None => thread::sleep(Duration::from_millis(5)),
         }

--- a/src/oven/legacy_cargo.rs
+++ b/src/oven/legacy_cargo.rs
@@ -7367,10 +7367,18 @@ fn run_legacy_cargo_invocation(
                     0
                 };
                 if reservation > transient_limit {
-                    terminate_process_group(&mut child).map_err(|source| OvenLegacyCargoError::Io {
-                        path: cargo.clone(),
-                        source,
-                    })?;
+                    let termination =
+                        terminate_process_group(&mut child).map_err(|source| OvenLegacyCargoError::Io {
+                            path: cargo.clone(),
+                            source,
+                        })?;
+                    if let Some(note) = termination.uncontained_note() {
+                        // The capacity guard exists to stop a runaway build consuming disk. Surviving descendants
+                        // keep writing, so the reservation this failure reports can still grow after it is raised.
+                        tracing::warn!(
+                            "terminated the publisher for exceeding its transient allowance, but {note}, so the measured reservation may continue to grow"
+                        );
+                    }
                     return Err(OvenLegacyCargoError::TransientCapacityExceeded {
                         path: capacity_root.to_path_buf(),
                         observed_physical_bytes: reservation,

--- a/src/oven/loaf.rs
+++ b/src/oven/loaf.rs
@@ -1474,13 +1474,19 @@ fn run_bounded_loaf_cargo(
         })?;
         peak = peak.max(observed);
         if observed > transient_limit {
-            terminate_process_group(&mut child).map_err(|source| OvenLoafError::Io {
+            let termination = terminate_process_group(&mut child).map_err(|source| OvenLoafError::Io {
                 path: PathBuf::from(label),
                 source,
             })?;
+            // The capacity guard exists to stop a runaway build consuming disk, so a host that cannot contain
+            // descendants has not actually stopped the growth this failure reports. Say so in the failure itself.
+            let containment = termination
+                .uncontained_note()
+                .map(|note| format!("; {note}, so the measured usage may continue to grow"))
+                .unwrap_or_default();
             return Err(OvenLoafError::Preparation {
                 message: format!(
-                    "{label} exceeded the {transient_limit}-byte Loaf transient allowance at {observed} bytes"
+                    "{label} exceeded the {transient_limit}-byte Loaf transient allowance at {observed} bytes{containment}"
                 ),
             });
         }

--- a/src/oven/native_test.rs
+++ b/src/oven/native_test.rs
@@ -825,10 +825,17 @@ fn terminate_native_batch_child(
     child: &mut std::process::Child,
     executable: &Path,
 ) -> Result<std::process::ExitStatus, OvenNativeTestError> {
-    terminate_process_group(child).map_err(|source| OvenNativeTestError::Io {
+    let termination = terminate_process_group(child).map_err(|source| OvenNativeTestError::Io {
         path: executable.to_path_buf(),
         source,
-    })
+    })?;
+    if let Some(note) = termination.uncontained_note() {
+        tracing::warn!(
+            "timed-out native test {} was terminated, but {note}",
+            executable.display()
+        );
+    }
+    Ok(termination.status)
 }
 
 /// Join one concurrent pipe reader and preserve its failure as an ordinary native-runner error.

--- a/src/oven/process.rs
+++ b/src/oven/process.rs
@@ -1,9 +1,57 @@
 //! Process-tree containment shared by Oven's bounded child-process paths.
+//!
+//! Containment is a host capability, not a guarantee this module can provide everywhere. Unix has process groups, so
+//! a bounded child and everything it spawns can be stopped together. Windows has an equivalent in Job Objects, but
+//! reaching them requires Win32 FFI that this crate cannot contain while it forbids `unsafe`; that work is #1341 and
+//! is scheduled for 0.7, where it can be an Incan-authored host component instead.
+//!
+//! Until then this module reports the gap rather than hiding it. Terminating a child on a host without containment
+//! reaps the child and leaves its descendants running, and callers are told so, because two of them terminate
+//! specifically to stop a runaway build consuming disk — something surviving descendants carry on doing.
 
 use std::io;
-use std::process::{Child, Command, ExitStatus, Stdio};
+use std::process::{Child, Command, ExitStatus};
 
-/// Put a child and all normally spawned descendants in an isolated process group.
+#[cfg(unix)]
+use std::process::Stdio;
+
+/// Whether this host can stop a child's descendants alongside the child itself.
+///
+/// Unix establishes a process group before spawning and signals the whole group on termination. No other supported
+/// host does yet, so termination there reaches the direct child only.
+const HOST_CONTAINS_DESCENDANTS: bool = cfg!(unix);
+
+/// Outcome of terminating a bounded child, including whether its descendants were contained.
+///
+/// A successful termination is not proof that the process tree stopped, which is why the two facts are returned
+/// together rather than as a bare [`ExitStatus`] a caller could mistake for containment.
+pub(crate) struct ProcessGroupTermination {
+    /// Exit status of the direct child.
+    pub(crate) status: ExitStatus,
+    /// Whether the host also stopped the processes the child had already spawned.
+    pub(crate) descendants_contained: bool,
+}
+
+impl ProcessGroupTermination {
+    /// Return a diagnostic clause naming the containment gap, or `None` when the tree really did stop.
+    ///
+    /// Callers append this to the failure they are already reporting so every site describes the same limitation in
+    /// the same words, rather than each inventing its own phrasing or omitting it.
+    pub(crate) fn uncontained_note(&self) -> Option<&'static str> {
+        if self.descendants_contained {
+            return None;
+        }
+        Some(
+            "this host cannot contain a terminated child's descendants, so processes it had already spawned may still be running and holding their output files open",
+        )
+    }
+}
+
+/// Put a child and all normally spawned descendants in an isolated process group where the host provides one.
+///
+/// This is a no-op on hosts without process groups. That is deliberate rather than overlooked: there is nothing to
+/// establish before spawning on Windows, because a Job Object is created separately and the child is assigned to it
+/// after it exists. [`terminate_process_group`] reports the resulting gap.
 pub(crate) fn isolate_process_group(command: &mut Command) {
     #[cfg(unix)]
     {
@@ -11,14 +59,25 @@ pub(crate) fn isolate_process_group(command: &mut Command) {
 
         command.process_group(0);
     }
+    #[cfg(not(unix))]
+    {
+        // Bind the parameter so the no-op is stated in code rather than surfacing as an unused-argument warning that
+        // a reader has to interpret.
+        let _ = command;
+    }
 }
 
-/// Terminate and reap an isolated child process group.
+/// Terminate and reap a bounded child, together with its process group where the host supports one.
 ///
-/// Cargo, Rustdoc, libtest, build scripts, compilers, and linkers inherit the isolated group unless they explicitly
-/// create a new session, which none of the supported Oven child paths permit or require. GNU `kill` needs `--`
-/// before a negative process-group ID, while the BSD implementation shipped by macOS rejects that separator.
-pub(crate) fn terminate_process_group(child: &mut Child) -> io::Result<ExitStatus> {
+/// On Unix, Cargo, Rustdoc, libtest, build scripts, compilers, and linkers inherit the isolated group unless they
+/// explicitly create a new session, which none of the supported Oven child paths permit or require, so the whole tree
+/// stops. GNU `kill` needs `--` before a negative process-group ID, while the BSD implementation shipped by macOS
+/// rejects that separator.
+///
+/// On every other host only the direct child is terminated. The returned
+/// [`ProcessGroupTermination::descendants_contained`] says which happened; callers must not infer containment from a
+/// successful return.
+pub(crate) fn terminate_process_group(child: &mut Child) -> io::Result<ProcessGroupTermination> {
     #[cfg(unix)]
     {
         let process_group = format!("-{}", child.id());
@@ -41,7 +100,10 @@ pub(crate) fn terminate_process_group(child: &mut Child) -> io::Result<ExitStatu
     #[cfg(not(unix))]
     child.kill()?;
 
-    child.wait()
+    Ok(ProcessGroupTermination {
+        status: child.wait()?,
+        descendants_contained: HOST_CONTAINS_DESCENDANTS,
+    })
 }
 
 #[cfg(all(test, unix))]
@@ -72,4 +134,22 @@ pub(crate) fn process_is_running(pid: u32) -> io::Result<bool> {
         return Ok(false);
     }
     Ok(!String::from_utf8_lossy(&status.stdout).trim_start().starts_with('Z'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::HOST_CONTAINS_DESCENDANTS;
+
+    /// The advertised containment capability must match the platform that actually implements it.
+    ///
+    /// This is the fact every caller's diagnostic depends on, so it is asserted rather than assumed. When #1341 adds
+    /// Job Object containment this test is the first thing that should change.
+    #[test]
+    fn containment_capability_matches_the_host() {
+        assert_eq!(
+            HOST_CONTAINS_DESCENDANTS,
+            cfg!(unix),
+            "only Unix establishes a process group today; see #1341 for Windows Job Objects"
+        );
+    }
 }

--- a/src/oven/rustc.rs
+++ b/src/oven/rustc.rs
@@ -5152,10 +5152,14 @@ fn run_supervised_rustdoc_command(
             Some(status) => break status,
             None if Instant::now() >= deadline => {
                 timed_out = true;
-                break terminate_process_group(&mut child).map_err(|source| OvenRustcError::Io {
+                let termination = terminate_process_group(&mut child).map_err(|source| OvenRustcError::Io {
                     path: rustdoc.to_path_buf(),
                     source,
                 })?;
+                if let Some(note) = termination.uncontained_note() {
+                    tracing::warn!("timed-out rustdoc was terminated, but {note}");
+                }
+                break termination.status;
             }
             None => thread::sleep(Duration::from_millis(1)),
         }


### PR DESCRIPTION
## Summary

On Windows, `terminate_process_group` reaped the direct child and returned a successful `ExitStatus` indistinguishable from a real process-group termination. Callers were told the process tree had been contained when it had not.

This makes the outcome honest. It is deliberately **not** the containment implementation — that is #1341, now retargeted to 0.7 where it can be an Incan-authored host component through #991's `process supervision` capability, rather than Win32 FFI wedged into a crate that carries `#![forbid(unsafe_code)]`.

## Type of change

- [x] Bug fix

## Area(s)

- [x] Tooling (CLI/formatter/test runner)

## Key details

`terminate_process_group` now returns a `ProcessGroupTermination` carrying the child's exit status **and** whether its descendants were contained. Returning them together is the point: a caller cannot accidentally read success as a stopped tree, because it has to destructure the fact to get the status.

All five call sites surface the gap in the diagnostic they already emit. Two of them matter more than the rest:

- `oven/legacy_cargo.rs` and `oven/loaf.rs` terminate specifically because a build is **exceeding a disk capacity limit**. Killing only the parent leaves the runaway descendants writing, so the guard was reporting containment while the disk kept filling — failing at the one job it exists to do, silently. Both now say the measured usage may continue to grow.
- `oven/interop.rs`, `oven/rustc.rs`, and `oven/native_test.rs` terminate on timeout. Orphans there keep **open file handles**, and Windows locks open files where Unix does not, so a survivor can make the *next* build fail with an access error that looks unrelated to the run that caused it.

Two smaller corrections in the same file:

- The rustdoc asserted that Cargo, Rustdoc, libtest, build scripts, compilers, and linkers "inherit the isolated group". True on Unix, false everywhere else, and precisely the sort of confident sentence that stops a reader from checking. It now states what each host actually does.
- `isolate_process_group`'s non-Unix no-op is now written explicitly rather than left to surface as an `unused variable: command` warning a reader has to interpret. The `Stdio` import moved under `cfg(unix)` for the same reason. Both warnings appeared in every Windows build of this crate and are now gone.

### Why the feature itself can wait

All five call sites are failure paths. Nothing reaches containment on a healthy build, so `incan build`, `run`, and `test` are unaffected and this does not gate native Windows being usable. What could not wait is claiming a guarantee the platform did not provide — the same "portability is truthful" rule RFC 112 already applies to filesystem durability.

## Testing / verification

- [x] `cargo test`
- [x] Manual verification described below

Full lib suite on native Windows x64, against the current `0.6.0-dev.windows` baseline:

| | passed | failed |
| --- | ---: | ---: |
| `0.6.0-dev.windows` | 2890 | 65 |
| this branch | 2891 | **65** |

**Zero regressions.** The extra pass is the one test added here, which asserts the advertised containment capability matches the platform that implements it — the fact every caller's diagnostic now depends on, so it is asserted rather than assumed. When #1341 lands, that test is the first thing that should change.

- `cargo check --all-targets` — 0 errors.
- `cargo clippy --all-targets` — no new warnings. `src/oven/process.rs` now has **zero**; the two it previously emitted in every Windows build are resolved. The 9 remaining warnings in touched files are pre-existing unused imports in test modules at lines far from any edit here.
- `cargo +nightly fmt` — clean.

No behavior change on Unix: `descendants_contained` is always `true` there, so every note is `None` and no diagnostic changes.

### Residual risk

`make pre-commit` (full) and `make test` were not run on this host; see #1345. The 65 failures are pre-existing native-Windows gaps tracked by #1343.

## Docs impact

- [x] No docs changes needed

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #1355.
