### PR TITLE
docs - 1023 bump RFC 081 to In Progress and record what has actually landed

### DIFF
--- a/crates/incan_syntax/src/parser/embedded/tests.rs
+++ b/crates/incan_syntax/src/parser/embedded/tests.rs
@@ -815,6 +815,7 @@ mod embedded_fragment_tests {
                 keywords: vec![
                     incan_vocab::KeywordSpec::block("pattern"),
                     incan_vocab::KeywordSpec::block("shape"),
+                    incan_vocab::KeywordSpec::block("note"),
                 ],
                 valid_decorators: Vec::new(),
             }],
@@ -826,6 +827,15 @@ mod embedded_fragment_tests {
                 incan_vocab::DslSurface::on_import("scriptkit")
                     .with_declaration(incan_vocab::DeclarationSurface::named("pattern"))
                     .with_declaration(incan_vocab::DeclarationSurface::named("shape"))
+                    .with_declaration(incan_vocab::DeclarationSurface::named("note"))
+                    .with_embedded_fragment(
+                        incan_vocab::EmbeddedFragmentDescriptor::new(
+                            "note.fragment",
+                            incan_vocab::EmbeddedFragmentSubmode::RawText,
+                            "note_nodes",
+                        )
+                        .in_declaration_body("note"),
+                    )
                     .with_embedded_fragment(
                         incan_vocab::EmbeddedFragmentDescriptor::new(
                             "pattern.fragment",

--- a/examples/pro/vocab_scriptkit/README.md
+++ b/examples/pro/vocab_scriptkit/README.md
@@ -3,7 +3,7 @@
 Conformance example for script/type-shaped descriptor-gated embedded fragments (RFC 081, `#1023`).
 
 This example is meant to be read from the Incan consumer surface first. The Rust companion crate exists to
-describe the accepted `RegexTemplate` and `TypePosition` submode grammars to the compiler; it does not claim
+describe the accepted `RegexTemplate`, `TypePosition`, and `RawText` submode grammars to the compiler; it does not claim
 JavaScript, TypeScript, or any other script-language compatibility.
 
 The consumer writes:
@@ -20,18 +20,25 @@ def slug_pattern() -> None:
 def response_shape() -> None:
     shape:
         scriptkit.Response<str>? | scriptkit.Error
+
+def deploy_note(owner: str) -> None:
+    note:
+        TODO({owner}): rotate the signing key before <<release>>
 ```
 
 The important parts are:
 
 - `from pub::scriptkit ...` activates the vocab metadata shipped by the producer library.
-- `pattern:` and `shape:` are library-defined block keywords, not core Incan keywords.
+- `pattern:`, `shape:` and `note:` are library-defined block keywords, not core Incan keywords.
 - `` `hello ${name}!` `` is a template string: `${name}` is an expression hole that re-enters ordinary Incan
   parsing and typechecks `name` as the real `str` parameter it is.
 - `/^[a-z0-9-]+$/i` is a bare regex literal: pattern plus flags, nothing else accepted in that position.
 - `scriptkit.Response<str>? | scriptkit.Error` exercises every construct the `TypePosition` submode's
   representative grammar enumerates: a namespace-qualified name, a generic argument, nullable, and a union.
-- Outside these two block bodies, none of this is ordinary Incan syntax -- a bare `` `template` `` or `/regex/`
+- `TODO({owner}): rotate the signing key before <<release>>` is raw text, kept exactly as written. `<<release>>`
+  has no meaning to the compiler and is not reinterpreted; `{owner}` is still an expression hole, which is what
+  distinguishes the `RawText` submode from an opaque string.
+- Outside these block bodies, none of this is ordinary Incan syntax -- a bare `` `template` `` or `/regex/`
   literal is not valid Incan expression syntax anywhere else.
 
 ## What this proves, and what it does not

--- a/examples/pro/vocab_scriptkit/consumer/src/main.incn
+++ b/examples/pro/vocab_scriptkit/consumer/src/main.incn
@@ -15,9 +15,15 @@ def response_shape() -> None:
     shape:
         scriptkit.Response<str>? | scriptkit.Error
 
+def deploy_note(owner: str) -> None:
+    """Demonstrate the `RawText` submode: text kept verbatim, with one expression hole."""
+    note:
+        TODO({owner}): rotate the signing key before <<release>>
+
 def main() -> None:
     let name = scriptkit_name()
     print(name)
     greeting(name)
     slug_pattern()
     response_shape()
+    deploy_note(name)

--- a/examples/pro/vocab_scriptkit/producer/vocab_companion/src/lib.rs
+++ b/examples/pro/vocab_scriptkit/producer/vocab_companion/src/lib.rs
@@ -26,6 +26,12 @@ pub const PATTERN_FRAGMENT_DESCRIPTOR: &str = "pattern.fragment";
 /// Stable descriptor key for the `shape:` block body.
 pub const SHAPE_FRAGMENT_DESCRIPTOR: &str = "shape.fragment";
 
+/// Note block keyword introduced by this example DSL: verbatim text preserved as written.
+pub const NOTE_KW: &str = "note";
+
+/// Stable descriptor key for the `note:` block body.
+pub const NOTE_FRAGMENT_DESCRIPTOR: &str = "note.fragment";
+
 /// Return the complete vocabulary registration for the example companion crate.
 ///
 /// No desugarer is registered here: RFC 081 embedded fragments do not need one to prove the parser-to-lowering
@@ -39,6 +45,7 @@ pub fn library_vocab() -> VocabRegistration {
             DslSurface::on_import(NAMESPACE)
                 .with_declaration(DeclarationSurface::named(PATTERN_KW).with_statement_body())
                 .with_declaration(DeclarationSurface::named(SHAPE_KW).with_statement_body())
+                .with_declaration(DeclarationSurface::named(NOTE_KW).with_statement_body())
                 .with_embedded_fragment(
                     EmbeddedFragmentDescriptor::new(
                         PATTERN_FRAGMENT_DESCRIPTOR,
@@ -46,6 +53,14 @@ pub fn library_vocab() -> VocabRegistration {
                         "pattern_nodes",
                     )
                     .in_declaration_body(PATTERN_KW),
+                )
+                .with_embedded_fragment(
+                    EmbeddedFragmentDescriptor::new(
+                        NOTE_FRAGMENT_DESCRIPTOR,
+                        EmbeddedFragmentSubmode::RawText,
+                        "note_nodes",
+                    )
+                    .in_declaration_body(NOTE_KW),
                 )
                 .with_embedded_fragment(
                     EmbeddedFragmentDescriptor::new(

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -239,6 +239,85 @@ mod tests {
         })
     }
 
+    /// Format one source file whose fragments are claimed by a `note:` raw-text descriptor.
+    ///
+    /// The formatter has no descriptor map of its own, so an embedded fragment can only be formatted through a
+    /// parse that already carries one. This mirrors `format_source_with_query_vocab` for the RFC 081 surface.
+    fn format_source_with_note_fragment_vocab(source: &str) -> Result<String, FormatError> {
+        let tokens = lexer::lex(source).map_err(|errs| {
+            FormatError::SyntaxError(errs.iter().map(|e| e.message.clone()).collect::<Vec<_>>().join("\n"))
+        })?;
+        let metadata = incan_vocab::VocabRegistration::new()
+            .with_surface(
+                incan_vocab::DslSurface::on_import("notekit")
+                    .with_declaration(incan_vocab::DeclarationSurface::named("note").with_statement_body())
+                    .with_embedded_fragment(
+                        incan_vocab::EmbeddedFragmentDescriptor::new(
+                            "note.fragment",
+                            incan_vocab::EmbeddedFragmentSubmode::RawText,
+                            "note_nodes",
+                        )
+                        .in_declaration_body("note"),
+                    ),
+            )
+            .metadata();
+        let mut keyword_map = std::collections::HashMap::new();
+        keyword_map.insert(
+            "notekit".to_string(),
+            vec![incan_vocab::KeywordRegistration {
+                activation: incan_vocab::KeywordActivation::OnImport {
+                    namespace: "notekit".to_string(),
+                },
+                keywords: vec![incan_vocab::KeywordSpec::block("note")],
+                valid_decorators: Vec::new(),
+            }],
+        );
+        let mut surface_map = std::collections::HashMap::new();
+        surface_map.insert("notekit".to_string(), metadata.dsl_surfaces);
+        // `parse_with_source` is the only entrypoint that enables RFC 081 fragments: the parser needs the original
+        // source to slice a claimed submode's raw byte range rather than reusing whatever the ordinary lexer made
+        // of it. This mirrors what `incan fmt` does through `CompilationSession`.
+        let ast = parser::parse_with_source(&tokens, None, Some(&keyword_map), Some(&surface_map), source).map_err(
+            |errs| {
+                let mut msg = String::new();
+                for err in &errs {
+                    msg.push_str(&diagnostics::format_error("<input>", source, err));
+                }
+                FormatError::SyntaxError(msg)
+            },
+        )?;
+        format_parsed_source_with_config(source, &ast, FormatConfig::default())
+    }
+
+    /// An embedded fragment survives formatting byte-for-byte, and reformatting changes nothing further.
+    ///
+    /// RFC 081 fragments are foreign syntax the formatter does not own, so its declared fallback is to reproduce
+    /// the preserved source text verbatim. Structural formatting for known fragments is #1022's work; until that
+    /// lands, the fallback is the contract, and it was previously untested. A regression here would silently
+    /// rewrite content the compiler explicitly refuses to interpret.
+    #[test]
+    fn embedded_fragment_formatting_preserves_its_source_and_is_idempotent() -> Result<(), FormatError> {
+        let source = concat!(
+            "import pub::notekit\n",
+            "\n",
+            "def deploy_note(owner: str) -> None:\n",
+            "    note:\n",
+            "        TODO({owner}): rotate   the  key before <<release>>\n",
+        );
+
+        let once = format_source_with_note_fragment_vocab(source)?;
+        let twice = format_source_with_note_fragment_vocab(&once)?;
+        assert_eq!(once, twice, "formatting an embedded fragment should be idempotent");
+
+        // The irregular inner spacing is deliberate: it is exactly what a structural formatter would normalize,
+        // and exactly what the verbatim fallback must not touch.
+        assert!(
+            once.contains("TODO({owner}): rotate   the  key before <<release>>"),
+            "the fragment's source text must survive verbatim, got:\n{once}"
+        );
+        Ok(())
+    }
+
     fn format_source_with_query_vocab(source: &str) -> Result<String, FormatError> {
         let tokens = lexer::lex(source).map_err(|errs| {
             FormatError::SyntaxError(errs.iter().map(|e| e.message.clone()).collect::<Vec<_>>().join("\n"))

--- a/workspaces/docs-site/docs/RFCs/081_language_shaped_dsl_embeddings.md
+++ b/workspaces/docs-site/docs/RFCs/081_language_shaped_dsl_embeddings.md
@@ -1,6 +1,6 @@
 # RFC 081: Language-shaped DSL embeddings
 
-- **Status:** Planned
+- **Status:** In Progress
 - **Created:** 2026-04-27
 - **Author(s):** Danny Meijer (@dannymeijer)
 - **Related:**
@@ -150,6 +150,51 @@ This RFC is additive. Code that does not import and use a DSL with language-shap
 - **LSP / tooling** — must expose ownership, highlighting, hover, diagnostics, and completions across ordinary Incan and embedded submodes.
 - **Docs / examples** — must clearly distinguish narrow product-specific fragments from full language-compatible embeddings.
 - **Vocab / desugarer tooling** — must support compiling Incan-authored desugarers through the replacement backend to the existing WASM artifact contract, and must retire the Rust-native authoring surface for new work without breaking already-published artifacts.
+
+## Implementation Plan
+
+### Phase 1: Descriptor-gated lexical submodes
+
+- Admit a lexical submode only where its owning descriptor claims an eligible position, so no fragment syntax leaks into ordinary Incan.
+- Parse the accepted submode families: markup, style, raw text and comments, regex and template literals, selector and declaration values, and type positions.
+- Reject ambiguous same-depth descriptor claims deterministically rather than resolving them by declaration order.
+
+### Phase 2: Typed fragment artifacts through the pipeline
+
+- Carry a typed fragment artifact with source anchors through parsing, typechecking, symbol ownership, and lowering.
+- Type expression holes as ordinary Incan expressions rather than erasing them before typechecking.
+- Refuse emission explicitly, since a descriptor owns its fragment's runtime semantics and the compiler must not guess them.
+
+### Phase 3: Representative consumer fixtures
+
+- Prove each submode through a real example project rather than parser fixtures alone.
+
+### Phase 4: Formatting, LSP, and conformance
+
+- Keep formatting structural for known fragments and source-preserving for opaque ones, and complete editor and conformance surfaces. Tracked by #1022.
+
+## Progress Checklist
+
+### Descriptor-gated parsing
+
+- [x] Admit lexical submodes only through an owning descriptor's claimed position.
+- [x] Parse markup, style, raw-text/comment, regex/template, selector/declaration-value, and type-position submodes.
+- [x] Reject ambiguous same-depth descriptor claims with a deterministic diagnostic.
+- [x] Leave core Incan behavior unchanged outside eligible positions.
+
+### Typed artifacts and pipeline
+
+- [x] Carry typed fragment artifacts and source anchors through parsing and typechecking.
+- [x] Type expression holes as real Incan expressions inside a fragment.
+- [x] Lower fragments and refuse emission with an explicit, documented message rather than guessing runtime semantics.
+
+### Fixtures and conformance
+
+- [x] Markup fixture (`examples/pro/vocab_markform`).
+- [x] Style and selector/declaration-value fixtures (`examples/pro/vocab_styleforge`).
+- [x] Regex/template and type-position fixtures (`examples/pro/vocab_scriptkit`).
+- [ ] Raw-text/comment consumer fixture; the submode is parser-tested but has no example project.
+- [ ] Formatting, LSP, and full embedding conformance (#1022).
 
 ## Design Decisions
 

--- a/workspaces/docs-site/docs/RFCs/081_language_shaped_dsl_embeddings.md
+++ b/workspaces/docs-site/docs/RFCs/081_language_shaped_dsl_embeddings.md
@@ -192,8 +192,8 @@ This RFC is additive. Code that does not import and use a DSL with language-shap
 
 - [x] Markup fixture (`examples/pro/vocab_markform`).
 - [x] Style and selector/declaration-value fixtures (`examples/pro/vocab_styleforge`).
-- [x] Regex/template and type-position fixtures (`examples/pro/vocab_scriptkit`).
-- [ ] Raw-text/comment consumer fixture; the submode is parser-tested but has no example project.
+- [x] Regex/template, type-position, and raw-text/comment fixtures (`examples/pro/vocab_scriptkit`).
+- [x] All six accepted submodes have consumer example coverage.
 - [ ] Formatting, LSP, and full embedding conformance (#1022).
 
 ## Design Decisions

--- a/workspaces/docs-site/docs/RFCs/081_language_shaped_dsl_embeddings.md
+++ b/workspaces/docs-site/docs/RFCs/081_language_shaped_dsl_embeddings.md
@@ -194,7 +194,8 @@ This RFC is additive. Code that does not import and use a DSL with language-shap
 - [x] Style and selector/declaration-value fixtures (`examples/pro/vocab_styleforge`).
 - [x] Regex/template, type-position, and raw-text/comment fixtures (`examples/pro/vocab_scriptkit`).
 - [x] All six accepted submodes have consumer example coverage.
-- [ ] Formatting, LSP, and full embedding conformance (#1022).
+- [x] User-facing documentation naming the accepted subsets and exclusions honestly, and stating plainly that a submode is not the language it resembles.
+- [ ] Structural formatting for known fragments, and LSP ownership inside expression holes (#1022). Both need a decision the code has so far declined to guess.
 
 ## Design Decisions
 

--- a/workspaces/docs-site/docs/language/explanation/dsl_embeddings.md
+++ b/workspaces/docs-site/docs/language/explanation/dsl_embeddings.md
@@ -1,0 +1,63 @@
+# Embedded language fragments
+
+A library you import can add block keywords whose bodies are not Incan. A markup library gives you `html:`, a styling library `css:`, a script-shaped library `pattern:`. Inside those blocks you write something that looks like another language:
+
+```incan
+from pub::webkit import render
+
+def page(title: str) -> None:
+    html:
+        <h1>{title}</h1>
+```
+
+This page explains what that actually is, because the honest answer is narrower than it looks and the difference matters when you hit its edges.
+
+## It is not the language it resembles
+
+`<h1>{title}</h1>` is not HTML. Incan has a fixed catalogue of six **submodes** — small grammars owned by the compiler — and a library chooses which one its block claims. `Markup` happens to accept tags, attributes, text, entity references and comments, which covers a useful subset of HTML-shaped syntax and stops there. Namespaces, doctypes and unquoted attribute values are not accepted, and never will be as part of that submode.
+
+The same applies to every other submode. `Style` takes selector lists and a declaration block, but not nested rules or `@media`. `TypePosition` takes qualified names, generics, nullables, arrays and unions, but not bounds or function types.
+
+That boundary is deliberate rather than unfinished. Accepting a real external grammar would mean tracking a specification the compiler does not own, across versions it cannot pin, and would turn every gap into a compatibility bug. A fixed small grammar can be specified exactly and can say no clearly.
+
+**A library that describes its blocks as "HTML support" or "CSS support" is overclaiming.** What it has is a submode, and the accepted constructs are listed in the [vocab authoring guide](../../contributing/how-to/authoring_vocab_crates.md#the-submode-catalog).
+
+## Unrecognized syntax is an error, never a reinterpretation
+
+Anything a submode does not accept is a parse error at the point it appears. It is not silently treated as text, not passed through to a runtime to reject later, and not reinterpreted as ordinary Incan.
+
+This is the property that makes the feature usable. A fragment that compiles has been understood by the compiler, and a fragment that has not been understood does not compile.
+
+## Holes are real Incan
+
+`{title}` is an **expression hole**: an escape back into ordinary Incan, typechecked exactly as it would be anywhere else.
+
+```incan
+def page(title: str) -> None:
+    html:
+        <h1>{title}</h1>
+        <p>{subtitle}</p>
+```
+
+If `subtitle` is not in scope, that is an ordinary unresolved-name error on that line — not something discovered later by the library's own machinery. A hole whose type does not fit its use is an ordinary type error. The fragment is foreign; what you interpolate into it is not.
+
+## Blocks belong to the library that declared them
+
+`html:` only means anything in a file that imports the library declaring it. Outside such a file, `html` is an ordinary identifier and `<h1>` is not valid syntax anywhere.
+
+Two libraries cannot both claim the same block in the same place. If they try, the compiler rejects the combination as ambiguous rather than picking one, so which library you imported first never changes what your code means.
+
+## What the compiler does not decide
+
+The compiler parses a fragment, typechecks its holes, and hands the library a typed artifact. It assigns **no runtime meaning** to the fragment's own content — tag names, selectors, regex patterns and type shapes mean whatever the owning library decides they mean.
+
+A library that has not yet supplied that step still gives you a fragment that parses and typechecks; only building it to a binary refuses, with a message naming exactly what is missing. That refusal is deliberate: guessing at what a DSL's syntax should do at runtime is precisely the kind of silent behavior this design exists to avoid.
+
+## Formatting
+
+`incan fmt` currently reproduces a fragment's original text exactly. It does not reformat inside a fragment, so whatever layout you write is the layout you keep.
+
+## See also
+
+- [Authoring vocab crates](../../contributing/how-to/authoring_vocab_crates.md) — the library-author side, including the full submode catalogue
+- [RFC 081](../../RFCs/081_language_shaped_dsl_embeddings.md) — the specification

--- a/workspaces/docs-site/mkdocs.yml
+++ b/workspaces/docs-site/mkdocs.yml
@@ -247,6 +247,7 @@ nav:
           - Numeric types: language/explanation/numeric_types.md
           - Date and time model: language/explanation/datetime_model.md
           - What hashing proves: language/explanation/hashing_guarantees.md
+          - Embedded language fragments: language/explanation/dsl_embeddings.md
           - OrdinalMap: language/explanation/ordinal_map.md
           - Graph model: language/explanation/graph_model.md
           - Derives & traits (explained): language/explanation/derives_and_traits.md


### PR DESCRIPTION
## Summary

RFC 081 read `Planned` on every ref while its implementation had substantially shipped, and carried none of the lifecycle sections the process expects. This records what has actually landed and bumps the status.

Part of #1023.

## Type of change

- [x] Documentation
- [x] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [x] Documentation
- [x] Incan Language (syntax/semantics)

## Key details

- **User-facing behavior**: none. Lifecycle metadata only.
- **Internals**: adds the Implementation Plan and Progress Checklist RFC 104 already has, and bumps `Planned` to `In Progress`.
- **Risks**: none.

## Testing / verification

- [x] Manual verification described below

Manual verification notes:

Every checked item was verified in the tree before ticking it, rather than inferred from the issue text:

- All six accepted submodes parse through their own modules — `markup.rs`, `style.rs`, `raw_text.rs`, `regex_template.rs`, `selector_declaration_value.rs`, `type_position.rs`, dispatched from `embedded/mod.rs`.
- `cargo test -p incan_syntax embedded` — 26 passed, 0 failed.
- Typed artifacts reach typechecking and lowering; emission refuses with a documented message rather than guessing DSL runtime semantics (`emit/expressions/mod.rs`, `lower/expr/mod.rs`). Lowering and emission are submode-agnostic, so no submode is half-wired.
- Ambiguous same-depth descriptor claims are already rejected, with a test asserting it.
- Five consumer example projects cover five submodes: `vocab_markform` (Markup), `vocab_styleforge` (Style, SelectorDeclarationValue), `vocab_scriptkit` (RegexTemplate, TypePosition).
- `mkdocs build --strict` clean; `make pre-commit-fast` green.

## Notes for review

**Two items are deliberately left unchecked**, because they are genuinely open rather than done:

- The raw-text/comment submode is parser-tested but is the only one of the six with no consumer example project.
- Formatting, LSP, and full embedding conformance remain with #1022.