### PR TITLE
chore - share the Linux SDK and measure cold preparation (#1424)

### DIFF
--- a/.github/actions/consume-sdk-provider-store/action.yml
+++ b/.github/actions/consume-sdk-provider-store/action.yml
@@ -1,0 +1,27 @@
+name: Consume the Linux SDK handoff
+description: Download this run's selected SDK and validate it with the matching compiler before exposing consumer paths.
+inputs:
+  store:
+    description: Local destination for the immutable SDK handoff.
+    default: target/incan_test_sdk_provider_store
+  path-file:
+    description: Local SDK path file used by Makefile test prerequisites.
+    default: target/incan_test_sdk_provider_path
+runs:
+  using: composite
+  steps:
+    - name: Download this run's SDK provider store
+      uses: actions/download-artifact@v7
+      with:
+        name: test-linux-sdk-provider-store
+        path: ${{ inputs.store }}
+    - name: Validate the exact SDK handoff
+      shell: bash
+      env:
+        HANDOFF_STORE: ${{ inputs.store }}
+        HANDOFF_PATH_FILE: ${{ inputs.path-file }}
+      run: >-
+        python3 scripts/ci_sdk_handoff.py consume
+        --artifact "$HANDOFF_STORE"
+        --path-file "$HANDOFF_PATH_FILE"
+        --env-file "$GITHUB_ENV"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,11 @@ jobs:
       - uses: ./.github/actions/setup-rust-sccache
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
+      # These source-free checks run independently of SDK publication so its consumers never wait for test linking.
+      - name: Compile and run SDK transport and CI contract regressions
+        run: |
+          CARGO_BUILD_JOBS=2 cargo test --locked --all-features --lib sdk_build_reports_
+          CARGO_BUILD_JOBS=2 cargo test --locked --all-features --test toolchain_installer_tests compiler_suite_action_composes_baker_guarded_runner_and_storage_evidence -- --exact
       - name: Show sccache stats
         if: always()
         run: ${SCCACHE_PATH:-sccache} --show-stats || true
@@ -243,10 +248,6 @@ jobs:
         run: |
           CARGO_BUILD_JOBS=2 cargo build --locked --features lsp --bins
           CARGO_BUILD_JOBS=2 cargo build --locked -p incan_core --bin generate_lang_reference
-      - name: Compile and run SDK transport and CI contract regressions
-        run: |
-          CARGO_BUILD_JOBS=2 cargo test --locked --features lsp --lib sdk_build_reports_
-          CARGO_BUILD_JOBS=2 cargo test --locked --features lsp --test toolchain_installer_tests compiler_suite_action_composes_baker_guarded_runner_and_storage_evidence -- --exact
       # Only this Linux job restores/saves the cross-run SDK cache. Same-run consumers receive an artifact even
       # when another workflow wins the immutable-cache reservation or saving the cache is unavailable.
       - uses: ./.github/actions/restore-sdk-provider-store

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,10 @@ on:
         description: Run the expensive Oven and platform suite regardless of branch
         type: boolean
         default: true
+      reference:
+        description: Include compiler, SDK, docs and reference checks when heavy is disabled
+        type: boolean
+        default: false
 
 concurrency:
   # Irrelevant label events skip the scope job, but still enter workflow concurrency. Give them a separate group so
@@ -52,6 +56,8 @@ jobs:
           BASE_BRANCH: ${{ github.base_ref }}
         run: |
           python3 scripts/test_release_version_consistency.py
+          python3 scripts/test_ci_scope.py
+          python3 scripts/test_ci_sdk_handoff.py
           python3 scripts/check_release_version_consistency.py \
             --release-branch "$RELEASE_BRANCH" --base-branch "$BASE_BRANCH"
       - name: Classify the pull request
@@ -62,89 +68,9 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
           REF_NAME: ${{ github.ref_name }}
           DISPATCH_HEAVY: ${{ inputs.heavy }}
+          DISPATCH_REFERENCE: ${{ inputs.reference }}
           PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
-        run: |
-          set -euo pipefail
-
-          docs_only=false
-          if [ "$EVENT_NAME" = "pull_request" ]; then
-            git fetch origin "$BASE_REF" --depth=1
-            base_ref="origin/$BASE_REF"
-            changed=false
-            docs_only=true
-
-            while IFS= read -r -d '' file; do
-              changed=true
-              # The two generated reference pages are derived from the compiler,
-              # so they must retain the full generated-reference check.
-              case "$file" in
-                workspaces/docs-site/docs/language/reference/language.md|workspaces/docs-site/docs/language/reference/feature_inventory.md|workspaces/docs-site/docs/_snippets/language/examples/verified_*.incn)
-                  docs_only=false
-                  break
-                  ;;
-                workspaces/docs-site/*)
-                  ;;
-                *)
-                  docs_only=false
-                  break
-                  ;;
-              esac
-            done < <(git diff --name-only -z "$base_ref" HEAD)
-
-            if [ "$changed" = false ]; then
-              docs_only=false
-            fi
-          fi
-
-          echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"
-
-          # The expensive half of this workflow -- four Oven replay shards, the prewarm that feeds them, the platform
-          # ABI matrix, the release-Loaf guard and the shadow-comparison evidence -- costs more than everything else
-          # combined. Spending it on every push to a development line pays release-gate prices for work that is not a
-          # release candidate yet. Run it where it decides something: an integration branch, a slice someone declares
-          # ready, or an explicit request.
-          heavy=false
-          case "$EVENT_NAME" in
-            workflow_dispatch)
-              [ "$DISPATCH_HEAVY" = "true" ] && heavy=true
-              ;;
-            pull_request)
-              # A pull request into `main` or a release branch is a release candidate. One into a development line
-              # is not, until it is labelled `full-ci`.
-              case "$BASE_REF" in
-                main|release/*) heavy=true ;;
-              esac
-              case ",$PR_LABELS," in
-                *,full-ci,*) heavy=true ;;
-              esac
-              ;;
-            *)
-              case "$REF_NAME" in
-                main|release/*) heavy=true ;;
-              esac
-              ;;
-          esac
-
-          echo "heavy=$heavy" >> "$GITHUB_OUTPUT"
-
-          # `Linux compiler and reference handoff` is a cold workspace build plus an SDK prewarm, and it typechecks the
-          # committed documentation examples. Once the expensive suite is gated off, its only remaining consumer is
-          # `Generated Reference Up-to-date`. Paying half an hour on every development pull request to re-derive a
-          # reference that can only change when the language registries, the generators, the committed reference pages
-          # or the verified examples change is the wrong trade -- so run the pair when one of those actually moved.
-          reference="$heavy"
-          if [ "$reference" != "true" ] && [ "$EVENT_NAME" = "pull_request" ]; then
-            while IFS= read -r -d '' file; do
-              case "$file" in
-                crates/incan_core/*) reference=true; break ;;
-                workspaces/docs-site/docs/language/reference/language.md) reference=true; break ;;
-                workspaces/docs-site/docs/language/reference/feature_inventory.md) reference=true; break ;;
-                workspaces/docs-site/docs/_snippets/language/examples/*) reference=true; break ;;
-              esac
-            done < <(git diff --name-only -z "$base_ref" HEAD)
-          fi
-
-          echo "reference=$reference" >> "$GITHUB_OUTPUT"
+        run: bash scripts/ci_scope.sh
 
   fmt:
     name: Format Check
@@ -249,11 +175,6 @@ jobs:
             runner: macos-latest
             toolchain: 1.98.0
             c_abi_test: check_verifies_c_bindings_against_a_declared_ios_interop_target
-          - id: linux-rust-1-98
-            name: ubuntu-latest, Rust 1.98.0
-            runner: ubuntu-latest
-            toolchain: 1.98.0
-            c_abi_test: check_verifies_c_bindings_against_a_declared_android_interop_target
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master
@@ -278,8 +199,7 @@ jobs:
       - name: Build the compiler
         run: CARGO_BUILD_JOBS=2 cargo build --locked --features lsp --bins
       - uses: ./.github/actions/restore-sdk-provider-store
-      # The Linux handoff below is the one complete Oven-suite authority. These jobs retain C-ABI coverage specific
-      # to macOS and Android without adding another Rust-version lane or independently baking the complete Loaf family.
+      # macOS retains its own compiler and SDK because the Linux handoff cannot supply a macOS toolchain.
       - name: Prewarm platform SDK providers
         run: >-
           CARGO_NET_OFFLINE=true
@@ -292,7 +212,7 @@ jobs:
           cargo test --locked --test cli_integration ${{ matrix.c_abi_test }} -- --exact
 
   linux-tool-handoff:
-    name: Linux compiler and reference handoff
+    name: Linux compiler and SDK handoff
     runs-on: ubuntu-latest
     needs: changes
     if: ${{ needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.reference == 'true' }}
@@ -323,19 +243,40 @@ jobs:
         run: |
           CARGO_BUILD_JOBS=2 cargo build --locked --features lsp --bins
           CARGO_BUILD_JOBS=2 cargo build --locked -p incan_core --bin generate_lang_reference
-      # `check-docs-examples` depends on `test-prewarm-sdk`, so this job builds the SDK provider store whether or not
-      # it is asked to. Without this restore it built one cold every run and discarded it with the runner, and
-      # `linux-oven-prewarm` then built the same store again. The action restores and saves under a key content-
-      # addressed on the provider closure and rustc identity, so the store is now built once per identity rather than
-      # twice per run: a hit here skips the build, and a miss here saves the store for the prewarm to restore.
-      #
-      # It must follow the compiler build, because deriving the cache key runs `incan oven sdk-provider-store-identity`.
+      - name: Compile and run SDK transport and CI contract regressions
+        run: |
+          CARGO_BUILD_JOBS=2 cargo test --locked --features lsp --lib sdk_build_reports_
+          CARGO_BUILD_JOBS=2 cargo test --locked --features lsp --test toolchain_installer_tests compiler_suite_action_composes_baker_guarded_runner_and_storage_evidence -- --exact
+      # Only this Linux job restores/saves the cross-run SDK cache. Same-run consumers receive an artifact even
+      # when another workflow wins the immutable-cache reservation or saving the cache is unavailable.
       - uses: ./.github/actions/restore-sdk-provider-store
-      - name: Check verified documentation examples
+      - name: Prepare the selected Linux SDK
+        env:
+          INCAN_INTERNAL_SDK_BUILD_REPORT_DIR: ${{ runner.temp }}/sdk-build-reports
+        run: |
+          mkdir -p "$INCAN_INTERNAL_SDK_BUILD_REPORT_DIR"
+          INCAN_TEST_COMPILER_ALREADY_BUILT=1 INCAN_TEST_PREWARM_TOOLCHAIN=1.98.0 make -s test-prewarm-sdk
+      - name: Stage the exact SDK handoff
         run: >-
-          INCAN_TEST_COMPILER_ALREADY_BUILT=1
-          INCAN_TEST_PREWARM_TOOLCHAIN=1.98.0
-          make -s check-docs-examples
+          python3 scripts/ci_sdk_handoff.py stage
+          --store target/incan_test_sdk_provider_store
+          --artifact target/ci-sdk-handoff
+      - name: Upload SDK preparation evidence
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: test-linux-sdk-preparation-reports
+          path: ${{ runner.temp }}/sdk-build-reports
+          if-no-files-found: warn
+          retention-days: 7
+      - name: Upload selected SDK provider store
+        uses: actions/upload-artifact@v6
+        with:
+          name: test-linux-sdk-provider-store
+          path: target/ci-sdk-handoff
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 1
       - name: Upload compiler and reference generators
         uses: actions/upload-artifact@v6
         with:
@@ -347,13 +288,89 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  verified-docs:
+    name: Verified documentation examples
+    runs-on: ubuntu-latest
+    needs: [changes, linux-tool-handoff]
+    if: ${{ needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.reference == 'true' }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.INCAN_RUST_TOOLCHAIN }}
+      - name: Restore Cargo sources
+        uses: actions/cache/restore@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: incan-oven-pr-sources-v1-1.98.0-Linux-X64-${{ hashFiles('Cargo.lock', 'crates/incan_stdlib/stdlib/components/**/vocab_companion/Cargo.lock', 'tests/fixtures/oven_loaf_dependencies/Cargo.lock', 'src/oven/fixtures/release_stdlib.toml') }}
+          restore-keys: |
+            incan-oven-pr-sources-v1-1.98.0-Linux-X64-
+      - name: Fetch locked compiler sources
+        run: make fetch-locked-cargo-sources
+      - name: Download matching compiler and reference generators
+        uses: actions/download-artifact@v7
+        with:
+          name: test-linux-tools
+          path: target/debug
+      - name: Restore executable permissions
+        run: chmod +x target/debug/incan target/debug/generate_lang_reference target/debug/generate_feature_inventory
+      - uses: ./.github/actions/consume-sdk-provider-store
+      - name: Check verified documentation examples
+        run: >-
+          INCAN_TEST_COMPILER_ALREADY_BUILT=1
+          INCAN_TEST_PREWARM_TOOLCHAIN=1.98.0
+          make -s check-docs-examples
+
+  oven-linux-platform-smoke:
+    name: Platform C ABI gate (ubuntu-latest, Rust 1.98.0)
+    runs-on: ubuntu-latest
+    needs: [changes, linux-tool-handoff]
+    if: ${{ needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.heavy == 'true' }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.INCAN_RUST_TOOLCHAIN }}
+      - name: Install WASI target for vocab desugarers
+        run: rustup target add wasm32-wasip1 --toolchain "${{ env.INCAN_RUST_TOOLCHAIN }}"
+      - name: Restore Cargo sources
+        uses: actions/cache/restore@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: incan-oven-pr-sources-v1-1.98.0-Linux-X64-${{ hashFiles('Cargo.lock', 'crates/incan_stdlib/stdlib/components/**/vocab_companion/Cargo.lock', 'tests/fixtures/oven_loaf_dependencies/Cargo.lock', 'src/oven/fixtures/release_stdlib.toml') }}
+          restore-keys: |
+            incan-oven-pr-sources-v1-1.98.0-Linux-X64-
+      - name: Fetch locked compiler and Loaf publisher sources
+        run: |
+          make fetch-locked-cargo-sources
+          make fetch-oven-loaf-sources
+          make fetch-release-support-workspace-sources
+      - name: Download matching compiler and reference generators
+        uses: actions/download-artifact@v7
+        with:
+          name: test-linux-tools
+          path: target/debug
+      - name: Restore executable permissions
+        run: chmod +x target/debug/incan target/debug/generate_lang_reference target/debug/generate_feature_inventory
+      - uses: ./.github/actions/consume-sdk-provider-store
+      # Cargo still compiles this test executable; downloading the CLI does not transfer its Cargo target graph.
+      - name: Run platform C ABI verification
+        run: >-
+          CARGO_NET_OFFLINE=true
+          cargo test --locked --test cli_integration
+          check_verifies_c_bindings_against_a_declared_android_interop_target -- --exact
+
   linux-oven-prewarm:
     name: Linux Oven prewarm
     runs-on: ubuntu-latest
     needs:
       - changes
       - linux-tool-handoff
-    if: ${{ needs.changes.outputs.docs_only != 'true' && (needs.changes.outputs.heavy == 'true' || needs.changes.outputs.reference == 'true') }}
+    if: ${{ needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.heavy == 'true' }}
     outputs:
       oven_suite_cache_key: ${{ steps.oven-suite-cache-key.outputs.key }}
     steps:
@@ -384,11 +401,7 @@ jobs:
           path: target/debug
       - name: Restore executable permissions
         run: chmod +x target/debug/incan target/debug/generate_lang_reference target/debug/generate_feature_inventory
-      # This source/toolchain-keyed input cache survives across compatible
-      # commits. The exact-SHA prepared-suite cache below is separately
-      # retained because the replay partitions must restore a self-contained
-      # immutable closure.
-      - uses: ./.github/actions/restore-sdk-provider-store
+      - uses: ./.github/actions/consume-sdk-provider-store
       - uses: ./.github/actions/install-nightly-toolchain
         with:
           toolchain: nightly-2026-03-24
@@ -416,13 +429,6 @@ jobs:
             target/oven-compiler-suite-store
             target/incan_test_sdk_provider_store
             target/incan_test_sdk_provider_path
-      - name: Upload SDK provider store
-        uses: actions/upload-artifact@v6
-        with:
-          name: test-linux-sdk-provider-store
-          path: target/incan_test_sdk_provider_store
-          if-no-files-found: error
-          retention-days: 1
 
   oven-process-containment:
     name: Oven process-containment regressions
@@ -492,7 +498,7 @@ jobs:
           path: target/debug
       - name: Restore executable permissions
         run: chmod +x target/debug/incan
-      - uses: ./.github/actions/restore-sdk-provider-store
+      - uses: ./.github/actions/consume-sdk-provider-store
       - name: Prove the source-observable comparison ran and agreed
         run: >-
           CARGO_NET_OFFLINE=true
@@ -662,7 +668,7 @@ jobs:
           path: target/debug
       - name: Restore executable permissions
         run: chmod +x target/debug/incan target/debug/generate_lang_reference target/debug/generate_feature_inventory
-      - uses: ./.github/actions/restore-sdk-provider-store
+      - uses: ./.github/actions/consume-sdk-provider-store
       - name: Bake the release Loafs and guard normal build, run, and test
         run: >-
           CARGO_NET_OFFLINE=true
@@ -845,13 +851,10 @@ jobs:
   generated-reference:
     name: Generated Reference Up-to-date
     runs-on: ubuntu-latest
-    # Depends on the two jobs whose artifacts it downloads: `test-linux-tools` from the handoff, and
-    # `test-linux-sdk-provider-store` from the prewarm, which it seeds from whenever its provider cache misses. It no
-    # longer waits on the Oven replay or the platform matrix, which it never consumed.
+    # Reference generation consumes the compiler/SDK handoff directly; no Loaf baking is needed.
     needs:
       - changes
       - linux-tool-handoff
-      - linux-oven-prewarm
     if: ${{ needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.reference == 'true' }}
     steps:
       - uses: actions/checkout@v5
@@ -876,29 +879,9 @@ jobs:
           path: target/debug
       - name: Restore executable permissions
         run: chmod +x target/debug/incan target/debug/generate_lang_reference target/debug/generate_feature_inventory
-      - name: Fingerprint checked feature inventory
-        id: inventory-identity
-        run: |
-          {
-            echo "compiler=$(shasum -a 256 target/debug/incan | awk '{print $1}')"
-            echo "lock=$(shasum -a 256 Cargo.lock | awk '{print $1}')"
-            echo "stdlib=$(git rev-parse HEAD:crates/incan_stdlib/stdlib)"
-          } >> "$GITHUB_OUTPUT"
-      - name: Restore checked feature inventory providers
-        id: inventory-provider-cache
-        uses: actions/cache@v5
+      - uses: ./.github/actions/consume-sdk-provider-store
         with:
-          path: target/incan_reference_sdk_provider_store
-          key: >-
-            incan-feature-inventory-provider-v1-${{ runner.os }}-${{ runner.arch }}-${{
-            steps.inventory-identity.outputs.compiler }}-${{ steps.inventory-identity.outputs.lock }}-${{
-            steps.inventory-identity.outputs.stdlib }}
-      - name: Seed checked feature inventory providers
-        if: steps.inventory-provider-cache.outputs.cache-hit != 'true'
-        uses: actions/download-artifact@v7
-        with:
-          name: test-linux-sdk-provider-store
-          path: target/incan_reference_sdk_provider_store
+          store: target/incan_reference_sdk_provider_store
       - name: Regenerate checked language references
         run: ./target/debug/generate_lang_reference
       - name: Regenerate checked capability inventory

--- a/scripts/ci_scope.sh
+++ b/scripts/ci_scope.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Classify CI work from the event and changed paths; emit GitHub job outputs.
+set -euo pipefail
+
+docs_only=false
+if [ "$EVENT_NAME" = "pull_request" ]; then
+  git fetch origin "$BASE_REF" --depth=1
+  comparison_ref="origin/$BASE_REF"
+  changed=false
+  docs_only=true
+
+  while IFS= read -r -d '' file; do
+    changed=true
+    # The two generated reference pages are derived from the compiler,
+    # so they must retain the full generated-reference check.
+    case "$file" in
+      workspaces/docs-site/docs/language/reference/language.md|workspaces/docs-site/docs/language/reference/feature_inventory.md|workspaces/docs-site/docs/_snippets/language/examples/verified_*.incn)
+        docs_only=false
+        break
+        ;;
+      workspaces/docs-site/*)
+        ;;
+      *)
+        docs_only=false
+        break
+        ;;
+    esac
+  done < <(git diff --name-only -z "$comparison_ref" HEAD)
+
+  if [ "$changed" = false ]; then
+    docs_only=false
+  fi
+fi
+
+echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"
+
+# The expensive half of this workflow -- four Oven replay shards, the prewarm that feeds them, the platform
+# ABI matrix, the release-Loaf guard and the shadow-comparison evidence -- costs more than everything else
+# combined. Spending it on every push to a development line pays release-gate prices for work that is not a
+# release candidate yet. Run it where it decides something: an integration branch, a slice someone declares
+# ready, or an explicit request.
+heavy=false
+case "$EVENT_NAME" in
+  workflow_dispatch)
+    [ "$DISPATCH_HEAVY" = "true" ] && heavy=true
+    ;;
+  pull_request)
+    # A pull request into `main` or a release branch is a release candidate. One into a development line
+    # is not, until it is labelled `full-ci`.
+    case "$BASE_REF" in
+      main|release/*) heavy=true ;;
+    esac
+    case ",$PR_LABELS," in
+      *,full-ci,*) heavy=true ;;
+    esac
+    ;;
+  *)
+    case "$REF_NAME" in
+      main|release/*) heavy=true ;;
+    esac
+    ;;
+esac
+
+echo "heavy=$heavy" >> "$GITHUB_OUTPUT"
+
+# Heavy coverage always requires the compiler/SDK producer. Dispatch can select its docs/reference
+# consumers alone, so cold/warm SDK experiments do not repeat the complete Oven suite.
+reference="$heavy"
+if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$DISPATCH_REFERENCE" = "true" ]; then
+  reference=true
+fi
+if [ "$reference" != "true" ] && [ "$EVENT_NAME" = "pull_request" ]; then
+  while IFS= read -r -d '' file; do
+    case "$file" in
+      crates/incan_core/*) reference=true; break ;;
+      workspaces/docs-site/docs/language/reference/language.md) reference=true; break ;;
+      workspaces/docs-site/docs/language/reference/feature_inventory.md) reference=true; break ;;
+      workspaces/docs-site/docs/_snippets/language/examples/*) reference=true; break ;;
+    esac
+  done < <(git diff --name-only -z "$comparison_ref" HEAD)
+fi
+
+echo "reference=$reference" >> "$GITHUB_OUTPUT"

--- a/scripts/ci_sdk_handoff.py
+++ b/scripts/ci_sdk_handoff.py
@@ -1,0 +1,185 @@
+"""Transfer one compiler-selected SDK between jobs without a cache or publisher fallback.
+
+The envelope binds transport bytes and build coordinates. The compiler remains the authority for
+SDK identity and inventory compatibility; consuming runs its canary with an explicit inventory.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path, PurePosixPath
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+
+
+DEADLINE = time.monotonic() + 270
+
+
+def run(command, workspace, environment):
+    """Bound external tools and preserve their diagnostics on failure."""
+    result = subprocess.run(command, cwd=workspace, env=environment, capture_output=True,
+                            timeout=max(1, DEADLINE - time.monotonic()))
+    if result.returncode:
+        details = (result.stderr + result.stdout).decode(errors="replace").strip()
+        raise ValueError(f"command failed ({result.returncode}): {details}")
+    return result.stdout
+
+
+def file_digest(path):
+    """Hash potentially large compiler binaries without loading them into memory."""
+    with path.open("rb") as source:
+        return hashlib.file_digest(source, "sha256").hexdigest()
+
+
+def payload_digest(root):
+    """Bind relative paths and bytes, refusing links outside the transferred tree."""
+    digest = hashlib.sha256()
+    for path in sorted(root.rglob("*")):
+        if path.is_symlink():
+            raise ValueError(f"SDK handoff cannot contain a symlink: {path}")
+        name = path.relative_to(root).as_posix().encode()
+        digest.update(len(name).to_bytes(8, "big"))
+        digest.update(name)
+        if path.is_dir():
+            digest.update(b"directory\0")
+        elif path.is_file():
+            digest.update(b"file\0")
+            digest.update(bytes.fromhex(file_digest(path)))
+        else:
+            raise ValueError(f"unsupported SDK handoff entry: {path}")
+    return digest.hexdigest()
+
+
+def coordinates(options):
+    """Derive expected inputs independently of the downloaded envelope."""
+    environment = dict(os.environ, INCAN_NO_BANNER="1", INCAN_SOURCE_ROOT=str(options.workspace))
+    identity = run([str(options.compiler), "oven", "sdk-provider-store-identity", "--compiler-root",
+                    str(options.workspace)], options.workspace, environment).decode().strip()
+    if len(identity) != 64 or any(char not in "0123456789abcdef" for char in identity):
+        raise ValueError("compiler returned an invalid SDK provider identity")
+    rustc = run([str(options.rustc), "--version", "--verbose"], options.workspace, environment)
+    return {"schema_version": 1, "provider_identity": identity,
+            "compiler_sha256": file_digest(options.compiler), "rustc_identity": hashlib.sha256(rustc).hexdigest()}
+
+
+def inventory(root):
+    """Require the exact published inventory before any compiler command can prepare providers."""
+    path = root / "sdk-inventory.json"
+    if not path.is_file() or path.is_symlink():
+        raise ValueError(f"SDK inventory is missing or not a regular file: {path}")
+    return path
+
+
+def stage(options, expected):
+    """Package only the successfully prewarmed identity; never copy unrelated store entries."""
+    selected = options.store / expected["provider_identity"]
+    inventory(selected)
+    if selected.is_symlink():
+        raise ValueError(f"SDK handoff cannot contain a symlink: {selected}")
+    expected["payload_sha256"] = payload_digest(selected)
+    # GitHub's file-oriented artifact upload omits empty directories, but provider integrity includes them.
+    expected["empty_directories"] = [path.relative_to(selected).as_posix() for path in sorted(selected.rglob("*"))
+                                     if path.is_dir() and not any(path.iterdir())]
+    if options.artifact.exists():
+        raise ValueError(f"SDK handoff output already exists: {options.artifact}")
+    options.artifact.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="sdk-handoff-", dir=options.artifact.parent) as temporary:
+        staged = Path(temporary) / "artifact"
+        staged.mkdir()
+        copied = staged / expected["provider_identity"]
+        shutil.copytree(selected, copied)
+        if payload_digest(copied) != expected["payload_sha256"]:
+            raise ValueError("SDK payload changed during handoff publication")
+        (staged / "handoff.json").write_text(json.dumps(expected, indent=2) + "\n")
+        staged.rename(options.artifact)
+    print(f"Staged SDK handoff {expected['provider_identity']} ({expected['payload_sha256']})")
+
+
+def consume(options, expected):
+    """Validate transport and compiler compatibility before exporting any consumer paths."""
+    envelope = json.loads((options.artifact / "handoff.json").read_text())
+    if not isinstance(envelope, dict) or envelope.get("schema_version") != 1:
+        raise ValueError("unsupported handoff schema")
+    for key, label in [("provider_identity", "provider identity"), ("compiler_sha256", "compiler digest"),
+                       ("rustc_identity", "rustc identity")]:
+        if envelope.get(key) != expected[key]:
+            raise ValueError(f"SDK handoff {label} mismatch")
+    selected = options.artifact / expected["provider_identity"]
+    selected_inventory = inventory(selected)
+    if selected.is_symlink():
+        raise ValueError(f"SDK handoff cannot contain a symlink: {selected}")
+    directories = envelope.get("empty_directories")
+    if not isinstance(directories, list):
+        raise ValueError("SDK handoff is missing its empty-directory manifest")
+    for directory in directories:
+        if not isinstance(directory, str):
+            raise ValueError("invalid SDK directory manifest entry")
+        relative = PurePosixPath(directory)
+        if (not directory or relative.is_absolute() or ".." in relative.parts
+                or relative.as_posix() != directory or directory == "."):
+            raise ValueError("SDK directory manifest entry must remain inside the selected provider")
+        path = selected / directory
+        if not path.resolve().is_relative_to(selected.resolve()):
+            raise ValueError("SDK directory manifest entry escapes the selected provider")
+        path.mkdir(parents=True, exist_ok=True)
+    if payload_digest(selected) != envelope.get("payload_sha256"):
+        raise ValueError("SDK handoff payload digest mismatch")
+    environment = dict(os.environ, INCAN_NO_BANNER="1", CARGO_NET_OFFLINE="true",
+                       INCAN_SOURCE_ROOT=str(options.workspace), INCAN_SDK_INVENTORY=str(selected_inventory))
+    # Explicit inventory discovery rejects absent/incompatible data before source-checkout preparation is considered.
+    try:
+        output = run([str(options.compiler), "check", "tests/fixtures/test_assert_canary.incn"],
+                     options.workspace, environment)
+    except ValueError as error:
+        raise ValueError(f"SDK validation failed: {error}") from error
+    if payload_digest(selected) != envelope["payload_sha256"]:
+        raise ValueError("SDK validation modified the transferred payload")
+    variables = {"INCAN_SDK_INVENTORY": str(selected_inventory),
+                 "INCAN_INTERNAL_SDK_PROVIDER_STORE": str(options.artifact),
+                 "INCAN_INTERNAL_SDK_PROVIDER_PATH_FILE": str(options.path_file),
+                 "INCAN_TEST_SDK_PROVIDER_STORE": str(options.artifact),
+                 "INCAN_TEST_SDK_PROVIDER_PATH_FILE": str(options.path_file)}
+    if any("\n" in value or "\r" in value for value in variables.values()):
+        raise ValueError("SDK handoff paths cannot contain line breaks")
+    options.path_file.parent.mkdir(parents=True, exist_ok=True)
+    options.path_file.write_text(f"{selected}\n")
+    with options.env_file.open("a") as environment_file:
+        environment_file.writelines(f"{key}={value}\n" for key, value in variables.items())
+    sys.stdout.buffer.write(output)
+    print(f"Validated SDK handoff {expected['provider_identity']}; source publication was not requested")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("mode", choices=["stage", "consume"])
+    parser.add_argument("--workspace", type=Path, default=Path.cwd())
+    parser.add_argument("--compiler", type=Path, default=Path("target/debug/incan"))
+    parser.add_argument("--rustc", default="rustc")
+    parser.add_argument("--artifact", type=Path, required=True)
+    parser.add_argument("--store", type=Path)
+    parser.add_argument("--path-file", type=Path)
+    parser.add_argument("--env-file", type=Path)
+    options = parser.parse_args()
+    for name in ("workspace", "compiler", "artifact", "store", "path_file", "env_file"):
+        path = getattr(options, name)
+        if path is not None:
+            setattr(options, name, path.resolve())
+    if options.mode == "stage" and options.store is None:
+        parser.error("stage requires --store")
+    if options.mode == "consume" and (options.path_file is None or options.env_file is None):
+        parser.error("consume requires --path-file and --env-file")
+    try:
+        expected = coordinates(options)
+        (stage if options.mode == "stage" else consume)(options, expected)
+    except (OSError, ValueError, subprocess.TimeoutExpired) as error:
+        print(f"SDK handoff failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_ci_scope.py
+++ b/scripts/test_ci_scope.py
@@ -1,0 +1,79 @@
+"""Run the workflow's scope command against event and changed-path scenarios."""
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).with_name("ci_scope.sh")
+
+
+class CiScopeTests(unittest.TestCase):
+    def scope(self, event="workflow_dispatch", *, heavy=False, reference=False, base="0.6.0-dev.4",
+              branch="0.6.0-dev.4", labels="", files=("src/main.rs",)):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            git = root / "git"
+            git.write_text(f"#!{sys.executable}\n" + '''
+import json, os, sys
+if sys.argv[1] == "fetch":
+    sys.exit(0)
+if sys.argv[1:3] == ["diff", "--name-only"]:
+    sys.stdout.buffer.write(b"".join(path.encode() + b"\\0" for path in json.loads(os.environ["PROBE_CHANGED_FILES"])))
+else:
+    sys.exit("unexpected Git command")
+''')
+            git.chmod(0o755)
+            output = root / "outputs"
+            environment = dict(os.environ, PATH=str(root) + os.pathsep + os.environ["PATH"],
+                               EVENT_NAME=event, DISPATCH_HEAVY=str(heavy).lower(),
+                               DISPATCH_REFERENCE=str(reference).lower(), BASE_REF=base,
+                               REF_NAME=branch, PR_LABELS=labels, GITHUB_OUTPUT=str(output),
+                               PROBE_CHANGED_FILES=json.dumps(files))
+            result = subprocess.run(["bash", str(SCRIPT)], env=environment, cwd=root,
+                                    capture_output=True, text=True, timeout=10)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            return dict(line.split("=", 1) for line in output.read_text().splitlines())
+
+    def test_reference_only_dispatch_does_not_enable_heavy_work(self):
+        self.assertEqual(self.scope(reference=True), {"docs_only": "false", "heavy": "false", "reference": "true"})
+
+    def test_default_light_dispatch_does_not_enable_reference(self):
+        self.assertEqual(self.scope(), {"docs_only": "false", "heavy": "false", "reference": "false"})
+
+    def test_every_heavy_event_also_selects_the_producer(self):
+        for arguments in [dict(heavy=True), dict(event="pull_request", base="main"),
+                          dict(event="pull_request", base="release/0.6"),
+                          dict(event="pull_request", labels="compiler,full-ci"),
+                          dict(event="push", branch="main"), dict(event="push", branch="release/0.6")]:
+            with self.subTest(arguments=arguments):
+                result = self.scope(**arguments)
+                self.assertEqual((result["heavy"], result["reference"]), ("true", "true"))
+
+    def test_reference_input_does_not_change_ordinary_push_or_pr_scope(self):
+        for event in ["push", "pull_request"]:
+            with self.subTest(event=event):
+                self.assertEqual(self.scope(event=event, reference=True), self.scope(event=event))
+
+    def test_registry_and_verified_example_prs_still_select_reference(self):
+        for path in ["crates/incan_core/src/lang/example.rs",
+                     "workspaces/docs-site/docs/language/reference/language.md",
+                     "workspaces/docs-site/docs/_snippets/language/examples/verified_web.incn"]:
+            with self.subTest(path=path):
+                self.assertEqual(self.scope(event="pull_request", files=(path,)),
+                                 {"docs_only": "false", "heavy": "false", "reference": "true"})
+
+    def test_ordinary_docs_only_pr_stays_docs_only(self):
+        self.assertEqual(self.scope(event="pull_request", files=("workspaces/docs-site/docs/index.md",)),
+                         {"docs_only": "true", "heavy": "false", "reference": "false"})
+
+    def test_empty_change_set_is_not_misreported_as_docs_only(self):
+        self.assertEqual(self.scope(event="pull_request", files=())["docs_only"], "false")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_ci_sdk_handoff.py
+++ b/scripts/test_ci_sdk_handoff.py
@@ -1,0 +1,222 @@
+"""Exercise SDK transfer and refusal through real helper/compiler subprocesses."""
+
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+import zipfile
+
+
+SCRIPT = Path(__file__).with_name("ci_sdk_handoff.py")
+IDENTITY = "a" * 64
+
+
+class SdkHandoffTests(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.root = Path(temporary.name).resolve()
+        self.workspace = self.root / "source checkout"
+        self.workspace.mkdir()
+        self.compiler = self.workspace / "incan"
+        self.compiler.write_text(f"#!{sys.executable}\n" + '''
+import json, os, pathlib, sys
+with open(os.environ["PROBE_TRACE"], "a") as trace:
+    trace.write(json.dumps({"args": sys.argv[1:], "inventory": os.environ.get("INCAN_SDK_INVENTORY"),
+        "store": os.environ.get("INCAN_INTERNAL_SDK_PROVIDER_STORE"),
+        "path_file": os.environ.get("INCAN_INTERNAL_SDK_PROVIDER_PATH_FILE")}) + "\\n")
+if sys.argv[1:3] == ["oven", "sdk-provider-store-identity"]:
+    print(os.environ.get("PROBE_IDENTITY", "a" * 64))
+elif sys.argv[1] == "check":
+    inventory = os.environ.get("INCAN_SDK_INVENTORY")
+    if not inventory:
+        pathlib.Path(os.environ["PROBE_COLD_PUBLISHER"]).touch()
+        sys.exit("unexpected cold publisher")
+    value = json.loads(pathlib.Path(inventory).read_text())
+    if not value.get("compatible"):
+        sys.exit("SDK provider codegen revision mismatch")
+else:
+    sys.exit("unexpected compiler command")
+''')
+        self.compiler.chmod(0o755)
+        self.rustc = self.workspace / "rustc"
+        self.rustc.write_text(f"#!{sys.executable}\nprint('rustc 1.98.0\\nhost: test-target')\n")
+        self.rustc.chmod(0o755)
+        self.store = self.root / "producer store"
+        self.sdk = self.store / IDENTITY
+        self.sdk.mkdir(parents=True)
+        (self.sdk / "sdk-inventory.json").write_text('{"compatible": true}')
+        (self.sdk / "components").mkdir()
+        (self.sdk / "components" / "provider.incnlib").write_bytes(b"immutable checked provider")
+        old = self.store / ("b" * 64)
+        old.mkdir()
+        (old / "sdk-inventory.json").write_text("old unrelated provider")
+        self.artifact = self.root / "handoff artifact"
+        self.env_file = self.root / "github env"
+        self.path_file = self.root / "local provider path"
+        self.trace = self.root / "compiler trace"
+        self.cold_publisher = self.root / "unexpected publisher"
+        self.environment = dict(os.environ, PROBE_TRACE=str(self.trace), PROBE_COLD_PUBLISHER=str(self.cold_publisher))
+
+    def command(self, mode, **environment):
+        args = [sys.executable, str(SCRIPT), mode, "--workspace", str(self.workspace),
+                "--compiler", str(self.compiler), "--rustc", str(self.rustc), "--artifact", str(self.artifact)]
+        if mode == "stage":
+            args += ["--store", str(self.store)]
+        else:
+            args += ["--path-file", str(self.path_file), "--env-file", str(self.env_file)]
+        return subprocess.run(args, env=dict(self.environment, **environment), text=True, capture_output=True, timeout=10)
+
+    def stage(self):
+        result = self.command("stage")
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def assert_refused(self, result, diagnostic):
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(diagnostic, result.stderr)
+        self.assertFalse(self.env_file.exists(), "rejected handoff exposed runtime environment")
+        self.assertFalse(self.path_file.exists(), "rejected handoff exposed SDK path")
+        self.assertFalse(self.cold_publisher.exists(), "rejection fell back to cold SDK publication")
+
+    def rewrite_envelope(self, **updates):
+        path = self.artifact / "handoff.json"
+        envelope = json.loads(path.read_text())
+        envelope.update(updates)
+        path.write_text(json.dumps(envelope))
+
+    def test_relocated_transfer_contains_only_selected_provider_and_checks_explicit_inventory(self):
+        self.stage()
+        self.assertEqual(sorted(p.name for p in self.artifact.iterdir()), [IDENTITY, "handoff.json"])
+        relocated = self.root / "consumer checkout" / "sdk"
+        relocated.parent.mkdir()
+        shutil.copytree(self.artifact, relocated)
+        shutil.rmtree(self.artifact)
+        shutil.rmtree(self.store)
+        self.artifact = relocated
+        result = self.command("consume")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        inventory = relocated / IDENTITY / "sdk-inventory.json"
+        self.assertEqual(self.path_file.read_text(), f"{inventory.parent}\n")
+        self.assertIn(f"INCAN_SDK_INVENTORY={inventory}\n", self.env_file.read_text())
+        calls = [json.loads(line) for line in self.trace.read_text().splitlines()]
+        self.assertEqual(calls[-1]["args"], ["check", "tests/fixtures/test_assert_canary.incn"])
+        self.assertEqual(calls[-1]["inventory"], str(inventory))
+        self.assertFalse(self.cold_publisher.exists())
+
+    def test_missing_producer_inventory_refuses_before_compiler_check(self):
+        (self.sdk / "sdk-inventory.json").unlink()
+        self.assert_refused(self.command("stage"), "SDK inventory is missing")
+        self.assertFalse(self.artifact.exists())
+
+    def test_missing_handoff_refuses_without_publishing(self):
+        self.assert_refused(self.command("consume"), "handoff")
+
+    def test_current_compiler_identity_overrules_tampered_envelope(self):
+        self.stage()
+        changed = "c" * 64
+        (self.artifact / IDENTITY).rename(self.artifact / changed)
+        self.rewrite_envelope(provider_identity=changed)
+        self.assert_refused(self.command("consume"), "provider identity mismatch")
+
+    def test_source_change_refuses_previously_valid_artifact(self):
+        self.stage()
+        self.assert_refused(self.command("consume", PROBE_IDENTITY="d" * 64), "provider identity mismatch")
+
+    def test_changed_compiler_bytes_refuse(self):
+        self.stage()
+        with self.compiler.open("a") as compiler:
+            compiler.write("\n# different compiler\n")
+        self.assert_refused(self.command("consume"), "compiler digest mismatch")
+
+    def test_wrong_toolchain_refuses(self):
+        self.stage()
+        self.rustc.write_text(f"#!{sys.executable}\nprint('rustc 1.99.0')\n")
+        self.assert_refused(self.command("consume"), "rustc identity mismatch")
+
+    def test_missing_consumer_inventory_refuses(self):
+        self.stage()
+        (self.artifact / IDENTITY / "sdk-inventory.json").unlink()
+        self.assert_refused(self.command("consume"), "SDK inventory is missing")
+
+    def test_modified_payload_refuses(self):
+        self.stage()
+        (self.artifact / IDENTITY / "components" / "provider.incnlib").write_bytes(b"changed provider")
+        self.assert_refused(self.command("consume"), "payload digest mismatch")
+
+    def test_compiler_rejects_inventory_even_when_transport_digest_matches(self):
+        (self.sdk / "sdk-inventory.json").write_text('{"compatible": false}')
+        self.stage()
+        self.assert_refused(self.command("consume"), "SDK provider codegen revision mismatch")
+
+    def test_malformed_inventory_is_rejected_by_compiler(self):
+        (self.sdk / "sdk-inventory.json").write_text("not JSON")
+        self.stage()
+        self.assert_refused(self.command("consume"), "SDK validation failed")
+
+    def test_symlink_payload_is_not_exported(self):
+        (self.sdk / "outside").symlink_to(self.compiler)
+        self.assert_refused(self.command("stage"), "symlink")
+        self.assertFalse(self.artifact.exists())
+
+    def test_unknown_envelope_version_refuses(self):
+        self.stage()
+        self.rewrite_envelope(schema_version=2)
+        self.assert_refused(self.command("consume"), "unsupported handoff schema")
+
+    def test_cache_is_not_needed_after_artifact_publication(self):
+        self.stage()
+        shutil.rmtree(self.store)
+        self.assertEqual(self.command("consume").returncode, 0)
+        self.assertFalse(self.store.exists())
+
+    def test_make_prerequisite_preserves_custom_handoff_paths(self):
+        self.stage()
+        consumed = self.command("consume")
+        self.assertEqual(consumed.returncode, 0, consumed.stderr)
+        compiler = self.workspace / "target" / "debug" / "incan"
+        compiler.parent.mkdir(parents=True)
+        shutil.copy2(self.compiler, compiler)
+        exports = dict(line.split("=", 1) for line in self.env_file.read_text().splitlines())
+        environment = dict(self.environment, **exports, INCAN_TEST_COMPILER_ALREADY_BUILT="1")
+        makefile = SCRIPT.parent.parent / "Makefile"
+        result = subprocess.run(["make", "-s", "-f", str(makefile), "test-prewarm-sdk"],
+                                cwd=self.workspace, env=environment, capture_output=True, text=True, timeout=10)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        call = json.loads(self.trace.read_text().splitlines()[-1])
+        self.assertEqual(call["inventory"], str(self.artifact / IDENTITY / "sdk-inventory.json"))
+        self.assertEqual(call["store"], str(self.artifact))
+        self.assertEqual(call["path_file"], str(self.path_file))
+        self.assertFalse(self.cold_publisher.exists())
+
+    def test_file_only_zip_transfer_restores_directory_integrity_and_hidden_payload(self):
+        (self.sdk / "empty" / "nested").mkdir(parents=True)
+        (self.sdk / ".metadata").write_bytes(b"hidden provider input")
+        self.stage()
+        archive = self.root / "artifact.zip"
+        with zipfile.ZipFile(archive, "w") as output:
+            for path in self.artifact.rglob("*"):
+                if path.is_file():
+                    output.write(path, path.relative_to(self.artifact))
+        shutil.rmtree(self.artifact)
+        with zipfile.ZipFile(archive) as source:
+            source.extractall(self.artifact)
+        empty = self.artifact / IDENTITY / "empty" / "nested"
+        self.assertFalse(empty.exists(), "file-only transfer unexpectedly preserved empty directories")
+        result = self.command("consume")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(empty.is_dir(), "consumer did not restore the authoritative provider directory tree")
+        self.assertEqual((self.artifact / IDENTITY / ".metadata").read_bytes(), b"hidden provider input")
+
+    def test_empty_directory_manifest_cannot_escape_selected_provider(self):
+        self.stage()
+        self.rewrite_envelope(empty_directories=["../../escaped"])
+        self.assert_refused(self.command("consume"), "must remain inside the selected provider")
+        self.assertFalse((self.root / "escaped").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/cli/commands/common.rs
+++ b/src/cli/commands/common.rs
@@ -93,6 +93,8 @@ pub(crate) const INTERNAL_LIBRARY_ARTIFACT_ONLY_ENV: &str = "INCAN_INTERNAL_LIBR
 /// Unlike artifact-only mode, an Oven direct-rustc dependency build must emit caller-owned rlibs. It still targets
 /// exactly the dependency project selected by the parent, even if that project is the root of a larger workspace.
 pub(crate) const INTERNAL_LIBRARY_DEPENDENCY_PREPARATION_ENV: &str = "INCAN_INTERNAL_LIBRARY_DEPENDENCY_PREPARATION";
+/// Optional external directory for SDK publication timing evidence.
+const INTERNAL_SDK_BUILD_REPORT_DIR_ENV: &str = "INCAN_INTERNAL_SDK_BUILD_REPORT_DIR";
 /// Internal provider-store override used by isolated compiler and packaging tests.
 const INTERNAL_SDK_PROVIDER_STORE_ENV: &str = "INCAN_INTERNAL_SDK_PROVIDER_STORE";
 /// Internal file through which release packaging receives the exact immutable SDK provider root.
@@ -797,6 +799,10 @@ pub(crate) fn prepare_sdk_provider_inventory_in_store(
         &distribution_profile,
     )?;
     let _lock = acquire_sdk_provider_store_lock(&store_root)?;
+    let mut build_reports = env::var_os(INTERNAL_SDK_BUILD_REPORT_DIR_ENV)
+        .filter(|path| !path.is_empty())
+        .map(|path| SdkBuildReports::new(Path::new(&path), &store_root, &identity))
+        .transpose()?;
     let artifact_root = store_root.join(&identity);
     let inventory_path = artifact_root.join(SDK_INVENTORY_FILE);
     if inventory_path.is_file() {
@@ -809,6 +815,9 @@ pub(crate) fn prepare_sdk_provider_inventory_in_store(
             )
             .map_err(|error| CliError::failure(error.to_string()))?;
         record_sdk_provider_root(&artifact_root)?;
+        if let Some(reports) = &mut build_reports {
+            reports.finish("cache_hit");
+        }
         return Ok(Arc::new(inventory));
     }
     if artifact_root.exists() {
@@ -825,8 +834,8 @@ pub(crate) fn prepare_sdk_provider_inventory_in_store(
         workspace_lock.as_deref(),
         &staging_root,
         &distribution_profile,
-        source_root_override,
-        &stdlib_root,
+        source_root_override.map(|source_root| (source_root, stdlib_root.as_path())),
+        build_reports.as_ref(),
     ) {
         Ok(inventory) => inventory,
         Err(error) => {
@@ -851,7 +860,125 @@ pub(crate) fn prepare_sdk_provider_inventory_in_store(
         ))
     })?;
     record_sdk_provider_root(&artifact_root)?;
+    if let Some(reports) = &mut build_reports {
+        reports.finish("published");
+    }
     Ok(Arc::new(published))
+}
+
+/// Optional operational evidence kept outside the immutable provider store.
+struct SdkBuildReports {
+    directory: PathBuf,
+    identity: String,
+    started: std::time::Instant,
+    completed: bool,
+}
+
+impl SdkBuildReports {
+    /// Require an existing external directory before creating a unique publication report session.
+    fn new(directory: &Path, store: &Path, identity: &str) -> CliResult<Self> {
+        let directory = fs::canonicalize(directory).map_err(|error| {
+            CliError::failure(format!(
+                "SDK build report directory must already exist: {}: {error}",
+                directory.display()
+            ))
+        })?;
+        let store = fs::canonicalize(store).map_err(|error| CliError::failure(error.to_string()))?;
+        if directory.starts_with(&store) || store.starts_with(&directory) {
+            return Err(CliError::failure(
+                "SDK build report directory must be separate from the provider store",
+            ));
+        }
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|error| CliError::failure(error.to_string()))?
+            .as_nanos();
+        let directory = directory.join(format!("sdk-build-{}-{nonce}", std::process::id()));
+        fs::create_dir(&directory).map_err(|error| CliError::failure(error.to_string()))?;
+        let reports = Self {
+            directory,
+            identity: identity.to_string(),
+            started: std::time::Instant::now(),
+            completed: false,
+        };
+        reports.summary("preparing");
+        Ok(reports)
+    }
+
+    /// Persist telemetry without changing the compiler's publication result or original failure diagnostic.
+    fn write(&self, name: &str, value: &serde_json::Value) {
+        let result = serde_json::to_vec_pretty(value)
+            .map_err(std::io::Error::other)
+            .and_then(|bytes| fs::write(self.directory.join(name), bytes));
+        if let Err(error) = result {
+            eprintln!("warning: SDK build timing report unavailable: {error}");
+        }
+    }
+
+    /// Describe work after acquiring the store lock; source identity calculation and lock waiting precede this scope.
+    fn summary(&self, status: &str) {
+        self.write(
+            "summary.json",
+            &serde_json::json!({
+                "schema_version": 1, "status": status, "sdk_store_identity": self.identity,
+                "elapsed_scope": "after_store_lock",
+                "elapsed_ms": self.started.elapsed().as_millis()
+            }),
+        );
+    }
+
+    /// Mark a successfully validated cache acquisition or completed publication.
+    fn finish(&mut self, status: &str) {
+        self.summary(status);
+        self.completed = true;
+    }
+
+    /// Select a component-specific child output; the SDK environment helper disables descendant report sessions.
+    fn configure(&self, command: &mut Command, component: &str) {
+        command
+            .args(["--report", "json", "--report-output"])
+            .arg(self.directory.join(format!("{component}.build.json")));
+    }
+
+    /// Retain bounded successful phase data and an explicit unavailable reason on missing or malformed child output.
+    fn component(&self, component: &str, elapsed: std::time::Duration, output: &std::process::Output) {
+        let path = self.directory.join(format!("{component}.build.json"));
+        let parsed = (|| -> Result<serde_json::Value, String> {
+            let metadata = fs::metadata(&path).map_err(|error| error.to_string())?;
+            if metadata.len() > 4 * 1024 * 1024 {
+                return Err("child report exceeds 4 MiB".to_string());
+            }
+            let bytes = fs::read(&path).map_err(|error| error.to_string())?;
+            let report: serde_json::Value = serde_json::from_slice(&bytes).map_err(|error| error.to_string())?;
+            let timings = report
+                .get("timings_ms")
+                .and_then(serde_json::Value::as_object)
+                .filter(|timings| !timings.is_empty() && timings.values().all(|value| value.as_u64().is_some()))
+                .ok_or("child report has no valid timings_ms")?;
+            Ok(serde_json::Value::Object(timings.clone()))
+        })();
+        let (status, timings, reason) = match parsed {
+            Ok(timings) => ("available", timings, None),
+            Err(reason) => ("unavailable", serde_json::Value::Null, Some(reason)),
+        };
+        self.write(
+            &format!("{component}.timing.json"),
+            &serde_json::json!({
+                "schema_version": 1, "component": component, "elapsed_ms": elapsed.as_millis(),
+                "success": output.status.success(), "exit_code": output.status.code(),
+                "report_status": status, "timings_ms": timings, "unavailable_reason": reason,
+                "timings_semantics": "inclusive_nested_scopes"
+            }),
+        );
+    }
+}
+
+impl Drop for SdkBuildReports {
+    fn drop(&mut self) {
+        if !self.completed {
+            self.summary("failed");
+        }
+    }
 }
 
 /// Report the exact immutable provider root to release packaging when requested.
@@ -874,8 +1001,8 @@ fn build_sdk_components_into_staging(
     workspace_lock: Option<&Path>,
     staging_root: &Path,
     distribution_profile: &str,
-    source_root_override: Option<&Path>,
-    stdlib_root: &Path,
+    toolchain_source: Option<(&Path, &Path)>,
+    build_reports: Option<&SdkBuildReports>,
 ) -> CliResult<SdkInventory> {
     fs::create_dir_all(staging_root).map_err(|error| {
         CliError::failure(format!(
@@ -930,7 +1057,7 @@ fn build_sdk_components_into_staging(
             &component.id,
             &cargo_target_dir,
             caller_cargo_target.as_deref(),
-            source_root_override.map(|source_root| (source_root, stdlib_root)),
+            toolchain_source,
         );
         if built_any {
             inventory
@@ -943,6 +1070,10 @@ fn build_sdk_components_into_staging(
         if let Some(workspace_lock) = workspace_lock {
             command.env(INTERNAL_CARGO_LOCK_PAYLOAD_PATH_ENV, workspace_lock);
         }
+        if let Some(reports) = build_reports {
+            reports.configure(&mut command, &component.id);
+        }
+        let component_started = std::time::Instant::now();
         let output = command.output().map_err(|error| {
             CliError::failure(format!(
                 "failed to run SDK component build for `{}` at {}: {error}",
@@ -950,6 +1081,9 @@ fn build_sdk_components_into_staging(
                 component.project_root.display()
             ))
         })?;
+        if let Some(reports) = build_reports {
+            reports.component(&component.id, component_started.elapsed(), &output);
+        }
         if !output.status.success() {
             return Err(nested_sdk_component_build_error(
                 component.id.as_str(),
@@ -1030,6 +1164,7 @@ fn configure_sdk_provider_build_environment(
     command
         .env_remove(INTERNAL_MANIFEST_OVERRIDE_ENV)
         .env_remove(INTERNAL_PROJECT_ROOT_OVERRIDE_ENV)
+        .env_remove(INTERNAL_SDK_BUILD_REPORT_DIR_ENV)
         .env(SDK_PROVIDER_BUILD_ENV, component_id)
         .env(INTERNAL_LIBRARY_ARTIFACT_ONLY_ENV, "1")
         // Share transient Cargo artifacts across components, then remove them before immutable provider publication.
@@ -5412,6 +5547,81 @@ mod tests {
 
         assert_eq!(binding.header, "interop/include/bridge.h");
         assert_eq!(resolved.header, "/workspace/c_header_fixture/interop/include/bridge.h");
+        Ok(())
+    }
+
+    #[test]
+    fn sdk_build_reports_reject_store_paths_and_distinguish_cache_hits() -> Result<(), Box<dyn std::error::Error>> {
+        let root = tempfile::tempdir()?;
+        let store = root.path().join("store");
+        let reports_root = root.path().join("reports");
+        fs::create_dir_all(store.join("artifact"))?;
+        fs::create_dir(&reports_root)?;
+        assert!(SdkBuildReports::new(&store.join("artifact"), &store, "identity").is_err());
+        let mut reports = SdkBuildReports::new(&reports_root, &store, "identity")?;
+        reports.finish("cache_hit");
+        let summary: serde_json::Value = serde_json::from_slice(&fs::read(reports.directory.join("summary.json"))?)?;
+        assert_eq!(summary["status"], "cache_hit");
+        assert_eq!(summary["elapsed_scope"], "after_store_lock");
+        assert_eq!(fs::read_dir(&reports.directory)?.count(), 1);
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sdk_build_reports_transport_mock_children_without_replacing_failures() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let root = tempfile::tempdir()?;
+        let store = root.path().join("store");
+        let reports_root = root.path().join("reports");
+        fs::create_dir(&store)?;
+        fs::create_dir(&reports_root)?;
+        let reports = SdkBuildReports::new(&reports_root, &store, "identity")?;
+        let mut child = Command::new("sh");
+        child.args([
+            "-c",
+            r#"printf '%s' '{"timings_ms":{"library_prepare_total":7}}' > "$4""#,
+            "mock",
+        ]);
+        configure_sdk_provider_build_environment(&mut child, "stdlib-data", root.path(), None, None);
+        reports.configure(&mut child, "stdlib-data");
+        assert!(
+            child
+                .get_envs()
+                .any(|(name, value)| name == INTERNAL_SDK_BUILD_REPORT_DIR_ENV && value.is_none())
+        );
+        let output = child.output()?;
+        assert!(output.status.success());
+        assert!(output.stdout.is_empty());
+        reports.component("stdlib-data", std::time::Duration::from_millis(11), &output);
+        let value: serde_json::Value =
+            serde_json::from_slice(&fs::read(reports.directory.join("stdlib-data.timing.json"))?)?;
+        assert_eq!(value["report_status"], "available");
+        assert_eq!(value["timings_semantics"], "inclusive_nested_scopes");
+        assert_eq!(value["timings_ms"]["library_prepare_total"], 7);
+        let failed = Command::new("sh")
+            .args(["-c", "printf original-diagnostic >&2; exit 9"])
+            .output()?;
+        reports.component("missing", std::time::Duration::ZERO, &failed);
+        fs::write(reports.directory.join("malformed.build.json"), "not-json")?;
+        reports.component("malformed", std::time::Duration::ZERO, &output);
+        for component in ["missing", "malformed"] {
+            let value: serde_json::Value =
+                serde_json::from_slice(&fs::read(reports.directory.join(format!("{component}.timing.json")))?)?;
+            assert_eq!(value["report_status"], "unavailable");
+            assert!(value["timings_ms"].is_null());
+        }
+        assert_eq!(failed.status.code(), Some(9));
+        assert_eq!(failed.stderr, b"original-diagnostic");
+        assert!(
+            nested_sdk_component_build_error("missing", root.path(), &failed)
+                .to_string()
+                .contains("original-diagnostic")
+        );
+        let directory = reports.directory.clone();
+        drop(reports);
+        let summary: serde_json::Value = serde_json::from_slice(&fs::read(directory.join("summary.json"))?)?;
+        assert_eq!(summary["status"], "failed");
         Ok(())
     }
 

--- a/tests/toolchain_installer_tests.rs
+++ b/tests/toolchain_installer_tests.rs
@@ -1188,24 +1188,27 @@ fn compiler_suite_action_composes_baker_guarded_runner_and_storage_evidence() ->
     let compiler_build = linux_tools_workflow
         .find("- name: Build Linux compiler and reference generators")
         .ok_or("pull-request CI is missing Linux compiler build")?;
-    let provider_restore = linux_prewarm_workflow
-        .find("- uses: ./.github/actions/restore-sdk-provider-store")
-        .ok_or("pull-request CI is missing SDK provider cache restore")?;
+    let provider_handoff = linux_prewarm_job
+        .find("- uses: ./.github/actions/consume-sdk-provider-store")
+        .ok_or("pull-request CI is missing the same-run SDK handoff")?;
     let complete_suite = linux_prewarm_workflow
         .find("- name: Prewarm the complete Linux Rust 1.98.0 Oven suite")
         .ok_or("pull-request CI is missing the complete pinned Linux Oven suite")?;
     assert!(
         compiler_build < linux_tools_workflow.len()
-            && provider_restore < complete_suite
+            && provider_handoff < complete_suite
+            && linux_tools_workflow.contains("uses: ./.github/actions/restore-sdk-provider-store")
             && linux_prewarm_workflow.contains("needs:\n      - changes\n      - linux-tool-handoff")
             && linux_prewarm_job.contains("- name: Save prepared Linux Rust 1.98.0 Oven suite")
             && linux_prewarm_job.contains("target/incan_test_sdk_provider_store"),
-        "pull-request CI must build the identity-bearing compiler once, reuse its persistent provider input cache in the single Linux prewarm, and capture that provider store in the immutable prepared-suite handoff"
+        "pull-request CI must prepare the SDK with its matching compiler, transfer it into the Linux prewarm, and capture that provider store in the immutable prepared-suite handoff"
     );
     assert_eq!(
-        linux_prewarm_job.matches("name: test-linux-sdk-provider-store").count(),
+        linux_tools_workflow
+            .matches("name: test-linux-sdk-provider-store")
+            .count(),
         1,
-        "the Linux prewarm is the sole publisher of the provider-store artifact"
+        "the compiler/SDK handoff is the sole publisher of the provider-store artifact"
     );
     assert!(
         !workflow.contains("INCAN_OVEN_NATIVE_TEST_CASE_TIMINGS"),
@@ -1300,7 +1303,6 @@ fn compiler_suite_action_composes_baker_guarded_runner_and_storage_evidence() ->
             && !workflow.contains("MSRV")
             && !workflow.contains("--toolchain stable")
             && !workflow.contains("dtolnay/rust-toolchain@stable")
-            && workflow.matches("Install WASI target for vocab desugarers").count() == 7
             && !workflow.contains("make test-oven-focused"),
         "pull-request CI must cancel superseded runs, prewarm the complete pinned Linux suite once, replay its four receipt partitions without rebaking, retain independent process-containment coverage, and carry no explicit per-job budgets: a version bump cold-starts every completion-gated cache, and any budget below a cold build means the job can never re-warm, so the runner-level 6-hour ceiling is the only bound"
     );
@@ -1330,7 +1332,7 @@ fn compiler_suite_action_composes_baker_guarded_runner_and_storage_evidence() ->
     assert!(
         release_gate.contains("needs:\n      - changes\n      - linux-tool-handoff")
             && !release_gate.contains("timeout-minutes:")
-            && release_gate.contains("restore-sdk-provider-store")
+            && release_gate.contains("consume-sdk-provider-store")
             && release_gate.contains("make -s test-oven-release-smoke")
             && !release_gate.contains("test-oven-partition"),
         "normal-command Cargo-guard proof must remain an independent Linux gate rather than extend the heaviest replay worker; per-job budgets are deliberately absent so completion-gated caches can save after a cold build"
@@ -1338,11 +1340,11 @@ fn compiler_suite_action_composes_baker_guarded_runner_and_storage_evidence() ->
     assert!(
         platform_gate.contains("make -s test-prewarm-sdk")
             && platform_gate.contains("${{ matrix.c_abi_test }}")
-            && platform_gate.contains("check_verifies_c_bindings_against_a_declared_android_interop_target")
             && platform_gate.contains("check_verifies_c_bindings_against_a_declared_ios_interop_target")
+            && workflow.contains("check_verifies_c_bindings_against_a_declared_android_interop_target")
             && !platform_gate.contains("test-one")
             && !platform_gate.contains("test-oven-release-smoke"),
-        "the pinned macOS and Android-targeted Linux gates must retain their platform-specific C-ABI assertions after one SDK prewarm, without repeating the Linux Oven suite bake"
+        "the pinned macOS and Android-targeted Linux gates must retain their platform-specific C-ABI assertions with prepared SDK providers, without repeating the Linux Oven suite bake"
     );
     assert!(
         evidence_workflow.contains("uses: ./.github/actions/run-oven-compiler-suite"),

--- a/workspaces/docs-site/docs/contributing/how-to/ci_and_automation.md
+++ b/workspaces/docs-site/docs/contributing/how-to/ci_and_automation.md
@@ -58,3 +58,23 @@ Build the docs site:
 ```bash
 make docs-build
 ```
+
+## Measure SDK preparation in hosted CI
+
+To run the compiler, SDK, verified documentation and generated-reference checks without the heavy Oven suite, dispatch CI against the branch you want to measure:
+
+```bash
+gh workflow run ci.yml --ref <branch> -f heavy=false -f reference=true
+```
+
+The Linux compiler and SDK handoff job restores the compatible SDK cache or prepares the SDK once, then publishes the selected provider artifact. Documentation and generated-reference jobs consume that artifact independently. Heavy runs also supply it to Linux C ABI, Oven preparation, shadow comparison and release checks. macOS prepares its own platform-specific SDK.
+
+After the run finishes, download its preparation evidence:
+
+```bash
+gh run download <run-id> -n test-linux-sdk-preparation-reports
+```
+
+Inspect the session's `summary.json` for `cache_hit`, `published` or `failed`. Its elapsed time starts after the SDK store lock is acquired. A cold publication also records each component's existing build report and a timing record; unavailable reports are marked explicitly. Build timings contain inclusive nested phases, so they must not be added together. Compare SDK preparation separately from the documentation-check step and native Loaf preparation.
+
+Repeat the dispatch at the same commit after the first run completes to measure reuse. A warm run should select the same SDK identity without rebuilding components. Keep the compiler, Rust toolchain and source unchanged between the pair. The cross-run cache can lose a save reservation to another run; the same-run artifact remains the required input for consumers. An absent or incompatible handoff fails validation instead of silently starting another SDK publication.


### PR DESCRIPTION
## Summary

Linux CI now builds one compiler and SDK provider set, then transfers the verified SDK to independent documentation, ABI, Oven, release, shadow and generated-reference consumers. Documentation checks no longer include SDK preparation, and generated references no longer wait for native Loaf preparation.

Final integration passes all 25 jobs and reconciles 5,281 native tests. A matched cold/warm experiment proves that the existing SDK can be reused in one second; actual docs checks take about 32 seconds. Cold SDK preparation still takes about 37 minutes and remains follow-up work.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / maintenance
- [x] Documentation
- [x] CI / tooling
- [ ] RFC

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **Workflow:** six Linux consumers use the same run's SDK artifact. macOS retains its platform preparation. A reference-only dispatch exercises compiler, SDK, docs and generated references without heavy replay. Focused compiled regressions run in the independent Clippy job so they no longer delay SDK consumers.
- **Authority:** the compiler derives the expected SDK identity independently of the downloaded envelope. Handoff validates compiler bytes, rustc identity, payload integrity and explicit-inventory compatibility before exporting paths. Same-run handoff does not depend on successful cross-run cache publication. Missing or incompatible artifacts fail before source publication.
- **Measurement:** `INCAN_INTERNAL_SDK_BUILD_REPORT_DIR` retains existing child build JSON and component wall times outside provider artifacts. Reports distinguish cache hits, publication and failure; unavailable timing data remains unavailable. Timing scopes are nested and inclusive.
- **Limits:** this removes duplicate Linux SDK publication and a serial test-compilation dependency. It does not reduce the cold compiler's checking/metadata costs or change SDK revision, semantic cache contracts or fixture concurrency. Those remain on #1424 and #1065.

## Testing / verification

- [x] Compiled SDK-report unit tests and installer CI contract regression
- [x] Matched cold/warm reference-only CI handoff experiment
- [x] Full heavy CI integration at the final head
- [x] Focused Python handoff and scope checks
- [x] Release consistency and transcript-retention regressions
- [x] Actionlint, shellcheck, whitespace and changed Rustdoc checks
- [x] Independent handoff review and parent timing-transport review
- [x] Strict MkDocs build

[Final integration 34224450105](https://github.com/encero-systems/incan/actions/runs/34224450105) passes all 25 jobs at `c123294c34634c80e4ea3ed384e85bdf4b1da4cf`. All six direct Linux consumers pass their exact SDK canaries with no SDK component rebuild. Four replay partitions reconcile 5,281 native inventory entries, passes and per-case timings across 90 distinct native roots, plus 11 rustdoc roots; there are no failed or ignored native cases. All reports share the same suite receipt. Clippy runs the relocated two SDK-report tests and one installer-contract test.

The reference-only [cold run 34218604990](https://github.com/encero-systems/incan/actions/runs/34218604990) and [warm run 34223054275](https://github.com/encero-systems/incan/actions/runs/34223054275) both pass at unchanged `7b911b250`. Their compiler/SDK/rustc/payload envelopes are identical. Cold SDK preparation takes 36m27s; warm preparation takes one second, with no SDK child builds. Docs take 32 seconds in each. The complete warm workflow takes 13m28s, including compiler/test compilation, transfer and scheduling.

At the final head, docs take 33 seconds and cold SDK preparation takes 37m08s. Module checking (1254.677s) and manifest metadata (933.079s) account for 98.245% of that cold preparation. The longest replay step takes 37m46s; measured compiler exit and wrapper retention intervals are below a quarter second each. These observations do not establish a controlled replay speedup or explain the historical unmeasured tail. The shadow gate passes with 12 green and 54 unavailable rows, not 66 parity matches.

Local Python tests use a mock compiler, including the real Makefile prerequisite; the production CI experiments provide actual compiler handoff evidence. `make examples` and Incan formatting are not applicable to this CI/reporting change. A separate local full `make pre-commit` run is not claimed.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent where applicable

The contributor [CI how-to](https://github.com/encero-systems/incan/blob/chore/1424-linux-sdk-handoff/workspaces/docs-site/docs/contributing/how-to/ci_and_automation.md) documents focused dispatch, evidence download and cold/warm comparison.

## Checklist

- [x] Public docs remain user-focused; operational details are in contributing docs
- [x] Canonical install/run instructions are not duplicated
- [x] Focused regressions cover meaningful handoff failures and preserved scope

Refs #1424. The shared Linux SDK handoff and measurement packet are complete; cold-path and cache-input work keep the issue open.
