### PR TITLE
bugfix - preserve canonical module-item imports (#1441)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1445,7 +1445,7 @@ dependencies = [
 
 [[package]]
 name = "incan"
-version = "0.6.0-dev.2"
+version = "0.6.0-dev.3"
 dependencies = [
  "blake2",
  "blake3",
@@ -1504,7 +1504,7 @@ dependencies = [
 
 [[package]]
 name = "incan_codegraph"
-version = "0.6.0-dev.2"
+version = "0.6.0-dev.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -1512,14 +1512,14 @@ dependencies = [
 
 [[package]]
 name = "incan_core"
-version = "0.6.0-dev.2"
+version = "0.6.0-dev.3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "incan_derive"
-version = "0.6.0-dev.2"
+version = "0.6.0-dev.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1528,7 +1528,7 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_core"
-version = "0.6.0-dev.2"
+version = "0.6.0-dev.3"
 dependencies = [
  "incan_core",
  "serde",
@@ -1537,7 +1537,7 @@ dependencies = [
 
 [[package]]
 name = "incan_semantics_stdlib"
-version = "0.6.0-dev.2"
+version = "0.6.0-dev.3"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "incan_stdlib"
-version = "0.6.0-dev.2"
+version = "0.6.0-dev.3"
 dependencies = [
  "axum",
  "incan_core",
@@ -1559,7 +1559,7 @@ dependencies = [
 
 [[package]]
 name = "incan_syntax"
-version = "0.6.0-dev.2"
+version = "0.6.0-dev.3"
 dependencies = [
  "incan_core",
  "incan_semantics_core",
@@ -1581,7 +1581,7 @@ dependencies = [
 
 [[package]]
 name = "incan_web_macros"
-version = "0.6.0-dev.2"
+version = "0.6.0-dev.3"
 dependencies = [
  "axum",
  "incan_stdlib",
@@ -3149,7 +3149,7 @@ dependencies = [
 
 [[package]]
 name = "rust_inspect"
-version = "0.6.0-dev.2"
+version = "0.6.0-dev.3"
 dependencies = [
  "hex",
  "incan_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ resolver = "2"
 ra_ap_proc_macro_api = { path = "crates/third_party/ra_ap_proc_macro_api" }
 
 [workspace.package]
-version = "0.6.0-dev.2"
+version = "0.6.0-dev.3"
 description = "The Incan programming language compiler"
 edition = "2024"
 rust-version = "1.98"

--- a/crates/incan_stdlib/stdlib/sdk-components.toml
+++ b/crates/incan_stdlib/stdlib/sdk-components.toml
@@ -1,7 +1,7 @@
 [sdk]
 id = "incan"
-version = "0.6.0-dev.2"
-compiler-requirement = ">=0.6.0-dev.2,<0.7.0"
+version = "0.6.0-dev.3"
+compiler-requirement = ">=0.6.0-dev.3,<0.7.0"
 
 [profiles]
 minimal = ["stdlib-core", "stdlib-interop"]

--- a/src/backend/ir/codegen.rs
+++ b/src/backend/ir/codegen.rs
@@ -4177,6 +4177,33 @@ def main() -> None:
         )]))
     }
 
+    #[test]
+    fn canonical_module_item_import_keeps_function_projection_for_both_spellings()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let helper = parse_program("pub def value() -> int:\n  return 42\n");
+        for (import, binding) in [
+            ("import helper::value", "value"),
+            ("import helper::value as answer", "answer"),
+            ("from helper import value", "value"),
+            ("from helper import value as answer", "answer"),
+        ] {
+            let main = parse_program(&format!(
+                "{import}\n\ndef main() -> None:\n  assert {binding}() == 42\n"
+            ));
+            let mut codegen = IrCodegen::new();
+            codegen.add_module("helper", &helper);
+            let (main_code, modules) = codegen.try_generate_multi_file(&main, &["helper"])?;
+            let helper_code = modules.get("helper").ok_or("missing helper output")?;
+            let projection = projected_name(helper_code, "value", SemanticSourceTargetKind::Function);
+            assert!(
+                main_code.contains(&format!("use crate::helper::{projection}")),
+                "{import}: {main_code}"
+            );
+            assert!(main_code.contains(&format!("{projection}()")), "{import}: {main_code}");
+        }
+        Ok(())
+    }
+
     fn generate_nested_store_code(store_source: &str) -> String {
         let db_module = db_module_program();
         let store_module = parse_program(store_source);

--- a/src/backend/ir/lower/decl/imports.rs
+++ b/src/backend/ir/lower/decl/imports.rs
@@ -14,6 +14,34 @@ impl AstLowering {
         i: &ast::ImportDecl,
         span: ast::Span,
     ) -> Result<IrDeclKind, LoweringError> {
+        // The frontend resolves `import module::item` before lowering. Once it proves an item identity, use the
+        // same item import route as `from module import item`, including canonical names and alias projections.
+        // A genuine module identity must retain module binding semantics even when its path has multiple segments.
+        if let ast::ImportKind::Module(path) = &i.kind
+            && let Some((name, parent)) = path.segments.split_last()
+            && let Some(identity) = self
+                .type_info
+                .as_ref()
+                .and_then(|info| info.resolved_import_identity(i.alias.as_deref().unwrap_or(name)))
+            && !matches!(identity.kind, SemanticSourceTargetKind::Module)
+            && matches!(identity.origin, SymbolOrigin::Module(_) | SymbolOrigin::Package { .. })
+        {
+            let mut item_import = i.clone();
+            item_import.kind = ast::ImportKind::From {
+                module: ast::ImportPath {
+                    segments: parent.to_vec(),
+                    is_absolute: path.is_absolute,
+                    parent_levels: path.parent_levels,
+                },
+                items: vec![ast::ImportItem {
+                    name: name.clone(),
+                    alias: i.alias.clone(),
+                }],
+            };
+            item_import.alias = None;
+            return self.lower_import(&item_import, span);
+        }
+
         let (path, ast_items) = match &i.kind {
             ast::ImportKind::Module(p) => (canonicalize_source_module_segments(&p.segments), vec![]),
             ast::ImportKind::From { module, items } => {

--- a/tests/canonical_item_imports.rs
+++ b/tests/canonical_item_imports.rs
@@ -1,0 +1,86 @@
+//! Native import spellings must select the same canonical function while preserving module bindings.
+
+use std::error::Error;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+mod support;
+
+/// Build and execute each spelling in a fresh two-file project so another import cannot supply its missing symbol.
+#[test]
+fn canonical_item_imports_link_and_run_through_oven() -> Result<(), Box<dyn Error>> {
+    for (label, import, expression, helper_path) in [
+        ("plain", "import helper::value", "value()", "helper.incn"),
+        ("aliased", "import helper::value as answer", "answer()", "helper.incn"),
+        ("from", "from helper import value", "value()", "helper.incn"),
+        (
+            "from_alias",
+            "from helper import value as answer",
+            "answer()",
+            "helper.incn",
+        ),
+        (
+            "nested_item",
+            "import package::helper::value",
+            "value()",
+            "package/helper.incn",
+        ),
+        (
+            "nested_module_alias",
+            "import package::helper as helpers",
+            "helpers.value()",
+            "package/helper.incn",
+        ),
+    ] {
+        let project = tempfile::tempdir()?;
+        let source_dir = project.path().join("src");
+        let helper = source_dir.join(helper_path);
+        let helper_parent = helper.parent().ok_or("helper source has no parent")?;
+        fs::create_dir_all(helper_parent)?;
+        fs::write(&helper, "pub def value() -> int:\n    return 42\n")?;
+        fs::write(
+            project.path().join("loaf.toml"),
+            "[project]\nname = \"canonical_import_probe\"\nversion = \"0.1.0\"\n",
+        )?;
+        fs::write(
+            source_dir.join("main.incn"),
+            format!(
+                "{import}\n\ndef main() -> None:\n    result = {expression}\n    assert result == 42\n    println(result)\n"
+            ),
+        )?;
+
+        let mut bake = project_command(project.path());
+        bake.args(["oven", "bake", "--project", "."]);
+        support::configure_explicit_oven_bake_command(&mut bake)?;
+        let baked = bake.output()?;
+        assert!(
+            baked.status.success(),
+            "{label}: native bake failed:\n{}\n{}",
+            String::from_utf8_lossy(&baked.stdout),
+            String::from_utf8_lossy(&baked.stderr)
+        );
+        let output = project_command(project.path())
+            .args(["run", "--locked", "src/main.incn"])
+            .output()?;
+        assert!(
+            output.status.success(),
+            "{label}: locked execution failed:\n{}\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "42", "{label}");
+    }
+    Ok(())
+}
+
+/// Retain the caller's SDK and shared Cargo selection while keeping generated project output under its temp root.
+fn project_command(project: &Path) -> Command {
+    let mut command = Command::new(support::incan_binary());
+    command
+        .current_dir(project)
+        .env("INCAN_NO_BANNER", "1")
+        .env_remove("INCAN_INTERNAL_PROJECT_ROOT")
+        .env_remove("INCAN_INTERNAL_MANIFEST_OVERRIDE");
+    command
+}

--- a/workspaces/release/npm/package.json
+++ b/workspaces/release/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@incan/toolchain",
-  "version": "0.6.0-dev.2",
+  "version": "0.6.0-dev.3",
   "description": "Command shims for the Incan toolchain",
   "license": "Apache-2.0",
   "homepage": "https://incan.io",

--- a/workspaces/release/pip/pyproject.toml
+++ b/workspaces/release/pip/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "incan"
-version = "0.6.0.dev2"
+version = "0.6.0.dev3"
 description = "Thin installer package for the Incan toolchain"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/workspaces/release/pip/src/incan_toolchain/__init__.py
+++ b/workspaces/release/pip/src/incan_toolchain/__init__.py
@@ -5,5 +5,5 @@ __all__ = ["__release_version__", "__version__"]
 # Python packages require PEP 440 versions, while toolchain release assets retain the
 # workspace's Cargo version spelling. Keep both identities explicit so an installer
 # never derives a GitHub release URL from a normalized distribution version.
-__release_version__ = "0.6.0-dev.2"
-__version__ = "0.6.0.dev2"
+__release_version__ = "0.6.0-dev.3"
+__version__ = "0.6.0.dev3"


### PR DESCRIPTION
## Summary

`import helper::value` typechecks but native compilation can call a canonical function name that its generated import does not bring into scope. Normalize checked module-item imports through the same lowering path as `from helper import value`, preserving aliases and genuine module imports.

This addresses the native failure exposed by `examples/advanced/multifile` and `examples/advanced/nested_project`, following the earlier typechecker fix in #1407 / #1412. Target: `0.6.0-dev.4`.

## Type of change

- [x] Bug fix

## Area(s)

- [x] Compiler (frontend/backend/codegen)

## Key details

- **User-facing behavior**: plain and aliased module-item spellings produce the same callable import as equivalent `from` imports.
- **Internals**: use the frontend's resolved non-module identity to select existing item lowering. Preserve absolute/parent path qualifiers and aliases; retain actual module bindings.
- **Risks**: ambiguous nested module/item paths. Regression coverage includes a genuine nested-module alias alongside nested item imports.
- This standalone branch contains the minimal import fix and tests over dev.4 plus the shared development-version baseline, without the TOML or example-lock work.

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples`
- [x] Manual verification described below

Manual verification notes:

- Static review completed; no demonstrated correctness defect identified.
- Added generated-Rust assertions for four plain/aliased item-import spellings.
- Added six isolated native two-file projects: plain module-item, aliased module-item, plain `from`, aliased `from`, nested item, and genuine nested-module alias. Each explicitly bakes, runs locked, and asserts/output-checks `42`.
- Before the repair, the minimal native bake failed E0425 and the generated-import regression failed. After integration, all 152 canonical-identity unit checks passed and the six-case native regression passed (40.76s), including actual bake and locked execution.
- Tests ran in the combined dev.4 integration checkout; this independent publication branch contains only the shared version baseline and import fix.
- Full example-gate verification is separate; no success claimed here.

## Docs impact

- [x] No docs changes needed

Restores the existing documented import syntax without introducing a new surface.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #1441
