### PR TITLE
bugfix - produce a Windows toolchain artifact: portable std.fs and write-capable flush (#1366, #1340)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1540,6 +1540,7 @@ dependencies = [
  "incan_core",
  "incan_derive",
  "inventory",
+ "rustix 1.1.4",
  "serde",
  "serde_json",
  "tokio",

--- a/crates/incan_stdlib/Cargo.toml
+++ b/crates/incan_stdlib/Cargo.toml
@@ -19,6 +19,11 @@ tokio = { version = "1", optional = true, features = ["rt-multi-thread", "macros
 inventory = { version = "0.3", optional = true }
 xxhash_rust = { package = "xxhash-rust", version = "0.8", optional = true, features = ["xxh3"] }
 
+[target.'cfg(unix)'.dependencies]
+# `statvfs` for `std.fs` disk usage. Unix-only by nature; the Windows side of `host_fs` does not use it.
+# Already resolved in the workspace lock, so this adds an edge rather than a new crate.
+rustix = { version = "1.1", features = ["fs"] }
+
 [features]
 default = []
 ordinal = ["dep:xxhash_rust"]

--- a/crates/incan_stdlib/src/host_fs.rs
+++ b/crates/incan_stdlib/src/host_fs.rs
@@ -1,0 +1,142 @@
+//! Filesystem operations the host exposes only through per-platform APIs.
+//!
+//! `std.fs` is one API on every supported host, but several of the operations behind it are reached differently on
+//! each. Incan has no conditional compilation, so a `.incn` source cannot carry a Unix branch and a Windows branch;
+//! it imports this module instead, and the platform difference is resolved here in Rust. That keeps the standard
+//! library's own sources platform-agnostic, which is also how they read best.
+
+use std::fs::File;
+use std::io;
+use std::path::Path;
+
+/// Take a blocking shared advisory lock on an open file.
+///
+/// Advisory locking became portable in Rust 1.89, which is below this workspace's minimum, so the platform split
+/// that used to require `rustix::fs::flock` no longer exists.
+pub fn lock_shared(file: &File) -> io::Result<()> {
+    file.lock_shared()
+}
+
+/// Take a blocking exclusive advisory lock on an open file.
+pub fn lock_exclusive(file: &File) -> io::Result<()> {
+    file.lock()
+}
+
+/// Attempt a shared advisory lock, reporting contention rather than failing.
+///
+/// Returns `Ok(false)` when another holder owns the lock, which callers translate into an empty optional result.
+/// Only genuine host failures surface as `Err`.
+pub fn try_lock_shared(file: &File) -> io::Result<bool> {
+    match file.try_lock_shared() {
+        Ok(()) => Ok(true),
+        Err(std::fs::TryLockError::WouldBlock) => Ok(false),
+        Err(std::fs::TryLockError::Error(error)) => Err(error),
+    }
+}
+
+/// Attempt an exclusive advisory lock, reporting contention rather than failing.
+pub fn try_lock_exclusive(file: &File) -> io::Result<bool> {
+    match file.try_lock() {
+        Ok(()) => Ok(true),
+        Err(std::fs::TryLockError::WouldBlock) => Ok(false),
+        Err(std::fs::TryLockError::Error(error)) => Err(error),
+    }
+}
+
+/// Create a symbolic link at `link` pointing at `original`.
+///
+/// Unix creates one kind of symlink and does not care what it points at. Windows has two, and the kind is fixed
+/// when the link is created rather than resolved when it is followed, so the target's kind is inspected first and a
+/// directory link is created only for an existing directory. A link to a missing target becomes a file link, which
+/// matches what a caller porting Unix code expects and is the only choice available without more information.
+///
+/// Windows additionally requires Developer Mode or elevation to create symlinks at all; without it the host refuses
+/// with a permission error, which is reported unchanged rather than translated into something that hides the cause.
+pub fn symlink(original: &Path, link: &Path) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(original, link)
+    }
+
+    #[cfg(windows)]
+    {
+        let target_is_directory = std::fs::metadata(original)
+            .map(|metadata| metadata.is_dir())
+            .unwrap_or(false);
+        if target_is_directory {
+            std::os::windows::fs::symlink_dir(original, link)
+        } else {
+            std::os::windows::fs::symlink_file(original, link)
+        }
+    }
+}
+
+/// Report whether a path is the root of the filesystem holding it.
+///
+/// Unix answers this by comparing the path's device against its parent's: a differing device means the boundary is
+/// here. The identity comparison is the Unix idiom for the question rather than the question itself, so Windows
+/// answers it directly instead — a path is a filesystem root there when it has no parent once canonicalized, which
+/// covers drive and UNC volume roots.
+///
+/// Known gap on Windows: a directory junction or a volume mounted into a folder is a filesystem boundary that this
+/// does not report, because recognising one requires reading its reparse tag through Win32. Callers get `false`
+/// for those rather than a wrong `true`.
+pub fn is_mount_point(path: &Path) -> io::Result<bool> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+
+        let Some(parent) = path.parent() else {
+            return Ok(true);
+        };
+        let current = std::fs::metadata(path)?;
+        let parent_metadata = std::fs::metadata(parent)?;
+        Ok(current.dev() != parent_metadata.dev() || current.ino() == parent_metadata.ino())
+    }
+
+    #[cfg(windows)]
+    {
+        // Canonicalize so a relative path, a trailing separator, or a `.` component cannot make a root look nested.
+        // The path must exist for the question to mean anything, and canonicalize reports that for us.
+        let canonical = std::fs::canonicalize(path)?;
+        Ok(canonical.parent().is_none())
+    }
+}
+
+/// Byte counts describing the filesystem holding one path.
+pub struct DiskUsageBytes {
+    /// Total capacity of the filesystem.
+    pub total: u64,
+    /// Bytes currently allocated.
+    pub used: u64,
+    /// Bytes available to this caller, which may be less than the unallocated total under quotas or reservations.
+    pub free: u64,
+}
+
+/// Read capacity information for the filesystem holding `path`.
+///
+/// Not yet implemented on Windows. The Win32 call that answers this, `GetDiskFreeSpaceExW`, is reachable only
+/// through FFI, and no crate already in this workspace's dependency graph wraps it — so supporting it means either
+/// admitting `unsafe` into a crate that ships inside every generated program, or adding a dependency, and that is a
+/// decision for the maintainer rather than something to settle here. Reporting the gap plainly is better than
+/// returning a plausible wrong number for a capacity check, which is the kind of value a caller acts on.
+pub fn disk_usage(path: &Path) -> io::Result<DiskUsageBytes> {
+    #[cfg(unix)]
+    {
+        let stats = rustix::fs::statvfs(path)?;
+        let block_size = stats.f_bsize;
+        let total = stats.f_blocks.saturating_mul(block_size);
+        let used = stats.f_blocks.saturating_sub(stats.f_bfree).saturating_mul(block_size);
+        let free = stats.f_bavail.saturating_mul(block_size);
+        Ok(DiskUsageBytes { total, used, free })
+    }
+
+    #[cfg(windows)]
+    {
+        let _ = path;
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "std.fs disk usage is not yet implemented on Windows",
+        ))
+    }
+}

--- a/crates/incan_stdlib/src/lib.rs
+++ b/crates/incan_stdlib/src/lib.rs
@@ -13,6 +13,7 @@ pub mod collections;
 pub mod conversions;
 pub mod errors;
 pub mod frozen;
+pub mod host_fs;
 pub mod iter;
 pub mod num;
 pub mod prelude;

--- a/crates/incan_stdlib/stdlib/fs/locking.incn
+++ b/crates/incan_stdlib/stdlib/fs/locking.incn
@@ -1,9 +1,8 @@
 """OS-backed advisory file locks for coordinated local publication."""
 
 from rust::std::fs import File as RustFile, OpenOptions
-from rust::std::io import ErrorKind
 from rust::std::path import Path as RustPath
-from rust::rustix::fs @ "1.1" with ["fs"] import FlockOperation, flock
+from rust::incan_stdlib::host_fs import lock_exclusive, lock_shared, try_lock_exclusive, try_lock_shared
 
 
 pub type FileLock = newtype RustFile:
@@ -41,7 +40,7 @@ def _open_lock(path: str) -> Result[RustFile, str]:
 def _lock_shared(path: str) -> Result[FileLock, str]:
     """Acquire a blocking shared advisory lock while retaining the owned descriptor in the guard."""
     file = _open_lock(path)?
-    match flock(file, FlockOperation.LockShared):
+    match lock_shared(file):
         Ok(_) => return Ok(FileLock(file))
         Err(err) => return Err(f"{err}")
 
@@ -49,7 +48,7 @@ def _lock_shared(path: str) -> Result[FileLock, str]:
 def _lock_exclusive(path: str) -> Result[FileLock, str]:
     """Acquire a blocking exclusive advisory lock while retaining the owned descriptor in the guard."""
     file = _open_lock(path)?
-    match flock(file, FlockOperation.LockExclusive):
+    match lock_exclusive(file):
         Ok(_) => return Ok(FileLock(file))
         Err(err) => return Err(f"{err}")
 
@@ -57,23 +56,23 @@ def _lock_exclusive(path: str) -> Result[FileLock, str]:
 def _try_lock_shared(path: str) -> Result[Option[FileLock], str]:
     """Attempt a shared lock and translate expected contention into an empty optional result."""
     file = _open_lock(path)?
-    match flock(file, FlockOperation.NonBlockingLockShared):
-        Ok(_) => return Ok(Some(FileLock(file)))
-        Err(err) =>
-            if err.kind() == ErrorKind.WouldBlock:
-                return Ok(None)
-            return Err(f"{err}")
+    match try_lock_shared(file):
+        Ok(acquired) =>
+            if acquired:
+                return Ok(Some(FileLock(file)))
+            return Ok(None)
+        Err(err) => return Err(f"{err}")
 
 
 def _try_lock_exclusive(path: str) -> Result[Option[FileLock], str]:
     """Attempt an exclusive lock and translate expected contention into an empty optional result."""
     file = _open_lock(path)?
-    match flock(file, FlockOperation.NonBlockingLockExclusive):
-        Ok(_) => return Ok(Some(FileLock(file)))
-        Err(err) =>
-            if err.kind() == ErrorKind.WouldBlock:
-                return Ok(None)
-            return Err(f"{err}")
+    match try_lock_exclusive(file):
+        Ok(acquired) =>
+            if acquired:
+                return Ok(Some(FileLock(file)))
+            return Ok(None)
+        Err(err) => return Err(f"{err}")
 
 
 pub def shared(path: str) -> Result[FileLock, str]:

--- a/crates/incan_stdlib/stdlib/fs/path.incn
+++ b/crates/incan_stdlib/stdlib/fs/path.incn
@@ -22,11 +22,10 @@ from rust::std::fs import (
     symlink_metadata,
     write as rust_write,
 )
-from rust::std::os::unix::fs import MetadataExt, symlink
+from rust::incan_stdlib::host_fs import disk_usage, is_mount_point, symlink
 from rust::std::path import Path as RustPath
 from rust::std::rc import Rc
 from rust::std::time import SystemTime
-from rust::rustix::fs @ "1.1" with ["fs"] import statvfs
 from std.fs.file import File, _decode_text, _encode_text, _open_file, _validate_open_options
 from std.fs.glob import matches
 from std.fs.locking import FileLock, exclusive as lock_exclusive, shared as lock_shared, try_exclusive as try_lock_exclusive, try_shared as try_lock_shared
@@ -689,13 +688,9 @@ pub type Path = newtype str:
         Returns:
             `DiskUsage` byte counts, or `Err(IoError)` if the host cannot stat the filesystem.
         """
-        match statvfs(RustPath.new(self.0)):
+        match disk_usage(RustPath.new(self.0)):
             Ok(stats) =>
-                block_size = int(stats.f_bsize)
-                total = int(stats.f_blocks) * block_size
-                used = (int(stats.f_blocks) - int(stats.f_bfree)) * block_size
-                free = int(stats.f_bavail) * block_size
-                return Ok(DiskUsage(total=total, used=used, free=free))
+                return Ok(DiskUsage(total=int(stats.total), used=int(stats.used), free=int(stats.free)))
             Err(err) => return Err(_io_error(self, err))
 
     def touch(self, exist_ok: bool) -> Result[None, IoError]:
@@ -743,12 +738,9 @@ pub type Path = newtype str:
         Returns:
             `Ok(true)` for a mount point, `Ok(false)` for a non-mount path, or `Err(IoError)` if metadata cannot be read.
         """
-        if let Some(parent) = RustPath.new(self.0).parent():
-            current = _metadata_for(self)?
-            parent_path = Path(parent.to_string_lossy().into_owned())
-            parent_meta = _metadata_for(parent_path)?
-            return Ok(current.dev() != parent_meta.dev() or current.ino() == parent_meta.ino())
-        return Ok(true)
+        match is_mount_point(RustPath.new(self.0)):
+            Ok(mounted) => return Ok(mounted)
+            Err(err) => return Err(_io_error(self, err))
 
     def expanduser(self) -> Result[Path, IoError]:
         """

--- a/src/oven/store.rs
+++ b/src/oven/store.rs
@@ -2188,14 +2188,13 @@ fn write_staged_entry(
                 source,
             })?;
         } else if is_private_publisher_materialized_source(root, &file.source_path)? {
-            OpenOptions::new()
-                .read(true)
-                .open(&file.source_path)
-                .and_then(|source| source.sync_all())
-                .map_err(|source| OvenStoreError::Io {
-                    path: file.source_path.clone(),
-                    source,
-                })?;
+            // The publisher's own file is about to become a store entry by hard link, so its bytes must be on
+            // disk first. Flushing needs a write-capable handle, and these staged files may already be read-only,
+            // which is why this goes through the shared helper rather than opening the path here.
+            crate::durable_publication::sync_file(&file.source_path).map_err(|source| OvenStoreError::Io {
+                path: file.source_path.clone(),
+                source,
+            })?;
             fs::hard_link(&file.source_path, &destination).map_err(|source| OvenStoreError::Io {
                 path: destination.clone(),
                 source,


### PR DESCRIPTION
## Summary

Closes #1366 and fixes a second instance of #1340. Stacked on #1365.

**This is the change that produces a Windows toolchain artifact.** With it, `package_archive.sh x86_64-pc-windows-msvc` completes and writes `incan-v0.6.0-dev.1.4-x86_64-pc-windows-msvc.tar.gz` (264 MB, 22,230 entries), which extracts and runs.

Two independent fixes, both required to get there.

### 1. `std.fs` no longer imports unix-only Rust (#1366)

`incan_stdlib_system` could not compile on Windows: `std.fs` imported `rustix::fs::{flock, statvfs}` and `std::os::unix::fs::{MetadataExt, symlink}`.

Incan has no conditional compilation — no `cfg`, nothing in the parser, no RFC — so a `.incn` source cannot carry a Unix branch beside a Windows one. The split moves to `crates/incan_stdlib/src/host_fs.rs`, reached through the `from rust::incan_stdlib::…` seam the stdlib already uses for `async::task` and `errors`, which leaves the standard library's own sources platform-agnostic.

Three of the four capabilities cost no new dependency:

- **Advisory locking** is now `std::fs::File::{lock, lock_shared, try_lock, try_lock_shared}`, stabilised in Rust 1.89 and below this workspace's minimum. `rustix` was in `std.fs` for a platform split that no longer exists. Contention is reported as `Ok(false)` rather than an error kind each caller has to recognise.
- **Symlink creation** picks the Windows link kind from the target's metadata, because Windows fixes the kind at creation rather than resolving it when followed. A missing target yields a file link — the only choice available without more information.
- **The mount-point test** asks its question directly. Comparing `dev`/`ino` against the parent is the Unix *idiom* for "is this the root of its filesystem", not the question itself; Windows answers it as "no parent once canonicalized". Junctions and folder-mounted volumes are not recognised, documented at the function: callers get `false` rather than a wrong `true`.

`rustix` survives only as a `cfg(unix)` dependency of the host module, for `statvfs`.

**`disk_usage` is not implemented on Windows** and says so with `ErrorKind::Unsupported`. `GetDiskFreeSpaceExW` is reachable only through FFI and nothing already in the graph wraps it, so supporting it means either admitting `unsafe` into a crate that ships inside every generated program, or adding a dependency — which the bake's `--offline` contract also touches. That is your call; returning a plausible wrong number for a capacity check seemed worse than reporting the gap. Flagging it as the one deliberate behavioural difference in this PR.

### 2. Publisher artifacts flush through a write-capable handle (#1340)

Hard-linking a publisher's own file into a store entry flushes it first, and did so by opening the path read-only and calling `sync_all`. On Windows `FlushFileBuffers` requires a write-capable handle, so this failed with `Access is denied` against the publisher's provenance record.

This is #1340's bug in a second location. `durable_publication::sync_file` already exists for exactly it — its rustdoc describes this failure — and additionally handles staged files that are already read-only, which no choice of open mode can flush.

## Type of change

- [x] Bug fix

## Area(s)

- [x] Runtime / Core crates (stdlib/core/derive)
- [x] Tooling (CLI/formatter/test runner)

## Testing / verification

- [x] `make pre-commit-fast`
- [x] `cargo build --release`
- [x] Manual verification described below

Manual verification notes:

- Release packaging bake on native Windows x64: `PACKAGE_EXIT=0`. Every failure class from this slice at zero — `LNK1181`, `LNK1104`, `A1009`, `invalid path url`, `Access is denied`, duplicate checked module, and `incan_stdlib_system` compile errors.
- All ten SDK components prepare, `stdlib-system` included.
- Archive extracted to a clean directory; `bin/incan.exe --version` reports `incan 0.6.0-dev.1.4`; `incan new hello --yes` scaffolds a project.

### Known gap, filed separately

`incan run` on that scaffolded project **fails**. The shipped store layout spends 134 characters on two 64-character digests (`loafs/generations/<digest>/<digest>.loaf/`) before Cargo's own layers, so a dependency rlib lands at 265 characters even with the install prefix at `C:\dev\_t\x`, and `link.exe` fails with `LNK1104`.

That is a runtime path-length defect in the shipped layout, distinct from the build-time ones fixed here, and it means the artifact is produced but not yet usable for building a project on Windows. It needs a layout decision rather than another abbreviation, so I have filed it rather than guessed.
