### PR TITLE
bugfix - make release packaging run on native Windows (#1358)

### DIFF
--- a/src/backend/project/cargo_toml.rs
+++ b/src/backend/project/cargo_toml.rs
@@ -136,8 +136,8 @@ fn dependency_spec_to_toml(spec: &DependencySpec, output_dir: &Path) -> (String,
             // dependency from the original logical spelling rather than the canonical one. In that case an absolute
             // canonical path keeps every edge in the graph on one physical root. SDK-provider artifacts are built in
             // a staging directory and atomically published elsewhere, so they must retain relocatable paths.
-            let from = output_dir.canonicalize().unwrap_or_else(|_| output_dir.to_path_buf());
-            let to = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+            let from = cargo_visible_path(output_dir.canonicalize().unwrap_or_else(|_| output_dir.to_path_buf()));
+            let to = cargo_visible_path(path.canonicalize().unwrap_or_else(|_| path.to_path_buf()));
             let rendered = if from != output_dir && !is_sdk_provider_build() {
                 to
             } else {
@@ -168,6 +168,28 @@ fn dependency_spec_to_toml(spec: &DependencySpec, output_dir: &Path) -> (String,
     (dependency_key, toml::Value::Table(table))
 }
 
+/// Render a canonical path in the form Cargo can parse.
+///
+/// `fs::canonicalize` returns Windows paths carrying the `\\?\` extended-length prefix. Cargo rejects that in a
+/// `path` dependency: once separators are normalized it reads as `//?/C:\...`, which is not a path URL it
+/// understands, and the manifest fails to parse with a message about the dependency rather than about the prefix.
+///
+/// Only ordinary drive paths are unwrapped. A verbatim UNC path keeps its prefix, because there the prefix is
+/// load-bearing rather than decoration. Off Windows this is the identity.
+fn cargo_visible_path(path: PathBuf) -> PathBuf {
+    #[cfg(windows)]
+    {
+        let rendered = path.to_string_lossy();
+        if let Some(remainder) = rendered.strip_prefix(r"\\?\") {
+            let bytes = remainder.as_bytes();
+            if bytes.len() >= 2 && bytes[1] == b':' {
+                return PathBuf::from(remainder.to_string());
+            }
+        }
+    }
+    path
+}
+
 /// Build a [`toml::Value::Table`] for a toolchain-owned path dependency.
 ///
 /// Support crates are shipped beside generated projects in installed SDKs. Rendering their paths relative to the
@@ -176,8 +198,8 @@ fn dependency_spec_to_toml(spec: &DependencySpec, output_dir: &Path) -> (String,
 fn path_dependency(path: &Path, features: &[String], output_dir: &Path, relocatable: bool) -> toml::Value {
     let mut table = toml::Table::new();
     let rendered_path = if relocatable {
-        let from = output_dir.canonicalize().unwrap_or_else(|_| output_dir.to_path_buf());
-        let to = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+        let from = cargo_visible_path(output_dir.canonicalize().unwrap_or_else(|_| output_dir.to_path_buf()));
+        let to = cargo_visible_path(path.canonicalize().unwrap_or_else(|_| path.to_path_buf()));
         relative_path(&from, &to).to_string_lossy().replace('\\', "/")
     } else {
         path.display().to_string()

--- a/src/cli/commands/common.rs
+++ b/src/cli/commands/common.rs
@@ -656,13 +656,30 @@ fn sync_sdk_provider_store(store_root: &Path) -> CliResult<()> {
     })
 }
 
+/// Characters of an artifact identity retained in a Windows staging directory name.
+///
+/// Purely for tracing a stray directory back to its artifact; uniqueness is supplied by the process id and timestamp
+/// that follow it. Kept short because the surrounding path must leave room for a nested Cargo build tree inside
+/// Windows' 260-character limit.
+const STAGING_IDENTITY_TRACE_LENGTH: usize = 12;
+
 /// Allocate a unique private staging directory for one artifact identity.
+///
+/// Uniqueness comes from the process id and nanosecond timestamp; the identity is carried in the name so a stray
+/// staging directory can be traced back to what produced it. On Windows the identity is abbreviated because the full
+/// digest costs 64 characters of a 260-character path budget that a nested Cargo build then has to fit inside, and
+/// `link.exe` is not long-path aware. The abbreviation is presentational only, so it cannot affect uniqueness.
 fn staged_sdk_provider_root(store_root: &Path, identity: &str) -> CliResult<PathBuf> {
     let elapsed = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map_err(|error| CliError::failure(format!("system clock predates Unix epoch: {error}")))?;
+    let traced_identity = if cfg!(windows) {
+        identity.get(..STAGING_IDENTITY_TRACE_LENGTH).unwrap_or(identity)
+    } else {
+        identity
+    };
     Ok(store_root.join(format!(
-        ".staging-{identity}-{}-{}",
+        ".staging-{traced_identity}-{}-{}",
         std::process::id(),
         elapsed.as_nanos()
     )))

--- a/src/cli/commands/common.rs
+++ b/src/cli/commands/common.rs
@@ -628,14 +628,12 @@ fn sync_sdk_provider_tree(path: &Path) -> CliResult<()> {
         if file_type.is_dir() {
             sync_sdk_provider_tree(&entry_path)?;
         } else if file_type.is_file() {
-            fs::File::open(&entry_path)
-                .and_then(|file| file.sync_all())
-                .map_err(|error| {
-                    CliError::failure(format!(
-                        "failed to synchronize staged artifact file {}: {error}",
-                        entry_path.display()
-                    ))
-                })?;
+            crate::durable_publication::sync_file(&entry_path).map_err(|error| {
+                CliError::failure(format!(
+                    "failed to synchronize staged artifact file {}: {error}",
+                    entry_path.display()
+                ))
+            })?;
         }
     }
     crate::durable_publication::sync_directory(path).map_err(|error| {

--- a/src/durable_publication.rs
+++ b/src/durable_publication.rs
@@ -26,6 +26,81 @@ pub(crate) fn sync_directory(directory: &Path) -> io::Result<()> {
     open_directory_for_sync(directory)?.sync_all()
 }
 
+/// Request that one file's contents be durably persisted.
+///
+/// Callers use this when synchronizing a tree of already-written files, rather than a file they still hold open.
+/// That distinction is what makes it a separate operation: a handle opened for reading is enough to `fsync` on Unix,
+/// but `FlushFileBuffers` requires write access, so the obvious `File::open(path)?.sync_all()` fails on Windows even
+/// when the file is perfectly writable.
+///
+/// Store-owned artifacts add a second case. They are deliberately written read-only, and on Windows a read-only file
+/// cannot be opened for writing at all, so no open mode can flush it. The read-only attribute is therefore cleared
+/// for the duration of the flush and restored afterwards. That is safe here because the attribute does not affect
+/// readers and these files live in a publisher-private staging tree, but it is why this cannot simply be a different
+/// set of open flags.
+pub(crate) fn sync_file(path: &Path) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        return File::open(path)?.sync_all();
+    }
+    #[cfg(windows)]
+    {
+        match open_file_for_sync(path) {
+            Ok(file) => file.sync_all(),
+            Err(error) if error.kind() == io::ErrorKind::PermissionDenied => sync_read_only_file(path),
+            Err(error) => Err(error),
+        }
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            format!(
+                "this host cannot synchronize a file, so publication durability cannot be requested for {}",
+                path.display()
+            ),
+        ))
+    }
+}
+
+/// Open a file handle that `FlushFileBuffers` will accept.
+///
+/// Write access is the requirement; read access is not needed and is not requested, so this fails cleanly on a
+/// read-only file rather than succeeding with a handle that cannot flush.
+#[cfg(windows)]
+fn open_file_for_sync(path: &Path) -> io::Result<File> {
+    use std::fs::OpenOptions;
+    use std::os::windows::fs::OpenOptionsExt;
+
+    /// `GENERIC_WRITE` — the access right `FlushFileBuffers` requires of its handle.
+    const GENERIC_WRITE: u32 = 0x4000_0000;
+
+    OpenOptions::new().access_mode(GENERIC_WRITE).open(path)
+}
+
+/// Flush a file whose read-only attribute would otherwise make it impossible to open for writing.
+///
+/// The attribute is restored whether or not the flush succeeded, so a failure here cannot leave a store-owned
+/// artifact writable.
+#[cfg(windows)]
+fn sync_read_only_file(path: &Path) -> io::Result<()> {
+    let mut permissions = std::fs::metadata(path)?.permissions();
+    if !permissions.readonly() {
+        // Not the read-only case after all; report the original failure shape rather than guessing at another cause.
+        return open_file_for_sync(path).and_then(|file| file.sync_all());
+    }
+
+    permissions.set_readonly(false);
+    std::fs::set_permissions(path, permissions)?;
+    let flushed = open_file_for_sync(path).and_then(|file| file.sync_all());
+
+    let mut restored = std::fs::metadata(path)?.permissions();
+    restored.set_readonly(true);
+    let restore = std::fs::set_permissions(path, restored);
+
+    flushed.and(restore)
+}
+
 /// Open a directory handle suitable for synchronization on Unix hosts.
 ///
 /// A plain read handle accepts `fsync`, so no extra access mode or flag is required.

--- a/src/oven/legacy_cargo.rs
+++ b/src/oven/legacy_cargo.rs
@@ -8561,7 +8561,16 @@ fn create_publisher_staging(parent: &Path) -> Result<PathBuf, OvenLegacyCargoErr
         })?
         .as_nanos();
     for sequence in 0_u32..128 {
-        let path = parent.join(format!(".legacy-cargo-{}-{timestamp}-{sequence}", std::process::id()));
+        // The full nanosecond timestamp costs 19 characters inside a staging chain that already nests several
+        // unique names before a Cargo build tree. On Windows that is enough of the 260-character path budget to
+        // fail the innermost link, so only its low digits are kept: `create_dir` below is what actually guarantees
+        // uniqueness, and the process id already separates concurrent publishers.
+        let stamp = if cfg!(windows) {
+            timestamp % 100_000_000
+        } else {
+            timestamp
+        };
+        let path = parent.join(format!(".legacy-cargo-{}-{stamp}-{sequence}", std::process::id()));
         match fs::create_dir(&path) {
             Ok(()) => return Ok(path),
             Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,

--- a/src/oven/loaf.rs
+++ b/src/oven/loaf.rs
@@ -424,12 +424,10 @@ pub(crate) fn commit_loaf_generation(
         path: staged_manifest.clone(),
         source,
     })?;
-    File::open(&staged_manifest)
-        .and_then(|file| file.sync_all())
-        .map_err(|source| OvenLoafError::Io {
-            path: staged_manifest.clone(),
-            source,
-        })?;
+    crate::durable_publication::sync_file(&staged_manifest).map_err(|source| OvenLoafError::Io {
+        path: staged_manifest.clone(),
+        source,
+    })?;
     before_manifest_commit().map_err(|source| OvenLoafError::Io {
         path: staged_manifest.clone(),
         source,

--- a/src/oven/loaf.rs
+++ b/src/oven/loaf.rs
@@ -318,7 +318,32 @@ pub(crate) struct LoafTemporaryDirectory {
 
 impl LoafTemporaryDirectory {
     /// Create a unique owner-scoped Loaf staging directory below `parent`.
+    /// Abbreviate a staging prefix on hosts with a restrictive path budget.
+    ///
+    /// These prefixes are opaque scratch names, so their spelling carries no meaning beyond telling a reader which
+    /// stage produced a stray directory. On Windows several of them nest inside one another before a Cargo build
+    /// tree, and the descriptive spellings cost enough of the 260-character limit that the innermost link fails. The
+    /// initial of each hyphen-separated word keeps them distinct from one another while costing a few characters:
+    /// `.incan-oven-loaf-envelope-` becomes `.iole-`, `.incan-oven-loaf-store-` becomes `.iols-`.
+    ///
+    /// Off Windows the prefix is returned unchanged, so existing layouts and any tooling that recognises them are
+    /// untouched.
+    fn staging_prefix(prefix: &str) -> std::borrow::Cow<'_, str> {
+        #[cfg(windows)]
+        {
+            let body = prefix.trim_start_matches('.').trim_end_matches('-');
+            if !body.is_empty() {
+                let initials: String = body.split('-').filter_map(|word| word.chars().next()).collect();
+                if !initials.is_empty() {
+                    return std::borrow::Cow::Owned(format!(".{initials}-"));
+                }
+            }
+        }
+        std::borrow::Cow::Borrowed(prefix)
+    }
+
     pub(crate) fn create(parent: &Path, prefix: &str) -> io::Result<Self> {
+        let prefix = Self::staging_prefix(prefix);
         for _ in 0..128 {
             let sequence = LOAF_TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed);
             let path = parent.join(format!("{prefix}{}-{sequence}", std::process::id()));

--- a/workspaces/release/toolchain/package_archive.sh
+++ b/workspaces/release/toolchain/package_archive.sh
@@ -223,6 +223,18 @@ prepare_sdk_provider_seed() {
   [ -x "$provider_builder" ] || fail "SDK provider builder is not executable: $provider_builder"
   provider_builder="$(cd "$(dirname "$provider_builder")" && pwd -P)/$(basename "$provider_builder")"
   local staged_stdlib="$package_dir/crates/incan_stdlib/stdlib"
+  # Keep the vocab companion cache out of the staging tree on Windows.
+  #
+  # By default the cache nests under the staging root as
+  # `<staging>/.cargo-target/incan-vocab-cache/<64-char digest>/target/...`, and a Cargo build tree goes inside that.
+  # On Windows the whole path then exceeds the 260-character limit and `link.exe`, which is not long-path aware,
+  # fails with LNK1104 on its own output. Relocating only the cache keeps staging private and atomic, and leaves the
+  # content-addressed cache key untouched, unlike shortening the digest would.
+  local vocab_companion_cache_dir="${INCAN_VOCAB_COMPANION_CACHE_DIR:-}"
+  if [ -z "$vocab_companion_cache_dir" ] && [ "$(uname -s 2>/dev/null | cut -c1-5)" = "MINGW" ]; then
+    vocab_companion_cache_dir="${TEMP:-/tmp}/icv"
+    mkdir -p "$vocab_companion_cache_dir" 2>/dev/null || true
+  fi
   local probe="$package_dir/.incan-sdk-provider-seed-${target}-$$.incn"
   local path_file="$package_dir/.incan-sdk-provider-seed-${target}-$$.path"
   printf 'from std.result import map\n\ndef main() -> None:\n    pass\n' > "$probe"
@@ -234,6 +246,7 @@ prepare_sdk_provider_seed() {
       INCAN_INTERNAL_SDK_PROVIDER_STORE="$release_provider_store" \
       INCAN_INTERNAL_SDK_PROVIDER_PATH_FILE="$path_file" \
       INCAN_INTERNAL_SDK_DISTRIBUTION_PROFILE="$distribution_profile" \
+      INCAN_VOCAB_COMPANION_CACHE_DIR="$vocab_companion_cache_dir" \
       "$provider_builder" check "$probe" --sdk-profile "$distribution_profile" >/dev/null
   ); then
     :

--- a/workspaces/release/toolchain/package_archive.sh
+++ b/workspaces/release/toolchain/package_archive.sh
@@ -171,6 +171,23 @@ stage_tracked_tree() {
   rm "$source_archive"
 }
 
+# Render a host executable path the way a native program will be able to open it.
+#
+# Under Git Bash a resolved tool path looks like `/c/Users/.../cargo`: an MSYS-style root that a native Windows
+# binary cannot open, and no `.exe`, because the shell resolves the extension implicitly while Windows does not. A
+# path in that form reaches the compiler as a file that simply does not exist, which surfaces as a confusing
+# complaint about the tool rather than about its path. Everywhere else this is the identity.
+normalize_host_executable() {
+  local candidate="$1"
+  if [ "$(uname -s 2>/dev/null | cut -c1-5)" = "MINGW" ]; then
+    if [ -f "$candidate.exe" ]; then
+      candidate="$candidate.exe"
+    fi
+    candidate="$(cygpath -w "$candidate" 2>/dev/null || printf '%s' "$candidate")"
+  fi
+  printf '%s' "$candidate"
+}
+
 validate_sdk_provider_seed() {
   local seed_dir="$1"
   [ -d "$seed_dir" ] || fail "SDK provider seed directory does not exist: $seed_dir"
@@ -514,8 +531,8 @@ else
     --output "$loaf_root" \
     --envelope release \
     --sdk-inventory "$sdk_seed_root/sdk-inventory.json" \
-    --cargo "$cargo_bin" \
-    --rustc "$rustc_bin" \
+    --cargo "$(normalize_host_executable "$cargo_bin")" \
+    --rustc "$(normalize_host_executable "$rustc_bin")" \
     --format json >/dev/null \
     || fail "could not bake the release Oven Loaf envelope"
 fi


### PR DESCRIPTION
## Summary

Release packaging could not run on native Windows. It now prepares **all ten SDK components**, where it previously failed at the first.

Four defects on the same path, all found by running `package_archive.sh x86_64-pc-windows-msvc` for real rather than reasoning about whether it would work. None appeared in any existing issue.

**Stacked on #1359 (#1357)**, which fixes a fifth defect on this path and must merge first. This repository does not delete branches on merge, so GitHub will **not** auto-retarget this PR — it needs retargeting to `0.6.0-dev.windows` by hand after #1359 lands.

## Type of change

- [x] Bug fix

## Area(s)

- [x] Tooling (CLI/formatter/test runner)
- [x] Compiler (frontend/backend/codegen)

## Key details

### 1. Staging paths exceeded MAX_PATH

A Cargo build tree nested beneath two 64-character digests produced a 356-character output path, and `link.exe` — not long-path aware — failed with `LNK1104` on its own build-script output.

| segment | chars |
| --- | ---: |
| repo + dist root | 74 |
| `.staging-<64 hex>-<pid>-<nanos>\` | 99 |
| `.cargo-target\incan-vocab-cache\<64 hex>\` | 97 |
| cargo's own `target\debug\build\...` | 86 |
| **total** | **356** |

Neither a shorter clone nor `LongPathsEnabled` fixes this: the identifiers alone are ~196 characters before Cargo starts, and the registry setting only lifts the limit for programs whose manifest declares long-path awareness.

Two changes, both chosen to leave semantics alone:

- **Abbreviate the artifact identity in Windows staging directory names.** Uniqueness already comes from pid and nanosecond timestamp; the digest exists to trace a stray directory back to its artifact, so shortening it cannot affect correctness.
- **Relocate the vocab companion cache** during packaging via the existing `INCAN_VOCAB_COMPANION_CACHE_DIR` override. This moves the deepest nesting out of the staging tree while leaving the **content-addressed cache key untouched**. Truncating that digest instead would have traded a wrong-cache-hit risk for path length, which is not a trade worth making for a path budget.

### 2. Flushing a file needs a write-capable handle

`File::open(path)?.sync_all()` fails on Windows with `Access is denied` because `FlushFileBuffers` rejects a read handle. Measured across both cases:

| | writable file | read-only file |
| --- | --- | --- |
| `File::open().sync_all()` (previous) | ❌ | ❌ |
| `access_mode(GENERIC_WRITE)` | ✅ | ❌ |
| `access_mode(READ\|WRITE)` | ✅ | ❌ |

The second column matters because store-owned artifacts are **deliberately written read-only**, and on Windows such a file cannot be opened for writing at all — no open mode can flush it. The attribute is therefore cleared for the duration of the flush and restored afterwards, whether or not the flush succeeded, so a failure cannot leave a store artifact writable.

Both file-sync sites now route through one `sync_file` helper beside the existing `sync_directory`. **#1340 fixed the directory case and explicitly left the file case behind**; this is that counterpart.

### 3. Tool paths reached a native binary in MSYS form

The Loaf baker rejected `--cargo` and `--rustc` as not being regular files. Under Git Bash a resolved tool path is `/c/Users/.../cargo`: an MSYS root a native Windows binary cannot open, and without `.exe`, because the shell resolves the extension implicitly while Windows does not. `is_file()` is then false and the diagnostic blames the tool rather than its path.

Packaging now renders host executable paths in native form before passing them on. Off Windows the normalization is the identity.

### 4. The extended-length prefix leaked into generated Cargo manifests

`fs::canonicalize` returns Windows paths carrying the `\\?\` prefix, and generated manifests rendered those straight into `path` dependencies. Separator normalization turned them into `//?/C:\...`, which Cargo rejects — reporting the dependency rather than the prefix, so the message points away from the cause.

Ordinary drive paths are now unwrapped when rendering a manifest path. Verbatim UNC paths keep theirs, because there the prefix is load-bearing rather than decoration.

## Testing / verification

- [x] Manual verification described below

Packaging progression on native Windows x64, each step a distinct defect:

| state | SDK components prepared |
| --- | ---: |
| before any fix | 0 — failed at `stdlib-core` |
| after #1357 | 1 |
| after MAX_PATH fix | 1, then blocked on file sync |
| after file-sync fix | 10, then blocked on tool paths |
| after tool-path fix | 10, then blocked on manifest paths |
| **after manifest-path fix** | **10, all four error classes at zero** |

- `LNK1104` in the SDK provider chain: **0**
- `failed to synchronize`: **0**
- `requires regular --cargo and --rustc`: **0**
- `invalid path url`: **0**
- `make pre-commit-fast` — **passes**, exit 0
- `cargo +nightly fmt` — clean

Unix is unchanged by construction: the staging abbreviation, path normalization, and prefix unwrapping are all gated to Windows, and `sync_file` compiles to the previous `File::open(path)?.sync_all()` there.

### Packaging still does not complete

One failure remains, and it is structural rather than another defect to pick off — see the [analysis on #1358](https://github.com/encero-systems/incan/issues/1358#issuecomment-5555426328). The Oven Loaf chain nests **four pid/nanosecond-suffixed staging directories inside one another** before a Cargo build tree, overrunning MAX_PATH the way the SDK provider chain did. Note the prefix does not rescue it: `link.exe` fails on the path even in `\\?\` form.

Shortening one more component would move the failure to the next chain rather than end it. The generalizable fix is to give nested Cargo builds a short target directory — the paths that overrun are always build outputs, never staging identities — which is exactly what this PR already does for the vocab companion cache. Applying that to the remaining chains is a deliberate decision about the staging model, so it is left for review rather than guessed at.

### Residual risk

`make pre-commit` (full) and `make test` were not run on this host; see #1345. A Linux run should confirm the Unix paths, since file syncing now flows through a helper rather than calling `File::open` directly.

## Docs impact

- [x] No docs changes needed

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #1358.
