### PR TITLE
chore - optimize the shared Linux CI compiler (#1424)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,10 +244,19 @@ jobs:
           make fetch-locked-cargo-sources
           make fetch-oven-loaf-sources
           make fetch-release-support-workspace-sources
-      - name: Build Linux compiler and reference generators
+      - name: Build optimized Linux compiler and reference generators
         run: |
-          CARGO_BUILD_JOBS=2 cargo build --locked --features lsp --bins
-          CARGO_BUILD_JOBS=2 cargo build --locked -p incan_core --bin generate_lang_reference
+          CARGO_BUILD_JOBS=2 cargo build --locked --release --features lsp --bin incan --bin generate_feature_inventory
+          CARGO_BUILD_JOBS=2 cargo build --locked --release -p incan_core --bin generate_lang_reference
+      - name: Stage exact release tools for SDK preparation and consumers
+        run: |
+          # Consumers use these stable delivery paths; all three executables were built with the release profile.
+          mkdir -p target/debug
+          for tool in incan generate_lang_reference generate_feature_inventory; do
+            install -m 755 "target/release/$tool" "target/debug/$tool"
+            cmp "target/release/$tool" "target/debug/$tool"
+            sha256sum "target/release/$tool" "target/debug/$tool"
+          done
       # Only this Linux job restores/saves the cross-run SDK cache. Same-run consumers receive an artifact even
       # when another workflow wins the immutable-cache reservation or saving the cache is unavailable.
       - uses: ./.github/actions/restore-sdk-provider-store
@@ -358,12 +367,17 @@ jobs:
       - name: Restore executable permissions
         run: chmod +x target/debug/incan target/debug/generate_lang_reference target/debug/generate_feature_inventory
       - uses: ./.github/actions/consume-sdk-provider-store
-      # Cargo still compiles this test executable; downloading the CLI does not transfer its Cargo target graph.
+      # Cargo builds test dependencies and enabled binaries in a separate target so it cannot replace the handoff CLI.
       - name: Run platform C ABI verification
-        run: >-
-          CARGO_NET_OFFLINE=true
-          cargo test --locked --test cli_integration
-          check_verifies_c_bindings_against_a_declared_android_interop_target -- --exact
+        env:
+          CARGO_NET_OFFLINE: "true"
+          CARGO_TARGET_DIR: ${{ runner.temp }}/incan-platform-test-target
+          CARGO_BIN_EXE_incan: ${{ github.workspace }}/target/debug/incan
+        run: |
+          sha256sum target/debug/incan > "$RUNNER_TEMP/compiler-handoff.sha256"
+          cargo test --locked --test cli_integration \
+            check_verifies_c_bindings_against_a_declared_android_interop_target -- --exact
+          sha256sum --check "$RUNNER_TEMP/compiler-handoff.sha256"
 
   linux-oven-prewarm:
     name: Linux Oven prewarm
@@ -501,10 +515,14 @@ jobs:
         run: chmod +x target/debug/incan
       - uses: ./.github/actions/consume-sdk-provider-store
       - name: Prove the source-observable comparison ran and agreed
-        run: >-
-          CARGO_NET_OFFLINE=true
-          INCAN_TEST_COMPILER_ALREADY_BUILT=1
+        env:
+          CARGO_NET_OFFLINE: "true"
+          CARGO_TARGET_DIR: ${{ runner.temp }}/incan-shadow-test-target
+          INCAN_TEST_COMPILER_ALREADY_BUILT: "1"
+        run: |
+          sha256sum target/debug/incan > "$RUNNER_TEMP/compiler-handoff.sha256"
           make -s shadow-comparison-evidence
+          sha256sum --check "$RUNNER_TEMP/compiler-handoff.sha256"
       - name: Upload the parity corpus summary
         if: always()
         uses: actions/upload-artifact@v5

--- a/tests/toolchain_installer_tests.rs
+++ b/tests/toolchain_installer_tests.rs
@@ -1097,6 +1097,7 @@ fn oven_alpha_benchmark_records_a_verified_cargo_guard_verdict() -> Result<(), B
     Ok(())
 }
 
+/// Keep the suite's producer, immutable handoff and guarded replay contracts connected across local and CI entrypoints.
 #[test]
 fn compiler_suite_action_composes_baker_guarded_runner_and_storage_evidence() -> Result<(), Box<dyn std::error::Error>>
 {
@@ -1186,8 +1187,17 @@ fn compiler_suite_action_composes_baker_guarded_runner_and_storage_evidence() ->
     let linux_prewarm_job = &linux_prewarm_workflow[..linux_prewarm_end];
     let linux_tools_workflow = &workflow[linux_tools..linux_prewarm];
     let compiler_build = linux_tools_workflow
-        .find("- name: Build Linux compiler and reference generators")
-        .ok_or("pull-request CI is missing Linux compiler build")?;
+        .find("cargo build --locked --release --features lsp --bin incan --bin generate_feature_inventory")
+        .ok_or("pull-request CI is missing the optimized Linux compiler build")?;
+    let reference_build = linux_tools_workflow
+        .find("cargo build --locked --release -p incan_core --bin generate_lang_reference")
+        .ok_or("pull-request CI is missing the optimized language reference generator build")?;
+    let tool_staging = linux_tools_workflow
+        .find("install -m 755 \"target/release/$tool\" \"target/debug/$tool\"")
+        .ok_or("pull-request CI is missing exact release-tool staging")?;
+    let provider_selection = linux_tools_workflow
+        .find("uses: ./.github/actions/restore-sdk-provider-store")
+        .ok_or("pull-request CI is missing SDK provider selection")?;
     let provider_handoff = linux_prewarm_job
         .find("- uses: ./.github/actions/consume-sdk-provider-store")
         .ok_or("pull-request CI is missing the same-run SDK handoff")?;
@@ -1195,9 +1205,11 @@ fn compiler_suite_action_composes_baker_guarded_runner_and_storage_evidence() ->
         .find("- name: Prewarm the complete Linux Rust 1.98.0 Oven suite")
         .ok_or("pull-request CI is missing the complete pinned Linux Oven suite")?;
     assert!(
-        compiler_build < linux_tools_workflow.len()
+        compiler_build < tool_staging
+            && reference_build < tool_staging
+            && tool_staging < provider_selection
+            && linux_tools_workflow.contains("cmp \"target/release/$tool\" \"target/debug/$tool\"")
             && provider_handoff < complete_suite
-            && linux_tools_workflow.contains("uses: ./.github/actions/restore-sdk-provider-store")
             && linux_prewarm_workflow.contains("needs:\n      - changes\n      - linux-tool-handoff")
             && linux_prewarm_job.contains("- name: Save prepared Linux Rust 1.98.0 Oven suite")
             && linux_prewarm_job.contains("target/incan_test_sdk_provider_store"),


### PR DESCRIPTION
## Summary

The shared Linux compiler now uses the release profile for SDK preparation and downstream CLI work. Its exact executable bytes are staged into the existing delivery paths before the SDK is selected and published. Cargo integration-test outputs are isolated so they cannot overwrite the handed-off compiler afterward.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / maintenance
- [ ] Documentation
- [x] CI / tooling
- [ ] RFC

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- Build only the three published tools with `--release`: `incan`, `generate_feature_inventory`, and `generate_lang_reference`. Stage them at the existing `target/debug` consumer paths with byte comparisons and SHA256 records; these are delivery paths, not the build profile.
- Keep normal SDK selection, compiler/payload identity checks and consumer canaries. The platform CLI test explicitly selects the handed-off executable. Its Cargo output and the shadow tests' Cargo output use separate targets, with compiler hashes checked after each run. Cargo still builds their test libraries and may build unused enabled binaries in those isolated targets.
- Leave developer profiles, separate macOS jobs and test-library profiles unchanged. This targets unoptimized compiler execution in the shared Linux path; it does not implement Jackhammer or remove Oven's Cargo dependency.

## Testing / verification

- [x] `make test` / `cargo test` — full CI passes at `2dec1d301`; no compiler production source changed.
- [ ] `make examples` — not relevant to this workflow-only diff.
- [ ] `incan fmt --check .` — no Incan source changed.
- [x] Manual verification described below.

`actionlint`, YAML parsing and `git diff --check` pass. Existing SDK handoff tests pass 17/17, CI scope tests 7/7 and release-baseline tests 4/4. Independent review traced the producer and Linux consumers; its compiler-overwrite finding was fixed and re-reviewed clean.

A task-local Rust-inspection probe ran the eleven actual web ABI queries in three randomized dev/release pairs on the same source, locked graph and prepared dependencies. Dev took 131.398, 131.347 and 134.043 seconds; release took 16.185, 16.152 and 16.333 seconds. All metadata matched, and every prepared target file remained unchanged with no added files. Both probe builds disabled debuginfo; normal profile assertions and overflow settings differed. This is an observed 8.119× query-workload ratio, **not a CI speedup or a matched cold-build cost comparison**.

The final-head [CI run 34250663609](https://github.com/encero-systems/incan/actions/runs/34250663609) passes all 25 jobs, including the corrected workflow contract, docs/reference checks, SDK and platform canaries, shadow validation and all four replay partitions. The replay reports reconcile 5,281 inventoried, passed and uniquely timed native cases across 90 roots, with no failures or ignored cases; 11 rustdoc roots bring the total to 101 shards. An artifact-service HTTP 403 initially prevented replay downloads. Only those four failed jobs were rerun; the 21 completed jobs and their prepared artifacts were reused.

Observed shared Linux producer costs:

| Run | Tool build | SDK preparation | Complete producer job |
| --- | ---: | ---: | ---: |
| #1452 final cold baseline | 4m52s | 37m08s | 43m17s |
| #1457 first cold run (`41cd34d0`) | 12m14s | 3m45s | 16m30s |
| #1457 corrected head (`2dec1d301`) | 12m50s | Cache hit; 0ms after lock | 13m19s |

The cold build-plus-SDK interval decreased from 42m00s to 15m59s in these observed runs. Compiler production sources and the SDK payload digest are identical between the cold comparison heads. The corrected head changes a test assertion; its three compiler-tool outputs are byte-identical to the first #1457 run, and its SDK was restored from that run. This is measured reuse across a test-only head change, not a second same-head producer execution.

Release compilation costs more upfront. The corrected run still rebuilt byte-identical tools for 12m50s; content-based tool reuse remains follow-up work. The heavy test roots also remain expensive: CLI integration took 48m29s versus 36m18s in the retained #1452 run, with the same 132 cases and 254 recorded nested commands. Integration tests took 38m22s versus 35m27s, with the same 281 cases and 120 commands. These are individual hosted-run observations, not a controlled attribution of that difference to this change. No whole-workflow speedup is claimed. Replay wrapper overhead beyond each report is below one second, so the retained evidence does not show the former unmeasured teardown gap.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

This changes the CI producer's build profile and artifact handling; public installation and command behavior are unchanged.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Refs #1424 and #1065. Content-based tool reuse and repeated fixture compilation remain open performance work.
