### PR TITLE
chore - let agents drive a goal to completion without halting

### DIFF
--- a/.agents/skills/start-work/SKILL.md
+++ b/.agents/skills/start-work/SKILL.md
@@ -18,17 +18,17 @@ If none is provided, ask the user what they want to work on.
 
 ---
 
-## Git commits — maintainer only
+## Git commits
 
-**Do not commit unless the user explicitly asks you to** (e.g. “commit this”, “make a commit”, “git commit with message …”). The maintainer is the only person who commits code to this repository by default.
+**Commit your own work.** Use the repo's message convention (`chore|bugfix|feature - <issue_id(s)> <description>`), push the branch, and open the PR when the work is ready. Do not leave finished work uncommitted waiting for the maintainer.
 
-Agents must **not** run, on their own initiative:
+Still off-limits on your own initiative:
 
-- `git commit` (any variant)
-- `git merge` / `git rebase` / `git cherry-pick` when the result would create or rewrite commits the user did not ask for
-- `git push` (unless the user explicitly asked to push)
+- anything that overwrites or deletes uncommitted work — `git checkout -- <path>`, `git restore <path>`, `git clean`, `git reset --hard`, `stash drop`
+- force-pushing a shared branch, or any branch whose PR has already merged
+- `git rebase` of a branch that is already pushed — sync it with a merge commit instead, so ancestry survives and no force-push is needed
 
-**Do** create branches, apply edits, run tests, and leave the working tree ready for the user to review and commit. If finishing a task, summarize what changed and suggest a commit message **as text**; the user runs `git commit` when they are ready.
+Two habits keep pushing safe. Re-check a PR's state immediately before pushing to its branch: a squash-merge silently strands anything pushed afterwards. And prove work reached the integration branch by content (`git show origin/<dev-line>:<file> | grep <symbol>`), never by PR status — a stacked PR reports `MERGED` once its own base absorbs it, which says nothing about the dev line.
 
 This policy applies whenever this skill is used (and is the default for Incan work even without `/start-work`).
 
@@ -179,5 +179,5 @@ Provide a concise summary:
 ## Edge cases
 
 - **No GitHub CLI (`gh`)**: Fall back to reading the RFC file directly. Note that the issue could not be fetched and ask the user for context.
-- **Dirty working tree**: Warn the user about uncommitted changes before switching branches. Ask whether to stash, commit themselves, or abort — do not commit on their behalf unless they explicitly asked you to commit.
+- **Dirty working tree**: uncommitted changes you did not make belong to the maintainer. Report them before switching branches and let them decide; never discard or revert them.
 - **Branch already exists with divergent history**: Always ask before overwriting.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,11 +8,17 @@ Incan is a Python-like language that compiles to Rust. The compiler itself is wr
 > Use `?` with `Result`-returning test functions, or propagate errors explicitly.
 > See [Error handling in tests](#error-handling-in-tests) for the correct pattern.
 
-> **CRITICAL — THE USER DECIDES WHAT IS RELEVANT.** Scope, PR boundaries, and which files “belong” on a branch are **the maintainer’s call**, not the agent’s. Never label work as “unrelated PR noise,” “cleanup,” or “hygiene” as a reason to remove or revert it. Always check with the user when in doubt.
+> **CRITICAL — DRIVE THE GOAL TO COMPLETION.** When the maintainer sets a goal, pursue it autonomously until it is delivered or provably impossible. Commit, push, and open PRs on your own initiative. Do not stop to report progress, seek reassurance, or hand back a decision the evidence already settles. If one part turns out to be impossible, finish every other part first, then state the blocking mechanism in a sentence or two — not a status essay.
 >
-> **FORBIDDEN without explicit user approval that quotes the exact paths or commands:** anything that overwrites or deletes uncommitted work — including `git checkout -- <path>`, `git restore <path>`, `git clean`, `git reset --hard`, `stash drop`, or equivalent. If you believe files should be split, reverted, or left out of a PR, **state that and ask**; do not run destructive git operations on your own initiative.
+> **A blocker is a claim that needs proof.** Read the owning issue’s own scope and “Done when” list bullet by bullet before calling anything blocked: one gated bullet does not gate the issue. Quote the exact spec text that is silent or contradictory. If you cannot quote it, keep working. Check that what you assume is missing is actually missing — grep for the type or function before declaring it unbuilt.
 >
-> **Commits and pushes:** The maintainer commits code unless they **explicitly** ask you to run `git commit` or `git push`. Implement and test in the working tree; offer a suggested commit message as text. The `/start-work` skill states the same rule.
+> **Do not manufacture decisions.** Ask only when the answer changes what you do next *and* the evidence genuinely does not settle it. Sizing your own PRs, reclaiming regenerable build caches, choosing between equivalent spellings, and ordinary cleanup are not the maintainer’s call. When a message asks *why* you did something, answer the question — do not start changing it.
+>
+> **CRITICAL — THE USER DECIDES WHAT IS RELEVANT.** Scope, PR boundaries, and which files “belong” on a branch are **the maintainer’s call**, not the agent’s. Never label work as “unrelated PR noise,” “cleanup,” or “hygiene” as a reason to remove or revert it.
+>
+> **FORBIDDEN without explicit user approval that quotes the exact paths or commands:** anything that overwrites or deletes uncommitted work — including `git checkout -- <path>`, `git restore <path>`, `git clean`, `git reset --hard`, `stash drop`, or equivalent — and force-pushing a shared branch or one whose PR has already merged. If you believe files should be split, reverted, or left out of a PR, **state that and ask**; do not run destructive git operations on your own initiative.
+>
+> **Commits and pushes are yours.** Commit your own work using the repo’s message convention, push the branch, and open the PR when it is ready. Two rules keep that safe: re-check a PR’s state immediately before pushing to its branch, because a squash-merge silently strands any later push; and prove work reached the integration branch by content (`git show origin/<dev-line>:<file> | grep <symbol>`), never by PR status alone. Sync a pushed branch with a merge commit rather than a rebase, so ancestry survives and no force-push is needed.
 
 ## Key References
 
@@ -40,12 +46,14 @@ Skills (`.agents/skills/`) and learnings (`.agents/learnings.md`) live under **t
 
 For every implementation issue in the `0.6 Release` milestone, [#1074](https://github.com/encero-systems/incan/issues/1074) is the central execution ledger. The RFC and owning issue remain the semantic authority; the ledger records delivery state, dependencies, and evidence across the programme.
 
-- Before the first production edit, post a structured `Active` update on #1074 that identifies the issue, branch or PR when one exists, intended scope, dependencies, and initial verification plan.
+- Post a structured `Active` update on #1074 once the work has a branch or PR, identifying the issue, intended scope, dependencies, and verification plan. Posting it is not a gate on starting: begin the work, then record it.
 - Post another update when the work is blocked, ready for integration, materially rescaled, or completed. Do not call v0.6 work ready to merge or complete without its ledger evidence.
 - Use the update format published on #1074. Updates are append-only comments so concurrent contributors do not overwrite each other; do not edit another contributor's update.
 - Keep public updates reproducible and repository-scoped: no local absolute paths, private environment details, or claims that unrun verification passed.
 
-This requirement applies to contributors and automated implementation workflows alike. If the current task does not authorize a GitHub write, prepare the exact update text and ask the maintainer to publish it before proceeding.
+This requirement applies to contributors and automated implementation workflows alike. If the current task does not authorize a GitHub write, put the update text in the PR description and carry on — do not pause the work waiting to publish it.
+
+Keep updates to the evidence: what changed, what proves it, what is left, and the mechanism blocking anything that is. Do not narrate process.
 
 ## General Workflow
 


### PR DESCRIPTION
## Summary

Removes the commit-permission contradiction in the agent instruction set, and rewrites the surrounding rules so an agent given a goal pursues it to completion instead of stopping to report.

AGENTS.md and `/start-work` both stated that the maintainer is the only one who commits, while the standing working agreement is that the agent commits its own work. An agent reading the repo found a rule telling it to halt at exactly the point it should carry on.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Releases

- **Commits, pushes, and PRs are the agent's.** `/start-work`'s "maintainer only" section is replaced accordingly. `.claude/skills` is a symlink to `.agents/skills`, so one edit covers both.
- **Drive the goal to completion.** Reporting a blocker mid-goal is not a deliverable. Finish everything else first, then state the mechanism in a sentence or two.
- **A blocker is a claim that needs proof.** Read the owning issue's own scope and *Done when* list bullet by bullet — one gated bullet does not gate the issue — and grep for a type before declaring it unbuilt.
- **Do not manufacture decisions.** PR sizing, regenerable build caches, and ordinary cleanup are not maintainer calls. A question asking *why* wants an answer, not a change.
- **The v0.6 ledger no longer gates the first production edit.** Recording delivery state is still required; blocking work on writing prose about it is not. Updates are also asked to stay on evidence rather than narrate process.

## Clamps kept, and one added

Everything protecting uncommitted maintainer work is unchanged: no `git checkout -- <path>`, `git restore`, `git clean`, `git reset --hard`, or `stash drop` without explicit approval quoting the paths, and no relabelling work as "noise" to justify removing it.

**Added:** force-pushing a shared branch, or one whose PR has already merged, joins that list; and a pushed branch is synced with a merge commit rather than a rebase, so ancestry survives and no force-push is needed.

Two push habits are recorded because they caused real loss:

- Re-check a PR's state immediately before pushing to its branch — a squash-merge silently strands anything pushed afterwards.
- Prove work reached the integration branch by content (`git show origin/<dev-line>:<file> | grep <symbol>`), never by PR status. A stacked PR reports `MERGED` once its own base absorbs it, which says nothing about the dev line.

## Testing / verification

- [x] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

- `make pre-commit-fast` clean, including `agents-doc-sync` (the skills table still matches `.agents/skills/`).
- `grep` across `AGENTS.md`, `CLAUDE.md`, `.agents/`, and `.claude/` finds no remaining "maintainer commits" / "maintainer is the only person" wording.

Docs-only; no code paths touched.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions
