### PR TITLE
chore - build the SDK provider store once per identity, not twice per run (#1065)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,6 +313,14 @@ jobs:
         run: |
           CARGO_BUILD_JOBS=2 cargo build --locked --features lsp --bins
           CARGO_BUILD_JOBS=2 cargo build --locked -p incan_core --bin generate_lang_reference
+      # `check-docs-examples` depends on `test-prewarm-sdk`, so this job builds the SDK provider store whether or not
+      # it is asked to. Without this restore it built one cold every run and discarded it with the runner, and
+      # `linux-oven-prewarm` then built the same store again. The action restores and saves under a key content-
+      # addressed on the provider closure and rustc identity, so the store is now built once per identity rather than
+      # twice per run: a hit here skips the build, and a miss here saves the store for the prewarm to restore.
+      #
+      # It must follow the compiler build, because deriving the cache key runs `incan oven sdk-provider-store-identity`.
+      - uses: ./.github/actions/restore-sdk-provider-store
       - name: Check verified documentation examples
         run: >-
           INCAN_TEST_COMPILER_ALREADY_BUILT=1


### PR DESCRIPTION
## Summary

`check-docs-examples` in the `linux-tool-handoff` job depends on `test-prewarm-sdk`, so that job builds the SDK provider store whether or not it means to. The job had no cache restore for it, so it built one cold on every run and discarded it with the runner — and `linux-oven-prewarm` then built the same store again.

This restores the existing shared `restore-sdk-provider-store` action there. Its key is content-addressed on the provider closure and the rustc identity, and it saves as well as restores, so a hit skips the build outright and a miss saves the store for the prewarm to restore rather than rebuild. The store is now built once per identity instead of twice per run.

It has to sit after the compiler build, because deriving the cache key runs `incan oven sdk-provider-store-identity`, which needs the binary.

Part of #1065.

## Type of change

- [x] CI / tooling

## Area(s)

- [x] Tooling (CLI/formatter/test runner)

## Key details

- **User-facing behavior**: none. This is CI wiring only.
- **Internals**: one `uses:` step added to `linux-tool-handoff`, between the compiler build and the docs-examples step.
- **Risks**: low, and bounded to CI. The action already runs in `linux-oven-prewarm` with the same key derivation, so this is a second consumer of a proven step rather than a new mechanism. A cache miss behaves exactly as today — the store is built — with the addition that it is now saved.

## Testing / verification

- [x] Manual verification described below

Manual verification notes:

- The diff is a single workflow step; its effect is only observable on a hosted runner, so the evidence that matters is the CI run on this PR: `linux-tool-handoff` should report a provider-store cache step, and `linux-oven-prewarm` should then hit rather than rebuild.
- `tests/toolchain_installer_tests.rs` asserts on this workflow's content; the assertions it makes are unaffected by an added `uses:` step.

## Docs impact

- [x] No docs changes needed

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions