### PR TITLE
bugfix - shorten the Windows staging chain to fit MASM's path limit (#1364)

### DIFF
--- a/src/cli/commands/oven.rs
+++ b/src/cli/commands/oven.rs
@@ -1257,7 +1257,9 @@ pub fn oven_legacy_cargo_bake_loafs(options: OvenLoafBakeCommandOptions) -> CliR
         .ok_or_else(|| CliError::failure("Loaf output has no parent directory".to_string()))?;
     let scratch = LoafTemporaryDirectory::create(output_parent, ".incan-oven-loaf-envelope-")
         .map_err(|error| CliError::failure(format!("could not allocate Loaf baker scratch directory: {error}")))?;
-    let staged_root = scratch.path().join("staged");
+    // Abbreviated on Windows: this segment sits above the publisher's nested Cargo build tree, whose
+    // innermost object paths must fit MASM's limit. See `LEGACY_CARGO_STAGING_DIRECTORY`.
+    let staged_root = scratch.path().join(if cfg!(windows) { "s" } else { "staged" });
     fs::create_dir_all(&staged_root)
         .map_err(|error| CliError::failure(format!("could not create Loaf staging root: {error}")))?;
 

--- a/src/oven/legacy_cargo.rs
+++ b/src/oven/legacy_cargo.rs
@@ -19,6 +19,7 @@ use serde::{Deserialize, Serialize};
 use crate::cli::commands::common::discover_active_sdk_inventory;
 use crate::host_paths::tool_visible_path;
 use crate::library_manifest::{LibraryManifest, digest_provider_artifact, digest_toolchain_source_tree_with_cache};
+use crate::oven::store::{LEGACY_CARGO_STAGING_DIRECTORY, LEGACY_CARGO_STAGING_PREFIX};
 use crate::provider::{SDK_INVENTORY_FILE, SdkInventory};
 
 use super::process::{isolate_process_group, terminate_process_group};
@@ -1370,7 +1371,7 @@ pub fn prepare_direct_rustc_plan(
             request.receipt.project.name.clone(),
         );
     }
-    let staging_parent = request.store.root().join("legacy-cargo-staging");
+    let staging_parent = request.store.root().join(LEGACY_CARGO_STAGING_DIRECTORY);
     let publisher_lock = acquire_publisher_lock(&staging_parent)?;
     // The fast lookup above deliberately precedes manifest inspection. Recheck after taking the cross-process
     // publisher lock so a concurrent winner cannot make this request rebuild and publish a second byte-distinct
@@ -1823,7 +1824,7 @@ pub fn prepare_compiler_test_suite(
     let _ =
         receipt_authorized_generated_root_bytes(&generated_project, &request.receipt, &request.source_evidence_key)?;
     let cargo_version = tool_version(&request.cargo, "cargo")?;
-    let staging_parent = request.store.root().join("legacy-cargo-staging");
+    let staging_parent = request.store.root().join(LEGACY_CARGO_STAGING_DIRECTORY);
     let publisher_lock = acquire_publisher_lock(&staging_parent)?;
     reclaim_stale_publisher_staging(&staging_parent)?;
     let publisher_reservation = request
@@ -8550,7 +8551,7 @@ fn reclaim_stale_publisher_staging(parent: &Path) -> Result<(), OvenLegacyCargoE
             source,
         })?;
         let name = entry.file_name();
-        if !name.to_string_lossy().starts_with(".legacy-cargo-") {
+        if !name.to_string_lossy().starts_with(LEGACY_CARGO_STAGING_PREFIX) {
             continue;
         }
         let path = entry.path();
@@ -8576,15 +8577,14 @@ fn create_publisher_staging(parent: &Path) -> Result<PathBuf, OvenLegacyCargoErr
         .as_nanos();
     for sequence in 0_u32..128 {
         // The full nanosecond timestamp costs 19 characters inside a staging chain that already nests several
-        // unique names before a Cargo build tree. On Windows that is enough of the 260-character path budget to
-        // fail the innermost link, so only its low digits are kept: `create_dir` below is what actually guarantees
+        // unique names before a Cargo build tree. On Windows that is enough of the path budget to fail the
+        // innermost compile, so only its low digits are kept: `create_dir` below is what actually guarantees
         // uniqueness, and the process id already separates concurrent publishers.
-        let stamp = if cfg!(windows) {
-            timestamp % 100_000_000
-        } else {
-            timestamp
-        };
-        let path = parent.join(format!(".legacy-cargo-{}-{stamp}-{sequence}", std::process::id()));
+        let stamp = if cfg!(windows) { timestamp % 100_000 } else { timestamp };
+        let path = parent.join(format!(
+            "{LEGACY_CARGO_STAGING_PREFIX}{}-{stamp}-{sequence}",
+            std::process::id()
+        ));
         match fs::create_dir(&path) {
             Ok(()) => return Ok(path),
             Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,

--- a/src/oven/store.rs
+++ b/src/oven/store.rs
@@ -40,9 +40,28 @@ const PHYSICAL_BYTES_CACHE_FILE: &str = ".physical-bytes-cache";
 const UNIQUE_FILE_RECORDS_CACHE_FILE: &str = ".physical-bytes-unique-cache";
 const ACTIVE_LOCK_FILE: &str = ".active.lock";
 const MANAGER_LOCK_FILE: &str = ".manager.lock";
-const LEGACY_CARGO_STAGING_DIRECTORY: &str = "legacy-cargo-staging";
+/// Directory below the store root holding publisher-owned staging trees.
+///
+/// Abbreviated on Windows. This name sits above a nested Cargo build tree whose innermost object paths
+/// must satisfy the shortest limit any tool in the chain imposes, and MASM's is tighter than `MAX_PATH`:
+/// `ml64.exe` accepts a 255-character output path and rejects 258 with `A1009`, a message about line length
+/// that says nothing about paths. The abbreviation is presentational, so it cannot affect correctness.
+#[cfg(windows)]
+pub(crate) const LEGACY_CARGO_STAGING_DIRECTORY: &str = "lcs";
+
+/// Directory below the store root holding publisher-owned staging trees.
+#[cfg(not(windows))]
+pub(crate) const LEGACY_CARGO_STAGING_DIRECTORY: &str = "legacy-cargo-staging";
 const LEGACY_CARGO_PUBLISHER_LOCK_FILE: &str = ".publisher.lock";
-const LEGACY_CARGO_STAGING_PREFIX: &str = ".legacy-cargo-";
+/// Prefix marking one publisher-owned staging tree, so a stray tree can be recognised and reclaimed.
+///
+/// Abbreviated on Windows for the reason given on [`LEGACY_CARGO_STAGING_DIRECTORY`].
+#[cfg(windows)]
+pub(crate) const LEGACY_CARGO_STAGING_PREFIX: &str = ".lc-";
+
+/// Prefix marking one publisher-owned staging tree, so a stray tree can be recognised and reclaimed.
+#[cfg(not(windows))]
+pub(crate) const LEGACY_CARGO_STAGING_PREFIX: &str = ".legacy-cargo-";
 static STAGING_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
 /// Policy enforced before an Oven artifact becomes visible in the store.


### PR DESCRIPTION
## Summary

Closes #1364. Stacked on #1363.

The publisher's transient Cargo build tree nests inside three staging layers before Cargo adds its own `target/<triple>/debug/build/<crate>-<hash>/out/`. On Windows the innermost object paths reached 286 characters and assembling `blake3` failed with `MASM : fatal error A1009:line too long` — a message about line length that says nothing about paths. `zstd-sys` and `lzma-sys` failed in the same phase for the same reason.

`ml64.exe`'s limit is tighter than `MAX_PATH`. Measured directly rather than assumed:

| object path length | result |
|---|---|
| 250 | OK |
| 255 | OK |
| 258 | `A1009` |
| 262 | `A1009` |

So the budget is ~255, not 260, and the shortfall was ~31 rather than the ~26 a `MAX_PATH` assumption would have suggested.

## Type of change

- [x] Bug fix

## Area(s)

- [x] Tooling (CLI/formatter/test runner)

## Key details

- **User-facing behavior**: the release packaging bake gets past assembling and compiling C/asm dependencies on native Windows. No change on other hosts — every abbreviation is `cfg(windows)`.
- **Internals**: four names in the chain are Incan's own and carry no information at that depth. On Windows `legacy-cargo-staging` becomes `lcs`, the `.legacy-cargo-` staging prefix becomes `.lc-`, the envelope's `staged` root becomes `s`, and the staging stamp drops three further digits — its uniqueness comes from `create_dir` and the process id, not its width. Together ~34 characters, landing the measured worst case near 252.
- **Risks**: the margin is real but not generous. The worst case is set by the longest `<crate>-<hash>/out/<hash>-<source>.o` in the dependency graph, currently `blake3`'s `_x86-64_windows_msvc.asm` objects. A future dependency with a longer crate name *and* long source basenames could re-cross the line, at which point the structural fix — relocating the transient tree, discussed on #1364 — becomes the answer rather than more abbreviation.

### Two things deliberately not done

**The `LoafTemporaryDirectory` prefixes are left alone.** They are already initials (`.iole-`, `.iols-`, `.ios-`, `.iis-`, `.iol-`), and my first attempt shortened them to a single letter taken from the last word. That would have collapsed `.incan-oven-suite-`, `.incan-interop-stage-` and `.incan-oven-loaf-store-` all onto `.s-`. That prefix is matched against when reclaiming stray staging trees, so the collision would have let one publisher's reclaim walk into another's tree. Caught before writing it; recording it because the abbreviation looks free and is not.

**No structural relocation.** Moving the transient target out of the staging tree would remove it from the allowance `conservative_directory_reservation` enforces, which is a decision about the publisher's transient contract rather than a path change. Written up on #1364.

## Testing / verification

- [x] `make pre-commit-fast`
- [x] `cargo build --release`
- [x] Manual verification described below

Manual verification notes:

- `ml64.exe`'s limit measured directly (table above) before choosing how much to save.
- Full release packaging bake on native Windows x64, cumulative across this PR and #1363:

  | | before #1363 | after #1363 | after this PR |
  |---|---|---|---|
  | `LNK1181` | 5 | 0 | 0 |
  | `invalid path url` | unreached | 0 | 0 |
  | `A1009` (MASM) | unreached | 3 | **0** |
  | `LNK1104` | 0 | 0 | 0 |
  | duplicate checked module | 0 | 0 | 0 |

- The bake still does not produce an archive. It now fails in a different place and for an unrelated reason: `incan_stdlib_system` does not compile on Windows, because the stdlib's own `std.fs` sources import unix-only Rust APIs (`rustix::fs::{flock, statvfs}`, `std::os::unix::fs::{MetadataExt, symlink}`). That is a standard-library portability gap rather than a toolchain path problem, and it is filed separately.

### Note on the hardcoded literals

`legacy_cargo.rs` carried two hardcoded copies of `"legacy-cargo-staging"` and one of `".legacy-cargo-"`, restating constants that live in `store.rs`. They now reference the constants. This is not tidying: the Windows abbreviation makes them load-bearing, and had they drifted the publisher would have staged into a directory the store does not reclaim.
