### PR TITLE
bugfix - select coherent completed library outputs (#1439)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1445,7 +1445,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.6.0-dev.2"
+version = "0.6.0-dev.3"
 dependencies = [
  "blake2",
  "blake3",
@@ -1504,7 +1504,7 @@ dependencies = [
 
 [[package]]
 name = "incan_codegraph"
-version = "0.6.0-dev.2"
+version = "0.6.0-dev.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -1512,14 +1512,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.6.0-dev.2"
+version = "0.6.0-dev.3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.6.0-dev.2"
+version = "0.6.0-dev.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1528,7 +1528,7 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.6.0-dev.2"
+version = "0.6.0-dev.3"
 dependencies = [
  "incan_core",
  "serde",
@@ -1537,7 +1537,7 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.6.0-dev.2"
+version = "0.6.0-dev.3"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.6.0-dev.2"
+version = "0.6.0-dev.3"
 dependencies = [
  "axum",
  "incan_core",
@@ -1559,7 +1559,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.6.0-dev.2"
+version = "0.6.0-dev.3"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1581,7 +1581,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.6.0-dev.2"
+version = "0.6.0-dev.3"
 dependencies = [
  "axum",
  "incan_stdlib",
@@ -3149,7 +3149,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.6.0-dev.2"
+version = "0.6.0-dev.3"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.6.0-dev.2"
+version = "0.6.0-dev.3"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.98"

--- a/crates/incan_stdlib/stdlib/sdk-components.toml
+++ b/crates/incan_stdlib/stdlib/sdk-components.toml
@@ -1,7 +1,7 @@
 [sdk]
 id = "incan"
-version = "0.6.0-dev.2"
-compiler-requirement = ">=0.6.0-dev.2,<0.7.0"
+version = "0.6.0-dev.3"
+compiler-requirement = ">=0.6.0-dev.3,<0.7.0"
 
 [profiles]
 minimal = ["stdlib-core", "stdlib-interop"]

--- a/src/cli/commands/build.rs
+++ b/src/cli/commands/build.rs
@@ -8528,15 +8528,40 @@ fn select_baked_project_output_with_source_authority(
     source_authority_digest: &str,
     required_target_toolchain: Option<(&str, &str)>,
 ) -> CliResult<Option<OvenStoredProjectOutput>> {
+    Ok(matching_baked_project_outputs_with_source_authority(
+        store,
+        project_root,
+        entrypoint,
+        target,
+        profile,
+        source_authority_digest,
+        required_target_toolchain,
+    )?
+    .into_iter()
+    .next())
+}
+
+/// Collect verified source-current outputs, preferring the local explicit-bake receipt and then canonical lock.
+///
+/// Keep older candidates available for coherent multi-profile selection and non-strict stale-lock warnings.
+fn matching_baked_project_outputs_with_source_authority(
+    store: &OvenStore,
+    project_root: &Path,
+    entrypoint: &Path,
+    target: OvenBakeProjectTarget,
+    profile: &str,
+    source_authority_digest: &str,
+    required_target_toolchain: Option<(&str, &str)>,
+) -> CliResult<Vec<OvenStoredProjectOutput>> {
     let Some(entrypoint_relative_path) = project_relative_entrypoint(project_root, entrypoint) else {
-        return Ok(None);
+        return Ok(Vec::new());
     };
     let target_identity = oven_bake_project_target_identity(project_root, target, entrypoint)?;
     if !project_root.join(LOAF_MANIFEST_FILENAME).is_file() {
-        return Ok(None);
+        return Ok(Vec::new());
     }
     let Some(native_target) = native_project_output_target() else {
-        return Ok(None);
+        return Ok(Vec::new());
     };
     let selected = store
         .select_payloads_matching_for_execution(|manifest| {
@@ -8575,12 +8600,37 @@ fn select_baked_project_output_with_source_authority(
             lease,
         )?);
     }
-    // An interrupted or repeated explicit bake may legitimately leave more than one fully verified result for the same
-    // source, receipt, plan, profile, and native target. They are interchangeable at the completed project-output
-    // boundary, so normal selection is deterministic and bounded retention can reclaim inactive duplicates without
-    // asking the user to bake again.
-    matches.sort_by(|left, right| left.identity.cmp(&right.identity));
-    Ok(matches.into_iter().next())
+    let current_receipt = current_project_output_receipt(project_root, target, entrypoint, profile)?;
+    let current_fingerprint = baked_project_lock_dependencies_fingerprint(project_root)?;
+    // Prefer the explicit bake's verified lineage before the derived lock fingerprint: a non-strict stale lock
+    // must not make an older SDK output outrank the current bake. Missing local receipts still permit store reuse.
+    matches.sort_by_key(|output| {
+        let current_lineage = current_receipt.as_ref().is_some_and(|receipt| {
+            output.payload.receipt_identity == receipt.identity
+                && output.payload.build_unit_identity == receipt.build_unit_identity
+                && output.intent == receipt.intent
+        });
+        (
+            !current_lineage,
+            output.payload.lock_dependencies_fingerprint != current_fingerprint,
+            output.identity.clone(),
+        )
+    });
+    Ok(matches)
+}
+
+/// Read a verified local bake lineage when available without requiring a mutable caller projection for reuse.
+fn current_project_output_receipt(
+    project_root: &Path,
+    target: OvenBakeProjectTarget,
+    entrypoint: &Path,
+    profile: &str,
+) -> CliResult<Option<crate::oven::OvenReceipt>> {
+    let path = project_bake_receipt_path(project_root, target, entrypoint, profile)?;
+    Ok(fs::read(path)
+        .ok()
+        .and_then(|bytes| serde_json::from_slice::<crate::oven::OvenReceipt>(&bytes).ok())
+        .filter(|receipt| receipt.verify_identity().is_ok()))
 }
 
 /// Select every source-current baked debug output through one leased ProjectOutput candidate scan.
@@ -9624,9 +9674,10 @@ fn select_default_library_project_outputs(
     let rustc = resolve_active_rustc().map_err(|error| CliError::failure(error.to_string()))?;
     let target = rustc_host_target(&rustc).map_err(|error| CliError::failure(error.to_string()))?;
     let toolchain = rustc_identity(&rustc).map_err(|error| CliError::failure(error.to_string()))?;
-    let mut outputs = Vec::new();
+    let mut profile_candidates = Vec::new();
+    let mut current_receipts = Vec::new();
     for profile in explicit_bake_profiles() {
-        let Some(selected) = select_baked_project_output_with_source_authority(
+        let candidates = matching_baked_project_outputs_with_source_authority(
             &store,
             &project_root,
             &entrypoint,
@@ -9634,8 +9685,8 @@ fn select_default_library_project_outputs(
             profile,
             &source_authority_digest,
             Some((&target, &toolchain)),
-        )?
-        else {
+        )?;
+        if candidates.is_empty() {
             if has_stale_baked_project_output(
                 &store,
                 &project_root,
@@ -9649,10 +9700,83 @@ fn select_default_library_project_outputs(
             }
             return Ok(None);
         };
-        if completed_output_default_backend_receipt(&selected).is_none() {
+        if let Some(receipt) =
+            current_project_output_receipt(&project_root, OvenBakeProjectTarget::Library, &entrypoint, profile)?
+        {
+            current_receipts.push(receipt);
+        }
+        profile_candidates.push(candidates);
+    }
+    select_coherent_library_outputs(
+        profile_candidates,
+        &current_receipts,
+        baked_project_lock_dependencies_fingerprint(&project_root)?.as_deref(),
+    )
+}
+
+/// Retain one shared lock cohort across all requested library profiles, including a coherent stale fallback.
+fn select_coherent_library_outputs(
+    profile_candidates: Vec<Vec<OvenStoredProjectOutput>>,
+    current_receipts: &[crate::oven::OvenReceipt],
+    current_fingerprint: Option<&str>,
+) -> CliResult<Option<Vec<OvenStoredProjectOutput>>> {
+    // Score semantic preferences directly: retained duplicates must never outweigh a verified local lineage.
+    let fingerprints = profile_candidates
+        .first()
+        .map(|candidates| {
+            candidates
+                .iter()
+                .map(|output| output.payload.lock_dependencies_fingerprint.clone())
+                .collect::<std::collections::BTreeSet<_>>()
+        })
+        .unwrap_or_default();
+    let selected_fingerprint = fingerprints
+        .into_iter()
+        .filter_map(|fingerprint| {
+            if !profile_candidates.iter().all(|candidates| {
+                candidates
+                    .iter()
+                    .any(|output| output.payload.lock_dependencies_fingerprint == fingerprint)
+            }) {
+                return None;
+            }
+            let lineage_matches = current_receipts
+                .iter()
+                .filter(|receipt| {
+                    profile_candidates.iter().flatten().any(|output| {
+                        output.payload.lock_dependencies_fingerprint == fingerprint
+                            && output.payload.receipt_identity == receipt.identity
+                            && output.payload.build_unit_identity == receipt.build_unit_identity
+                            && output.intent == receipt.intent
+                    })
+                })
+                .count();
+            Some((
+                (
+                    std::cmp::Reverse(lineage_matches),
+                    fingerprint.as_deref() != current_fingerprint,
+                ),
+                fingerprint,
+            ))
+        })
+        .min_by(|left, right| left.0.cmp(&right.0));
+    let Some((_, fingerprint)) = selected_fingerprint else {
+        return Err(CliError::failure(
+            "Oven has no coherent completed library output cohort across the requested profiles. Run `incan oven bake --project .` before a normal library build.",
+        ));
+    };
+    let mut outputs = Vec::new();
+    for candidates in profile_candidates {
+        let Some(output) = candidates
+            .into_iter()
+            .find(|output| output.payload.lock_dependencies_fingerprint == fingerprint)
+        else {
+            return Ok(None);
+        };
+        if completed_output_default_backend_receipt(&output).is_none() {
             return Ok(None);
         }
-        outputs.push(selected);
+        outputs.push(output);
     }
     Ok(Some(outputs))
 }
@@ -16016,6 +16140,147 @@ headers = ["interop/include/bridge.h"]
             build_report: None,
         })?;
         Ok((receipt, payload, files))
+    }
+
+    #[test]
+    fn completed_output_selection_prefers_current_receipt_then_lock_and_keeps_stale_fallback()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let project = tempfile::tempdir()?;
+        let store_dir = tempfile::tempdir()?;
+        let store = OvenStore::new(
+            store_dir.path(),
+            crate::oven::store::OvenStoreLimits::new(1024 * 1024, 1024 * 1024, 1024 * 1024),
+        );
+        fs::create_dir(project.path().join("src"))?;
+        fs::write(project.path().join("loaf.toml"), "[project]\nname = \"fixture\"\n")?;
+        fs::write(project.path().join("src/main.incn"), "def main() -> None:\n    pass\n")?;
+        let lock_path = project.path().join("oven.lock");
+        let write_lock = |fingerprint: &str| {
+            IncanLock::new(
+                fingerprint.to_string(),
+                CargoFeatureSelection::default(),
+                "version = 4\n".to_string(),
+            )
+            .write(&lock_path)
+        };
+        write_lock("sha256:old")?;
+        let (old_receipt, old_payload, old_files) =
+            fixture_project_output_publication(project.path(), "release", "old")?;
+        publish_project_output_loaf(&store, &old_receipt, &old_payload, &old_files)?;
+        write_lock("sha256:current")?;
+        let (receipt, payload, files) = fixture_project_output_publication(project.path(), "release", "current")?;
+        publish_project_output_loaf(&store, &receipt, &payload, &files)?;
+        let entrypoint = project.path().join("src/main.incn");
+        let select = || {
+            select_baked_project_output(
+                &store,
+                project.path(),
+                &entrypoint,
+                OvenBakeProjectTarget::Executable,
+                "release",
+            )
+        };
+        let selected = select()?.ok_or("missing output without local receipt")?;
+        assert_eq!(
+            selected.payload.lock_dependencies_fingerprint.as_deref(),
+            Some("sha256:current")
+        );
+        let receipt_path = project_bake_receipt_path(
+            project.path(),
+            OvenBakeProjectTarget::Executable,
+            &entrypoint,
+            "release",
+        )?;
+        write_receipt(&receipt, &receipt_path)?;
+        write_lock("sha256:old")?;
+        let selected = select()?.ok_or("missing current lineage with stale lock")?;
+        assert_eq!(selected.payload.receipt_identity, receipt.identity);
+        warn_for_completed_output_lock_fingerprint_drift(project.path(), [&selected])?;
+        Ok(())
+    }
+
+    #[test]
+    fn completed_output_library_selection_keeps_one_cohort_across_profiles() -> Result<(), Box<dyn std::error::Error>> {
+        let project = tempfile::tempdir()?;
+        let store_dir = tempfile::tempdir()?;
+        let store = OvenStore::new(
+            store_dir.path(),
+            crate::oven::store::OvenStoreLimits::new(1024 * 1024, 1024 * 1024, 1024 * 1024),
+        );
+        fs::create_dir(project.path().join("src"))?;
+        fs::write(project.path().join("loaf.toml"), "[project]\nname = \"fixture\"\n")?;
+        fs::write(project.path().join("src/main.incn"), "def main() -> None:\n    pass\n")?;
+        let mut current_receipts = Vec::new();
+        for profile in ["debug", "release"] {
+            for cohort in ["old", "current"] {
+                let (receipt, mut payload, files) =
+                    fixture_project_output_publication(project.path(), profile, cohort)?;
+                payload.lock_dependencies_fingerprint = Some(format!("sha256:{cohort}"));
+                publish_project_output_loaf(&store, &receipt, &payload, &files)?;
+                if profile == "debug" && cohort == "current" {
+                    current_receipts.push(receipt);
+                }
+            }
+        }
+        let (receipt, mut duplicate, files) =
+            fixture_project_output_publication(project.path(), "release", "old_duplicate")?;
+        duplicate.lock_dependencies_fingerprint = Some("sha256:old".to_string());
+        publish_project_output_loaf(&store, &receipt, &duplicate, &files)?;
+        let entrypoint = project.path().join("src/main.incn");
+        let authority = digest_baked_project_source_authority(project.path())?;
+        let mut groups = Vec::new();
+        for profile in ["debug", "release"] {
+            let mut candidates = matching_baked_project_outputs_with_source_authority(
+                &store,
+                project.path(),
+                &entrypoint,
+                OvenBakeProjectTarget::Executable,
+                profile,
+                &authority,
+                None,
+            )?;
+            // Model opposing hash order across profiles; both profiles must still choose one cohort.
+            candidates.sort_by_key(|output| {
+                (output.payload.lock_dependencies_fingerprint.as_deref() == Some("sha256:current"))
+                    == (profile == "debug")
+            });
+            groups.push(candidates);
+        }
+        let outputs = select_coherent_library_outputs(groups, &current_receipts, Some("sha256:old"))?
+            .ok_or("missing coherent cohort")?;
+        assert_eq!(outputs.len(), 2);
+        assert_eq!(
+            outputs[0].payload.lock_dependencies_fingerprint.as_deref(),
+            Some("sha256:current"),
+            "a current debug receipt outranks a stale lock even with duplicate stale release outputs and no local release receipt"
+        );
+        assert_eq!(
+            outputs[0].payload.lock_dependencies_fingerprint,
+            outputs[1].payload.lock_dependencies_fingerprint
+        );
+        let mut disjoint = Vec::new();
+        for (profile, fingerprint) in [("debug", "sha256:old"), ("release", "sha256:current")] {
+            let candidates = matching_baked_project_outputs_with_source_authority(
+                &store,
+                project.path(),
+                &entrypoint,
+                OvenBakeProjectTarget::Executable,
+                profile,
+                &authority,
+                None,
+            )?;
+            disjoint.push(
+                candidates
+                    .into_iter()
+                    .filter(|output| output.payload.lock_dependencies_fingerprint.as_deref() == Some(fingerprint))
+                    .collect(),
+            );
+        }
+        let Err(error) = select_coherent_library_outputs(disjoint, &[], None) else {
+            return Err("disjoint profile cohorts must require an explicit bake".into());
+        };
+        assert!(error.message.contains("no coherent completed library output cohort"));
+        Ok(())
     }
 
     #[test]

--- a/workspaces/release/npm/package.json
+++ b/workspaces/release/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@incan/toolchain",
-  "version": "0.6.0-dev.2",
+  "version": "0.6.0-dev.3",
   "description": "Command shims for the Incan toolchain",
   "license": "Apache-2.0",
   "homepage": "https://incan.io",

--- a/workspaces/release/pip/pyproject.toml
+++ b/workspaces/release/pip/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "incan"
-version = "0.6.0.dev2"
+version = "0.6.0.dev3"
 description = "Thin installer package for the Incan toolchain"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/workspaces/release/pip/src/incan_toolchain/__init__.py
+++ b/workspaces/release/pip/src/incan_toolchain/__init__.py
@@ -5,5 +5,5 @@ __all__ = ["__release_version__", "__version__"]
 # Python packages require PEP 440 versions, while toolchain release assets retain the
 # workspace's Cargo version spelling. Keep both identities explicit so an installer
 # never derives a GitHub release URL from a normalized distribution version.
-__release_version__ = "0.6.0-dev.2"
-__version__ = "0.6.0.dev2"
+__release_version__ = "0.6.0-dev.3"
+__version__ = "0.6.0.dev3"


### PR DESCRIPTION
## Summary

Fix completed library builds selecting debug and release outputs from different SDK cohorts in a warm Oven store. The failing querykit producer now selects its current debug/release pair without rebaking, clearing the store, or changing lock bytes. This unblocks the locked-build validation for #1149.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: ordinary library builds reuse one coherent lock cohort across requested profiles. Missing coherent output pairs produce explicit bake guidance; existing non-strict stale-lock warnings remain available.
- **Internals**: candidates prefer verified current local receipt lineage before the canonical lock fingerprint. Cohort scoring uses receipt matches and lock equality directly, so duplicate retained outputs cannot outweigh current authority. Missing local receipts still permit verified store reuse.
- **Risks**: completed-output selection affects warm executable and library reuse. Coverage checks missing receipts, stale locks, duplicate old outputs, disjoint profile cohorts, and existing output publication/restoration behavior.

Targets `0.6.0-dev.4` independently of the TOML implementation stack. The branch also carries the shared `0.6.0-dev.3` version baseline (`277666bcb`); the selector fix is `7fe30ae37`.

## Testing / verification

- [x] Focused `cargo test --release --lib` filters: 3 `completed_output_` tests and 5 existing `project_output_` tests passed.
- [ ] Full `make test` / CI: pending.
- [ ] `make examples`: tracked in #1149 final validation.
- [x] Rust formatting and `git diff --check`.
- [x] Manual verification described below.

Manual verification notes:

- Rebuilt compiler tested against the original failing warm store before any rebake, SDK refresh, reseed, or store cleanup: `incan build --locked --lib src/lib.incn` in `examples/pro/vocab_querykit/producer` passed.
- The successful command selected current debug Loaf `0b2b9058` and current release Loaf `95e7d589`. Both older competing outputs remained present; the old selector had mixed current debug with old release `8ad2e45f`.
- All ten tracked example lock files remained byte-identical during the successful proof.
- The stale-lock regression emitted the existing warning while retaining current receipt preference. Independent review is clean after adding the duplicate-output/missing-peer-receipt regression.

## Docs impact

- [x] No public docs changes needed; existing CLI behavior is restored.
- [x] Internal selector rustdocs/comments updated.
- [x] Docs follow Divio intent where applicable.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate.
- [x] I avoided duplicating canonical install/run instructions in multiple places.
- [x] I added/updated tests where it materially reduces regressions.

Closes #1439
