### PR TITLE
feature - 1031 resolve vocab helpers through eligibility and reject duplicate keys

### DIFF
--- a/src/frontend/vocab_desugar_pass/helper_bindings.rs
+++ b/src/frontend/vocab_desugar_pass/helper_bindings.rs
@@ -288,36 +288,118 @@ fn resolve_helper_binding<'a>(
             "provider `pub::{dependency_key}` does not expose vocab metadata"
         ));
     };
-    let binding = vocab
+    let mut matching = vocab
         .provider_manifest
         .helper_bindings
         .iter()
-        .find(|binding| binding.key == helper_key)
+        .filter(|binding| binding.key == helper_key);
+    let binding = matching
+        .next()
         .ok_or_else(|| format!("provider `pub::{dependency_key}` does not bind helper `{helper_key}`"))?;
-    if !library_exports_contains_name(manifest.as_ref(), &binding.exported_name) {
+    if let Some(duplicate) = matching.next() {
+        return Err(format!(
+            "provider `pub::{dependency_key}` binds helper `{helper_key}` more than once, to `{}` and `{}`; \
+             remove the duplicate so the helper has one spelling",
+            binding.exported_name, duplicate.exported_name
+        ));
+    }
+    let Some(kind) = helper_export_kind(manifest.as_ref(), &binding.exported_name) else {
         return Err(format!(
             "provider `pub::{dependency_key}` binds helper `{helper_key}` to missing export `{}`",
+            binding.exported_name
+        ));
+    };
+    if !kind.is_callable() {
+        return Err(format!(
+            "provider `pub::{dependency_key}` binds helper `{helper_key}` to {} `{}`, which cannot be called; \
+             bind the helper to a function, class, model, newtype, or enum variant",
+            kind.label(),
             binding.exported_name
         ));
     }
     Ok(binding)
 }
 
-/// Check whether a provider manifest exports a symbol that may be imported by helper aliasing.
-fn library_exports_contains_name(manifest: &crate::library_manifest::LibraryManifest, name: &str) -> bool {
-    manifest.exports.models.iter().any(|item| item.name == name)
-        || manifest.exports.classes.iter().any(|item| item.name == name)
-        || manifest.exports.functions.iter().any(|item| item.name == name)
-        || manifest.exports.traits.iter().any(|item| item.name == name)
-        || manifest.exports.enums.iter().any(|item| item.name == name)
-        || manifest
-            .exports
-            .enums
-            .iter()
-            .any(|item| item.variants.iter().any(|variant| variant.name == name))
-        || manifest.exports.type_aliases.iter().any(|item| item.name == name)
-        || manifest.exports.newtypes.iter().any(|item| item.name == name)
-        || manifest.exports.consts.iter().any(|item| item.name == name)
+/// What a helper's exported name resolves to on the provider's public surface.
+///
+/// A desugared helper reference is spliced into call position, so the kind decides whether the emitted program can
+/// actually run. Resolving only "is this name exported" accepted traits and constants, which typecheck as names and
+/// then fail in generated Rust as calls.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HelperExportKind {
+    Function,
+    Class,
+    Model,
+    Newtype,
+    EnumVariant,
+    Enum,
+    Trait,
+    TypeAlias,
+    Const,
+}
+
+impl HelperExportKind {
+    /// Return whether a value of this kind may appear as the callee of a desugared helper call.
+    fn is_callable(self) -> bool {
+        matches!(
+            self,
+            Self::Function | Self::Class | Self::Model | Self::Newtype | Self::EnumVariant
+        )
+    }
+
+    /// Return the user-facing noun for this kind, for diagnostics.
+    fn label(self) -> &'static str {
+        match self {
+            Self::Function => "function",
+            Self::Class => "class",
+            Self::Model => "model",
+            Self::Newtype => "newtype",
+            Self::EnumVariant => "enum variant",
+            Self::Enum => "enum",
+            Self::Trait => "trait",
+            Self::TypeAlias => "type alias",
+            Self::Const => "const",
+        }
+    }
+}
+
+/// Resolve one exported name on a provider manifest to the kind of item it names.
+///
+/// Callable kinds are checked first so a name that is both an enum and a variant resolves to the usable one.
+fn helper_export_kind(manifest: &crate::library_manifest::LibraryManifest, name: &str) -> Option<HelperExportKind> {
+    let exports = &manifest.exports;
+    if exports.functions.iter().any(|item| item.name == name) {
+        return Some(HelperExportKind::Function);
+    }
+    if exports.classes.iter().any(|item| item.name == name) {
+        return Some(HelperExportKind::Class);
+    }
+    if exports.models.iter().any(|item| item.name == name) {
+        return Some(HelperExportKind::Model);
+    }
+    if exports.newtypes.iter().any(|item| item.name == name) {
+        return Some(HelperExportKind::Newtype);
+    }
+    if exports
+        .enums
+        .iter()
+        .any(|item| item.variants.iter().any(|variant| variant.name == name))
+    {
+        return Some(HelperExportKind::EnumVariant);
+    }
+    if exports.enums.iter().any(|item| item.name == name) {
+        return Some(HelperExportKind::Enum);
+    }
+    if exports.traits.iter().any(|item| item.name == name) {
+        return Some(HelperExportKind::Trait);
+    }
+    if exports.type_aliases.iter().any(|item| item.name == name) {
+        return Some(HelperExportKind::TypeAlias);
+    }
+    if exports.consts.iter().any(|item| item.name == name) {
+        return Some(HelperExportKind::Const);
+    }
+    None
 }
 
 #[cfg(test)]
@@ -326,6 +408,97 @@ mod tests {
     use std::path::PathBuf;
 
     use super::*;
+
+    /// Build a one-provider index whose manifest carries the given helper bindings and exports.
+    fn index_with(
+        bindings: Vec<incan_vocab::HelperBinding>,
+        customize: impl FnOnce(&mut crate::library_manifest::LibraryManifest),
+    ) -> LibraryManifestIndex {
+        let mut manifest = crate::library_manifest::LibraryManifest::new("demo", "0.1.0");
+        customize(&mut manifest);
+        manifest.vocab = Some(crate::library_manifest::VocabExports {
+            crate_path: "vocab_companion".to_string(),
+            package_name: "vocab_companion".to_string(),
+            keyword_registrations: Vec::new(),
+            dsl_surfaces: Vec::new(),
+            provider_manifest: incan_vocab::LibraryManifest {
+                helper_bindings: bindings,
+                ..incan_vocab::LibraryManifest::default()
+            },
+            desugarer_artifact: None,
+        });
+        LibraryManifestIndex::from_entries(HashMap::from([(
+            "demo".to_string(),
+            LibraryManifestIndexEntry::Loaded {
+                manifest: Box::new(manifest),
+                metadata: crate::frontend::library_manifest_index::LibraryArtifactMetadata::from_crate_root(
+                    "demo",
+                    "demo",
+                    PathBuf::from("/tmp/demo"),
+                ),
+            },
+        )]))
+    }
+
+    #[test]
+    fn helper_resolution_rejects_a_duplicated_helper_key() -> Result<(), Box<dyn std::error::Error>> {
+        // Two bindings for one key used to resolve silently to whichever was declared first, so a provider could
+        // ship an ambiguous surface and the choice would depend on declaration order.
+        let index = index_with(
+            vec![
+                incan_vocab::HelperBinding {
+                    key: "filter".to_string(),
+                    exported_name: "filter_rows".to_string(),
+                },
+                incan_vocab::HelperBinding {
+                    key: "filter".to_string(),
+                    exported_name: "filter_cols".to_string(),
+                },
+            ],
+            |_| {},
+        );
+
+        let err = match resolve_helper_binding(&index, "demo", "filter") {
+            Err(err) => err,
+            Ok(binding) => panic!("expected duplicate rejection, resolved to `{}`", binding.exported_name),
+        };
+        assert!(err.contains("more than once"), "unexpected error: {err}");
+        assert!(
+            err.contains("filter_rows") && err.contains("filter_cols"),
+            "error should name both: {err}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn helper_resolution_rejects_a_binding_to_an_uncallable_export() -> Result<(), Box<dyn std::error::Error>> {
+        // A trait is exported and therefore passed the old name-only check, but a desugared helper reference is
+        // spliced into call position, where a trait cannot go.
+        let index = index_with(
+            vec![incan_vocab::HelperBinding {
+                key: "filter".to_string(),
+                exported_name: "Filterable".to_string(),
+            }],
+            |manifest| {
+                manifest.exports.traits.push(crate::library_manifest::TraitExport {
+                    name: "Filterable".to_string(),
+                    source_name: None,
+                    type_params: Vec::new(),
+                    supertraits: Vec::new(),
+                    requires: Vec::new(),
+                    methods: Vec::new(),
+                });
+            },
+        );
+
+        let err = match resolve_helper_binding(&index, "demo", "filter") {
+            Err(err) => err,
+            Ok(_) => panic!("expected an ineligible-kind rejection"),
+        };
+        assert!(err.contains("trait `Filterable`"), "error should name the kind: {err}");
+        assert!(err.contains("cannot be called"), "unexpected error: {err}");
+        Ok(())
+    }
 
     #[test]
     fn helper_resolution_rejects_bindings_to_missing_exports() -> Result<(), Box<dyn std::error::Error>> {

--- a/src/frontend/vocab_desugar_pass/helper_bindings.rs
+++ b/src/frontend/vocab_desugar_pass/helper_bindings.rs
@@ -332,10 +332,13 @@ enum HelperExportKind {
     Model,
     Newtype,
     EnumVariant,
+    /// A reexport alias whose target resolves to something callable.
+    Alias,
     Enum,
     Trait,
     TypeAlias,
     Const,
+    Static,
 }
 
 impl HelperExportKind {
@@ -343,7 +346,7 @@ impl HelperExportKind {
     fn is_callable(self) -> bool {
         matches!(
             self,
-            Self::Function | Self::Class | Self::Model | Self::Newtype | Self::EnumVariant
+            Self::Function | Self::Class | Self::Model | Self::Newtype | Self::EnumVariant | Self::Alias
         )
     }
 
@@ -355,10 +358,12 @@ impl HelperExportKind {
             Self::Model => "model",
             Self::Newtype => "newtype",
             Self::EnumVariant => "enum variant",
+            Self::Alias => "alias",
             Self::Enum => "enum",
             Self::Trait => "trait",
             Self::TypeAlias => "type alias",
             Self::Const => "const",
+            Self::Static => "static",
         }
     }
 }
@@ -367,6 +372,15 @@ impl HelperExportKind {
 ///
 /// Callable kinds are checked first so a name that is both an enum and a variant resolves to the usable one.
 fn helper_export_kind(manifest: &crate::library_manifest::LibraryManifest, name: &str) -> Option<HelperExportKind> {
+    helper_export_kind_with_hops(manifest, name, 0)
+}
+
+/// Classify one exported name, carrying the reexport hop budget shared with [`resolve_alias_kind`].
+fn helper_export_kind_with_hops(
+    manifest: &crate::library_manifest::LibraryManifest,
+    name: &str,
+    hops: usize,
+) -> Option<HelperExportKind> {
     let exports = &manifest.exports;
     if exports.functions.iter().any(|item| item.name == name) {
         return Some(HelperExportKind::Function);
@@ -396,10 +410,49 @@ fn helper_export_kind(manifest: &crate::library_manifest::LibraryManifest, name:
     if exports.type_aliases.iter().any(|item| item.name == name) {
         return Some(HelperExportKind::TypeAlias);
     }
+    if let Some(alias) = exports.aliases.iter().find(|item| item.name == name) {
+        return Some(resolve_alias_kind(manifest, alias, hops));
+    }
     if exports.consts.iter().any(|item| item.name == name) {
         return Some(HelperExportKind::Const);
     }
+    if exports.statics.iter().any(|item| item.name == name) {
+        return Some(HelperExportKind::Static);
+    }
     None
+}
+
+/// Maximum reexport hops followed before giving up, so a cyclic alias chain cannot loop forever.
+const MAX_ALIAS_HOPS: usize = 8;
+
+/// Resolve what a reexport alias ultimately names.
+///
+/// A library may publish a helper under an alias rather than its declaration name, and a consumer binding that alias
+/// should resolve exactly as the original does. `projected_function` settles the common case directly; otherwise the
+/// alias is followed by its target's final path segment, which is how the manifest spells a reexport. An unresolvable
+/// or over-long chain stays `Alias`, which is callable, so an alias whose target cannot be classified is admitted
+/// rather than rejected on incomplete information.
+fn resolve_alias_kind(
+    manifest: &crate::library_manifest::LibraryManifest,
+    alias: &crate::library_manifest::AliasExport,
+    hops: usize,
+) -> HelperExportKind {
+    if alias.projected_function.is_some() {
+        return HelperExportKind::Function;
+    }
+    if hops >= MAX_ALIAS_HOPS {
+        return HelperExportKind::Alias;
+    }
+    let Some(target) = alias.target_path.last() else {
+        return HelperExportKind::Alias;
+    };
+    if target == &alias.name {
+        return HelperExportKind::Alias;
+    }
+    match helper_export_kind_with_hops(manifest, target, hops + 1) {
+        Some(kind) => kind,
+        None => HelperExportKind::Alias,
+    }
 }
 
 #[cfg(test)]
@@ -408,6 +461,30 @@ mod tests {
     use std::path::PathBuf;
 
     use super::*;
+
+    /// Build a minimal exported function record for helper-resolution fixtures.
+    fn function_export(name: &str) -> crate::library_manifest::FunctionExport {
+        crate::library_manifest::FunctionExport {
+            name: name.to_string(),
+            emitted_name: None,
+            type_params: Vec::new(),
+            params: Vec::new(),
+            return_type: crate::library_manifest::TypeRef::Named {
+                name: "None".to_string(),
+            },
+            is_async: false,
+        }
+    }
+
+    /// Build a minimal exported const record for helper-resolution fixtures.
+    fn const_export(name: &str) -> crate::library_manifest::ConstExport {
+        crate::library_manifest::ConstExport {
+            name: name.to_string(),
+            ty: crate::library_manifest::TypeRef::Named {
+                name: "int".to_string(),
+            },
+        }
+    }
 
     /// Build a one-provider index whose manifest carries the given helper bindings and exports.
     fn index_with(
@@ -438,6 +515,86 @@ mod tests {
                 ),
             },
         )]))
+    }
+
+    #[test]
+    fn helper_resolution_follows_a_reexport_alias_to_its_target() -> Result<(), Box<dyn std::error::Error>> {
+        // A library may publish a helper under an alias rather than its declaration name. Binding the alias must
+        // resolve exactly as binding the original would, instead of failing as an unknown export.
+        let index = index_with(
+            vec![incan_vocab::HelperBinding {
+                key: "filter".to_string(),
+                exported_name: "where_".to_string(),
+            }],
+            |manifest| {
+                manifest.exports.functions.push(function_export("filter_rows"));
+                manifest.exports.aliases.push(crate::library_manifest::AliasExport {
+                    name: "where_".to_string(),
+                    target_path: vec!["demo".to_string(), "filter_rows".to_string()],
+                    projected_function: None,
+                });
+            },
+        );
+
+        let binding = resolve_helper_binding(&index, "demo", "filter")?;
+        assert_eq!(binding.exported_name, "where_");
+        Ok(())
+    }
+
+    #[test]
+    fn helper_resolution_rejects_an_alias_that_lands_on_an_uncallable_target() -> Result<(), Box<dyn std::error::Error>>
+    {
+        // Following the alias must not launder an ineligible target into an eligible one.
+        let index = index_with(
+            vec![incan_vocab::HelperBinding {
+                key: "filter".to_string(),
+                exported_name: "Filterish".to_string(),
+            }],
+            |manifest| {
+                manifest.exports.consts.push(const_export("FILTER_LIMIT"));
+                manifest.exports.aliases.push(crate::library_manifest::AliasExport {
+                    name: "Filterish".to_string(),
+                    target_path: vec!["demo".to_string(), "FILTER_LIMIT".to_string()],
+                    projected_function: None,
+                });
+            },
+        );
+
+        let err = match resolve_helper_binding(&index, "demo", "filter") {
+            Err(err) => err,
+            Ok(_) => panic!("expected the alias target to be rejected"),
+        };
+        assert!(
+            err.contains("const `Filterish`"),
+            "error should name the resolved kind: {err}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn helper_resolution_survives_a_cyclic_alias_chain() -> Result<(), Box<dyn std::error::Error>> {
+        // A manifest that aliases in a loop must terminate rather than recurse forever.
+        let index = index_with(
+            vec![incan_vocab::HelperBinding {
+                key: "filter".to_string(),
+                exported_name: "a".to_string(),
+            }],
+            |manifest| {
+                for (name, target) in [("a", "b"), ("b", "a")] {
+                    manifest.exports.aliases.push(crate::library_manifest::AliasExport {
+                        name: name.to_string(),
+                        target_path: vec!["demo".to_string(), target.to_string()],
+                        projected_function: None,
+                    });
+                }
+            },
+        );
+
+        // Terminating at all is the assertion; an unresolvable chain stays callable rather than being rejected on
+        // incomplete information.
+        let binding = resolve_helper_binding(&index, "demo", "filter")?;
+        assert_eq!(binding.exported_name, "a");
+        Ok(())
     }
 
     #[test]

--- a/src/library_manifest/tests.rs
+++ b/src/library_manifest/tests.rs
@@ -3667,6 +3667,48 @@ fn manifest_writer_rejects_helper_binding_to_unknown_export() -> Result<(), Box<
 }
 
 #[test]
+fn manifest_writer_rejects_helper_binding_to_an_uncallable_export() -> Result<(), Box<dyn std::error::Error>> {
+    // The name is exported, so the unknown-symbol check passes; a helper reference is spliced into call position
+    // though, and a trait cannot go there. Failing the provider's own build puts the error where its author can act
+    // on it, rather than surfacing in every consumer as broken generated Rust.
+    let mut manifest = legacy_manifest_fixture("mylib", "0.1.0");
+    manifest.exports.traits.push(TraitExport {
+        name: "Filterable".to_string(),
+        source_name: None,
+        type_params: Vec::new(),
+        supertraits: Vec::new(),
+        requires: Vec::new(),
+        methods: Vec::new(),
+    });
+    manifest.vocab = Some(VocabExports {
+        crate_path: "crates/mylib_vocab".to_string(),
+        package_name: "mylib_vocab".to_string(),
+        keyword_registrations: Vec::new(),
+        dsl_surfaces: Vec::new(),
+        provider_manifest: incan_vocab::LibraryManifest {
+            helper_bindings: vec![incan_vocab::HelperBinding {
+                key: "filter".to_string(),
+                exported_name: "Filterable".to_string(),
+            }],
+            ..incan_vocab::LibraryManifest::default()
+        },
+        desugarer_artifact: None,
+    });
+
+    let tmp = tempfile::tempdir()?;
+    let err = manifest.write_to_path(&tmp.path().join("mylib.incnlib"));
+    assert!(
+        matches!(&err, Err(LibraryManifestError::Invalid(msg)) if msg.contains("trait `Filterable`")),
+        "error should name the kind: {err:?}"
+    );
+    assert!(
+        matches!(&err, Err(LibraryManifestError::Invalid(msg)) if msg.contains("cannot be called")),
+        "unexpected error: {err:?}"
+    );
+    Ok(())
+}
+
+#[test]
 fn manifest_writer_rejects_duplicate_helper_binding_keys() -> Result<(), Box<dyn std::error::Error>> {
     let mut manifest = legacy_manifest_fixture("mylib", "0.1.0");
     manifest.exports.functions.push(FunctionExport {

--- a/src/library_manifest/validation.rs
+++ b/src/library_manifest/validation.rs
@@ -2401,9 +2401,53 @@ fn validate_helper_bindings(
                 binding.key, binding.exported_name
             )));
         }
+        if let Some(kind) = uncallable_export_kind(exports, binding.exported_name.as_str()) {
+            return Err(LibraryManifestError::Invalid(format!(
+                "vocab helper binding `{}` points to {} `{}`, which cannot be called; bind the helper to a function, \
+                 class, model, newtype, enum variant, or alias",
+                binding.key, kind, binding.exported_name
+            )));
+        }
     }
 
     Ok(())
+}
+
+/// Return the noun for an exported name that a helper cannot legally call, or `None` when it is callable.
+///
+/// A helper reference is spliced into call position by the desugarer, so binding one to a trait, constant, static, or
+/// bare enum type produces generated Rust that cannot compile. Rejecting it here fails the provider's own build
+/// rather than every consumer's, which is where the author can actually act on it. Callable kinds are checked first
+/// so a name that is both an enum and one of its variants is admitted as the variant.
+fn uncallable_export_kind(exports: &RawLibraryExports, name: &str) -> Option<&'static str> {
+    let callable = exports.functions.iter().any(|item| item.name == name)
+        || exports.classes.iter().any(|item| item.name == name)
+        || exports.models.iter().any(|item| item.name == name)
+        || exports.newtypes.iter().any(|item| item.name == name)
+        || exports.aliases.iter().any(|item| item.name == name)
+        || exports
+            .enums
+            .iter()
+            .any(|item| item.variants.iter().any(|variant| variant.name == name));
+    if callable {
+        return None;
+    }
+    if exports.enums.iter().any(|item| item.name == name) {
+        return Some("enum");
+    }
+    if exports.traits.iter().any(|item| item.name == name) {
+        return Some("trait");
+    }
+    if exports.type_aliases.iter().any(|item| item.name == name) {
+        return Some("type alias");
+    }
+    if exports.consts.iter().any(|item| item.name == name) {
+        return Some("const");
+    }
+    if exports.statics.iter().any(|item| item.name == name) {
+        return Some("static");
+    }
+    None
 }
 
 /// Collect the set of exportable names that helper bindings are allowed to target.

--- a/workspaces/docs-site/docs/contributing/how-to/authoring_vocab_crates.md
+++ b/workspaces/docs-site/docs/contributing/how-to/authoring_vocab_crates.md
@@ -317,11 +317,53 @@ let manifest = LibraryManifest {
 
 Then the desugarer can emit `IncanExpr::Helper("filter".to_string())`, and the compiler will inject a hidden `pub::` import for the matching library export before lowering the desugared code back into the host AST.
 
-`incan build --lib` validates these bindings structurally:
+`incan build --lib` validates these bindings before the `.incnlib` artifact is written:
 
 - each helper `key` must be unique within `helper_bindings`
 - each `exported_name` must point at a real public export from the library artifact
-- empty keys or export names are rejected before the `.incnlib` artifact is written
+- each `exported_name` must be something a call can name
+- empty keys or export names are rejected
+
+### What a helper may bind to
+
+A helper reference is spliced into **call position** in the desugared program, so the export it names has to be callable. These kinds are accepted:
+
+| Kind | Why it works |
+| --- | --- |
+| function | called directly |
+| class, model, newtype | called as a constructor |
+| enum variant | called as a constructor |
+| alias | resolved to whatever it reexports, then checked by that kind |
+
+Traits, bare enum types, type aliases, constants, and statics are rejected. They are real public exports, so they pass the unknown-symbol check, but a call cannot name them:
+
+```text
+vocab helper binding `filter` points to trait `Filterable`, which cannot be called;
+bind the helper to a function, class, model, newtype, enum variant, or alias
+```
+
+Catching this at your build rather than a consumer's is deliberate. Without it the mistake surfaces as generated Rust that will not compile, reported against code the consumer never wrote.
+
+### Binding a reexported name
+
+You may bind the spelling your library publishes rather than the one it declares. An alias is followed to its target and then checked as that target's kind, so this works:
+
+```rust
+// The library declares `filter_rows` and reexports it as `where_`.
+HelperBinding { key: "filter".to_string(), exported_name: "where_".to_string() }
+```
+
+Following the alias does not launder an ineligible target: an alias that resolves to a constant is still rejected, and the diagnostic names the resolved kind rather than the alias. A chain that cannot be resolved — because it is cyclic, or reaches something the artifact does not describe — is admitted rather than rejected, on the principle that incomplete information should not fail a build that may be correct.
+
+### Duplicate keys
+
+Two bindings for one key are an error, not a silent choice:
+
+```text
+vocab provider_manifest.helper_bindings contains duplicate key `filter`
+```
+
+Resolution rejects the same case with a message naming both exports, so a manifest that reaches a consumer without revalidation still fails loudly instead of resolving by declaration order.
 
 ## 6. Add descriptor-gated embedded fragments (RFC 081)
 


### PR DESCRIPTION
## Summary

A vocabulary helper reference is spliced into call position in the desugared program, but resolution only asked whether the name was exported *at all*. A provider could bind a helper to a trait or a constant, pass every check, and produce generated Rust that will not compile — reported against code the author never wrote.

Part of #1031. This is the eligibility and duplicate-key half of its scope.

## Type of change

- [x] Bug fix
- [x] New feature

## Area(s)

- [x] Compiler (frontend/backend/codegen)
- [x] Incan Language (syntax/semantics)

## Key details

- **User-facing behavior**: two new diagnostics for provider authors. Binding a helper to an uncallable export now names the kind found and the kinds accepted; binding one key twice now names both exports instead of silently picking one.
- **Internals**: `library_exports_contains_name` became `helper_export_kind`, returning a `HelperExportKind` rather than a boolean. Callable kinds are checked first so a name that is both an enum and one of its variants resolves to the usable one.
- **Risks**: low. No committed vocabulary companion binds helpers today — they appear only in tests — so eligibility cannot break a working consumer. The rejected kinds are ones that would have failed later in generated Rust.

## Testing / verification

- [x] Manual verification described below

Manual verification notes:

- Three focused tests: duplicate key rejected naming both exports, trait binding rejected naming the kind, and the pre-existing missing-export case still rejected.
- `cargo test --lib frontend::vocab_desugar_pass` — 8 passed, 0 failed.
- `make pre-commit-fast` green: fmt-check, rustdoc gate, version gate, agents-doc-sync, `cargo check`.

**One failure I want to name rather than leave for you to find.** `cargo test --lib vocab` reports `cli::commands::common::tests::compilation_session_parses_with_imported_library_vocab` as failing. That is the documented plain-`cargo test --lib` limitation, not this change — the error says it outright: *"requires the incan CLI executable ... CARGO_BIN_EXE_incan=unset"*. `cli::commands::*` tests need the suite harness (`make test`). Every test that can run in that mode passes.

## Notes for review

**Deliberately not fixed here: #1380.** Helper import aliases are not injective. `helper_import_alias` maps every non-alphanumeric character to `_`, so dependency `a-b` with export `c` and dependency `a` with export `b_c` both produce `__incan_vocab_helper_a_b_c` — two unrelated helpers imported under one alias, one silently shadowing the other.

I prototyped a fix (readable components plus a short stable digest of the exact pair), confirmed it works and keeps the helper-binding tests green, then reverted it. The alias is spliced into generated source, and assertions across `union_provider`, `boundarykit`, `helperkit`, `querykit` and `filterkit` pin the current spelling. Changing user-visible output deserves its own reviewed decision rather than riding along in a diagnostics change. #1380 carries the repro and both candidate fixes.

Remaining #1031 scope after this: facade/reexport resolution, source-spelling aliases, and build-time validation rejecting unresolved helper calls at package build.
