### PR TITLE
bugfix - reuse SDK providers after CI-only changes (#1424)

### DIFF
--- a/src/cli/commands/common.rs
+++ b/src/cli/commands/common.rs
@@ -522,7 +522,10 @@ fn is_sdk_provider_compiler_checkout(candidate: &Path, stdlib_root: &Path) -> bo
     fs::canonicalize(&expected_stdlib_root).ok() == fs::canonicalize(stdlib_root).ok()
 }
 
-/// Hash only compiler-authoritative checkout inputs, excluding generated output and test-only trees.
+/// Hash compiler-authoritative checkout inputs, excluding generated output, test trees, and root CI administration.
+///
+/// The root `.github` directory configures repository automation; compilation does not read it. This exclusion is
+/// deliberately root-only so similarly named directories within compiler sources retain their existing authority.
 fn hash_sdk_provider_compiler_source_tree(root: &Path, current: &Path, hasher: &mut Sha256) -> CliResult<()> {
     let mut entries = fs::read_dir(current)
         .map_err(|error| {
@@ -554,6 +557,9 @@ fn hash_sdk_provider_compiler_source_tree(root: &Path, current: &Path, hasher: &
                 path.display()
             ))
         })?;
+        if file_type.is_dir() && relative == Path::new(".github") {
+            continue;
+        }
         if file_type.is_dir()
             && relative.components().any(|component| {
                 matches!(
@@ -5705,6 +5711,24 @@ mod tests {
             "test-only source must not republish SDK providers"
         );
 
+        let workflow_dir = checkout.join(".github/workflows");
+        fs::create_dir_all(&workflow_dir)?;
+        fs::write(workflow_dir.join("ci.yml"), "name: original CI\n")?;
+        let with_workflow =
+            sdk_provider_store_identity(&stdlib_root, &executable, Some(&checkout.join("Cargo.lock")), "full")?;
+        assert_eq!(
+            initial, with_workflow,
+            "CI configuration does not change SDK compilation inputs"
+        );
+        fs::write(workflow_dir.join("ci.yml"), "name: reordered CI\n")?;
+        fs::rename(workflow_dir.join("ci.yml"), workflow_dir.join("renamed.yml"))?;
+        let changed_workflow =
+            sdk_provider_store_identity(&stdlib_root, &executable, Some(&checkout.join("Cargo.lock")), "full")?;
+        assert_eq!(
+            initial, changed_workflow,
+            "CI edits and administrative path changes must reuse SDK providers"
+        );
+
         fs::write(
             checkout.join("src/compiler.rs"),
             "pub fn compile() { let changed = true; }\n",
@@ -5714,6 +5738,24 @@ mod tests {
         assert_ne!(
             initial, changed_source,
             "a compiler source change must still invalidate SDK provider artifacts"
+        );
+        fs::write(
+            stdlib_root.join("components/core.incn"),
+            "pub def core() -> int:\n  return 2\n",
+        )?;
+        let changed_stdlib =
+            sdk_provider_store_identity(&stdlib_root, &executable, Some(&checkout.join("Cargo.lock")), "full")?;
+        assert_ne!(
+            changed_source, changed_stdlib,
+            "stdlib source remains part of SDK provider identity"
+        );
+        fs::create_dir_all(checkout.join("src/.github"))?;
+        fs::write(checkout.join("src/.github/input.txt"), "compiler-owned input")?;
+        let nested_directory =
+            sdk_provider_store_identity(&stdlib_root, &executable, Some(&checkout.join("Cargo.lock")), "full")?;
+        assert_ne!(
+            changed_stdlib, nested_directory,
+            "only root CI administration is excluded"
         );
         Ok(())
     }


### PR DESCRIPTION
## Summary

Editing, adding or renaming a workflow currently changes the SDK provider cache identity even when compilation inputs are unchanged. Exclude the checkout's root `.github` directory from that identity so repository automation changes can reuse the existing SDK providers.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [x] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: workflow-only edits reuse the SDK source identity. This avoids that cause of unnecessary preparation; cold SDK compilation remains separate work.
- **Internals**: one root-directory exclusion in the existing compiler source walker. Compiler sources, stdlib sources, lock data, version/profile inputs and installed executable hashing retain their authority. Artifact verification is unchanged.
- **Risks**: the exclusion relies on root `.github` being repository administration rather than a compilation input. Current production source, include-macro and Cargo manifest checks found no consumption of that directory. The exclusion is root-only; nested source directories named `.github` remain hashed.

## Testing / verification

- [x] `cargo test` — focused release/lsp SDK identity and report tests
- [ ] `make examples` (not applicable: no language/native behavior change)
- [ ] `incan fmt --check .` (not applicable: no Incan source changes)
- [x] Manual verification described below

Manual verification notes:

- Targeted rustfmt, `git diff --check` and changed Rustdoc gate pass.
- Existing SDK identity regression now covers workflow creation, content edits and rename with the same identity; compiler, stdlib and nested source-directory changes must alter it.
- At `887a299d`, SDK identity tests pass 2/2 and SDK report tests pass 2/2; scoped release library Clippy with warnings denied passes. The identity gate compiles in 3m31s and executes in 0.01s; the report gate reuses that executable. Rust 1.98.0, locked/offline dependencies and the current dev.4 base are pinned.
- Full CI and a separate full local `make pre-commit` are not claimed. Existing SDK artifact/canary validation is unchanged; this PR makes no cold-compilation speedup claim.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

Source-key rustdoc describes the root CI exclusion. No new public API, command or documentation page.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Independent follow-up to merged #1452, based on dev.4 commit `6c3fc2170`. Partial follow-up for #1424. Cold metadata/checking cost and broader content-addressed reuse remain open.
