### PR TITLE
bugfix - hand Cargo target paths in a form link.exe can canonicalize (#1362)

### DIFF
--- a/src/backend/project/cargo_toml.rs
+++ b/src/backend/project/cargo_toml.rs
@@ -15,6 +15,7 @@ use std::path::{Path, PathBuf};
 
 use serde::Serialize;
 
+use crate::host_paths::tool_visible_path;
 use crate::manifest::{DependencySource, DependencySpec, GitReference};
 
 use super::generator::{ProjectGenerator, is_sdk_provider_build};
@@ -136,8 +137,8 @@ fn dependency_spec_to_toml(spec: &DependencySpec, output_dir: &Path) -> (String,
             // dependency from the original logical spelling rather than the canonical one. In that case an absolute
             // canonical path keeps every edge in the graph on one physical root. SDK-provider artifacts are built in
             // a staging directory and atomically published elsewhere, so they must retain relocatable paths.
-            let from = cargo_visible_path(output_dir.canonicalize().unwrap_or_else(|_| output_dir.to_path_buf()));
-            let to = cargo_visible_path(path.canonicalize().unwrap_or_else(|_| path.to_path_buf()));
+            let from = tool_visible_path(output_dir.canonicalize().unwrap_or_else(|_| output_dir.to_path_buf()));
+            let to = tool_visible_path(path.canonicalize().unwrap_or_else(|_| path.to_path_buf()));
             let rendered = if from != output_dir && !is_sdk_provider_build() {
                 to
             } else {
@@ -168,41 +169,22 @@ fn dependency_spec_to_toml(spec: &DependencySpec, output_dir: &Path) -> (String,
     (dependency_key, toml::Value::Table(table))
 }
 
-/// Render a canonical path in the form Cargo can parse.
-///
-/// `fs::canonicalize` returns Windows paths carrying the `\\?\` extended-length prefix. Cargo rejects that in a
-/// `path` dependency: once separators are normalized it reads as `//?/C:\...`, which is not a path URL it
-/// understands, and the manifest fails to parse with a message about the dependency rather than about the prefix.
-///
-/// Only ordinary drive paths are unwrapped. A verbatim UNC path keeps its prefix, because there the prefix is
-/// load-bearing rather than decoration. Off Windows this is the identity.
-fn cargo_visible_path(path: PathBuf) -> PathBuf {
-    #[cfg(windows)]
-    {
-        let rendered = path.to_string_lossy();
-        if let Some(remainder) = rendered.strip_prefix(r"\\?\") {
-            let bytes = remainder.as_bytes();
-            if bytes.len() >= 2 && bytes[1] == b':' {
-                return PathBuf::from(remainder.to_string());
-            }
-        }
-    }
-    path
-}
-
 /// Build a [`toml::Value::Table`] for a toolchain-owned path dependency.
 ///
 /// Support crates are shipped beside generated projects in installed SDKs. Rendering their paths relative to the
 /// generated crate keeps a compiled library artifact relocatable instead of binding it to the checkout that produced
 /// it.
+///
+/// Both branches render through [`tool_visible_path`]: Cargo cannot parse a `path` dependency that carries the
+/// Windows extended-length prefix, and reports it against the dependency rather than the prefix.
 fn path_dependency(path: &Path, features: &[String], output_dir: &Path, relocatable: bool) -> toml::Value {
     let mut table = toml::Table::new();
     let rendered_path = if relocatable {
-        let from = cargo_visible_path(output_dir.canonicalize().unwrap_or_else(|_| output_dir.to_path_buf()));
-        let to = cargo_visible_path(path.canonicalize().unwrap_or_else(|_| path.to_path_buf()));
+        let from = tool_visible_path(output_dir.canonicalize().unwrap_or_else(|_| output_dir.to_path_buf()));
+        let to = tool_visible_path(path.canonicalize().unwrap_or_else(|_| path.to_path_buf()));
         relative_path(&from, &to).to_string_lossy().replace('\\', "/")
     } else {
-        path.display().to_string()
+        tool_visible_path(path.to_path_buf()).display().to_string()
     };
     table.insert("path".into(), rendered_path.into());
     if !features.is_empty() {

--- a/src/host_paths.rs
+++ b/src/host_paths.rs
@@ -1,0 +1,72 @@
+//! Path forms that external host tooling can consume.
+//!
+//! Incan canonicalizes paths freely, and on Windows `fs::canonicalize` returns the extended-length `\\?\` form. That
+//! form is correct for Rust's own file APIs but is not universally understood by the third-party executables this
+//! compiler drives. Handing it to them fails in ways that name something other than the path, so the rule lives here
+//! once rather than being rediscovered at each boundary.
+
+use std::path::PathBuf;
+
+/// The Windows extended-length path prefix, which `fs::canonicalize` prepends to every path it returns.
+#[cfg(windows)]
+const EXTENDED_LENGTH_PREFIX: &str = r"\\?\";
+
+/// Render a path in the form external host tooling can consume.
+///
+/// On Windows, strips the extended-length prefix that `fs::canonicalize` adds. Two independent boundaries need this,
+/// and both fail misleadingly without it:
+///
+/// - **Cargo manifests.** A `path` dependency carrying the prefix reads as `//?/C:\...` once separators are normalized,
+///   which is not a path URL Cargo understands. The manifest fails to parse with a message about the dependency rather
+///   than about the prefix.
+/// - **The MSVC linker.** Given a prefixed path whose length exceeds `MAX_PATH`, `link.exe` fails to canonicalize it
+///   and derives an *empty* filename, then reports the default object extension: `LNK1181: cannot open input file
+///   '.obj'`. The same paths in ordinary drive form link successfully well past `MAX_PATH`, because that form goes
+///   through Windows long-path support. The error names neither the file nor the prefix that caused it.
+///
+/// Only ordinary drive paths are unwrapped. A verbatim UNC path keeps its prefix, because there the prefix is
+/// load-bearing rather than decoration. Off Windows this is the identity.
+pub(crate) fn tool_visible_path(path: PathBuf) -> PathBuf {
+    #[cfg(windows)]
+    {
+        let rendered = path.to_string_lossy();
+        if let Some(remainder) = rendered.strip_prefix(EXTENDED_LENGTH_PREFIX) {
+            let drive_letter_follows = remainder.as_bytes().get(1) == Some(&b':');
+            if drive_letter_follows {
+                return PathBuf::from(remainder.to_string());
+            }
+        }
+    }
+    path
+}
+
+#[cfg(test)]
+mod tests {
+    use super::tool_visible_path;
+    use std::path::PathBuf;
+
+    /// A canonicalized drive path is the case both boundaries hit, and the prefix is pure decoration there.
+    #[test]
+    #[cfg(windows)]
+    fn drive_paths_lose_the_extended_length_prefix() {
+        assert_eq!(
+            tool_visible_path(PathBuf::from(r"\\?\C:\dev\incan\target")),
+            PathBuf::from(r"C:\dev\incan\target")
+        );
+    }
+
+    /// On a verbatim UNC path the prefix carries meaning, so removing it would name a different location.
+    #[test]
+    #[cfg(windows)]
+    fn verbatim_unc_paths_keep_their_prefix() {
+        let unc = PathBuf::from(r"\\?\UNC\server\share\dir");
+        assert_eq!(tool_visible_path(unc.clone()), unc);
+    }
+
+    /// Paths that never carried the prefix must survive untouched, on every host.
+    #[test]
+    fn ordinary_paths_are_unchanged() {
+        let plain = PathBuf::from(if cfg!(windows) { r"C:\dev\incan" } else { "/dev/incan" });
+        assert_eq!(tool_visible_path(plain.clone()), plain);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ pub mod format;
 pub mod frontend;
 #[cfg(feature = "cli")]
 pub(crate) mod generated_cache;
+pub(crate) mod host_paths;
 pub mod library_manifest;
 pub mod lockfile;
 #[cfg(feature = "lsp")]

--- a/src/oven/legacy_cargo.rs
+++ b/src/oven/legacy_cargo.rs
@@ -17,6 +17,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use serde::{Deserialize, Serialize};
 
 use crate::cli::commands::common::discover_active_sdk_inventory;
+use crate::host_paths::tool_visible_path;
 use crate::library_manifest::{LibraryManifest, digest_provider_artifact, digest_toolchain_source_tree_with_cache};
 use crate::provider::{SDK_INVENTORY_FILE, SdkInventory};
 
@@ -7224,8 +7225,12 @@ fn run_legacy_cargo_invocation(
         .arg(cargo_manifest)
         .arg("--target")
         .arg(target_triple)
+        // Only the target directory is handed over in tool-visible form; see `tool_visible_path`. Cargo echoes each
+        // input path back in the spelling it was given, so converting this one moves the build outputs -- the paths
+        // that reach `link.exe` -- out of verbatim form while leaving every source path canonical, and with it the
+        // module identity that the rest of the pipeline derives from source spelling.
         .arg("--target-dir")
-        .arg(target)
+        .arg(tool_visible_path(target.to_path_buf()))
         .arg("--message-format=json-render-diagnostics");
     // Existing locks are immutable publisher authority. The explicit project publisher alone may resolve a missing
     // first lock; once Cargo writes it, every remaining publisher action is locked and offline. Compiler-root and
@@ -7298,6 +7303,12 @@ fn run_legacy_cargo_invocation(
     // StableCrateId values). Remapping every machine-variant root to a stable virtual prefix makes identical units
     // byte-identical everywhere, so shared leaves reconcile by digest instead. RUSTFLAGS do not enter the
     // extra-filename hash, so these per-machine flag strings never fork unit identities.
+    //
+    // Each prefix must be spelled the way the paths it covers are spelled. rustc normalizes `/` against `\` before
+    // comparing, so separator spelling is free, but it treats the extended-length `\\?\` prefix as part of the
+    // string: a verbatim prefix never matches a plain path, nor the reverse, and a mismatched flag fails open and
+    // silent. The target directory alone is passed to Cargo in tool-visible form, so its prefix is converted to
+    // match while the others stay canonical.
     let cargo_home = std::env::var_os("CARGO_HOME")
         .map(PathBuf::from)
         .or_else(|| std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".cargo")));
@@ -7309,7 +7320,10 @@ fn run_legacy_cargo_invocation(
         ));
     }
     remap_flags.push(format!("--remap-path-prefix={}=/incan/package", package_root.display()));
-    remap_flags.push(format!("--remap-path-prefix={}=/incan/target", target.display()));
+    remap_flags.push(format!(
+        "--remap-path-prefix={}=/incan/target",
+        tool_visible_path(target.to_path_buf()).display()
+    ));
     // Standard-library spans leak through inlined core/alloc generics. A toolchain with the `rust-src` component
     // resolves them to its real sysroot checkout while one without emits the virtual `/rustc/<commit>` form, so the
     // same unit compiles to different bytes depending on which components happen to be installed. Remap the source


### PR DESCRIPTION
## Summary

Closes #1362.

The Oven publisher derived `--target-dir` from the canonicalized store root, which on Windows carries the extended-length `\\?\` prefix. Cargo echoes each input path back in the spelling it was given, so every build output beneath it reached `link.exe` in verbatim form — and `link.exe` cannot canonicalize a verbatim path past `MAX_PATH`. It does not report the path it failed on: it derives an *empty* filename, applies the default object extension, and fails with `LNK1181: cannot open input file '.obj'`, naming neither the file nor the prefix responsible. Every dependency build script in the release Oven Loaf bake failed this way, so no Windows release artifact could be produced.

Stacked on #1360.

## Type of change

- [x] Bug fix

## Area(s)

- [x] Tooling (CLI/formatter/test runner)

## Key details

- **User-facing behavior**: the release packaging bake gets past the Oven Loaf envelope's dependency build scripts on native Windows. No behavior change on other hosts — the helper is the identity off Windows.
- **Internals**: the "render a path external host tooling can consume" rule moves to `src/host_paths.rs` as `tool_visible_path`, shared by the two boundaries that need it. `--target-dir` and the coupled `/incan/target` remap prefix now render through it, as does the absolute branch of `path_dependency`.
- **Risks**: the change is deliberately narrow. Converting more than the target directory is *not* safe — see below.

### Why only the target directory

Cargo echoes each input path back independently, so converting `--target-dir` alone moves the build outputs out of verbatim form while leaving source paths canonical. That distinction is load-bearing: my first attempt converted the manifest path and cwd as well, which reintroduced the duplicate-checked-module failure fixed in #1357, because module identity downstream is derived from source spelling.

### The coupled remap prefix

rustc treats `\\?\C:\x` and `C:\x` as different strings when matching `--remap-path-prefix` (it *does* normalize `/` against `\`; see the measurements in #1361). Leaving the `/incan/target` prefix canonical while the paths it covers became plain would have silently switched that flag off, costing the cross-machine byte reproducibility the flags exist for. It is converted in the same commit and the coupling is documented beside the flags, because a mismatched prefix fails open and silent.

## Testing / verification

- [x] `cargo test` (the three new `host_paths` unit tests, plus the existing suite unaffected)
- [x] `make pre-commit-fast`
- [x] Manual verification described below

Manual verification notes:

- Root cause established by A/B on one directory, holding length constant and varying only the spelling handed to Cargo: verbatim → `LNK1181: cannot open input file '.obj'`; ordinary drive form → clean build. Ordinary drive paths link successfully at 285 characters, because that form goes through Windows long-path support.
- Full release packaging bake on native Windows x64 before and after:

  | | before | after |
  |---|---|---|
  | `LNK1181` | 5 | **0** |
  | `LNK1104` | 0 | 0 |
  | `invalid path url` | — (unreached) | **0** |
  | duplicate checked module | 0 | 0 |

- The bake still fails, further along, on `MASM : fatal error A1009: line too long` from `ml64.exe` at a 286-character output path while assembling `blake3`. That is ordinary `MAX_PATH` pressure against a tool with a shorter limit, not the verbatim problem this PR fixes, and it is filed separately.

### One note on how this was verified

An earlier revision of `host_paths.rs` was written through a shell heredoc that silently collapsed `r"\\?\"` to `r"\?\"`, making the helper a no-op — and its unit tests passed because their fixtures were mangled identically. Three bakes looked green on that build and should not have been believed. The tests in this PR use the real prefix and fail against the no-op version; the table above is from a run gated on those tests passing first.
