### PR TITLE
bugfix - 1386 return a trailing match instead of discarding it

### DIFF
--- a/src/backend/ir/emit/decls/functions.rs
+++ b/src/backend/ir/emit/decls/functions.rs
@@ -670,7 +670,7 @@ impl<'a> IrEmitter<'a> {
             })
             .collect();
         *self.current_function_return_type.borrow_mut() = Some(func.return_type.clone());
-        let body_stmts = self.emit_stmts(&func.body)?;
+        let body_stmts = self.emit_function_body(&func.body, func.is_generator)?;
         *self.current_function_return_type.borrow_mut() = None;
 
         let async_kw = if func.is_async {
@@ -1067,7 +1067,7 @@ impl<'a> IrEmitter<'a> {
         let static_init_stmt = self.emit_module_static_init_call();
 
         *self.current_function_return_type.borrow_mut() = Some(func.return_type.clone());
-        let body_stmts = self.emit_stmts(&func.body)?;
+        let body_stmts = self.emit_function_body(&func.body, func.is_generator)?;
         *self.current_function_return_type.borrow_mut() = None;
         let lint_allows = self.emit_rust_lint_allows(&func.lint_allows);
         let rust_attrs = self.emit_rust_attributes(&func.rust_attributes);
@@ -1364,7 +1364,7 @@ impl<'a> IrEmitter<'a> {
             })
         } else {
             *self.current_function_return_type.borrow_mut() = Some(func.return_type.clone());
-            let body_stmts = self.emit_stmts(&func.body)?;
+            let body_stmts = self.emit_function_body(&func.body, func.is_generator)?;
             *self.current_function_return_type.borrow_mut() = None;
 
             let lint_allows = self.emit_rust_lint_allows(&func.lint_allows);

--- a/src/backend/ir/emit/expressions/mod.rs
+++ b/src/backend/ir/emit/expressions/mod.rs
@@ -1376,7 +1376,7 @@ impl<'a> IrEmitter<'a> {
                     .iter()
                     .map(|arm| {
                         let (pat, pattern_guard) = self.emit_pattern_for_scrutinee(&arm.pattern, &scrutinee.ty);
-                        let body = self.emit_match_arm_body(arm)?;
+                        let body = self.emit_match_arm_body(arm, Some(&expr.ty))?;
                         let guard = self.emit_match_arm_guard(arm, pattern_guard)?;
                         if let Some(guard) = guard {
                             Ok(quote! { #pat if #guard => #body })

--- a/src/backend/ir/emit/statements.rs
+++ b/src/backend/ir/emit/statements.rs
@@ -793,6 +793,54 @@ impl<'a> IrEmitter<'a> {
         self.emit_stmts_with_tail(stmts, &[], None)
     }
 
+    /// Emit a function body, treating a trailing value-producing expression statement as the return value.
+    ///
+    /// A statement-position `match` lowers to an expression statement, so a function whose last statement is a
+    /// value-producing `match` would otherwise emit `let _ = match ...;` and then fall off the end of the block.
+    /// Rust rejects that whenever the function declares a non-unit return type, so rewriting the trailing statement
+    /// into a `return` only reshapes output the Rust compiler would have refused anyway (#1386).
+    ///
+    /// Generators are excluded: their declared `Iterator[T]` return type describes what the generator yields, not a
+    /// value the body itself hands back.
+    pub(super) fn emit_function_body(
+        &self,
+        stmts: &[IrStmt],
+        is_generator: bool,
+    ) -> Result<Vec<TokenStream>, EmitError> {
+        if is_generator || !self.trailing_stmt_is_return_value(stmts) {
+            return self.emit_stmts(stmts);
+        }
+
+        let mut rewritten = stmts.to_vec();
+        if let Some(last) = rewritten.last_mut()
+            && let IrStmtKind::Expr(expr) = &last.kind
+        {
+            let value = expr.clone();
+            last.kind = IrStmtKind::Return(Some(value));
+        }
+        self.emit_stmts(&rewritten)
+    }
+
+    /// Check whether a function body's last statement carries the value the function has to return.
+    ///
+    /// The value-less block shape is excluded because lowering uses it to splice tuple-unpack and chained-assignment
+    /// bindings into the enclosing scope rather than to produce a value.
+    fn trailing_stmt_is_return_value(&self, stmts: &[IrStmt]) -> bool {
+        let Some(last) = stmts.last() else {
+            return false;
+        };
+        let IrStmtKind::Expr(expr) = &last.kind else {
+            return false;
+        };
+        if matches!(expr.kind, IrExprKind::Block { value: None, .. }) || matches!(expr.ty, IrType::Unit) {
+            return false;
+        }
+        self.current_function_return_type
+            .borrow()
+            .as_ref()
+            .is_some_and(|return_type| !matches!(return_type, IrType::Unit))
+    }
+
     /// Emit statements that precede a final expression in the same Rust block.
     pub(super) fn emit_stmts_before_expr(
         &self,
@@ -862,6 +910,33 @@ impl<'a> IrEmitter<'a> {
             quote! { incan_stdlib::storage::StaticBinding::from_value((#emitted).into()) }
         };
         Ok(quote! { #n = #v; })
+    }
+
+    /// Emit a value that has to satisfy a known target type, applying that site's ownership plan.
+    ///
+    /// `emit_assignment_value` already routes bare `Call`/`MethodCall` values through `emit_expr_for_use`, which
+    /// applies the ownership plan itself; re-applying it here would double-convert (e.g. `.clone().clone()`). Every
+    /// other expression shape still needs this application, because `emit_assignment_value`'s remaining exit paths
+    /// (its plain `emit_expr` fallback, and wrapped shapes like `Cast`/`InteropCoerce`) do not plan at this site.
+    ///
+    /// This is what turns a bare `str` literal into an owned `String` when the target asks for one, so every context
+    /// that hands a value to a typed slot goes through it: a `let`, or a `match` arm feeding the match's own result.
+    pub(super) fn emit_value_for_target(
+        &self,
+        value: &TypedExpr,
+        target_ty: &IrType,
+    ) -> Result<TokenStream, EmitError> {
+        let emitted = self.emit_assignment_value(value, Some(target_ty))?;
+        if matches!(value.kind, IrExprKind::Call { .. } | IrExprKind::MethodCall { .. }) {
+            return Ok(emitted);
+        }
+        Ok(plan_value_use(
+            value,
+            ValueUseSite::Assignment {
+                target_ty: Some(target_ty),
+            },
+        )
+        .apply(emitted))
     }
 
     /// Emit an assignment RHS, seeding `Result` constructors from the assignment type when possible.
@@ -1077,23 +1152,7 @@ impl<'a> IrEmitter<'a> {
                 };
                 let n = Self::rust_ident(&emitted_name);
                 let value_target_ty = type_annotation.as_ref().unwrap_or(ty);
-                let v = self.emit_assignment_value(value, Some(value_target_ty))?;
-                // `emit_assignment_value` already routes bare `Call`/`MethodCall` values through
-                // `emit_expr_for_use`, which now applies the ownership plan itself; re-applying it here would
-                // double-convert (e.g. `.clone().clone()`). Every other expression shape still needs this
-                // statement-level application, since `emit_assignment_value`'s other exit paths (its plain
-                // `emit_expr` fallback, and wrapped shapes like `Cast`/`InteropCoerce`) do not plan at this site.
-                let converted_v = if matches!(value.kind, IrExprKind::Call { .. } | IrExprKind::MethodCall { .. }) {
-                    v
-                } else {
-                    plan_value_use(
-                        value,
-                        ValueUseSite::Assignment {
-                            target_ty: Some(value_target_ty),
-                        },
-                    )
-                    .apply(v)
-                };
+                let converted_v = self.emit_value_for_target(value, value_target_ty)?;
                 let annotation = type_annotation
                     .as_ref()
                     .and_then(|annotated_ty| self.emit_local_let_annotation(annotated_ty));
@@ -1352,7 +1411,7 @@ impl<'a> IrEmitter<'a> {
                     .map(|arm| {
                         let pattern = erase_unused_pattern_bindings(&arm.pattern, arm);
                         let (pat, pattern_guard) = self.emit_pattern_for_scrutinee(&pattern, &scrutinee.ty);
-                        let body = self.emit_match_arm_body(arm)?;
+                        let body = self.emit_match_arm_body(arm, None)?;
                         let guard = self.emit_match_arm_guard(arm, pattern_guard)?;
                         if let Some(guard) = guard {
                             Ok(quote! { #pat if #guard => #body })

--- a/src/backend/ir/emit/types.rs
+++ b/src/backend/ir/emit/types.rs
@@ -570,8 +570,20 @@ impl<'a> IrEmitter<'a> {
     }
 
     /// Emit a match arm body, including compiler-introduced bindings required by narrowed pattern lowering.
-    pub(super) fn emit_match_arm_body(&self, arm: &MatchArm) -> Result<TokenStream, EmitError> {
-        let body = self.emit_expr(&arm.body)?;
+    ///
+    /// `result_ty` is the type the whole `match` produces, when the arms are producing a value rather than running
+    /// for effect. Every arm has to hand back that one type, so the arm body is emitted through the same conversion
+    /// path a `let` of that type would use; without it a `str` arm stays a `&str` literal and the `match` cannot
+    /// satisfy a `String` binding or return type.
+    pub(super) fn emit_match_arm_body(
+        &self,
+        arm: &MatchArm,
+        result_ty: Option<&IrType>,
+    ) -> Result<TokenStream, EmitError> {
+        let body = match result_ty {
+            Some(ty) => self.emit_value_for_target(&arm.body, ty)?,
+            None => self.emit_expr(&arm.body)?,
+        };
         if arm.bindings.is_empty() {
             return Ok(body);
         }

--- a/tests/codegen_snapshot_tests.rs
+++ b/tests/codegen_snapshot_tests.rs
@@ -4375,6 +4375,54 @@ fn test_value_enums_codegen() {
 }
 
 // ============================================================================
+// Statement-position `match` as a function's returned value (#1386)
+// ============================================================================
+
+#[test]
+fn test_trailing_match_statement_is_returned_not_discarded() {
+    // A statement-position `match` is the documented spelling for pattern alternation, so a function whose last
+    // statement is one has to hand that value back. Discarding it into `let _ = match ...;` leaves the function
+    // falling off the end of its block, which Rust rejects for any non-unit return type (#1386).
+    let source = "def pick(n: int) -> str:\n    match n:\n        1 => \"one\"\n        _ => \"other\"\n\ndef main() -> None:\n    println(pick(1))\n";
+    let rust_code = generate_rust(source);
+
+    assert!(
+        !rust_code.contains("let _ = match"),
+        "Trailing match should carry the return value, not be discarded:\n{rust_code}"
+    );
+    assert!(
+        rust_code.contains("return match"),
+        "Trailing match should be emitted as the returned value:\n{rust_code}"
+    );
+}
+
+#[test]
+fn test_match_arms_convert_to_the_match_result_type() {
+    // Every arm has to produce the one type the `match` yields, so a `str` arm needs the same owned-`String`
+    // conversion a `let` of that type would apply. Without it the arms stay `&str` and no `String` slot accepts them.
+    let source = "def pick(n: int) -> str:\n    label = match n:\n        1 => \"one\"\n        _ => \"other\"\n    return label\n\ndef main() -> None:\n    println(pick(1))\n";
+    let rust_code = generate_rust(source);
+
+    assert!(
+        rust_code.contains("\"one\".to_string()"),
+        "Match arms should convert to the match's own result type:\n{rust_code}"
+    );
+}
+
+#[test]
+fn test_trailing_match_statement_in_unit_function_stays_a_statement() {
+    // A `match` run purely for effect has no value to hand back, so a `-> None` function must keep emitting it as a
+    // plain statement instead of turning it into a `return`.
+    let source = "def report(n: int) -> None:\n    match n:\n        1 => println(\"one\")\n        _ => println(\"other\")\n\ndef main() -> None:\n    report(1)\n";
+    let rust_code = generate_rust(source);
+
+    assert!(
+        !rust_code.contains("return match"),
+        "Effectful match in a unit function should stay a statement:\n{rust_code}"
+    );
+}
+
+// ============================================================================
 // Additional migration tests
 // ============================================================================
 

--- a/workspaces/docs-site/docs/release_notes/0_6.md
+++ b/workspaces/docs-site/docs/release_notes/0_6.md
@@ -95,6 +95,7 @@ The CLI, LSP, Architect, MCP tools, and Rust/Oven views will consume the same so
 - **Compiler**: Unreachable code after an unconditional return is reported. (#1117, #1134)
 - **Compiler**: A package that calls between its own modules again projects the callee's emitted name. A package origin identifies which library declares a method; it does not make that method foreign to the build producing it, and reading it as foreign made a package decline to name a wrapper it was itself emitting. (#1174)
 - **Compiler**: A `Result`-returning `main` retains ordinary runtime panic diagnostics and requested `import this` output, matching the existing setup in other entrypoint forms. (#1249)
+- **Language**: A `match` written as a function's last statement now returns its value instead of being discarded, and every arm converts to the type the `match` produces. The documented spelling for pattern alternation previously emitted `let _ = match ...;`, so a value-returning function built from it produced Rust that would not compile, and `str` arms stayed borrowed where an owned `String` was required. (#1386)
 
 ## What this does not claim
 


### PR DESCRIPTION
## Summary

Fixes #1386. A `match` written as a function's last statement was emitted as `let _ = match ...;`, so the value was discarded and the function fell off the end of its block. For any non-unit return type that is Rust the compiler rejects, which meant the documented spelling for pattern alternation produced a program that never built.

Fixing that exposed a second defect on the same path: match arms were emitted with no target type, so a `str` arm stayed a borrowed literal that no `String` slot would accept. That one reproduces without the first fix, through a plain `let` and `return`, so it is fixed here too.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [x] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

**User-facing behavior.** This now compiles and runs:

```incan
def pick(n: int) -> str:
    match n:
        1 => "one"
        _ => "other"
```

Before, it emitted `let _ = match n { 1 => "one", ... };` and failed with two `E0308`s. The only workaround was a `return` in every arm, which makes the source stop matching the documented catalogue form.

**Internals.** Two changes, both in emission:

- `emit_function_body` replaces the three `emit_stmts(&func.body)` body-assembly sites in `decls/functions.rs`. When the last statement is a value-producing expression statement and the function declares a non-unit return type, it is emitted as `Return(Some(expr))` instead of a discarded expression. Reusing the existing `Return` statement kind means the arm inherits the return-site conversion and divergence handling already there, and the local-usage and mutability analyses already treat `Expr(e)` and `Return(Some(e))` identically.
- `emit_match_arm_body` now takes the type the `match` produces and emits each arm through it. The conversion the `Let` arm was doing inline is extracted as `emit_value_for_target`, so a `let` and a match arm feeding the match's own result share one path rather than two copies.

**Risks.** The trailing-statement rewrite is confined to output Rust would already have rejected: a non-unit function whose final emitted statement is a discarded expression cannot type-check either way, so no currently-building program can reach it. Generators are excluded, since their declared `Iterator[T]` describes what they yield rather than a value the body hands back; a unit-returning function keeps emitting an effectful `match` as a plain statement.

The arm-conversion change has the wider reach — it touches every match expression — which is why the snapshot evidence below matters: 261 codegen snapshots pass with zero churn, so no previously working output moved.

## Testing / verification

- [x] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `cargo test --test codegen_snapshot_tests` — 261 passed, 0 failed, **no snapshot churn**. Three new tests cover the returned trailing match, the arm conversion, and the unit-function case that must stay a statement.
- `cargo test --lib` — 3248 passed, 28 failed, 5 ignored. All 28 failures are environmental and unrelated: 25 need `CARGO_BIN_EXE` (unset outside the full harness), 2 hit the local Oven's unlinked `incan_derive`, and 1 is a transient missing working directory. No assertion or codegen-shaped failure.
- `make pre-commit-fast` and `make lint` clean.
- Baked and ran each shape end to end through `incan run` — `str`, `int`, `enum`, `bool`, and a match bound through a `let` — and confirmed the generated Rust is `return match n { 1 => "one".to_string(), ... };`.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

Release notes entry added under Bugfixes in `workspaces/docs-site/docs/release_notes/0_6.md`.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions
