### PR TITLE
bugfix - render Loaf directory names short enough for Windows consumers (#1368)

### DIFF
--- a/src/cli/commands/oven.rs
+++ b/src/cli/commands/oven.rs
@@ -1343,9 +1343,7 @@ pub fn oven_legacy_cargo_bake_loafs(options: OvenLoafBakeCommandOptions) -> CliR
         &serde_json::to_vec(&(loaf_envelope_name(envelope), &compatibility_evidence))
             .map_err(|error| CliError::failure(format!("could not encode Loaf generation identity: {error}")))?,
     );
-    let generation_name = generation_identity
-        .strip_prefix("sha256:")
-        .unwrap_or(&generation_identity);
+    let generation_name = crate::oven::loaf::loaf_directory_component(&generation_identity);
     let generation_relative = Path::new("generations").join(generation_name);
     let generation_output = options.output.join(&generation_relative);
     let generations_root = options.output.join("generations");
@@ -1582,11 +1580,7 @@ pub fn oven_legacy_cargo_bake_loafs(options: OvenLoafBakeCommandOptions) -> CliR
         loafs: pending
             .iter()
             .map(|entry| {
-                let identity = entry
-                    .result
-                    .loaf_identity
-                    .strip_prefix("sha256:")
-                    .unwrap_or(&entry.result.loaf_identity);
+                let identity = crate::oven::loaf::loaf_directory_component(&entry.result.loaf_identity);
                 OvenLoafEnvelopeMember {
                     label: entry.label.clone(),
                     profile: entry.profile.clone(),
@@ -6104,11 +6098,8 @@ mod tests {
             &rustc,
         )?;
         let generation_identity = digest_bytes(b"generation");
-        let generation = Path::new("generations").join(
-            generation_identity
-                .strip_prefix("sha256:")
-                .unwrap_or(&generation_identity),
-        );
+        let generation =
+            Path::new("generations").join(crate::oven::loaf::loaf_directory_component(&generation_identity));
         let mut members = Vec::new();
         for specification in loaf_envelope_specifications(OvenLoafEnvelope::Release) {
             let action = match specification.action {
@@ -6146,7 +6137,7 @@ mod tests {
             let loaf_identity = digest_bytes(&serde_json::to_vec_pretty(&loaf)?);
             let relative_directory = generation.join(format!(
                 "{}.loaf",
-                loaf_identity.strip_prefix("sha256:").unwrap_or(&loaf_identity)
+                crate::oven::loaf::loaf_directory_component(&loaf_identity)
             ));
             let directory = output.path().join(&relative_directory);
             fs::create_dir_all(&directory)?;
@@ -6604,10 +6595,7 @@ mod tests {
 
         let manifest: OvenLoafEnvelopeManifest =
             serde_json::from_slice(&fs::read(output.path().join("envelope.json"))?)?;
-        let generation = manifest
-            .generation_identity
-            .strip_prefix("sha256:")
-            .ok_or("generation identity is not content-addressed")?;
+        let generation = crate::oven::loaf::loaf_directory_component(&manifest.generation_identity);
         assert!(
             output
                 .path()

--- a/src/oven/legacy_cargo.rs
+++ b/src/oven/legacy_cargo.rs
@@ -9219,6 +9219,14 @@ mod tests {
         Ok(())
     }
 
+    /// Generation identity every Loaf fixture in these tests declares.
+    ///
+    /// The envelope manifest and the on-disk directory both derive from it, and production renders that
+    /// directory name through `loaf_directory_component`, so fixtures must use the same rendering or the
+    /// reader looks for a directory the fixture did not create.
+    const TEST_LOAF_GENERATION_IDENTITY: &str =
+        "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
     fn write_test_loaf_envelope(
         loafs: &std::path::Path,
         members: Vec<OvenLoafEnvelopeMember>,
@@ -9229,8 +9237,7 @@ mod tests {
             serde_json::to_vec(&OvenLoafEnvelopeManifest {
                 schema_version: OVEN_LOAF_ENVELOPE_MANIFEST_SCHEMA_VERSION,
                 envelope: "compiler-suite".to_string(),
-                generation_identity: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-                    .to_string(),
+                generation_identity: TEST_LOAF_GENERATION_IDENTITY.to_string(),
                 evidence: BTreeMap::new(),
                 loafs: members,
             })?,
@@ -11303,8 +11310,9 @@ version = "1.0.0"
             };
             let loaf_identity = crate::oven::digest_bytes(&serde_json::to_vec_pretty(&loaf)?);
             let relative = PathBuf::from(format!(
-                "generations/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/{}.loaf/loaf.json",
-                loaf_identity.strip_prefix("sha256:").unwrap_or(&loaf_identity)
+                "generations/{}/{}.loaf/loaf.json",
+                crate::oven::loaf::loaf_directory_component(TEST_LOAF_GENERATION_IDENTITY),
+                crate::oven::loaf::loaf_directory_component(&loaf_identity)
             ));
             let loaf_path = loafs.join(&relative);
             fs::create_dir_all(loaf_path.parent().ok_or("Loaf parent missing")?)?;
@@ -11379,8 +11387,9 @@ version = "1.0.0"
             .insert("runtime-lock".to_string(), "sha256:old".to_string());
         let loaf_identity = crate::oven::digest_bytes(&serde_json::to_vec_pretty(&loaf)?);
         let relative = PathBuf::from(format!(
-            "generations/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/{}.loaf/loaf.json",
-            loaf_identity.strip_prefix("sha256:").unwrap_or(&loaf_identity)
+            "generations/{}/{}.loaf/loaf.json",
+            crate::oven::loaf::loaf_directory_component(TEST_LOAF_GENERATION_IDENTITY),
+            crate::oven::loaf::loaf_directory_component(&loaf_identity)
         ));
         let loaf_path = loafs.join(&relative);
         fs::create_dir_all(loaf_path.parent().ok_or("Loaf parent missing")?)?;

--- a/src/oven/loaf.rs
+++ b/src/oven/loaf.rs
@@ -66,6 +66,33 @@ pub const OVEN_NO_IMPLICIT_DEPENDENCY_BUILD: &str = "will not compile them for y
 /// it only after proving that it seals the vocabulary helper itself.
 pub const OVEN_SOURCE_COMPILER_VOCAB_SUPPORT_BUILD_INPUT: &str = "source-compiler-vocab-support";
 const TOOLCHAIN_LOAF_RELATIVE_ROOT: &str = "share/incan/oven/loafs";
+
+/// Digest characters kept in an on-disk Loaf directory name on Windows.
+///
+/// The shipped layout nests a generation directory inside `loafs/` and a `<identity>.loaf` directory inside that,
+/// so a full 64-character digest in each spends 134 characters before Cargo's own
+/// `target/<triple>/debug/deps/<crate>-<hash>.rlib` layers begin. That overruns `MAX_PATH` for every consumer of
+/// the toolchain, not just its build, and `link.exe` fails with `LNK1104` on a dependency it cannot open. Sixty-four
+/// bits of digest distinguishes the handful of generations a store holds with room to spare.
+const LOAF_DIRECTORY_DIGEST_LENGTH: usize = 16;
+
+/// Render one content identity as the directory-name component the Loaf layout uses for it.
+///
+/// Every site that writes, resolves, or validates a Loaf directory name goes through here, because the name is
+/// recorded in the envelope manifest at bake time and recomputed when the toolchain reads it: a writer and a reader
+/// that disagree would produce a store whose entries cannot be found, which is a worse failure than the path-length
+/// one this exists to avoid.
+///
+/// This shortens the *rendered name only*. The identity itself is unchanged wherever it is recorded or compared, and
+/// the digest is still validated at full length where it is checked as an identity rather than used as a name.
+pub(crate) fn loaf_directory_component(identity: &str) -> &str {
+    let digest = identity.strip_prefix("sha256:").unwrap_or(identity);
+    if cfg!(windows) {
+        digest.get(..LOAF_DIRECTORY_DIGEST_LENGTH).unwrap_or(digest)
+    } else {
+        digest
+    }
+}
 static LOAF_TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 const OVEN_LOAF_ENVELOPE_LOCK_FILE: &str = ".envelope.lock";
 
@@ -392,9 +419,7 @@ pub(crate) fn retire_unreferenced_loaf_generations(
     if !generations_root.is_dir() {
         return Ok(());
     }
-    let active_name = generation_identity
-        .strip_prefix("sha256:")
-        .unwrap_or(generation_identity);
+    let active_name = loaf_directory_component(generation_identity);
     let active_generation = generations_root.join(active_name);
     let retired_root = scratch.join("retired");
     fs::create_dir_all(&retired_root).map_err(|source| OvenLoafError::Io {
@@ -1046,10 +1071,7 @@ pub fn prepare_loaf_from_generated_project(
         source_compiler_vocab_support: false,
         base_loaf: None,
     })?;
-    let identity = receipt
-        .build_unit_identity
-        .strip_prefix("sha256:")
-        .unwrap_or(receipt.build_unit_identity.as_str());
+    let identity = loaf_directory_component(&receipt.build_unit_identity);
     let output_directory = loaf_root.join(format!(".building-{identity}.loaf"));
     if output_directory.exists() {
         return Err(OvenLoafError::Preparation {
@@ -1065,10 +1087,7 @@ pub fn prepare_loaf_from_generated_project(
         publication.registry_leaves,
         &output_directory,
     )?;
-    let loaf_name = result
-        .loaf_identity
-        .strip_prefix("sha256:")
-        .unwrap_or(&result.loaf_identity);
+    let loaf_name = loaf_directory_component(&result.loaf_identity);
     let content_directory = loaf_root.join(format!("{loaf_name}.loaf"));
     if content_directory.exists() {
         return Err(OvenLoafError::Preparation {
@@ -2400,12 +2419,7 @@ fn committed_loaf_metadata_paths_with_role(
             message: format!("unsupported envelope manifest schema {}", manifest.schema_version),
         });
     }
-    let generation_prefix = Path::new("generations").join(
-        manifest
-            .generation_identity
-            .strip_prefix("sha256:")
-            .unwrap_or(&manifest.generation_identity),
-    );
+    let generation_prefix = Path::new("generations").join(loaf_directory_component(&manifest.generation_identity));
     let mut paths = Vec::with_capacity(manifest.loafs.len());
     for member in &manifest.loafs {
         if member.path.is_absolute()
@@ -2431,13 +2445,7 @@ fn committed_loaf_metadata_paths_with_role(
             });
         }
         let identity = loaf_file_identity(&path)?;
-        let expected_name = format!(
-            "{}.loaf",
-            member
-                .loaf_identity
-                .strip_prefix("sha256:")
-                .unwrap_or(&member.loaf_identity)
-        );
+        let expected_name = format!("{}.loaf", loaf_directory_component(&member.loaf_identity));
         if identity != member.loaf_identity
             || path.parent().and_then(Path::file_name).and_then(|name| name.to_str()) != Some(expected_name.as_str())
         {
@@ -3187,7 +3195,7 @@ pub(crate) fn validate_stored_loaf_for_reuse(
 /// Verify that a Loaf manifest's digest is also the name of its containing `.loaf` directory.
 fn validate_loaf_content_address(loaf_path: &Path) -> Result<String, OvenLoafError> {
     let identity = loaf_file_identity(loaf_path)?;
-    let expected_name = format!("{}.loaf", identity.strip_prefix("sha256:").unwrap_or(&identity));
+    let expected_name = format!("{}.loaf", loaf_directory_component(&identity));
     let actual_name = loaf_path
         .parent()
         .and_then(Path::file_name)
@@ -3439,6 +3447,7 @@ fn read_loaf(loaf_path: &Path) -> Result<OvenLoaf, OvenLoafError> {
 
 #[cfg(test)]
 mod tests {
+    use super::loaf_directory_component;
     use std::collections::{BTreeMap, BTreeSet};
     use std::fs;
     use std::path::{Path, PathBuf};
@@ -3599,9 +3608,7 @@ mod tests {
         let committed_identity = digest_bytes(&committed_bytes);
         let committed = PathBuf::from(format!(
             "generations/current/{}.loaf/loaf.json",
-            committed_identity
-                .strip_prefix("sha256:")
-                .unwrap_or(&committed_identity)
+            loaf_directory_component(&committed_identity)
         ));
         let stale = root.path().join("generations/stale/two.loaf/loaf.json");
         fs::create_dir_all(root.path().join(committed.parent().ok_or("committed parent missing")?))?;


### PR DESCRIPTION
## Summary

Closes #1368. Stacked on #1367.

**With this, the packaged Windows toolchain builds and runs a program.** Extracted from the artifact #1367 produces: `incan new hello --yes` scaffolds, `incan run` prints `Hello from hello!`, exit 0.

The shipped store layout nests `generations/<digest>/<digest>.loaf/`, spending 134 characters on two 64-character content digests before Cargo's own `target/<triple>/debug/deps/<crate>-<hash>.rlib` layers begin. A dependency rlib therefore landed at 265 characters with the install prefix only eleven characters long, and `link.exe` failed with `LNK1104`.

This is unlike the earlier path fixes in this slice. Those were build-time paths inside the publisher's staging, which the bake controls. This is the layout **every user reads on every build**, so no amount of care during packaging avoids it.

## Type of change

- [x] Bug fix

## Area(s)

- [x] Tooling (CLI/formatter/test runner)

## Key details

- **User-facing behavior**: a packaged Windows toolchain can build projects. No change elsewhere — the shortening is `cfg(windows)` only.
- **Internals**: every site that writes, resolves, or validates a Loaf directory name renders it through one `loaf_directory_component`, keeping sixteen digest characters on Windows and the full digest elsewhere.
- **Risks**: this changes on-disk layout, so it deserves the closest look of anything in this stack. Two specifics below.

### Why one function rather than seven edits

The directory name is recorded in the envelope manifest when a Loaf is baked and recomputed when the toolchain reads it. A writer and a reader that disagree produce a store whose entries cannot be found — a worse failure than the path-length one, and a silent one.

That is not hypothetical. My first attempt converted the readers in `oven/loaf.rs` and missed the two writers in `cli/commands/oven.rs`. `cargo check` passed, `make pre-commit-fast` passed, the bake ran to completion — and then the packager rejected its own output for containing no recognisable Loafs. It is why the verification below runs the bake *and* uses the artifact, rather than inspecting the diff.

### What is deliberately not shortened

`committed_envelope_manifest` still validates the generation identity at its full 64 characters. There the digest is being checked as an identity, not used as a name, and truncating it would have broken the check while looking like the same edit. The identity is likewise unchanged everywhere it is recorded or compared; only the rendered name is shorter.

Sixteen hex characters is 64 bits, against the handful of generations a store holds. It reclaims 96 of the 134 characters, which leaves headroom for a normal install location rather than the short one this was measured at — a `%LOCALAPPDATA%\Programs\incan` prefix is about 30 characters longer than the path that failed.

## Testing / verification

- [x] `cargo test` — full `--lib` suite
- [x] `make pre-commit-fast`
- [x] Manual verification described below

Manual verification notes:

End-to-end on native Windows x64, from a clean bake through to running a program:

| step | result |
|---|---|
| `make pre-commit-fast` | pass |
| `cargo test --lib oven::loaf::` | 25 passed |
| `cargo build --release` | pass |
| `package_archive.sh x86_64-pc-windows-msvc` | exit 0, archive written |
| extract, `incan --version` | `incan 0.6.0-dev.1.4` |
| `incan new hello --yes` | exit 0 |
| `incan run` | exit 0, `Hello from hello!` |

The last two rows are the ones this PR is for; the bake alone was already passing before it.

### Worth carrying into #1284

A Windows gate that only ran the bake would have called the previous state green. Baking successfully and the toolchain working are different claims here, and the gap was only visible by extracting the artifact and using it. Whatever that gate checks should scaffold and build a project with the packaged toolchain, not just produce it.
