### PR TITLE
chore - complete the Windows prerequisites and correct the long-path claim (#1397)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ Thank you for your interest in contributing to the Incan programming language! T
 
 ### Developing on native Windows
 
-Native Windows x64 works. It needs three host tools that Linux and macOS supply by default, and one habit about where you clone.
+Native Windows x64 works. It needs a handful of host tools that Linux and macOS supply by default, and one habit about where you clone.
 
 Run `make` targets from **Git Bash**, not PowerShell or `cmd`. Git for Windows supplies the POSIX tools the Makefile relies on — `sh`, `sed`, `awk`, `grep`, `date` — and GNU Make discovers Git's `sh.exe` automatically, so no extra configuration is required.
 
@@ -58,7 +58,34 @@ winget install Python.Python.3.13
 
 The Makefile resolves the interpreter through `$(PYTHON)`, which defaults to `python` on Windows. This is deliberate: `python3` is not a real command there, and on a default install that name resolves to a Microsoft Store alias stub that prints an advert and exits without running anything. Override with `make PYTHON=<interpreter> <target>` if your host needs a different name.
 
-Finally, **clone to a short path** such as `C:\dev\incan`. Windows limits paths to 260 characters. The `LongPathsEnabled` registry setting lifts that limit only for programs that declare themselves long-path aware, and neither `link.exe` nor libgit2 does, so a deeply nested clone fails at link time with `LNK1104` on a file whose path is simply too long. Pointing `CARGO_TARGET_DIR` at a short directory is an equally good fix, because the paths that overrun are the build outputs rather than the sources.
+**jq** is required by the roadmap tooling under `workspaces/docs-site/scripts/v0_6_roadmap/`; neither
+`refresh_github.sh` nor `render_roadmap.sh` runs without it.
+
+```powershell
+winget install jqlang.jq
+```
+
+**Node.js** is required by `make docs-build`, which runs `scripts/check_incan_mermaid_runtime.mjs`. Its installer
+requests elevation, so it cannot be installed unattended the way the others can.
+
+```powershell
+winget install OpenJS.NodeJS.LTS
+```
+
+**The docs Python requirements** are separate from the interpreter itself. Without them `make docs-build` stops at
+`ModuleNotFoundError: No module named 'mkdocs_gen_files'`.
+
+```powershell
+python -m pip install -r workspaces/docs-site/requirements-docs.txt
+```
+
+Finally, **clone to a short path** such as `C:\dev\incan`. Windows limits paths to 260 characters, and a nested Cargo build tree spends most of that budget before your sources are reached. Pointing `CARGO_TARGET_DIR` at a short directory is an equally good fix, because the paths that overrun are the build outputs rather than the sources.
+
+The tools disagree about where the limit actually falls, which makes their errors hard to read:
+
+- `link.exe` opens ordinary drive paths well past 260 characters when `LongPathsEnabled` is set — measured at 285. What it cannot do is canonicalize an *extended-length* path (one prefixed `\\?\`) beyond the limit: it derives an empty filename and reports the default extension, so the failure reads `LNK1181: cannot open input file '.obj'` and names neither the file nor the prefix responsible.
+- `ml64.exe` (MASM) is stricter than `MAX_PATH`. It accepts a 255-character output path and rejects 258, reporting `A1009: line too long`, which says nothing about paths at all.
+- libgit2 is not long-path aware, so a deeply nested clone can fail before any of the above matters.
 
 Line endings need no configuration: the repository's `.gitattributes` normalizes every text file to LF, which matters because the snapshot fixtures compare compiler output byte for byte.
 


### PR DESCRIPTION
## Summary

Closes #1397.

Two corrections to `CONTRIBUTING.md`'s "Developing on native Windows", both found by following the section on a clean Windows host after #1345 merged.

### Three unlisted prerequisites

`jq` (the roadmap tooling under `workspaces/docs-site/scripts/v0_6_roadmap/` will not run without it), Node.js (`make docs-build` shells out to `check_incan_mermaid_runtime.mjs`), and `workspaces/docs-site/requirements-docs.txt` (without which `make docs-build` stops at `ModuleNotFoundError: No module named 'mkdocs_gen_files'`).

Each of these currently surfaces as a missing command or module, not as a missing prerequisite. The Node entry notes that its installer requests elevation, since that stops an unattended setup script dead.

### A claim that was wrong

The section asserted that `LongPathsEnabled` helps only long-path-aware programs and that `link.exe` is not one. #1362 measured otherwise: with the setting on, `link.exe` opened a **285-character** ordinary drive path. What it cannot do is canonicalize an *extended-length* (`\?\`) path past the limit — there it derives an empty filename and reports the default extension, so the error reads `LNK1181: cannot open input file '.obj'` and names neither the file nor the prefix responsible.

The advice to clone shallowly is unchanged and still right. The reason given for it was pointing readers away from the actual failure mode.

Since the three tools disagree about where the limit falls, each is now stated with the error it actually produces — including MASM's 255-character ceiling from #1364, which reports `A1009: line too long` and mentions no path at all.

## Type of change

- [x] Documentation

## Area(s)

- [x] Documentation

## Key details

- **User-facing behavior**: none; contributor documentation only.
- **Risks**: none to code. The measured figures come from #1362 and #1364 and are quoted with the errors they produce, so a reader hitting one can match it to the text.

Scoped deliberately narrow: this is the contributor-setup half only. The full user-facing documentation pass remains #1353.

## Testing / verification

- [x] `make pre-commit-fast` — passes
- [x] Manual verification described below

Manual verification notes:

- Every prerequisite listed was actually installed on this host during the slice, in the order the section now gives; `jq` and the docs requirements install unattended, Node does not.
- The `link.exe` and `ml64.exe` figures are the measurements recorded in #1362 and #1364, not estimates.

Targets `0.6.0-dev.windows`, since the Windows section only exists there — `main` has no such section yet.
