### PR TITLE
chore - warn once when a Loaf project ignores a Cargo.toml (#1008)

### DIFF
--- a/src/cli/commands/build.rs
+++ b/src/cli/commands/build.rs
@@ -10123,6 +10123,7 @@ pub fn build_file(
 ) -> CliResult<ExitCode> {
     reject_normal_cargo_controls(&options.cargo_policy, options.generated_cargo_target_dir.as_ref())?;
     ensure_backend_request_available(&options.backend)?;
+    super::common::warn_once_about_ignored_cargo_manifest(&resolve_project_root(Path::new(file_path)));
     if options.backend.requested == BackendKind::Replacement {
         let report = build_replacement_file_report(file_path, options, &report_options)?;
         emit_workspace_build_report(&report, &report_options)?;
@@ -13841,6 +13842,16 @@ pub fn build_library(
     }
     let artifact_only = env::var_os(INTERNAL_LIBRARY_ARTIFACT_ONLY_ENV).is_some();
     if !artifact_only {
+        // A nested dependency-library build is not the user's project, so it does not repeat the warning for a
+        // directory they did not invoke a command in. Without an explicit entry file the library root is the
+        // working directory, which is where `incan build --lib` was run.
+        let library_root = match file_path {
+            Some(path) => resolve_project_root(Path::new(path)),
+            None => PathBuf::from("."),
+        };
+        super::common::warn_once_about_ignored_cargo_manifest(&library_root);
+    }
+    if !artifact_only {
         reject_normal_cargo_controls(&options.cargo_policy, options.generated_cargo_target_dir.as_ref())?;
         let completed_output_policy = CompletedOutputPolicy {
             cargo_policy: &options.cargo_policy,
@@ -14696,6 +14707,7 @@ pub fn run_file(
     release: bool,
 ) -> CliResult<ExitCode> {
     reject_normal_cargo_controls(&cargo_policy, None)?;
+    super::common::warn_once_about_ignored_cargo_manifest(&resolve_project_root(Path::new(file_path)));
     let profile = if release { "release" } else { "debug" };
     let completed_output_policy = CompletedOutputPolicy {
         cargo_policy: &cargo_policy,

--- a/src/cli/commands/common.rs
+++ b/src/cli/commands/common.rs
@@ -46,10 +46,11 @@ use crate::library_manifest::{
     digest_provider_artifact,
 };
 use crate::lockfile::CargoFeatureSelection;
-use crate::manifest::{DependencySource, DependencySpec};
 use crate::manifest::{
-    INTERNAL_MANIFEST_OVERRIDE_ENV, INTERNAL_PROJECT_ROOT_OVERRIDE_ENV, LOAF_MANIFEST_FILENAME, ProjectManifest,
+    CARGO_MANIFEST_FILENAME, DiscoveredManifest, INTERNAL_MANIFEST_OVERRIDE_ENV, INTERNAL_PROJECT_ROOT_OVERRIDE_ENV,
+    LOAF_MANIFEST_FILENAME, ManifestError, ProjectManifest, discovered_manifest_kind,
 };
+use crate::manifest::{DependencySource, DependencySpec};
 use crate::project_lifecycle::toolchain::ToolchainConstraintSet;
 use crate::provider::{
     BackendImplementationRequirement, FeatureSelection, PackageFeatureGraph, PackageFeaturePlan,
@@ -76,6 +77,14 @@ static PREPARED_LIBRARY_DEPENDENCIES: LazyLock<Mutex<HashMap<PathBuf, BTreeSet<S
     LazyLock::new(|| Mutex::new(HashMap::new()));
 static SDK_PROVIDER_COMPILER_DIGESTS: LazyLock<Mutex<HashMap<PathBuf, [u8; 32]>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
+/// Project roots already told that their `Cargo.toml` is ignored, so one command warns once.
+///
+/// Oven prepares a project more than once per command — once per selected profile, and again for a caller-owned
+/// library graph — so emitting at the preparation boundary without this would repeat the same line several times for
+/// a single `incan build`. Keyed by project root rather than a global flag, so a workspace build still reports each
+/// member that has one.
+static IGNORED_CARGO_MANIFESTS_REPORTED: LazyLock<Mutex<HashSet<PathBuf>>> =
+    LazyLock::new(|| Mutex::new(HashSet::new()));
 /// Shared immutable provider projections indexed by the canonical modules an invocation uses.
 type ProviderPlanCache = Arc<Mutex<BTreeMap<BTreeSet<Vec<String>>, Arc<ProviderPlan>>>>;
 pub(crate) const INTERNAL_LIBRARY_ARTIFACT_ONLY_ENV: &str = "INCAN_INTERNAL_LIBRARY_ARTIFACT_ONLY";
@@ -4499,6 +4508,42 @@ pub(crate) fn topologically_sort_modules(
     }
 
     Ok(sorted)
+}
+
+/// Report an ignored `Cargo.toml` beside a Loaf manifest, at most once per project root per invocation.
+///
+/// RFC 117 rule 11: a `loaf.toml` project containing `Cargo.toml` must warn and ignore the Cargo configuration, and
+/// the diagnostic must name the ignored file and explain that Cargo compatibility is selected explicitly. Both are
+/// carried by [`ManifestError::CargoIgnored`], which renders the text; this decides only when it reaches the user.
+///
+/// It warns rather than fails, and never inspects the Cargo file: the RFC requires Oven to "continue as a Loaf
+/// project" and say what it ignored, and reading the file to describe it better would be the parsing rule 11
+/// forbids. A directory that holds no `loaf.toml` is silent here — a Cargo-only project is Cargo-compatibility
+/// mode's subject, not an ignored file.
+///
+/// Callers are the project-scale command entry points rather than one deep shared helper, because Oven's cached
+/// paths return a completed output without preparing the project at all; a warning behind preparation would appear
+/// on a cold build and vanish on a warm one, which is worse than not having it.
+pub(crate) fn warn_once_about_ignored_cargo_manifest(project_root: &Path) {
+    let DiscoveredManifest::Loaf(_) = discovered_manifest_kind(project_root) else {
+        return;
+    };
+    let cargo_manifest = project_root.join(CARGO_MANIFEST_FILENAME);
+    if !cargo_manifest.is_file() {
+        return;
+    }
+    let key = project_root
+        .canonicalize()
+        .unwrap_or_else(|_| project_root.to_path_buf());
+    let Ok(mut reported) = IGNORED_CARGO_MANIFESTS_REPORTED.lock() else {
+        // A poisoned registry means another thread panicked mid-report. Losing the deduplication is the right
+        // failure here: a repeated warning is noise, a dropped one hides that Cargo configuration was ignored.
+        eprintln!("warning: {}", ManifestError::CargoIgnored { path: cargo_manifest });
+        return;
+    };
+    if reported.insert(key) {
+        eprintln!("warning: {}", ManifestError::CargoIgnored { path: cargo_manifest });
+    }
 }
 
 /// Resolve the project root from a source file path.

--- a/src/cli/commands/oven.rs
+++ b/src/cli/commands/oven.rs
@@ -128,6 +128,7 @@ pub fn oven_bake_project(
     package_features: FeatureSelection,
     format: OvenOutputFormat,
 ) -> CliResult<ExitCode> {
+    super::common::warn_once_about_ignored_cargo_manifest(&project);
     let report = super::build::bake_oven_project_targets(&project, &package_features)?;
     match format {
         OvenOutputFormat::Text => {

--- a/src/cli/test_runner/mod.rs
+++ b/src/cli/test_runner/mod.rs
@@ -1339,6 +1339,10 @@ pub fn run_tests(config: TestRunConfig<'_>) -> CliResult<ExitCode> {
 
     let path = Path::new(path);
     enforce_test_path_toolchain_constraint(path)?;
+    // `incan test` builds and runs under Oven authority like `build` and `run`, so RFC 117 rule 11 applies here too.
+    crate::cli::commands::common::warn_once_about_ignored_cargo_manifest(
+        &crate::cli::commands::common::resolve_project_root(path),
+    );
     let stable_id_root = stable_id_root(path);
     let candidates = discover_test_file_candidates(path);
     if candidates.is_empty() {

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -26,6 +26,11 @@ pub const LOAF_MANIFEST_FILENAME: &str = "loaf.toml";
 /// the old manifest" rather than "this directory holds no project" — a distinction the two situations deserve, since
 /// only one of them is a mistake the author can fix by renaming.
 pub const LEGACY_MANIFEST_FILENAME: &str = "incan.toml";
+/// Cargo's manifest filename, recognized only so a Loaf project can report ignoring one.
+///
+/// Nothing here reads it. RFC 117 keeps Cargo compatibility as a deliberately explicit mode, so a `Cargo.toml` next to
+/// a `loaf.toml` contributes nothing to the Loaf build and is named in a diagnostic instead.
+pub const CARGO_MANIFEST_FILENAME: &str = "Cargo.toml";
 /// Internal manifest-path override used for nested `incan` subprocesses launched via `incan env run`.
 pub const INTERNAL_MANIFEST_OVERRIDE_ENV: &str = "INCAN_INTERNAL_MANIFEST_OVERRIDE";
 /// Internal project-root override used for nested `incan` subprocesses launched via `incan env run`.
@@ -592,6 +597,21 @@ impl ProjectManifest {
     /// Project-owned SDK profile and component refinements.
     pub fn sdk(&self) -> Option<&SdkSection> {
         self.sdk.as_ref()
+    }
+
+    /// The `Cargo.toml` beside this Loaf manifest, when one is present.
+    ///
+    /// RFC 117 rule 11 makes such a file ignored rather than merged: a directory containing `loaf.toml` is a Loaf
+    /// project, and Oven "must not parse, merge, or infer dependency, feature, source, workspace, build-script, or
+    /// target policy from the adjacent Cargo manifest."
+    ///
+    /// This reports the file and nothing more. Whether that becomes a warning, and at which point in a command's
+    /// life, is the caller's decision — this module has no output channel and acquiring one to satisfy a diagnostic
+    /// would put presentation behind manifest parsing, where the language server and every internal manifest read
+    /// would inherit it.
+    pub fn ignored_cargo_manifest(&self) -> Option<PathBuf> {
+        let candidate = self.project_root().join(CARGO_MANIFEST_FILENAME);
+        candidate.is_file().then_some(candidate)
     }
 
     /// Target-specific checked C interop requirements, if the project declares them.
@@ -2187,6 +2207,40 @@ mod tests {
             DiscoveredManifest::Loaf(path) => assert_eq!(path, dir.path().join("loaf.toml")),
             other => return Err(format!("expected the Loaf manifest to win, got {other:?}").into()),
         }
+        Ok(())
+    }
+
+    #[test]
+    fn a_cargo_manifest_beside_the_loaf_manifest_is_reported_as_ignored() -> TestResult {
+        let dir = tempfile::tempdir()?;
+        fs::write(dir.path().join(LOAF_MANIFEST_FILENAME), "[project]\nname = \"demo\"\n")?;
+        fs::write(dir.path().join(CARGO_MANIFEST_FILENAME), "[package]\nname = \"demo\"\n")?;
+        let manifest = ProjectManifest::discover(dir.path())?.ok_or("the Loaf manifest was not discovered")?;
+        assert_eq!(
+            manifest.ignored_cargo_manifest(),
+            Some(dir.path().join(CARGO_MANIFEST_FILENAME))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn a_loaf_project_without_cargo_reports_nothing_to_ignore() -> TestResult {
+        // The query must stay silent on the ordinary project, or rule 11's warning fires for everyone.
+        let dir = tempfile::tempdir()?;
+        fs::write(dir.path().join(LOAF_MANIFEST_FILENAME), "[project]\nname = \"demo\"\n")?;
+        let manifest = ProjectManifest::discover(dir.path())?.ok_or("the Loaf manifest was not discovered")?;
+        assert_eq!(manifest.ignored_cargo_manifest(), None);
+        Ok(())
+    }
+
+    #[test]
+    fn a_cargo_directory_is_not_mistaken_for_a_loaf_project() -> TestResult {
+        // RFC 117 rule 13 keeps a Cargo-only directory available to explicit Cargo-compatibility mode. It must not
+        // become a Loaf project by proximity, and it is not the legacy-manifest case either.
+        let dir = tempfile::tempdir()?;
+        fs::write(dir.path().join(CARGO_MANIFEST_FILENAME), "[package]\nname = \"demo\"\n")?;
+        assert_eq!(discovered_manifest_kind(dir.path()), DiscoveredManifest::None);
+        assert!(ProjectManifest::discover(dir.path())?.is_none());
         Ok(())
     }
 

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -8671,6 +8671,51 @@ fn build_frozen_rejects_missing_lockfile() -> Result<(), Box<dyn std::error::Err
 }
 
 #[test]
+fn a_cargo_manifest_beside_a_loaf_manifest_warns_without_stopping_the_build() -> Result<(), Box<dyn std::error::Error>>
+{
+    let tmp = tempfile::tempdir()?;
+    let main_path = write_minimal_project(tmp.path(), "cli_ignored_cargo_project", "")?;
+    // Deliberately a Cargo manifest that would fail if anything tried to use it: rule 11 requires Oven to ignore the
+    // file, not to parse it and find it acceptable.
+    fs::write(
+        tmp.path().join("Cargo.toml"),
+        "[package]\nname = \"not-a-real-crate\"\nversion = \"0.0.0\"\n\n[dependencies]\nthis-crate-does-not-exist = \"9999\"\n",
+    )?;
+
+    // Rule 11's subject is Oven, so the warning is emitted where Oven takes authority over the project rather than at
+    // manifest discovery. `incan check` never reaches that point and stays silent, which is why this drives a build.
+    let assert_rule_11 = |output: &Output, context: &str| {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("Cargo.toml"),
+            "{context}: rule 11 requires the diagnostic to name the ignored file, got:\n{stderr}"
+        );
+        assert!(
+            stderr.contains("Cargo-compatibility mode"),
+            "{context}: rule 11 requires the diagnostic to explain explicit Cargo-compatibility selection, got:\n{stderr}"
+        );
+        assert_eq!(
+            stderr.matches("Cargo files here do not contribute").count(),
+            1,
+            "{context}: one command must warn once, got:\n{stderr}"
+        );
+    };
+
+    let bake_output = run_explicit_oven_bake(tmp.path())?;
+    assert_success(&bake_output, "incan oven bake with an ignored Cargo.toml");
+    assert_rule_11(&bake_output, "oven bake");
+
+    let build_output = run_incan(
+        tmp.path(),
+        &["build", main_path.to_str().ok_or("main path was not valid UTF-8")?],
+    )?;
+    assert_success(&build_output, "incan build with an ignored Cargo.toml");
+    assert_rule_11(&build_output, "build");
+
+    Ok(())
+}
+
+#[test]
 fn build_frozen_does_not_read_a_pre_rename_lock() -> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir()?;
     let main_path = write_minimal_project(tmp.path(), "cli_pre_rename_lock_project", "")?;


### PR DESCRIPTION
## Summary

Seventh and final boundary of #1008, stacked on #1415. **Targets `chore/1008-loaf-manifest-cutover`** — the stack is #1404 → #1405 → #1408 → #1411 → #1413 → #1415 → this; retarget as each merges.

RFC 117 rule 11: a `loaf.toml` project containing `Cargo.toml` must warn and ignore the Cargo configuration, naming the ignored file and explaining that Cargo compatibility is selected explicitly. `ManifestError::CargoIgnored` has carried that text since #1408; nothing constructed it. This wires it, and with it RFC 117's conformance surface for this stack is complete.

## Type of change

- [x] New feature

## Area(s)

- [x] Tooling (CLI/formatter/test runner)

## Key details

- **User-facing behavior**: `incan build`, `incan build --lib`, `incan run`, `incan test`, and `incan oven bake` warn once per project root when a `Cargo.toml` sits beside the Loaf manifest, and continue. Nothing fails.
- **Internals**: `ProjectManifest::ignored_cargo_manifest` (a pure query), `CARGO_MANIFEST_FILENAME`, and a warn-once emitter in the CLI layer.
- **Risks**: low. Additive, and silent for every project that has no `Cargo.toml`.

### Where the warning is emitted, and why not somewhere tidier

Two earlier placements were wrong, and both are worth recording because the second was caught by a test rather than by reading the code.

**Not in `manifest.rs`.** That module has no output channel. Giving it one to satisfy a diagnostic would put presentation behind manifest parsing, which the language server and every internal manifest read would inherit. So the module gets a query — does a `Cargo.toml` sit beside this manifest — and nothing else.

**Not in `prepare_oven_project`.** That is the one function every Oven project operation appears to pass through, which makes it look like the obvious single site. It is not: Oven's cached paths return a completed output *without preparing the project at all*. A warning there appears on a cold build and vanishes on a warm one, which is worse than not having it. The integration test failed on exactly that, against a project that had just been baked.

**So: the command entry points** — `build_file`, `build_library`, `run_file`, `run_tests`, `oven_bake_project`. Five sites, each a place where Oven takes authority over a project the user invoked a command in. A nested dependency-library build is deliberately excluded, since it is not the user's project and they did not ask about that directory.

### Two smaller decisions

**Deduplicated per project root, not by a global flag.** Oven prepares a project once per selected profile and again for a caller-owned library graph, so an undeduplicated warning repeats several times for one `incan build`. Keying by project root rather than a single "already warned" bit keeps a workspace build reporting each member that has one.

**The query never opens the Cargo file.** Reading it to describe it more precisely would be the parsing rule 11 forbids — "Oven must not parse, merge, or infer dependency, feature, source, workspace, build-script, or target policy from the adjacent Cargo manifest."

### What stays silent

`incan check`. Rule 11's subject is Oven, and `check` never plans a build, so nothing was ignored. The test says so in a comment rather than leaving it looking like an oversight.

A Cargo-only directory is also silent — that is Cargo-compatibility mode's subject under rule 13, not an ignored file. `a_cargo_directory_is_not_mistaken_for_a_loaf_project` pins that it is neither a Loaf project nor the legacy-manifest case.

### The test uses a Cargo manifest that could not work

`a_cargo_manifest_beside_a_loaf_manifest_warns_without_stopping_the_build` plants a `Cargo.toml` depending on `this-crate-does-not-exist = "9999"`. Rule 11 requires the file to be *ignored*, not parsed and found acceptable — a valid fixture could not tell those apart. It then asserts the warning on both `incan oven bake` and `incan build`, and that each emits it exactly once.

## Testing / verification

- [x] `make test` / `cargo test`
- [x] Manual verification described below

| Suite | Result |
| --- | --- |
| `cargo test --lib` | **3298 passed, 0 failed** |
| `cargo test --test cli_integration` (rule 11 test) | 1 passed |
| `cargo test --test cli_integration workspace` | 12 passed, 1 failed |
| `cargo test --test codegen_snapshot_tests` | 259 passed, zero churn |
| `cargo test --test layering_guard` | 7 passed |
| `cargo test --test vocab_guardrails` | 3 passed |

The `+3` on the library count is exactly the three manifest tests this adds.

The one integration failure is `workspace_lock_is_published_once_at_the_root_from_any_member`, unchanged from #1415 and byte-identical on the base commit — it needs a per-test project bake this environment does not perform.

All of the above ran with the Oven prewarm in place (`make test-prewarm-oven-loafs`), which is what `make test` does before its replay suite. Without it a raw `cargo test --lib` fails a set of `collect_modules`, library-registry, and API-metadata tests with `dependencies have not been compiled yet`; the earlier PRs in this stack recorded that set as an environment limit, and their bodies now carry the correction.

`cargo check --workspace --all-targets` and `cargo clippy --workspace --all-targets` clean, `make fmt` applied, rustdoc gate passes.

## Docs impact

- [x] No docs changes needed

`project_configuration.md` already documents Cargo compatibility as an explicit mode; this makes the toolchain say so at the point it matters. The 0.6 release notes already state that Cargo cannot silently retake authority over a Loaf project's build.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions
