### PR TITLE
chore - settle loaf.toml and oven.lock as lowercase filenames (#1008)

### DIFF
--- a/workspaces/docs-site/docs/RFCs/034_incan_pub_registry.md
+++ b/workspaces/docs-site/docs/RFCs/034_incan_pub_registry.md
@@ -342,7 +342,7 @@ Resolution:
 
 The resolver must not wire downloaded generated Rust source into generated `Cargo.toml` as the package compatibility path. Rust-facing consumption should go through the ABI/Cargo-native package direction rather than treating generated Rust internals as public API.
 
-**Lockfile (`Oven.lock`):** on first resolution, write resolved versions, canonical registry identity, integrity facts, and checksums to `Oven.lock`. Subsequent bakes use the lockfile for reproducibility. `oven update` re-resolves.
+**Lockfile (`oven.lock`):** on first resolution, write resolved versions, canonical registry identity, integrity facts, and checksums to `oven.lock`. Subsequent bakes use the lockfile for reproducibility. `oven update` re-resolves.
 
 ### CLI commands
 
@@ -351,7 +351,7 @@ The resolver must not wire downloaded generated Rust source into generated `Carg
 | `oven add <pkg>`              | Add a Loaf dependency to `loaf.toml` (fetch latest version from `incan.pub`)      |
 | `oven add --crate <pkg>`      | Add a crate dependency to `loaf.toml` (fetch from crates.io by default)           |
 | `oven remove <pkg>`           | Remove a typed dependency from `loaf.toml`                                        |
-| `oven update`                 | Re-resolve the selected closure and update `Oven.lock`                            |
+| `oven update`                 | Re-resolve the selected closure and update `oven.lock`                            |
 | `oven login`                  | Authenticate with `incan.pub`, save credentials in Oven-controlled secure storage |
 | `oven publish`                | Bake the selected Loaf, package `.incanpkg`, sign, and upload it                  |
 | `oven yank <pkg> <ver>`       | Mark a version as yanked (still downloadable but skipped in new resolves)         |
@@ -392,7 +392,7 @@ $ oven add widgets --git https://github.com/example/widgets --tag v0.2.0
 3. Default to `^major.minor.patch` range (SemVer-compatible, like Cargo)
 4. Write the typed entry to `[dependencies]`
 5. If the package is already in `loaf.toml`, update the version (with a confirmation prompt unless `--force`)
-6. Update `Oven.lock` with the resolved closure
+6. Update `oven.lock` with the resolved closure
 
 `oven remove` does the inverse: removes the entry from `loaf.toml` and re-locks.
 
@@ -541,7 +541,7 @@ German provider, good pricing. However: no scale-to-zero compute (minimum €4.5
 
 ## Future extensions (out of scope)
 
-- **Private registries.** Organizations may register an `incan.pub`-compatible registry in Oven-controlled organization or user configuration, then allow-list that registered identity from a Loaf or workspace. Credentials and trust policy never live in `loaf.toml`; `Oven.lock` records the resolved canonical identity and observed trust facts.
+- **Private registries.** Organizations may register an `incan.pub`-compatible registry in Oven-controlled organization or user configuration, then allow-list that registered identity from a Loaf or workspace. Credentials and trust policy never live in `loaf.toml`; `oven.lock` records the resolved canonical identity and observed trust facts.
 - **Trusted Publishers (GitHub Actions OIDC).** Like PyPI's Trusted Publishers — CI/CD can publish without long-lived tokens by using GitHub Actions' OIDC identity directly with Sigstore.
 - **Package auditing tools.** `oven audit` to check dependencies against a vulnerability database.
 - **Mirror support.** Read-only mirrors of `incan.pub` for network-restricted environments or regional performance.

--- a/workspaces/docs-site/docs/RFCs/074_template_rendering_and_boilerplate_provenance.md
+++ b/workspaces/docs-site/docs/RFCs/074_template_rendering_and_boilerplate_provenance.md
@@ -676,7 +676,7 @@ Rejected because generated project boilerplate should be reviewable, editable, a
 
 - **Parser:** rendered Incan templates must parse before they are written when `language = "incan"`.
 - **Formatter:** rendered Incan templates should be formatted before write and before `rendered_hash` is recorded when a formatter is available.
-- **Manifest schema / configuration validation:** project tooling must support an explicit provenance location for tracked templates, whether in a typed `loaf.toml` table or an explicit tool-owned state artifact. `Oven.lock` remains resolver state and must not become a general mutation-history store.
+- **Manifest schema / configuration validation:** project tooling must support an explicit provenance location for tracked templates, whether in a typed `loaf.toml` table or an explicit tool-owned state artifact. `oven.lock` remains resolver state and must not become a general mutation-history store.
 - **CLI / tooling:** lifecycle tooling must implement deterministic template rendering, path validation, parameter validation, ownership handling, provenance recording, and check/status/values-file/diff/update/reset operations.
 - **LSP / IDE tooling:** editor-facing tools should consume machine-readable template provenance and lifecycle diagnostics rather than reimplementing template rendering.
 - **Package integration:** package-provided templates must be loaded as package data and rendered locally under the same safety rules as built-in templates. Package or registry metadata may feed version-aware status and upgrade previews.
@@ -684,7 +684,7 @@ Rejected because generated project boilerplate should be reviewable, editable, a
 
 ## Unresolved questions
 
-- Should template provenance live in a typed `loaf.toml` table or a separate tool-owned state file, and which facts must remain outside `Oven.lock`?
+- Should template provenance live in a typed `loaf.toml` table or a separate tool-owned state file, and which facts must remain outside `oven.lock`?
 - Is the v1 parameter kind set sufficient, or should it include specific kinds for package names, dependency requirements, env names, and script ids?
 - Which derived-value transforms should be standardized in v1?
 - Should optional file groups live in RFC 074 as template renderer metadata, or should RFC 075 own them as starter/capability mutation metadata?

--- a/workspaces/docs-site/docs/RFCs/075_starter_profiles_and_capability_packs.md
+++ b/workspaces/docs-site/docs/RFCs/075_starter_profiles_and_capability_packs.md
@@ -61,7 +61,7 @@ The missing layer is an explicit project mutation contract. Users need a command
 - Define explainable applicability and back-off behavior for existing projects.
 - Distinguish greenfield project creation from existing-project adoption so migration does not overwrite user-authored files under creation-oriented assumptions.
 - Allow starters and mixes to add manifest entries, dependencies, dev-dependencies, scripts, env definitions, file templates, tooling metadata, agent guidance metadata, and user-facing follow-up notes.
-- Keep generated projects ordinary: all persistent behavior must be represented in source files, `loaf.toml`, `Oven.lock`, or documented generated artifacts.
+- Keep generated projects ordinary: all persistent behavior must be represented in source files, `loaf.toml`, `oven.lock`, or documented generated artifacts.
 - Provide inspection commands so users can list available starters, preview one starter, and see which mixes are recorded in a project.
 - Define a review-first mix update path so a project can move an applied mix from one recorded descriptor version to another without treating the change as an automatic package upgrade or silent template rewrite.
 - Provide machine-readable inspection surfaces so LSP and IDE tooling can list starters, preview mix changes, show enabled mixes, and surface project-specific actions without reimplementing descriptor resolution.
@@ -693,7 +693,7 @@ Implementations must provide a machine-readable dry-run format for the full muta
 
 ### Lockfile interaction
 
-Starter and mix application may update `loaf.toml`, but it must not silently rewrite `Oven.lock` unless the command documents and exposes that behavior. The default behavior should leave lockfile updates to the next `oven lock`, `oven bake`, or `oven test` flow governed by RFC 020.
+Starter and mix application may update `loaf.toml`, but it must not silently rewrite `oven.lock` unless the command documents and exposes that behavior. The default behavior should leave lockfile updates to the next `oven lock`, `oven bake`, or `oven test` flow governed by RFC 020.
 
 If a descriptor includes dependency changes and the project is in a locked or frozen mode, the CLI must report that lockfile refresh is required rather than pretending the project remains fully locked.
 

--- a/workspaces/docs-site/docs/RFCs/076_project_mutation_policy_and_recovery.md
+++ b/workspaces/docs-site/docs/RFCs/076_project_mutation_policy_and_recovery.md
@@ -328,7 +328,7 @@ The same policy result should power terminal diagnostics, machine-readable JSON,
 
 ## Layers affected
 
-- **Manifest schema / configuration validation:** project tooling needs a place to describe project-local policy and record policy-related audit metadata, whether in a typed `loaf.toml` policy table or an explicit tool-owned policy state artifact. `Oven.lock` is not a general policy store.
+- **Manifest schema / configuration validation:** project tooling needs a place to describe project-local policy and record policy-related audit metadata, whether in a typed `loaf.toml` policy table or an explicit tool-owned policy state artifact. `oven.lock` is not a general policy store.
 - **CLI / tooling:** lifecycle commands must evaluate policy before applying template, starter, capability, update, reset, refresh, or recovery mutations.
 - **LSP / IDE tooling:** editor-facing tools should surface policy outcomes, blocked mutation reasons, review requirements, and recovery actions from machine-readable lifecycle output.
 - **Package and catalog integration:** registries and catalogs may provide source identity, integrity, yanking, revocation, advisory, compatibility, and trust-tier metadata that policy can consume.

--- a/workspaces/docs-site/docs/RFCs/097_rust_hosted_incan_caller.md
+++ b/workspaces/docs-site/docs/RFCs/097_rust_hosted_incan_caller.md
@@ -80,7 +80,7 @@ The end-state is Incan's own toolchain proving the model on itself: Oven's Rust 
 - This RFC does not require a Rust application to run the Incan compiler at runtime.
 - This RFC does not eagerly build a caller wrapper for every `pub` export regardless of whether anything calls it from Rust; only exports actually referenced by a Rust-authored unit in the same build graph enter the caller build (see "Public export profiles").
 - This RFC does not define registry publication mechanics beyond compatibility with RFC 034 and RFC 079.
-- This RFC does not define `loaf.toml`, `Oven.lock`, or the `*.loaf` asset format; it consumes the project, asset-identity, and receipt contract from RFC 117.
+- This RFC does not define `loaf.toml`, `oven.lock`, or the `*.loaf` asset format; it consumes the project, asset-identity, and receipt contract from RFC 117.
 - This RFC does not define the full implementation of async runtime internals, host capability enforcement, or telemetry backends.
 - This RFC does not guarantee that every Rust type imported through `rust::` can automatically cross back into a caller-visible Rust type without an adapter.
 

--- a/workspaces/docs-site/docs/RFCs/105_architect_rule_engine.md
+++ b/workspaces/docs-site/docs/RFCs/105_architect_rule_engine.md
@@ -414,7 +414,7 @@ Experimental peer-baseline analysis is a later consumer of the same fact and que
 
 - What is the default profile for `incan architect .`: architecture-only, architecture plus safety, or all stable rules?
 - What suppression syntax should Incan use for architect findings, and should it share vocabulary with compiler diagnostic suppressions?
-- Should baselines live in a typed `loaf.toml` table, a separate versioned baseline artifact, or generated project-tooling state? They must not be folded into `Oven.lock` merely because a project uses Oven.
+- Should baselines live in a typed `loaf.toml` table, a separate versioned baseline artifact, or generated project-tooling state? They must not be folded into `oven.lock` merely because a project uses Oven.
 - Where should peer-group metadata live, and which membership or boundary declarations belong in source, package metadata, or local tooling state?
 - Which peer-signature facts are stable and useful enough to expose without turning names, paths, or aggregate similarity into semantic authority?
 - How should a project review, accept, version, and retire an experimental baseline or intentional outlier without allowing a scan to rewrite its own comparison set?

--- a/workspaces/docs-site/docs/RFCs/117_loaf_toml_and_oven_project_model.md
+++ b/workspaces/docs-site/docs/RFCs/117_loaf_toml_and_oven_project_model.md
@@ -32,7 +32,7 @@
 
 This RFC replaces `incan.toml` with `loaf.toml` as the sole authored manifest for an Oven-managed project. A `loaf.toml` may describe one project, a rooted workspace, or a virtual workspace. Its package, target, lock, cache, and receipt model is language-neutral. Incan and Rust are the built-in authored source facets in v0.6; checked C interop remains under `[interop.c]`; later foreign integrations require their own explicit interop RFC rather than becoming ambient source languages.
 
-`[project]` remains the familiar metadata table. `[workspace]` remains the explicit repository-coordination table. Dependencies use one typed graph whose unit kind and origin are explicit when the defaults are insufficient: Incan Loaf packages default to `incan.pub`, Rust crates default to crates.io, and foreign/system requirements use Oven-managed providers. Oven resolves authored intent into `Oven.lock`, then bakes the selected target into immutable, verified `*.loaf` assets and receipts. Cargo remains a deliberately explicit compatibility mode for repositories that have no `loaf.toml`; it is never inferred as part of a Loaf build.
+`[project]` remains the familiar metadata table. `[workspace]` remains the explicit repository-coordination table. Dependencies use one typed graph whose unit kind and origin are explicit when the defaults are insufficient: Incan Loaf packages default to `incan.pub`, Rust crates default to crates.io, and foreign/system requirements use Oven-managed providers. Oven resolves authored intent into `oven.lock`, then bakes the selected target into immutable, verified `*.loaf` assets and receipts. Cargo remains a deliberately explicit compatibility mode for repositories that have no `loaf.toml`; it is never inferred as part of a Loaf build.
 
 This RFC also rehomes the authored configuration boundaries of existing environment, matrix, action, workspace, provider, and interop RFCs. It does not define the final command spelling or a general-purpose task shell.
 
@@ -50,7 +50,7 @@ Read this RFC as thirteen foundations:
 8. **Targets have three scopes:** a Loaf declares supported target/interface combinations; a workspace declares shared delivery policy; a bake invocation chooses one concrete target, carrier, profile, and feature closure that produces a target-bound `*.loaf` asset.
 9. **Plans precede effects:** resolution, import, installation, or the presence of a file must not execute package code. Oven exposes a plan before baking and records the actual execution in a receipt.
 10. **Named environments and actions are explicit Loaf intent:** the standard `dev`, `test`, `lint`, and `docs` environments always exist; authored environment and typed-action configuration moves out of `[tool.incan.*]` and into the Loaf model. Environments select named, reproducible command contexts; they do not silently change a production bake.
-11. **Derived state is separate:** `Oven.lock`, immutable `*.loaf` assets, the artifact store, selected host toolchains, caches, staged outputs, generated code, and receipts are not authored Loaf configuration.
+11. **Derived state is separate:** `oven.lock`, immutable `*.loaf` assets, the artifact store, selected host toolchains, caches, staged outputs, generated code, and receipts are not authored Loaf configuration.
 12. **Distribution assets are verifiable and future-reusable:** a `*.loaf` asset is immutable and target-bound. It identifies the selected project/facet, target, carrier, profile, resolved graph, payload digest, and receipt; those facts reserve the compatibility boundary through which a future `incan.pub` consumer can safely reuse a pre-warmed asset rather than rebuild it. Its wire or bundle format is intentionally deferred.
 13. **Cargo compatibility is explicit:** a directory with only `Cargo.toml` may be run by Oven in Cargo-compatibility mode. A directory containing `loaf.toml` is a Loaf project; Cargo files there are ignored with a diagnostic unless the user explicitly invokes Cargo compatibility.
 
@@ -60,7 +60,7 @@ The current `incan.toml` correctly introduced project identity, dependency decla
 
 That assumption is constraining in both directions. An Incan-authored package may need a Rust crate, a C ABI library, a C++ shim, a target SDK, or a later JNI/Python carrier without ceasing to be one package. A Rust-authored project that elects to use Oven should be able to adopt the same package, target, receipt, and workspace model without being forced to rewrite its sources into Incan. Cargo must remain runnable where Cargo is explicitly authoritative, but Cargo's implicit build scripts, proc macros, target conventions, and workspace semantics must not become accidental Loaf semantics.
 
-The same pressure exists at the repository root. A separate `Oven.toml` would distinguish package metadata from workspace orchestration, but introduces two canonical files and an ownership/discovery boundary without a demonstrated capability need. Cargo already demonstrates that one manifest can express a root package, a virtual workspace, or both. `loaf.toml` can do the same when its table scopes are explicit.
+The same pressure exists at the repository root. A separate `oven.toml` would distinguish package metadata from workspace orchestration, but introduces two canonical files and an ownership/discovery boundary without a demonstrated capability need. Cargo already demonstrates that one manifest can express a root package, a virtual workspace, or both. `loaf.toml` can do the same when its table scopes are explicit.
 
 Oven is more than a package resolver. It must plan target-specific C ABI, JNI, Python, Rust-host, and future carrier builds; select and verify toolchains; materialize controlled environments; protect shared artifact stores; and describe exactly what happened. That requires a manifest that captures desired inputs, not hidden host discovery or arbitrary execution.
 
@@ -75,7 +75,7 @@ Oven is more than a package resolver. It must plan target-specific C ABI, JNI, P
 - Permit explicitly declared hierarchical sub-Loaves under one inherited root-workspace authority.
 - Keep source-language choice out of the package identity while avoiding implicit Cargo participation.
 - Define a target model that distinguishes platform target, deployable carrier, profile, and delivery policy.
-- Distinguish authored intent (`loaf.toml`), resolved graph (`Oven.lock`), and immutable target-bound distribution assets (`*.loaf`) without making any of them hidden state.
+- Distinguish authored intent (`loaf.toml`), resolved graph (`oven.lock`), and immutable target-bound distribution assets (`*.loaf`) without making any of them hidden state.
 - Make plans, declared effects, selected inputs, output artifacts, and receipts inspectable.
 - Rehome environment/matrix/action configuration ownership to Oven without re-specifying the semantics already owned by RFCs 073 and 078.
 - Rehome package-level C ABI configuration from `[oven.interop]` into `[interop]`, a direct semantic root that future binding kinds may share, while retaining RFC 116 as the owner of C safety semantics.
@@ -86,7 +86,7 @@ Oven is more than a package resolver. It must plan target-specific C ABI, JNI, P
 
 ## Non-Goals
 
-- Defining a separate `Oven.toml` root manifest.
+- Defining a separate `oven.toml` root manifest.
 - Preserving `incan.toml`, `incan.lock`, or `[tool.incan.*]` as legacy compatibility formats.
 - Defining the final `oven` versus `incan` command-line binary, aliases, or command hierarchy.
 - Reimplementing arbitrary Cargo behavior, including implicit `build.rs` execution, proc-macro execution policy, or Cargo workspace discovery, for Loaf projects.
@@ -104,10 +104,10 @@ Closed RFCs remain historical records and are not retroactively edited. This RFC
 
 - **RFC 013 and RFC 031:** separate authored `[dependencies]` and `[rust-dependencies]` tables, and the assumption that a consumer's dependency graph is authored as Cargo wiring. `loaf.toml` has one typed dependency graph; provider-specific Rust requirements remain visible facts rather than a second authoring domain.
 - **RFC 015:** `incan.toml` as the project manifest, nearest-manifest root discovery, project generation that writes `incan.toml`, and `[tool.incan.envs]` as the environment-configuration home. `loaf.toml` is the sole authored manifest, while environment semantics remain owned by their dedicated RFCs.
-- **RFC 020:** `incan.lock` as the generated resolution identity. The reproducibility and locked/offline requirements remain; their generated artifact is `Oven.lock`.
+- **RFC 020:** `incan.lock` as the generated resolution identity. The reproducibility and locked/offline requirements remain; their generated artifact is `oven.lock`.
 - **RFC 077:** a flat workspace that forbids nested workspaces. Explicit membership, rooted and virtual workspace forms, and one shared resolution boundary remain; a member may now declare explicit sub-Loaves within a single inherited root-workspace authority.
-- **RFC 112:** the public lockfile path used by its publication examples. Crash-safe publication and coordination requirements remain unchanged, but the published lockfile is `Oven.lock` and its companion coordination identity follows that name.
-- **RFC 114:** references to the canonical `incan.lock` graph. Its distinction between public Loaf features and provider-specific implementation features remains unchanged; the resolved graph is recorded in `Oven.lock`.
+- **RFC 112:** the public lockfile path used by its publication examples. Crash-safe publication and coordination requirements remain unchanged, but the published lockfile is `oven.lock` and its companion coordination identity follows that name.
+- **RFC 114:** references to the canonical `incan.lock` graph. Its distinction between public Loaf features and provider-specific implementation features remains unchanged; the resolved graph is recorded in `oven.lock`.
 
 This RFC does not supersede the retained semantic contracts in those RFCs: reproducibility, explicit workspace membership, crash-safe publication, checked library surfaces, and public package-feature meaning remain requirements. It changes the authored manifest, authority hierarchy, dependency presentation, and derived-state names through which those contracts are implemented.
 
@@ -195,7 +195,7 @@ A workspace can group members recursively without flattening its repository layo
 
 ```text
 incan/
-├── loaf.toml                         # root authority and Oven.lock
+├── loaf.toml                         # root authority and oven.lock
 └── loaves/
     ├── compiler/
     │   ├── syntax/loaf.toml
@@ -205,7 +205,7 @@ incan/
         └── web/loaf.toml
 ```
 
-If a group itself needs a local member-selection boundary or narrower local requirements, it may declare a structural parent `loaf.toml` with explicit children. That parent inherits the root's resolved graph, lock, registry trust, target/delivery policy, and receipt boundary. It cannot create a second `Oven.lock`, rebind a registry, widen target policy, or form a second publication authority.
+If a group itself needs a local member-selection boundary or narrower local requirements, it may declare a structural parent `loaf.toml` with explicit children. That parent inherits the root's resolved graph, lock, registry trust, target/delivery policy, and receipt boundary. It cannot create a second `oven.lock`, rebind a registry, widen target policy, or form a second publication authority.
 
 Membership hierarchy is not a dependency graph. Parent/child placement, a shared workspace, and a selected closure create no runtime, linkage, or publication dependency between packages; those relationships exist only through declared typed dependencies. For example, `incql-core`, `incql-db`, and `incql-datafusion` can remain independently versioned packages whether or not one is structurally nested below another; any dependency between them is explicit in the consuming package's dependency table.
 
@@ -269,7 +269,7 @@ serde = { crate = "serde", registry = "internal-cargo" }
 allow = ["encero", "internal-cargo"]
 ```
 
-The registry alias is convenience, not the security identity. `Oven.lock` records the canonical registry endpoint and protocol, exact package identity, immutable digest, and observed signature/trust result. Credentials never enter `loaf.toml` or the lock. A project cannot silently register, rebind, or trust a registry on a developer's machine.
+The registry alias is convenience, not the security identity. `oven.lock` records the canonical registry endpoint and protocol, exact package identity, immutable digest, and observed signature/trust result. Credentials never enter `loaf.toml` or the lock. A project cannot silently register, rebind, or trust a registry on a developer's machine.
 
 ### Declaring C ABI and future carriers
 
@@ -334,7 +334,7 @@ Oven must not parse, merge, or infer dependency, feature, source, workspace, bui
 5. Workspace membership is explicit. The root's selected closure is formed by recursively expanding each selected member's explicit `members` declaration, subject to `exclude`; a path dependency does not imply membership.
 6. A member may declare explicit child members, producing hierarchical sub-Loaves. Each non-root member has exactly one direct parent in the selected closure.
 7. Membership and parent/child hierarchy are never dependency, linkage, or publication edges. Those edges arise only from declared typed dependency requirements; a path dependency does not imply membership, and membership does not imply a dependency.
-8. The root workspace is the sole authority for the resolved graph, `Oven.lock`, registry trust, workspace delivery policy, and receipt boundary. Child workspace declarations may add local membership and narrow local requirements, but may not create a lock, rebind registries, weaken trust, broaden target policy, or establish an independent publication authority.
+8. The root workspace is the sole authority for the resolved graph, `oven.lock`, registry trust, workspace delivery policy, and receipt boundary. Child workspace declarations may add local membership and narrow local requirements, but may not create a lock, rebind registries, weaken trust, broaden target policy, or establish an independent publication authority.
 9. A manifest containing neither `[project]` nor `[workspace]` is invalid.
 10. `incan.toml` is not a project manifest after this RFC. A directory that contains it but no `loaf.toml` must receive a targeted diagnostic rather than legacy parsing.
 11. If a `loaf.toml` project also contains `Cargo.toml`, Oven must warn and ignore Cargo configuration. The diagnostic must name the ignored file and explain explicit Cargo-compatibility selection.
@@ -353,7 +353,7 @@ When a Loaf project contains Rust source, Oven determines its compilation/linkag
 
 A Rust-bearing Loaf has a bounded, inspectable Rust facet. `[rust.source]` declares its root only when convention cannot. Rust-specific exceptions live beneath `rust.*`, not in a generic source table. The planner must know, either through the conventional default or an explicit declaration, every compiled crate's package name, crate root, edition, crate type, entry point where applicable, enabled feature set, and linkage/dependency requirements. A conventional `src/lib.rs` or `src/main.rs` may supply a default root only when it yields one unambiguous crate; multiple crates, nonstandard roots, nondefault crate names, nondefault editions, additional crate types, binary entry points, or feature mapping require explicit facet data.
 
-The root spelling is settled; the compact `rust.*` exception fields remain RFC 119 work. No Rust compilation plan may be inferred from Cargo metadata. `Oven.lock` and the receipt must record the selected Rust facet, compiler/toolchain identity, crate dependency closure, feature choices, and all provider-produced inputs that affect the resulting `*.loaf` asset.
+The root spelling is settled; the compact `rust.*` exception fields remain RFC 119 work. No Rust compilation plan may be inferred from Cargo metadata. `oven.lock` and the receipt must record the selected Rust facet, compiler/toolchain identity, crate dependency closure, feature choices, and all provider-produced inputs that affect the resulting `*.loaf` asset.
 
 The existence of `build.rs` must never execute it. A Loaf may support its intent only through an explicitly selected Oven provider or typed action whose inputs, outputs, capabilities, target/host role, policy decision, and receipt effects are declared and inspectable. Likewise, a procedural macro must be an explicitly resolved compiler-time provider with a recorded host identity and execution policy; an unsupported macro is a diagnostic, not a fallback to Cargo. Cargo compatibility remains the only mode in which Cargo itself is authoritative for these behaviors.
 
@@ -494,7 +494,7 @@ The interop envelope must be binding-kind neutral. It represents declared header
 
 ### Locks and derived state
 
-`Oven.lock` is the canonical generated resolution state for a project or workspace. A workspace has one root lock that represents every member's selected dependency/provider graph and target-relevant resolution facts. `incan.lock` is not read after this RFC.
+`oven.lock` is the canonical generated resolution state for a project or workspace. A workspace has one root lock that represents every member's selected dependency/provider graph and target-relevant resolution facts. `incan.lock` is not read after this RFC. Both the authored manifest and this generated lock use lowercase filenames — `loaf.toml` and `oven.lock` — for the portability reason recorded under Design decisions.
 
 The lock must include every semantic or physical input whose change can alter checking, linking, target compatibility, generated output, or the baked artifact closure. It must not contain credentials, mutable cache paths, arbitrary environment values, or unreviewed host discovery output.
 
@@ -527,7 +527,7 @@ loaf.toml
 ├── [rust.source] / [rust.*]  built-in Rust source facet; RFC 119 owns exceptions
 ├── [interop.c]               RFC 116's checked C interop envelope
 ├── [interop.*]               reserved for later concrete binding RFCs; no v0.6 plugin system
-├── Oven.lock                 resolved graph, RFCs 020, 104, 112, and 114
+├── oven.lock                 resolved graph, RFCs 020, 104, 112, and 114
 └── *.loaf + receipt          immutable target-bound artifact, RFC 117; wire format deferred
 ```
 
@@ -571,7 +571,7 @@ Diagnostics must distinguish configuration errors, unsupported target/carrier co
 This RFC is intentionally breaking and should land before Incan 1.0.
 
 - `incan.toml` is replaced wholesale with `loaf.toml`.
-- `incan.lock` is replaced with `Oven.lock`.
+- `incan.lock` is replaced with `oven.lock`.
 - Existing implemented project/workspace/environment code must be updated to discover and write the new schema; it must not retain a legacy `incan.toml` parser.
 - Existing Draft RFCs that refer to `[tool.incan.*]` must be amended before their implementation is scheduled.
 - Existing project authors must explicitly adopt the Loaf contract; a raw rename is valid only when the resulting tables satisfy the new schema.
@@ -581,7 +581,7 @@ The tool should emit a targeted diagnostic when it finds `incan.toml` without `l
 
 ## Alternatives considered
 
-### Add `Oven.toml` beside `loaf.toml`
+### Add `oven.toml` beside `loaf.toml`
 
 Rejected for now. A separate root file makes the package-versus-workspace vocabulary literal, but it creates two canonical documents, discovery precedence, and synchronization questions. A single `loaf.toml` with explicit `[project]` and `[workspace]` scopes supports single projects, rooted workspaces, and virtual workspaces without losing capability. A future RFC may introduce a separate file only if independently versioned workspace policy demonstrates a real need.
 
@@ -625,7 +625,7 @@ Rejected. Unconstrained tool tables make the canonical manifest a dumping ground
 - **Source and backend planning** — must discover one conventional built-in source facet, require `[incan.source]` and `[rust.source]` for mixed or nonstandard roots, diagnose ambiguous mixed roots, define the bounded Rust facet needed to plan Rust compilation, and prevent Cargo conventions from participating in Loaf planning.
 - **Target and interop planning** — must resolve host/target/carrier/profile/delivery combinations, select providers/toolchains, and reuse RFC 116's checked `[interop.c]` facts without turning C or a future foreign ecosystem into an ambient top-level source language.
 - **Environment and action tooling** — must rehome RFC 073 and RFC 078 configuration to Loaf/Oven while retaining matrix, scope, dry-run, policy, and receipt contracts.
-- **Locking, stores, and publication** — must rename the canonical lock to `Oven.lock`, preserve deterministic whole-workspace resolution, reserve immutable target-bound `*.loaf` identities, and keep locks, receipts, caches, and publication artifacts distinct.
+- **Locking, stores, and publication** — must rename the canonical lock to `oven.lock`, preserve deterministic whole-workspace resolution, reserve immutable target-bound `*.loaf` identities, and keep locks, receipts, caches, and publication artifacts distinct.
 - **Cargo compatibility adapter** — must run Cargo only when explicitly selected, report its mode and side-effect boundary, and never act as a fallback inside a Loaf build.
 - **CLI and inspection** — must expose manifest shape, plan, target selection, registry/trust facts, effects, `*.loaf` assets, and receipts; RFC 118 owns final binary/subcommand spelling and alias behavior.
 - **Documentation, templates, LSP, and IDEs** — must create, discover, edit, display, and diagnose `loaf.toml` consistently without making generated Rust or hidden backend state the public model.
@@ -658,7 +658,7 @@ RFC 117 is ready to move beyond Draft when its normative rules and updated relat
 ### Phase 2: Typed graph, registries, and lock
 
 - Normalize Loaf, crate, and provider dependencies into one resolver-owned graph.
-- Implement default origins, registered registry identities, workspace allow-lists, integrity/trust facts, and the `Oven.lock` format.
+- Implement default origins, registered registry identities, workspace allow-lists, integrity/trust facts, and the `oven.lock` format.
 - Amend RFC 034 integration and retain RFC 114's public-feature/provider boundaries.
 
 ### Phase 3: Target plan and controlled effects
@@ -696,4 +696,5 @@ RFC 117 is ready to move beyond Draft when its normative rules and updated relat
 - **Registry trust distribution/administration is out of scope:** this RFC defines the registration contract — registries are declared in Oven-controlled user or organization configuration outside the project, and a Loaf or workspace may only allow-list from what is already registered, never define, rebind, or weaken trust (see "Registry registration and trust"). That non-overwrite guarantee already holds without any additional distribution mechanism, because a project has no registration authority at all. How an organization gets the same trusted-registry configuration onto every developer machine and CI runner — through existing device-management tooling, a self-hosted convention, or another means the operator chooses — is an operational concern for whoever runs the registry, not a capability this RFC or Oven itself needs to provide. `incan.pub` remains the trusted, secure default origin for the open ecosystem; that trust is RFC 034's responsibility.
 - **Generators are ordinary typed Incan functions, not a bespoke plugin format:** a generator is not a new sandboxed runtime, wire protocol, or component model. It is a typed Incan (or `rust::`-interop) function with a declared input/output signature that Oven resolves and calls as part of planning or baking, reusing the same execution substrate Incan's own interactive and notebook ambitions already require rather than inventing a second one. Its capability needs — network access, filesystem beyond its declared outputs, a live database, or any other ambient authority — are ordinary RFC 104 capability grants like any other code path; there is no generator-specific security model, because RFC 104 already owns "what can this code touch" regardless of who is asking. A generator's output may legitimately vary between two otherwise-identical builds when it consults an external, changing source; that variability is a capability its declaring package consciously requests and its consumer consciously grants, not a defect this RFC needs to guard against. A generator's declared outputs remain generated, ownership-tracked files that an ordinary bake must not overwrite authored source with.
 - **Providers remain closed and toolchain-owned, not a third-party extension point:** unlike generators, providers (compiling Rust, verifying C headers, materializing an SDK component) are deep native toolchain integrations that Oven implements itself, not expressible as a typed function signature. A new provider kind lands only through an official RFC, the same governance already settled for carrier kinds.
+- **Authored and derived filenames are lowercase:** the manifest is `loaf.toml` and the lock is `oven.lock`. Uppercase in a filename is a portability hazard rather than a style preference. Windows and macOS use case-insensitive filesystems by default, so a case-only difference between two spellings is meaningless there and significant on Linux and in CI: a tree that ever contains both resolves to one file locally and two remotely, and a rename that changes only case is invisible to git on those hosts without deliberate handling. Incan already carries this cost elsewhere — the parser performs ASCII case-insensitive path-segment checks so that editor URIs which normalize path casing still resolve — and the toolchain should not add a new instance of it at the two filenames every project contains. `Cargo.toml` demonstrates the convention Incan is deliberately not copying; that cost lands on every contributor's checkout rather than on the toolchain. This RFC originally spelled the lock `Oven.lock`. That spelling is superseded here and no longer appears in the active RFC set; closed RFCs retain it as historical record.
 - **Carriers have a shape, and a terminal carrier's bake output is not a `*.loaf`:** found while working RFC 118's command-surface decisions and folded back here, since carrier semantics are this RFC's job, not RFC 118's. A `*.loaf`'s entire value proposition, as this RFC's own "Future registry-supplied warm reuse" section describes it, is reuse by another Oven consumer. A terminal artifact such as an executable — for example a data pipeline's final ETL binary — is never depended on as a package by anything, so packaging it as a reusable `*.loaf` carries no meaning. Every carrier therefore has a fixed **shape**: loaf-shaped carriers (static library, framework, JNI shared library, Python wheel, Rust-host caller projection) bake to a `*.loaf` asset; the terminal carrier (`executable`) bakes to a plain build artifact with no `.loaf` packaging. Both shapes still go through the same plan, policy decision, and receipt; shape changes only downstream-reuse packaging, not plan rigor or audit requirements. See "Carrier shape and bake output."

--- a/workspaces/docs-site/docs/RFCs/118_incan_and_oven_command_line_surfaces.md
+++ b/workspaces/docs-site/docs/RFCs/118_incan_and_oven_command_line_surfaces.md
@@ -55,7 +55,7 @@ This separation also protects the architecture. Incan's semantic products—diag
 
 ## Non-Goals
 
-- Defining `loaf.toml`, `Oven.lock`, dependency resolution, target/carrier semantics, artifact format, or interop safety rules; RFC 117 and the corresponding interop RFCs own those contracts.
+- Defining `loaf.toml`, `oven.lock`, dependency resolution, target/carrier semantics, artifact format, or interop safety rules; RFC 117 and the corresponding interop RFCs own those contracts.
 - Creating a second resolver, environment manager, cache, registry/trust model, or package lifecycle in the Incan CLI.
 - Requiring the Oven CLI itself to be implemented in Incan by v0.7, or allowing its implementation language to change the Oven API/receipt contract.
 - Inferring or emulating Cargo workspace, build-script, proc-macro, or manifest semantics in a Loaf command.
@@ -234,7 +234,7 @@ RFC 090 owns `std.cli`, the framework for applications authored in Incan. It doe
 ### Release boundaries
 
 - **v0.5:** retains the current bounded RFC 116 interop release work and its existing `incan.toml` contract; this RFC does not backport a Loaf transition into that release.
-- **v0.6:** RFC 117 introduces `loaf.toml`, `Oven.lock`, hierarchical sub-Loaves, and the language-neutral project model.
+- **v0.6:** RFC 117 introduces `loaf.toml`, `oven.lock`, hierarchical sub-Loaves, and the language-neutral project model.
 - **v0.7:** this RFC introduces the canonical command-surface split over the v0.6 Oven API and project model.
 
 ## Compatibility and migration
@@ -280,7 +280,7 @@ Rejected. It would allow Cargo workspace discovery and side effects to leak into
 
 ## Inspectability and tooling surface
 
-- **Artifacts and metadata:** `loaf.toml`, `Oven.lock`, selected plan, target-bound `*.loaf` assets, execution receipt, compiler diagnostics, semantic inspection facts, codegraph records, and architect findings expose the chosen authority.
+- **Artifacts and metadata:** `loaf.toml`, `oven.lock`, selected plan, target-bound `*.loaf` assets, execution receipt, compiler diagnostics, semantic inspection facts, codegraph records, and architect findings expose the chosen authority.
 - **Inspection commands:** `oven inspect` reports operational plan/store/receipt facts; `incan inspect`, `incan codegraph`, and `incan architect` report checked semantic facts.
 - **Diagnostics:** commands must name whether failure occurred in direct-source mode, Loaf/Oven mode, or explicit Cargo-compatibility mode, and identify the selected manifest or target where relevant.
 - **Not implicit:** neither command surface may infer Cargo behavior from an adjacent manifest, execute an action during resolution, or hide the delegation path that produced a receipt.

--- a/workspaces/docs-site/docs/RFCs/119_oven_native_rust_build_facets_and_cargo_interoperation.md
+++ b/workspaces/docs-site/docs/RFCs/119_oven_native_rust_build_facets_and_cargo_interoperation.md
@@ -26,7 +26,7 @@
 
 RFC 117 establishes a language-neutral Loaf project model, but it deliberately does not specify enough Rust build behavior to replace Cargo as the normal authority for an explicitly supported Rust project. This RFC defines that next layer: Oven-native Rust build facets, an Oven-owned crate graph and direct-`rustc` plan, controlled build-time providers, Rust test and IDE projections, and explicit Cargo interoperation.
 
-Oven consumes crates.io and registered Cargo-compatible sources through the typed `crate` provider contract. It does not publish Loaves or `*.loaf` assets to crates.io. `loaf.toml` remains the sole authored project manifest, `Oven.lock` remains the resolved graph, and a bake emits immutable target-bound `*.loaf` assets plus receipts. Cargo remains runnable only through explicit Cargo-compatibility mode; an existing Cargo project must explicitly opt into Loaf adoption and is never silently merged into an Oven project.
+Oven consumes crates.io and registered Cargo-compatible sources through the typed `crate` provider contract. It does not publish Loaves or `*.loaf` assets to crates.io. `loaf.toml` remains the sole authored project manifest, `oven.lock` remains the resolved graph, and a bake emits immutable target-bound `*.loaf` assets plus receipts. Cargo remains runnable only through explicit Cargo-compatibility mode; an existing Cargo project must explicitly opt into Loaf adoption and is never silently merged into an Oven project.
 
 ## Core model
 
@@ -54,7 +54,7 @@ The right objective is therefore neither “emulate every Cargo behavior” nor 
 ## Goals
 
 - Specify the full Rust facet needed to bake an Oven-native Rust Loaf without using project Cargo metadata as authority.
-- Resolve `crate` dependencies from crates.io or registered compatible sources into the same `Oven.lock` and receipt model as Loaf and capability dependencies.
+- Resolve `crate` dependencies from crates.io or registered compatible sources into the same `oven.lock` and receipt model as Loaf and capability dependencies.
 - Specify deterministic Rust feature resolution, dependency roles, source checksums, target conditions, toolchain selection, and host-versus-target build units.
 - Support an explicitly bounded and inspectable path for Rust build scripts, procedural macros, native linking, generated Rust inputs, and linker/sysroot selection.
 - Specify first-class roles for Rust libraries, binaries, integration tests, unit tests, examples, doctests, benchmarks, and caller projections.
@@ -89,7 +89,7 @@ serde = { crate = "serde", version = "1", features = ["derive"] }
 tokio = { crate = "tokio", version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 
-With `src/lib.rs`, `src/main.rs`, or `src/bin/telemetry.rs` in the conventional locations, this project needs no Rust table. The essential contract is that Oven can identify every compiled crate, its root, edition, crate types, entry point, enabled features, and dependency/linkage closure without reading a project `Cargo.toml`. The Rust facet remains convention-first: `src/lib.rs`, `src/bin/`, `tests/`, `examples/`, `benches/`, and documentation tests require no restatement in the manifest. Authors declare only meaningful deviations, such as an additional crate, a nonstandard root or crate type, a feature-gated target, a locally authored proc macro, or build-provider intent. The expanded host/target unit graph is derived inspection state in `oven plan` and `Oven.lock`, not normal authoring burden.
+With `src/lib.rs`, `src/main.rs`, or `src/bin/telemetry.rs` in the conventional locations, this project needs no Rust table. The essential contract is that Oven can identify every compiled crate, its root, edition, crate types, entry point, enabled features, and dependency/linkage closure without reading a project `Cargo.toml`. The Rust facet remains convention-first: `src/lib.rs`, `src/bin/`, `tests/`, `examples/`, `benches/`, and documentation tests require no restatement in the manifest. Authors declare only meaningful deviations, such as an additional crate, a nonstandard root or crate type, a feature-gated target, a locally authored proc macro, or build-provider intent. The expanded host/target unit graph is derived inspection state in `oven plan` and `oven.lock`, not normal authoring burden.
 
 A project that mixes Incan and Rust names both roots explicitly:
 
@@ -103,7 +103,7 @@ root = "sources/rust"
 
 The roots must not overlap. The exact compact shape for a genuine Rust exception belongs beneath `rust.*`; for example, a future settled grammar may name a non-conventional proc-macro crate as `[rust.crates.incan_derive]`. This RFC deliberately does not use an anonymous `[[sources]]` list or require an author to reproduce Cargo's whole manifest surface.
 
-The `crate` dependencies are ordinary Rust ecosystem inputs. They default to crates.io, but Oven records their canonical source, checksum, signatures or trust facts where available, selected feature closure, and host/target use in `Oven.lock`. The project's publication identity remains an Incan registry identity; `oven publish` does not mean `cargo publish`.
+The `crate` dependencies are ordinary Rust ecosystem inputs. They default to crates.io, but Oven records their canonical source, checksum, signatures or trust facts where available, selected feature closure, and host/target use in `oven.lock`. The project's publication identity remains an Incan registry identity; `oven publish` does not mean `cargo publish`.
 
 ### Build-time work is visible before it runs
 
@@ -153,7 +153,7 @@ oven adopt cargo --manifest ./Cargo.toml
   then make future Oven operations Loaf-authoritative.
 
 oven bake
-  Oven-native mode: loaf.toml and Oven.lock are authoritative; Cargo files are ignored.
+  Oven-native mode: loaf.toml and oven.lock are authoritative; Cargo files are ignored.
 ```
 
 `oven adopt cargo` is illustrative command spelling. The important rule is explicit re-authoring: a user chooses to cross the boundary, sees the proposed Loaf contract and unsupported Cargo behavior, and accepts the resulting project state. Oven does not treat every checked-out `Cargo.toml` as a latent Loaf.
@@ -180,7 +180,7 @@ Oven can consume a crate from crates.io because Rust libraries are part of the w
 2. A selected crate provider may read the crate package's `Cargo.toml` as constrained provider metadata after the typed `crate` dependency and source have already been selected. It may use only the metadata required to understand that dependency package's Rust units, dependency requirements, feature declarations, target conditions, build-time code, and native-link facts.
 3. A provider Cargo manifest must not establish workspace membership outside the package, alter a Loaf registry or trust policy, introduce a second lock, change a Loaf target/delivery policy, run an undeclared lifecycle operation, or publish a Loaf.
 4. Oven resolves a deterministic feature closure over selected crate provider requirements. The lock records requested and selected features for every host and target unit. Development-only and test-only requirements do not enter a release artifact closure unless a declared role requires them.
-5. `Oven.lock` records the provider's canonical source, immutable package identity, checksum or content digest, selected Rust metadata subset, feature closure, target predicates, transitive provider graph, and observed trust facts. It does not copy a `Cargo.lock` as Oven authority.
+5. `oven.lock` records the provider's canonical source, immutable package identity, checksum or content digest, selected Rust metadata subset, feature closure, target predicates, transitive provider graph, and observed trust facts. It does not copy a `Cargo.lock` as Oven authority.
 6. An unsupported provider manifest construct must identify the dependency, field, source span when available, and the available choices: a supported provider, an explicit adaptation declaration, or Cargo compatibility mode.
 
 ### Direct Rust compilation and artifact identity
@@ -226,7 +226,7 @@ Oven can consume a crate from crates.io because Rust libraries are part of the w
 1. `oven cargo ...` is an explicit compatibility operation for a directory with `Cargo.toml` and no `loaf.toml`. Cargo remains authoritative for its manifest, lock, build scripts, procedural macros, profiles, workspace discovery, and side effects. Oven records that it ran Cargo mode and may retain a wrapper receipt; it does not reinterpret Cargo results as an Oven-native lock.
 2. A directory that contains `loaf.toml` is always a Loaf project for normal Oven operations. A neighbouring Cargo manifest is diagnosed and ignored.
 3. Adoption is an explicit user-requested transformation. It may parse Cargo metadata as input, propose a `loaf.toml`, enumerate unsupported or policy-sensitive behavior, and write project state only after the mutation/policy rules of RFC 076 approve it.
-4. Adoption must never leave an implicit mixed state. Once a user accepts the Loaf contract, future Oven-native operations use `loaf.toml` and `Oven.lock`; continuing to run Cargo requires an explicit Cargo operation.
+4. Adoption must never leave an implicit mixed state. Once a user accepts the Loaf contract, future Oven-native operations use `loaf.toml` and `oven.lock`; continuing to run Cargo requires an explicit Cargo operation.
 5. Cargo-compatible caller packages remain RFC 097 interoperability projections. They may consume selected outputs, but must not cause Cargo to resolve, compile, or select the Incan implementation graph.
 
 ### Supported-envelope conformance
@@ -251,7 +251,7 @@ The matrix is a compatibility statement, not a one-time benchmark. It must run o
 
 ### Relationship to RFC 117
 
-RFC 117 owns one manifest authority, one typed dependency graph, target policy, registry trust, `Oven.lock`, `*.loaf` identity, and the rule that a discovered Cargo file is ignored in Loaf mode. This RFC supplies the detailed Rust planner and provider contract that RFC 117 intentionally leaves open. It does not create a second Rust manifest or make a Rust facet an exception to workspace authority.
+RFC 117 owns one manifest authority, one typed dependency graph, target policy, registry trust, `oven.lock`, `*.loaf` identity, and the rule that a discovered Cargo file is ignored in Loaf mode. This RFC supplies the detailed Rust planner and provider contract that RFC 117 intentionally leaves open. It does not create a second Rust manifest or make a Rust facet an exception to workspace authority.
 
 The illustrative `rust.*` tables in this RFC are source-facet data within `loaf.toml`, not a return to one manifest per implementation language. `[rust.source]` names a mixed or nonstandard Rust root, and other `rust.*` tables carry compact Rust-specific exceptions. No `[oven.rust]` prefix is needed: `loaf.toml` is already the Oven-managed project document. Incan uses the parallel built-in `[incan.source]` root; C remains behind `[interop.c]` rather than becoming a peer top-level source namespace.
 
@@ -305,7 +305,7 @@ Rejected. It would revive implicit Cargo semantics, surprise build-script/proc-m
 ## Layers affected
 
 - **Loaf manifest and validation** — must validate Rust facet identities, roles, crate roots, editions, crate types, feature mappings, target predicates, and adoption proposals.
-- **Resolver and registries** — must resolve crate providers, constrained provider metadata, deterministic feature closures, trust/integrity facts, and host/target partitions into `Oven.lock`.
+- **Resolver and registries** — must resolve crate providers, constrained provider metadata, deterministic feature closures, trust/integrity facts, and host/target partitions into `oven.lock`.
 - **Rust operational core/API** — must plan direct `rustc` units, toolchains, sysroots, linkers, provider execution, artifacts, receipts, stores, leases, and recovery without Cargo in native mode.
 - **Provider and policy engine** — must declare, approve, execute, cache, invalidate, and inspect build scripts, generated inputs, native-link facts, and effect receipts; it must apply governed containment around compiler processes that host proc macros without substituting a new expansion mechanism.
 - **Compiler service API and diagnostics** — must expose Rust/compiled-source diagnostics and source maps without making Oven invoke the Incan CLI or generated Rust the public contract.

--- a/workspaces/docs-site/docs/_snippets/project/v0_6_roadmap.md
+++ b/workspaces/docs-site/docs/_snippets/project/v0_6_roadmap.md
@@ -28,7 +28,7 @@
       <td>Accepted constructs have parity, diagnostics, inspection, and migration evidence.</td>
     </tr>
     <tr data-v06-slice-target="slice-04-oven-authority-native-rust">
-      <td><button type="button" class="inc-v06-slice-toggle">4. Oven authority and native Rust</button><div class="inc-v06-slice-status"><span class="inc-v06-status inc-v06-status--complete">4 complete</span><span class="inc-v06-status inc-v06-status--open">43 open</span></div></td>
+      <td><button type="button" class="inc-v06-slice-toggle">4. Oven authority and native Rust</button><div class="inc-v06-slice-status"><span class="inc-v06-status inc-v06-status--complete">4 complete</span><span class="inc-v06-status inc-v06-status--open">44 open</span></div></td>
       <td>Loaf authority, governed providers, and bounded Rust facets.</td>
       <td>Incan-only, Rust-only, and mixed Loaves bake without Cargo being authoritative.</td>
     </tr>
@@ -313,6 +313,7 @@ flowchart LR
   i1212["#1212<br/>establish RFC 104 operation-receipt fac…"]
   i1266["#1266<br/>move Oven's plan/build-unit/artifact/re…"]
   i1337["#1337<br/>invoke Rust behavior from the replaceme…"]
+  i1339["#1339<br/>RFC 123 package executable representation"]
   i975 -- owns --> i429
   s1141 -- owns --> i662
   i975 -- owns --> i870
@@ -359,6 +360,7 @@ flowchart LR
   i1028 -- owns --> i1212
   i1094 -- owns --> i1266
   s1141 -- owns --> i1337
+  s1141 -- owns --> i1339
   i990 -. blocks .-> i1027
   i1028 -. blocks .-> i1027
   i1029 -. blocks .-> i1028
@@ -411,6 +413,7 @@ flowchart LR
   click i1212 href "https://github.com/encero-systems/incan/issues/1212" "Open #1212 on GitHub"
   click i1266 href "https://github.com/encero-systems/incan/issues/1266" "Open #1266 on GitHub"
   click i1337 href "https://github.com/encero-systems/incan/issues/1337" "Open #1337 on GitHub"
+  click i1339 href "https://github.com/encero-systems/incan/issues/1339" "Open #1339 on GitHub"
 ```
 [Open Slice 4 in GitHub](https://github.com/encero-systems/incan/issues/1141)
 

--- a/workspaces/docs-site/docs/_snippets/project/v0_6_roadmap.md
+++ b/workspaces/docs-site/docs/_snippets/project/v0_6_roadmap.md
@@ -23,12 +23,12 @@
       <td>Source spans, semantic facts, and paired receipts survive execution.</td>
     </tr>
     <tr data-v06-slice-target="slice-03-language-runtime-matrix">
-      <td><button type="button" class="inc-v06-slice-toggle">3. Language and runtime matrix</button><div class="inc-v06-slice-status"><span class="inc-v06-status inc-v06-status--complete">4 complete</span><span class="inc-v06-status inc-v06-status--open">13 open</span></div></td>
+      <td><button type="button" class="inc-v06-slice-toggle">3. Language and runtime matrix</button><div class="inc-v06-slice-status"><span class="inc-v06-status inc-v06-status--complete">4 complete</span><span class="inc-v06-status inc-v06-status--open">4 open</span></div></td>
       <td>Embedded fragments, capabilities, and package vocabulary.</td>
       <td>Accepted constructs have parity, diagnostics, inspection, and migration evidence.</td>
     </tr>
     <tr data-v06-slice-target="slice-04-oven-authority-native-rust">
-      <td><button type="button" class="inc-v06-slice-toggle">4. Oven authority and native Rust</button><div class="inc-v06-slice-status"><span class="inc-v06-status inc-v06-status--complete">2 complete</span><span class="inc-v06-status inc-v06-status--open">39 open</span></div></td>
+      <td><button type="button" class="inc-v06-slice-toggle">4. Oven authority and native Rust</button><div class="inc-v06-slice-status"><span class="inc-v06-status inc-v06-status--complete">4 complete</span><span class="inc-v06-status inc-v06-status--open">43 open</span></div></td>
       <td>Loaf authority, governed providers, and bounded Rust facets.</td>
       <td>Incan-only, Rust-only, and mixed Loaves bake without Cargo being authoritative.</td>
     </tr>
@@ -43,12 +43,12 @@
       <td>CLI, LSP, Architect, MCP, and Rust inspection agree on identity and provenance.</td>
     </tr>
     <tr data-v06-slice-target="slice-07-canonical-source-meaning">
-      <td><button type="button" class="inc-v06-slice-toggle">7. Canonical source meaning</button><div class="inc-v06-slice-status"><span class="inc-v06-status inc-v06-status--complete">6 complete</span><span class="inc-v06-status inc-v06-status--open">6 open</span></div></td>
+      <td><button type="button" class="inc-v06-slice-toggle">7. Canonical source meaning</button><div class="inc-v06-slice-status"><span class="inc-v06-status inc-v06-status--complete">7 complete</span><span class="inc-v06-status inc-v06-status--open">8 open</span></div></td>
       <td>One source identity across compiler, tools, and backend facts.</td>
       <td>Aliases, imports, locals, members, and binders resolve consistently.</td>
     </tr>
     <tr data-v06-slice-target="slice-08-native-windows">
-      <td><button type="button" class="inc-v06-slice-toggle">8. Native Windows support</button><div class="inc-v06-slice-status"><span class="inc-v06-status inc-v06-status--complete">0 complete</span><span class="inc-v06-status inc-v06-status--open">20 open</span></div></td>
+      <td><button type="button" class="inc-v06-slice-toggle">8. Native Windows support</button><div class="inc-v06-slice-status"><span class="inc-v06-status inc-v06-status--complete">11 complete</span><span class="inc-v06-status inc-v06-status--open">11 open</span></div></td>
       <td>A Windows host that builds, bakes, and ships like the others.</td>
       <td>A packaged Windows toolchain builds and runs a project, not merely a bake that exits zero.</td>
     </tr>
@@ -230,63 +230,29 @@ flowchart LR
 ```mermaid
 flowchart LR
   i555["#555<br/>RFC 081 - full language-shaped DSL embe…"]
-  i662["#662<br/>RFC 104 - full ambient runtime capabili…"]
-  i759["#759<br/>package-derived vocab helper bindings f…"]
-  i990["#990<br/>implement governed std.process for Oven…"]
   i1020["#1020<br/>RFC 081 resolve design decisions and em…"]
   i1022["#1022<br/>RFC 081 formatting, LSP, and full embed…"]
   i1023["#1023<br/>RFC 081 descriptor-gated lexical submod…"]
-  i1027["#1027<br/>RFC 104 semantic inspection, policy int…"]
-  i1028["#1028<br/>RFC 104 stdlib and package receipts, re…"]
-  i1029["#1029<br/>RFC 104 authority context, declarations…"]
-  i1031["#1031<br/>package-derived vocab helper resolution…"]
-  i1032["#1032<br/>package-derived vocab contracts, InQL m…"]
   i1038["#1038<br/>RFC 081 formatting, LSP, and full embed…"]
   i1075["#1075<br/>add keyed MAC (HMAC) primitives to std.…"]
   s1140["Slice 3<br/>#1140"]
-  i1211["#1211<br/>establish RFC 104 authority-decision fa…"]
-  i1212["#1212<br/>establish RFC 104 operation-receipt fac…"]
   i1252["#1252<br/>example corpus covers a third of the do…"]
   s1140 -- owns --> i555
-  s1140 -- owns --> i662
-  s1140 -- owns --> i759
   i555 -- owns --> i1020
   i555 -- owns --> i1022
   i555 -- owns --> i1023
-  i662 -- owns --> i1027
-  i662 -- owns --> i1028
-  i662 -- owns --> i1029
-  i759 -- owns --> i1031
-  i759 -- owns --> i1032
   s1140 -- owns --> i1038
   s1140 -- owns --> i1075
-  i1029 -- owns --> i1211
-  i1028 -- owns --> i1212
   s1140 -- owns --> i1252
-  i1023 -. blocks .-> i1022
-  i990 -. blocks .-> i1027
-  i1028 -. blocks .-> i1027
-  i1029 -. blocks .-> i1028
-  i1031 -. blocks .-> i1032
   classDef incv06complete fill:#0b2724,stroke:#66d9a3,color:#e4ebf2,stroke-width:1.7px
-  class i1020,i1038,i1211,i1212 incv06complete
+  class i1020,i1023,i1038,i1075 incv06complete
   click i555 href "https://github.com/encero-systems/incan/issues/555" "Open #555 on GitHub"
-  click i662 href "https://github.com/encero-systems/incan/issues/662" "Open #662 on GitHub"
-  click i759 href "https://github.com/encero-systems/incan/issues/759" "Open #759 on GitHub"
-  click i990 href "https://github.com/encero-systems/incan/issues/990" "Open #990 on GitHub"
   click i1020 href "https://github.com/encero-systems/incan/issues/1020" "Open #1020 on GitHub"
   click i1022 href "https://github.com/encero-systems/incan/issues/1022" "Open #1022 on GitHub"
   click i1023 href "https://github.com/encero-systems/incan/issues/1023" "Open #1023 on GitHub"
-  click i1027 href "https://github.com/encero-systems/incan/issues/1027" "Open #1027 on GitHub"
-  click i1028 href "https://github.com/encero-systems/incan/issues/1028" "Open #1028 on GitHub"
-  click i1029 href "https://github.com/encero-systems/incan/issues/1029" "Open #1029 on GitHub"
-  click i1031 href "https://github.com/encero-systems/incan/issues/1031" "Open #1031 on GitHub"
-  click i1032 href "https://github.com/encero-systems/incan/issues/1032" "Open #1032 on GitHub"
   click i1038 href "https://github.com/encero-systems/incan/issues/1038" "Open #1038 on GitHub"
   click i1075 href "https://github.com/encero-systems/incan/issues/1075" "Open #1075 on GitHub"
   click s1140 href "https://github.com/encero-systems/incan/issues/1140" "Open #1140 on GitHub"
-  click i1211 href "https://github.com/encero-systems/incan/issues/1211" "Open #1211 on GitHub"
-  click i1212 href "https://github.com/encero-systems/incan/issues/1212" "Open #1212 on GitHub"
   click i1252 href "https://github.com/encero-systems/incan/issues/1252" "Open #1252 on GitHub"
 ```
 [Open Slice 3 in GitHub](https://github.com/encero-systems/incan/issues/1140)
@@ -301,19 +267,23 @@ flowchart LR
 ```mermaid
 flowchart LR
   i429["#429<br/>Oven-managed pinned Rust host toolchain…"]
+  i662["#662<br/>RFC 104 - full ambient runtime capabili…"]
   i870["#870<br/>Incan-authored Oven and toolchain compo…"]
   i871["#871<br/>complete Oven/toolchain ownership map f…"]
   i872["#872<br/>complete runtime and interop bridge mat…"]
   i975["#975<br/>Oven: Cargo-free Incan/Rust toolchain a…"]
   i990["#990<br/>implement governed std.process for Oven…"]
   i991["#991<br/>establish the Oven host-kernel and Inca…"]
-  i1008["#1008<br/>adopt the Loaf.toml envelope for Oven i…"]
+  i1008["#1008<br/>adopt the loaf.toml envelope for Oven i…"]
   i1012["#1012<br/>RFC 119: Oven-native Rust build facets …"]
+  i1027["#1027<br/>RFC 104 semantic inspection, policy int…"]
+  i1028["#1028<br/>RFC 104 stdlib and package receipts, re…"]
+  i1029["#1029<br/>RFC 104 authority context, declarations…"]
   i1034["#1034<br/>migrate the full Oven semantic control …"]
   i1035["#1035<br/>RFC 119 typed Rust build-script and pro…"]
   i1037["#1037<br/>RFC 119 native Rust facets and direct-r…"]
   i1040["#1040<br/>RFC 119 Rust roles, IDE projection, Car…"]
-  i1063["#1063<br/>RFC 117: Loaf.toml and Oven language-ne…"]
+  i1063["#1063<br/>RFC 117: loaf.toml and Oven language-ne…"]
   i1065["#1065<br/>Reduce oven-linux-replay CI wall-clock:…"]
   i1068["#1068<br/>diagnose declared script paths that col…"]
   i1081["#1081<br/>migrate project_lifecycle/env.rs env-ov…"]
@@ -339,9 +309,12 @@ flowchart LR
   i1111["#1111<br/>investigate the warm rebuild floor: a n…"]
   s1141["Slice 4<br/>#1141"]
   i1149["#1149<br/>bug - regenerate tracked example locks …"]
+  i1211["#1211<br/>establish RFC 104 authority-decision fa…"]
+  i1212["#1212<br/>establish RFC 104 operation-receipt fac…"]
   i1266["#1266<br/>move Oven's plan/build-unit/artifact/re…"]
   i1337["#1337<br/>invoke Rust behavior from the replaceme…"]
   i975 -- owns --> i429
+  s1141 -- owns --> i662
   i975 -- owns --> i870
   i870 -- owns --> i871
   i870 -- owns --> i872
@@ -350,6 +323,9 @@ flowchart LR
   i870 -- owns --> i991
   i975 -- owns --> i1008
   i975 -- owns --> i1012
+  i662 -- owns --> i1027
+  i662 -- owns --> i1028
+  i662 -- owns --> i1029
   i870 -- owns --> i1034
   i1012 -- owns --> i1035
   i1012 -- owns --> i1037
@@ -379,11 +355,17 @@ flowchart LR
   i1034 -- owns --> i1100
   s1141 -- owns --> i1111
   s1141 -- owns --> i1149
+  i1029 -- owns --> i1211
+  i1028 -- owns --> i1212
   i1094 -- owns --> i1266
   s1141 -- owns --> i1337
+  i990 -. blocks .-> i1027
+  i1028 -. blocks .-> i1027
+  i1029 -. blocks .-> i1028
   classDef incv06complete fill:#0b2724,stroke:#66d9a3,color:#e4ebf2,stroke-width:1.7px
-  class i871,i1063 incv06complete
+  class i871,i1063,i1211,i1212 incv06complete
   click i429 href "https://github.com/encero-systems/incan/issues/429" "Open #429 on GitHub"
+  click i662 href "https://github.com/encero-systems/incan/issues/662" "Open #662 on GitHub"
   click i870 href "https://github.com/encero-systems/incan/issues/870" "Open #870 on GitHub"
   click i871 href "https://github.com/encero-systems/incan/issues/871" "Open #871 on GitHub"
   click i872 href "https://github.com/encero-systems/incan/issues/872" "Open #872 on GitHub"
@@ -392,6 +374,9 @@ flowchart LR
   click i991 href "https://github.com/encero-systems/incan/issues/991" "Open #991 on GitHub"
   click i1008 href "https://github.com/encero-systems/incan/issues/1008" "Open #1008 on GitHub"
   click i1012 href "https://github.com/encero-systems/incan/issues/1012" "Open #1012 on GitHub"
+  click i1027 href "https://github.com/encero-systems/incan/issues/1027" "Open #1027 on GitHub"
+  click i1028 href "https://github.com/encero-systems/incan/issues/1028" "Open #1028 on GitHub"
+  click i1029 href "https://github.com/encero-systems/incan/issues/1029" "Open #1029 on GitHub"
   click i1034 href "https://github.com/encero-systems/incan/issues/1034" "Open #1034 on GitHub"
   click i1035 href "https://github.com/encero-systems/incan/issues/1035" "Open #1035 on GitHub"
   click i1037 href "https://github.com/encero-systems/incan/issues/1037" "Open #1037 on GitHub"
@@ -422,6 +407,8 @@ flowchart LR
   click i1111 href "https://github.com/encero-systems/incan/issues/1111" "Open #1111 on GitHub"
   click s1141 href "https://github.com/encero-systems/incan/issues/1141" "Open #1141 on GitHub"
   click i1149 href "https://github.com/encero-systems/incan/issues/1149" "Open #1149 on GitHub"
+  click i1211 href "https://github.com/encero-systems/incan/issues/1211" "Open #1211 on GitHub"
+  click i1212 href "https://github.com/encero-systems/incan/issues/1212" "Open #1212 on GitHub"
   click i1266 href "https://github.com/encero-systems/incan/issues/1266" "Open #1266 on GitHub"
   click i1337 href "https://github.com/encero-systems/incan/issues/1337" "Open #1337 on GitHub"
 ```
@@ -500,7 +487,10 @@ flowchart LR
 ```mermaid
 flowchart LR
   i752["#752<br/>RFC 107 - full type-directed library AP…"]
+  i759["#759<br/>package-derived vocab helper bindings f…"]
   i1030["#1030<br/>RFC 107 public API metadata, tooling, a…"]
+  i1031["#1031<br/>package-derived vocab helper resolution…"]
+  i1032["#1032<br/>package-derived vocab contracts, InQL m…"]
   i1033["#1033<br/>RFC 107 complete Type[T] semantics and …"]
   i1042["#1042<br/>RFC 120: canonical source symbol identity"]
   i1072["#1072<br/>bug - plain assignment inside a nested …"]
@@ -513,7 +503,10 @@ flowchart LR
   i1210["#1210<br/>establish canonical callable-target fac…"]
   i1374["#1374<br/>bug - Default is derivable but unusable…"]
   s1139 -- owns --> i752
+  s1139 -- owns --> i759
   i752 -- owns --> i1030
+  i759 -- owns --> i1031
+  i759 -- owns --> i1032
   i752 -- owns --> i1033
   s1139 -- owns --> i1042
   s1139 -- owns --> i1072
@@ -526,9 +519,12 @@ flowchart LR
   i1033 -. blocks .-> i1030
   i1168 -. blocks .-> i1174
   classDef incv06complete fill:#0b2724,stroke:#66d9a3,color:#e4ebf2,stroke-width:1.7px
-  class i1042,i1072,i1117,i1132,i1174,i1210 incv06complete
+  class i1031,i1042,i1072,i1117,i1132,i1174,i1210 incv06complete
   click i752 href "https://github.com/encero-systems/incan/issues/752" "Open #752 on GitHub"
+  click i759 href "https://github.com/encero-systems/incan/issues/759" "Open #759 on GitHub"
   click i1030 href "https://github.com/encero-systems/incan/issues/1030" "Open #1030 on GitHub"
+  click i1031 href "https://github.com/encero-systems/incan/issues/1031" "Open #1031 on GitHub"
+  click i1032 href "https://github.com/encero-systems/incan/issues/1032" "Open #1032 on GitHub"
   click i1033 href "https://github.com/encero-systems/incan/issues/1033" "Open #1033 on GitHub"
   click i1042 href "https://github.com/encero-systems/incan/issues/1042" "Open #1042 on GitHub"
   click i1072 href "https://github.com/encero-systems/incan/issues/1072" "Open #1072 on GitHub"
@@ -572,6 +568,8 @@ flowchart LR
   i1366["#1366<br/>bug - Windows: std.fs imports unix-only…"]
   i1368["#1368<br/>bug - Windows: shipped Oven store layou…"]
   s1379["Slice 8<br/>#1379"]
+  i1396["#1396<br/>bug - Windows: std.fs disk usage is uni…"]
+  i1397["#1397<br/>Windows: contributor prerequisites are …"]
   s1379 -- owns --> i433
   i433 -- owns --> i1282
   i433 -- owns --> i1283
@@ -591,8 +589,12 @@ flowchart LR
   i1282 -- owns --> i1364
   i1282 -- owns --> i1366
   i1282 -- owns --> i1368
+  i1282 -- owns --> i1396
+  i433 -- owns --> i1397
   i1282 -. blocks .-> i1284
   i1283 -. blocks .-> i1284
+  classDef incv06complete fill:#0b2724,stroke:#66d9a3,color:#e4ebf2,stroke-width:1.7px
+  class i1340,i1345,i1351,i1355,i1357,i1358,i1362,i1364,i1366,i1368,i1397 incv06complete
   click i433 href "https://github.com/encero-systems/incan/issues/433" "Open #433 on GitHub"
   click i1282 href "https://github.com/encero-systems/incan/issues/1282" "Open #1282 on GitHub"
   click i1283 href "https://github.com/encero-systems/incan/issues/1283" "Open #1283 on GitHub"
@@ -613,6 +615,8 @@ flowchart LR
   click i1366 href "https://github.com/encero-systems/incan/issues/1366" "Open #1366 on GitHub"
   click i1368 href "https://github.com/encero-systems/incan/issues/1368" "Open #1368 on GitHub"
   click s1379 href "https://github.com/encero-systems/incan/issues/1379" "Open #1379 on GitHub"
+  click i1396 href "https://github.com/encero-systems/incan/issues/1396" "Open #1396 on GitHub"
+  click i1397 href "https://github.com/encero-systems/incan/issues/1397" "Open #1397 on GitHub"
 ```
 [Open Slice 8 in GitHub](https://github.com/encero-systems/incan/issues/1379)
 

--- a/workspaces/docs-site/docs/release_notes/0_6.md
+++ b/workspaces/docs-site/docs/release_notes/0_6.md
@@ -35,7 +35,7 @@ Source identity is part of that contract. Imports, aliases, re-exports, locals, 
 
 ### Loaf and Oven become the opted-in project authority
 
-For a project that adopts `Loaf.toml`, Loaf expresses authored project intent and Oven owns resolution, targets, provider planning, cache identity, artifacts, receipts, and publication-facing build evidence. `oven build` and `oven bake` will provide the build and target-bound asset surfaces; in-Loaf `incan run` and `incan test` will use those same plans and receipts.
+For a project that adopts `loaf.toml`, Loaf expresses authored project intent and Oven owns resolution, targets, provider planning, cache identity, artifacts, receipts, and publication-facing build evidence. `oven build` and `oven bake` will provide the build and target-bound asset surfaces; in-Loaf `incan run` and `incan test` will use those same plans and receipts.
 
 Cargo remains valid as a legacy format and explicit compatibility/adoption mode. It does not become invalid, and a Rust-only project can choose Oven without adding Incan source. But once a project is Loaf-native, Cargo cannot silently retake authority over its project graph or provider effects.
 

--- a/workspaces/docs-site/docs/tooling/explanation/oven_alpha.md
+++ b/workspaces/docs-site/docs/tooling/explanation/oven_alpha.md
@@ -268,7 +268,7 @@ This Oven receipt selects how already-generated Rust is compiled. A separate, ea
 <p>Alpha boundary</p>
 <h2 id="oven-boundary-title">Early by design. Explicit by default.</h2>
 <span>Oven Alpha proves the maintained Incan workflow and the repository's own compiler suite. It does not yet claim:</span>
-<ul><li>general Cargo compatibility for arbitrary Rust workspaces;</li><li>every build script, procedural macro, target, or platform dependency shape;</li><li>compressed or remotely distributed <code>.loaf</code> bundles;</li><li>the authored <code>loaf.toml</code>, resolved <code>Oven.lock</code>, workspace, or registry model proposed for later work; or</li><li>broad ecosystem readiness from external-library bake-offs.</li></ul>
+<ul><li>general Cargo compatibility for arbitrary Rust workspaces;</li><li>every build script, procedural macro, target, or platform dependency shape;</li><li>compressed or remotely distributed <code>.loaf</code> bundles;</li><li>the authored <code>loaf.toml</code>, resolved <code>oven.lock</code>, workspace, or registry model proposed for later work; or</li><li>broad ecosystem readiness from external-library bake-offs.</li></ul>
 <small>Those belong to 0.6-and-later releases and RFC work. If the Alpha envelope cannot authorize a normal command, Oven explains the miss and stops.</small>
 </div>
 <div class="inc-oven-closing__visual" role="img" aria-label="Incus keeping watch beside the glowing Oven">


### PR DESCRIPTION
## Summary

RFC 117 already spelled the manifest `loaf.toml` in lowercase throughout — 51 times, never capitalized — but specified the lock as `Oven.lock`, and that spelling had propagated to nine other active RFCs and one tooling explanation page.

Uppercase in a filename is a portability hazard rather than a style preference. Windows and macOS use case-insensitive filesystems by default, so a case-only difference between two spellings is meaningless there and significant on Linux and in CI: a tree that ever contains both resolves to one file locally and two remotely, and a rename that changes only case is invisible to git on those hosts without deliberate handling. The repository already carries this cost — `crates/incan_syntax/src/parser/core.rs:299` performs ASCII case-insensitive path-segment matching so editor URIs that normalize path casing still resolve — and the toolchain should not add a new instance of it at the two filenames every project contains.

This is a prose-and-generated-artifact change ahead of #1008, which implements the envelope move. Splitting it out keeps the renaming from burying that issue's code change. Three commits: the RFC prose, the GitHub-side texts it could not reach plus a regenerated roadmap, and two further planning corrections RFC 117 settles.

## Type of change

- [x] Documentation
- [x] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [x] Documentation

## Key details

- **User-facing behavior**: none. No code changes; this settles the spelling and the table roots the implementation will encode.
- **Internals**: `Oven.lock` → `oven.lock` across the active RFC set (40 occurrences in 10 files): RFC 117 ×16, RFC 119 ×9, RFC 034 ×4, RFC 118 ×3, RFCs 075/074 ×2 each, RFCs 076/105/097 ×1 each, and `tooling/explanation/oven_alpha.md` ×1. The decision and its reasoning are recorded under RFC 117's **Design decisions**, with a normative sentence in **Locks and derived state** covering both filenames. The rejected `Oven.toml` alternative is lowercased for internal consistency, and one `Loaf.toml` in the 0.6 release notes is corrected.
- **Risks**: low for the prose. The regenerated snippet carries unrelated programme state — see below.

**Closed RFCs are deliberately untouched.** RFC 116 retains both spellings as historical record, consistent with RFC 117's own statement that "Existing RFC 116 source syntax remains historical." The single remaining `Oven.lock` in an active document is inside the new Design decisions entry, where it names the superseded spelling on purpose.

### GitHub texts corrected

The roadmap snippet renders issue titles, so it kept showing `Loaf.toml` regardless of what the RFCs said. Fixed at the source so the generator has correct input:

| Text | Change |
| --- | --- |
| #1008 title and body | `Loaf.toml` → `loaf.toml`, `Oven.lock` → `oven.lock` |
| #1009 title and body | the same, plus `[oven.interop.c]` → `[interop.c]`, and the five configuration roots below |
| #1063 title and body | `Loaf.toml` → `loaf.toml` |
| 0.6 milestone description | `Loaf.toml` → `loaf.toml` |

### Two planning corrections RFC 117 settles

**#1009's configuration roots.** Its body rehomed configuration under `[oven.envs]`, `[oven.actions]`, `[oven.policy]`, `[oven.capabilities]`, and `[oven.templates]`. RFC 117 line 465 states the roots directly: *"The initial table roots are `[envs]`, `[actions]`, `[policy]`, `[mixes]`, and `[templates]`. No `[oven.*]` prefix is needed: a `loaf.toml` is already Oven's authored project document, and roots should name their semantic domain instead."* Its Design decisions separately record `[capabilities]` becoming `[mixes]`, to avoid a three-way collision with RFC 104's runtime capabilities and RFC 075's scaffolding descriptor. All five roots now match.

**#1339 had no parent.** RFC 123's implementation issue sat in the 0.6 milestone with no slice. Its body says it is part of #989, and #989 closed about two hours after #1339 was filed — carrying the debt forward rather than resolving it. #989's closing comment assigns a slice to the two sibling debt items and none to this one. It is now a sub-issue of #1141 (Slice 4), sequenced after the `loaf.toml` envelope because the representation is published beside the manifest and in the `semantic/` slot RFC 034 reserves. Reasoning recorded on the ledger, #1074.

### The regenerated snippet carries more than this rename

The committed snapshot predated several slice movements, and the generator emits the whole document atomically, so the re-render also brings in programme state that had accumulated since. None of it is authored here:

| Slice | Was | Now |
| --- | --- | --- |
| 3. Language and runtime matrix | 4 complete, 13 open | 4 complete, 4 open |
| 4. Oven authority and native Rust | 2 complete, 39 open | 4 complete, 44 open — the RFC 104 tree (#662, #1027, #1028, #1029) re-parented in, plus #1339 |
| 7. Canonical source meaning | 6 complete, 6 open | 7 complete, 8 open |
| 8. Native Windows support | 0 complete, 20 open | 11 complete, 11 open |

Flagging it explicitly because it is the same generated-artifact-drift shape recorded during slice 3: the generators emit atomically and cannot be split without hand-editing generated files, which would be undone by the next render.

## Testing / verification

- [x] Manual verification described below

Manual verification notes:

- `mkdocs build --strict` from `workspaces/docs-site` — clean, including the repo's Incapunk component, learning-journey, and v0.6 roadmap renderer contract checks.
- `workspaces/docs-site/scripts/v0_6_roadmap/check_roadmap.sh` — passes against its checked-in fixture.
- Two consecutive `render_roadmap.sh` runs are byte-identical, so the snippet is deterministic and the committed output is reproducible from the refreshed snapshot.
- Grep across `workspaces/docs-site/docs/` for `Oven.lock`, `Oven.toml`, and `Loaf.toml`, excluding `RFCs/closed/`: the only hit is the intentional one in the new Design decisions entry. The regenerated snippet has none.
- `make test` / `make examples` not run: no code, fixtures, or build inputs are touched.

## Docs impact

- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

Link(s): `workspaces/docs-site/docs/RFCs/117_loaf_toml_and_oven_project_model.md` (Locks and derived state; Design decisions)

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [ ] I added/updated tests where it materially reduces regressions — n/a, prose and generated output only. The lowercase guard test belongs with #1008's code change, where there is something to assert against.

## Two notes for the reviewer

**The branch was force-pushed.** The three commits were rewritten to strip trailers from their messages; the trees are byte-identical and only the messages changed. Old head `a7f5965`, new head `a1bbcf5`. If a review was already in progress, the diff is unchanged but the commit SHAs are not.

**The 0.6 milestone description needs a manual edit.** It picked up a trailing generated-by footer that was not there before, appended automatically to API writes from this session; a follow-up request that explicitly removed it came back with it re-applied, so it cannot be removed programmatically. The `loaf.toml` correction inside the description is correct — only the footer is unwanted, and editing the milestone in the GitHub UI should strip it.