### PR TITLE
chore - enforce the development release baseline before merging to main (#1140)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,14 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 1
+      - name: Verify the release baseline
+        env:
+          RELEASE_BRANCH: ${{ github.head_ref }}
+          BASE_BRANCH: ${{ github.base_ref }}
+        run: |
+          python3 scripts/test_release_version_consistency.py
+          python3 scripts/check_release_version_consistency.py \
+            --release-branch "$RELEASE_BRANCH" --base-branch "$BASE_BRANCH"
       - name: Classify the pull request
         id: scope
         shell: bash

--- a/scripts/check_release_version_consistency.py
+++ b/scripts/check_release_version_consistency.py
@@ -17,6 +17,7 @@ they are reported for awareness but never fail the check.
 
 from __future__ import annotations
 
+import argparse
 import re
 import subprocess
 import sys
@@ -117,8 +118,24 @@ def example_lock_versions() -> list[tuple[Path, str]]:
 
 
 def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--release-branch", default="", help="Pull-request source branch, when checking a release merge")
+    parser.add_argument("--base-branch", default="", help="Pull-request destination branch")
+    args = parser.parse_args()
     version = workspace_version()
     failures: list[str] = []
+
+    # A development line may integrate work while retaining the preceding released baseline. Its PR into main is
+    # the point at which it declares the new release, so mirror agreement alone is insufficient at that boundary.
+    if (
+        args.base_branch == "main"
+        and re.fullmatch(r"\d+\.\d+\.\d+-dev\.\d+", args.release_branch)
+        and version != args.release_branch
+    ):
+        failures.append(
+            f"release branch {args.release_branch!r} targets main, but the workspace is {version!r}; "
+            "bump the workspace version and its mirrors on the release branch before merging"
+        )
 
     # `Cargo.lock` is not hand-written, but bumping the workspace version without letting Cargo refresh it leaves the
     # two disagreeing, and every release job builds with `--locked`. That fails on the runner rather than here, after
@@ -144,7 +161,7 @@ def main() -> int:
             failures.append(f"{relative}: reads {match.group(1)!r}, workspace is {version!r} (expected {expected!r})")
 
     if failures:
-        print(f"check_release_version_consistency: workspace is {version}, but mirrored literals disagree:")
+        print(f"check_release_version_consistency: workspace is {version}, but version checks failed:")
         for failure in failures:
             print(f"  {failure}")
         print("\nThe npm and pip literals are overwritten during packaging, so a release still publishes the right")

--- a/scripts/test_release_version_consistency.py
+++ b/scripts/test_release_version_consistency.py
@@ -1,0 +1,41 @@
+"""Check release-branch version enforcement through the real command-line gate."""
+
+from pathlib import Path
+import re
+import subprocess
+import sys
+import unittest
+
+
+ROOT = Path(__file__).resolve().parent.parent
+GATE = ROOT / "scripts/check_release_version_consistency.py"
+VERSION = re.search(r'^version = "([^"]+)"$', (ROOT / "Cargo.toml").read_text(), re.MULTILINE).group(1)
+
+
+class ReleaseBaselineTests(unittest.TestCase):
+    def gate(self, head: str, base: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(GATE), "--release-branch", head, "--base-branch", base],
+            cwd=ROOT, text=True, capture_output=True, check=False,
+        )
+
+    def test_matching_release_baseline_passes(self):
+        result = self.gate(VERSION, "main")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_previous_cohort_cannot_land_as_a_new_release(self):
+        result = self.gate("0.6.0-dev.999", "main")
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("0.6.0-dev.999", result.stdout)
+
+    def test_topic_branch_does_not_declare_a_release(self):
+        result = self.gate("bugfix/1068-script-targets", "main")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_development_integration_does_not_force_a_release(self):
+        result = self.gate("0.6.0-dev.999", "0.6.0-dev.4")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

A numbered development branch could merge into main while every version field still agreed on the preceding release. The version gate now checks the declared release branch as well as mirror consistency, so `0.6.0-dev.3 → main` requires a `0.6.0-dev.3` workspace baseline.

The actual six-file dev.3 version bump is already on main in [commit766c5f403](https://github.com/encero-systems/incan/commit/766c5f40318b4a78ea99fa914cbdcfa7c08513f6). The dev.3 branch includes that commit too, so those version edits correctly do not appear in this PR diff. This PR adds the missing release-branch guard. Workspace, Cargo lock, SDK dependency and npm/Python release mirrors pass the version-consistency check; generated example locks remain separate #1149 work in #1446.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / maintenance
- [ ] Documentation
- [x] CI / tooling
- [ ] RFC

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- Enforce the release baseline on numbered development branches targeting main; ordinary topic PRs and development integration branches keep their existing version policy.
- Run the version checks before CI scope selection, including documentation-only release PRs.
- Preserve historical example-lock compiler versions; they remain regenerated by their owning issue.

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Four real-command regression tests pass. The incorrect-release case failed against the old gate. The explicit dev.3-to-main check and `git diff --check` pass. No Rust code changed; the full compiler suite was not run locally.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [x] Docs follow Divio intent where applicable

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Release-baseline follow-up for #1140.

