### PR TITLE
bugfix - preserve published native store bytes during imports (#1458)

### DIFF
--- a/src/cli/commands/build.rs
+++ b/src/cli/commands/build.rs
@@ -20252,7 +20252,7 @@ pub model Nested:
                 .ok_or("fixture has no materialized leaf")?;
             let source = entry_artifacts.join(&leaf.relative_path);
             let original = fs::metadata(&source)?.permissions();
-            fs::set_permissions(&source, fs::Permissions::from_mode(0))?;
+            fs::set_permissions(&source, fs::Permissions::from_mode(0o0))?;
             let unreadable = fs::File::open(&source).is_err();
             let warm = import_checked_packaged_library_loaf(&consumer_store, &checked);
             fs::set_permissions(&source, original)?;

--- a/src/cli/commands/build.rs
+++ b/src/cli/commands/build.rs
@@ -108,7 +108,7 @@ use crate::oven::rustc::{
 };
 use crate::oven::store::{
     OvenArtifactKind, OvenArtifactMaterializedFile, OvenArtifactPublishRequest, OvenStore, OvenStoreError,
-    OvenStoreLease,
+    OvenStoreLease, PublishedOvenStore,
 };
 use crate::oven::{
     OvenGeneratedProjectRequest, digest_bytes, digest_dependency_specs, digest_project_source_tree,
@@ -13331,25 +13331,8 @@ fn copy_receipted_oven_store_entry(
     entry_kind: OvenArtifactKind,
     operation: &str,
 ) -> CliResult<crate::oven::store::OvenArtifactManifest> {
-    let existing = destination_store
-        .select_payloads_matching_for_execution(|manifest| {
-            manifest.identity == entry_identity
-                && manifest.kind == entry_kind
-                && manifest.receipt_identity == receipt.identity
-                && manifest.build_unit_identity == receipt.build_unit_identity
-                && manifest.intent == receipt.intent
-        })
-        .map_err(|error| CliError::failure(format!("failed to inspect provider Loaf before {operation}: {error}")))?;
-    if existing.len() > 1 {
-        return Err(CliError::failure(format!(
-            "expected at most one existing provider Loaf `{entry_identity}` before {operation}, found {}",
-            existing.len()
-        )));
-    }
-    if let Some(existing) = existing.into_iter().next() {
-        // Immutable store selection validates the manifest and payload while holding an active lease. Repeating the
-        // full closure hash on a warm explicit bake would turn a valid package reuse into a multi-gigabyte scan.
-        return Ok(existing.manifest);
+    if let Some(existing) = existing_provider_loaf(destination_store, receipt, entry_identity, entry_kind, operation)? {
+        return Ok(existing);
     }
     let mut selected = source_store
         .select_payloads_matching_for_execution(|manifest| {
@@ -13376,7 +13359,60 @@ fn copy_receipted_oven_store_entry(
             selected.len()
         )));
     }
-    let (manifest, artifact_root, payload, _lease) = selected.remove(0).into_parts();
+    publish_selected_provider_loaf(
+        selected.remove(0),
+        destination_store,
+        receipt,
+        entry_identity,
+        entry_kind,
+        operation,
+    )
+}
+
+/// Select an already admitted destination entry without rereading another store's materialized closure.
+fn existing_provider_loaf(
+    destination_store: &OvenStore,
+    receipt: &crate::oven::OvenReceipt,
+    entry_identity: &str,
+    entry_kind: OvenArtifactKind,
+    operation: &str,
+) -> CliResult<Option<crate::oven::store::OvenArtifactManifest>> {
+    let existing = destination_store
+        .select_payloads_matching_for_execution(|manifest| {
+            manifest.identity == entry_identity
+                && manifest.kind == entry_kind
+                && manifest.receipt_identity == receipt.identity
+                && manifest.build_unit_identity == receipt.build_unit_identity
+                && manifest.intent == receipt.intent
+        })
+        .map_err(|error| CliError::failure(format!("failed to inspect provider Loaf before {operation}: {error}")))?;
+    if existing.len() > 1 {
+        return Err(CliError::failure(format!(
+            "expected at most one existing provider Loaf `{entry_identity}` before {operation}, found {}",
+            existing.len()
+        )));
+    }
+    Ok(existing.into_iter().next().map(|payload| payload.manifest))
+}
+
+/// Import a leased, verified source entry through the destination store's ordinary bounded publication.
+fn publish_selected_provider_loaf(
+    selected: crate::oven::store::OvenStoreExecutionPayload,
+    destination_store: &OvenStore,
+    receipt: &crate::oven::OvenReceipt,
+    entry_identity: &str,
+    entry_kind: OvenArtifactKind,
+    operation: &str,
+) -> CliResult<crate::oven::store::OvenArtifactManifest> {
+    if let Some(existing) = existing_provider_loaf(destination_store, receipt, entry_identity, entry_kind, operation)? {
+        return Ok(existing);
+    }
+    selected.verify_materialized_files().map_err(|error| {
+        CliError::failure(format!(
+            "failed to verify source provider Loaf during {operation}: {error}"
+        ))
+    })?;
+    let (manifest, artifact_root, payload, _lease) = selected.into_parts();
     if manifest.kind != entry_kind
         || manifest.build_unit_identity != receipt.build_unit_identity
         || manifest.intent != receipt.intent
@@ -13917,24 +13953,66 @@ fn import_checked_packaged_library_loaf(
     checked: &CheckedPackagedProviderProfile,
 ) -> CliResult<()> {
     let package_profile = &checked.package;
-    let package_store = OvenStore::new(
-        packaged_library_loaf_store_root(&checked.artifact_root),
-        *consumer_store.limits(),
-    );
-    let source_store = if has_complete_packaged_library_loaf(&package_store, &package_profile.entries)? {
-        &package_store
-    } else if has_complete_packaged_library_loaf(consumer_store, &package_profile.entries)? {
-        consumer_store
-    } else {
+    let package_store_root = packaged_library_loaf_store_root(&checked.artifact_root);
+    let package_store_exists = package_store_root.try_exists().map_err(|error| {
+        CliError::failure(format!(
+            "failed to inspect published provider store {}: {error}",
+            package_store_root.display()
+        ))
+    })?;
+    if package_store_exists {
+        let selected = PublishedOvenStore::new(&package_store_root)
+            .select_payloads_matching_for_execution(|stored| {
+                package_profile.entries.iter().any(|entry| {
+                    stored.identity == entry.identity
+                        && stored.kind == entry.kind
+                        && stored.receipt_identity == entry.receipt.identity
+                        && stored.build_unit_identity == entry.receipt.build_unit_identity
+                        && stored.intent == entry.receipt.intent
+                })
+            })
+            .map_err(|error| {
+                CliError::failure(format!(
+                    "failed to read published package Loaf for pub::{}: {error}",
+                    checked.dependency_key
+                ))
+            })?;
+        if selected.len() == package_profile.entries.len() {
+            for payload in selected {
+                let identity = payload.manifest.identity.clone();
+                let kind = payload.manifest.kind;
+                let entry = package_profile
+                    .entries
+                    .iter()
+                    .find(|entry| entry.identity == identity)
+                    .ok_or_else(|| CliError::failure("selected package Loaf is absent from its checked profile"))?;
+                let imported = publish_selected_provider_loaf(
+                    payload,
+                    consumer_store,
+                    &entry.receipt,
+                    &identity,
+                    kind,
+                    "consumer package-Loaf import",
+                )?;
+                if imported.identity != identity {
+                    return Err(CliError::failure(format!(
+                        "consumer package-Loaf import changed the sealed entry identity `{identity}`"
+                    )));
+                }
+            }
+            return Ok(());
+        }
+    }
+    if !has_complete_packaged_library_loaf(consumer_store, &package_profile.entries)? {
         return Err(CliError::failure(format!(
             "Oven Alpha cannot import pub::{}: its portable package Loaf is absent and the current Oven store has no matching receipt-bound closure; run `incan oven bake --project {}`",
             checked.dependency_key,
             checked.artifact_root.display()
         )));
-    };
+    }
     for entry in &package_profile.entries {
         let imported = copy_receipted_oven_store_entry(
-            source_store,
+            consumer_store,
             consumer_store,
             &entry.receipt,
             &entry.identity,
@@ -20155,7 +20233,38 @@ pub model Nested:
         };
         let consumer_store_root = tempfile::tempdir()?;
         let consumer_store = OvenStore::new(consumer_store_root.path(), limits);
+        let (entry, lease) = package_store.select(&stored.identity)?;
+        #[cfg(unix)]
+        let entry_artifacts = entry.materialized_root();
+        let entry_root = entry.path;
+        drop(lease);
+        fs::write(entry_root.join("last-used"), b"1\n")?;
+        let published_digest = digest_provider_artifact(&checked.artifact_root)?;
         import_checked_packaged_library_loaf(&consumer_store, &checked)?;
+        assert_eq!(digest_provider_artifact(&checked.artifact_root)?, published_digest);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let leaf = stored
+                .materialized_files
+                .first()
+                .ok_or("fixture has no materialized leaf")?;
+            let source = entry_artifacts.join(&leaf.relative_path);
+            let original = fs::metadata(&source)?.permissions();
+            fs::set_permissions(&source, fs::Permissions::from_mode(0))?;
+            let unreadable = fs::File::open(&source).is_err();
+            let warm = import_checked_packaged_library_loaf(&consumer_store, &checked);
+            fs::set_permissions(&source, original)?;
+            assert!(
+                unreadable,
+                "the test host must enforce the source leaf's read permissions"
+            );
+            warm?;
+        }
+        import_checked_packaged_library_loaf(&consumer_store, &checked)?;
+        assert_eq!(digest_provider_artifact(&checked.artifact_root)?, published_digest);
+        assert_eq!(fs::read(entry_root.join("last-used"))?, b"1\n");
         let selected = select_packaged_provider_plan(&consumer_store, &[checked], "debug", &consumer_receipt)?
             .ok_or("consumer should select the imported direct-plan package Loaf")?;
         let OvenDirectRustcPlanSelection::PackagedProvider(packages) = selected else {

--- a/src/oven/compiler_suite_env.rs
+++ b/src/oven/compiler_suite_env.rs
@@ -54,6 +54,7 @@ impl OvenCompilerSuiteTargetCapabilities {
             ("incan", "test", "tests/cli_integration.rs")
                 | ("incan", "test", "tests/integration_tests.rs")
                 | ("incan", "test", "tests/canonical_item_imports.rs")
+                | ("incan", "test", "tests/package_boundary_facade_tests.rs")
         );
         Self {
             generated_rust_closure,

--- a/src/oven/store.rs
+++ b/src/oven/store.rs
@@ -3390,14 +3390,16 @@ mod tests {
     use crate::oven::{
         OvenGeneratedProjectRequest, OvenImportRequest, import_frozen_project, receipt_generated_project,
     };
+    use std::collections::BTreeMap;
     use std::fs::{self, OpenOptions};
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
+
+    /// Relative directory entries and exact file bytes in a published store.
+    type PublishedInventory = BTreeMap<PathBuf, Option<Vec<u8>>>;
 
     /// Capture every directory and file, including mutable-store bookkeeping, without following links.
-    fn published_inventory(
-        root: &Path,
-    ) -> Result<std::collections::BTreeMap<std::path::PathBuf, Option<Vec<u8>>>, Box<dyn std::error::Error>> {
-        let mut inventory = std::collections::BTreeMap::new();
+    fn published_inventory(root: &Path) -> Result<PublishedInventory, Box<dyn std::error::Error>> {
+        let mut inventory = PublishedInventory::new();
         let mut pending = vec![root.to_path_buf()];
         while let Some(directory) = pending.pop() {
             for entry in fs::read_dir(directory)? {

--- a/src/oven/store.rs
+++ b/src/oven/store.rs
@@ -209,6 +209,18 @@ pub struct OvenStoreExecutionPayload {
 }
 
 impl OvenStoreExecutionPayload {
+    /// Verify the complete materialized file closure while retaining this payload's active lease.
+    ///
+    /// Call before importing the source files. An already admitted destination can reuse its own leased content
+    /// without rereading the source closure. This verification does not populate physical-accounting caches.
+    pub fn verify_materialized_files(&self) -> Result<(), OvenStoreError> {
+        let entry_root = self.artifact_root.parent().ok_or_else(|| OvenStoreError::Integrity {
+            identity: self.manifest.identity.clone(),
+            message: "selected artifact root has no containing store entry".to_string(),
+        })?;
+        verify_materialized_files(entry_root, &self.manifest).map(|_| ())
+    }
+
     /// Consume this selected payload while retaining the execution lease for the caller's complete use of it.
     #[must_use]
     pub fn into_parts(self) -> (OvenArtifactManifest, PathBuf, Vec<u8>, OvenStoreLease) {
@@ -307,6 +319,55 @@ pub enum OvenStoreError {
 pub struct OvenStore {
     root: PathBuf,
     limits: OvenStoreLimits,
+}
+
+/// Read-only access to an Oven store embedded in a published, content-addressed package.
+///
+/// Published packages are immutable inputs, not LRU caches. This handle requires their existing lock files and
+/// verifies selected content while retaining the same active leases as a writable store. It never creates layout,
+/// reclaims staging, records access times, or populates accounting caches.
+#[derive(Debug, Clone)]
+pub struct PublishedOvenStore {
+    root: PathBuf,
+}
+
+impl PublishedOvenStore {
+    /// Refer to an already published store; selection validates its existing layout and locks.
+    #[must_use]
+    pub fn new(root: impl AsRef<Path>) -> Self {
+        Self {
+            root: root.as_ref().to_path_buf(),
+        }
+    }
+
+    /// Read verified manifests and payloads without changing package files.
+    ///
+    /// The shared manager lock prevents a concurrent publisher from pruning candidates before their active leases
+    /// are acquired. Missing locks are errors: a consumer cannot repair a published artifact in place. Before
+    /// importing source files, verify their closure with [`OvenStoreExecutionPayload::verify_materialized_files`].
+    pub fn select_payloads_matching_for_execution<F>(
+        &self,
+        matches: F,
+    ) -> Result<Vec<OvenStoreExecutionPayload>, OvenStoreError>
+    where
+        F: Fn(&OvenArtifactManifest) -> bool,
+    {
+        let manager_path = self.root.join(MANAGER_LOCK_FILE);
+        let manager = File::open(&manager_path).map_err(|source| OvenStoreError::Io {
+            path: manager_path.clone(),
+            source,
+        })?;
+        manager.lock_shared().map_err(|source| OvenStoreError::Io {
+            path: manager_path,
+            source,
+        })?;
+        Ok(
+            select_matching_execution_payloads(&self.root.join(ENTRIES_DIRECTORY), matches)?
+                .into_iter()
+                .map(|(_, payload)| payload)
+                .collect(),
+        )
+    }
 }
 
 /// Validated batch member retained while the store serializes one related publication.
@@ -1028,66 +1089,13 @@ impl OvenStore {
             source,
         })?;
         self.reclaim_stale_staging()?;
-        let root = self.entries_root();
-        if !root.exists() {
-            return Ok(Vec::new());
-        }
-
-        let mut selected = Vec::new();
-        for candidate in fs::read_dir(&root).map_err(|source| OvenStoreError::Io {
-            path: root.clone(),
-            source,
-        })? {
-            let candidate = candidate.map_err(|source| OvenStoreError::Io {
-                path: root.clone(),
-                source,
-            })?;
-            let path = candidate.path();
-            if !path.is_dir() {
-                return Err(OvenStoreError::Integrity {
-                    identity: path.display().to_string(),
-                    message: "entries root contains a non-directory item".to_string(),
-                });
-            }
-            let manifest = verify_entry_manifest(&path)?;
-            if !matches(&manifest) {
-                continue;
-            }
-            let payload_path = path.join(PAYLOAD_FILE);
-            let payload = fs::read(&payload_path).map_err(|source| OvenStoreError::Io {
-                path: payload_path,
-                source,
-            })?;
-            if u64::try_from(payload.len()).ok() != Some(manifest.payload.logical_bytes)
-                || digest_bytes(&payload) != manifest.payload.digest
-            {
-                return Err(OvenStoreError::Integrity {
-                    identity: manifest.identity,
-                    message: "manifest payload descriptor disagrees with stored bytes".to_string(),
-                });
-            }
-            let lease_path = path.join(ACTIVE_LOCK_FILE);
-            let file = OpenOptions::new()
-                .read(true)
-                .write(true)
-                .open(&lease_path)
-                .map_err(|source| OvenStoreError::Io {
-                    path: lease_path.clone(),
-                    source,
-                })?;
-            file.lock_shared().map_err(|source| OvenStoreError::Io {
-                path: lease_path,
-                source,
-            })?;
-            touch_entry(&path)?;
-            selected.push(OvenStoreExecutionPayload {
-                manifest,
-                artifact_root: path.join(MATERIALIZED_DIRECTORY),
-                payload,
-                _lease: OvenStoreLease { file },
-            });
-        }
-        Ok(selected)
+        select_matching_execution_payloads(&self.entries_root(), matches)?
+            .into_iter()
+            .map(|(path, payload)| {
+                touch_entry(&path)?;
+                Ok(payload)
+            })
+            .collect()
     }
 
     /// Return immutable manifest headers for candidate selection without turning ordinary cache lookup into a full
@@ -1939,6 +1947,72 @@ impl Drop for OvenStoreLease {
     fn drop(&mut self) {
         let _ = self.file.unlock();
     }
+}
+
+/// Acquire matching payloads while the caller holds this store's manager lock.
+///
+/// Both published readers and mutable caches share manifest, payload, and active-lease validation. The caller owns
+/// any additional materialized-closure verification or writable-cache bookkeeping.
+fn select_matching_execution_payloads<F>(
+    root: &Path,
+    matches: F,
+) -> Result<Vec<(PathBuf, OvenStoreExecutionPayload)>, OvenStoreError>
+where
+    F: Fn(&OvenArtifactManifest) -> bool,
+{
+    let mut selected = Vec::new();
+    for candidate in fs::read_dir(root).map_err(|source| OvenStoreError::Io {
+        path: root.to_path_buf(),
+        source,
+    })? {
+        let candidate = candidate.map_err(|source| OvenStoreError::Io {
+            path: root.to_path_buf(),
+            source,
+        })?;
+        let path = candidate.path();
+        if !path.is_dir() {
+            return Err(OvenStoreError::Integrity {
+                identity: path.display().to_string(),
+                message: "entries root contains a non-directory item".to_string(),
+            });
+        }
+        let manifest = verify_entry_manifest(&path)?;
+        if !matches(&manifest) {
+            continue;
+        }
+        let payload_path = path.join(PAYLOAD_FILE);
+        let payload = fs::read(&payload_path).map_err(|source| OvenStoreError::Io {
+            path: payload_path,
+            source,
+        })?;
+        if u64::try_from(payload.len()).ok() != Some(manifest.payload.logical_bytes)
+            || digest_bytes(&payload) != manifest.payload.digest
+        {
+            return Err(OvenStoreError::Integrity {
+                identity: manifest.identity,
+                message: "manifest payload descriptor disagrees with stored bytes".to_string(),
+            });
+        }
+        let lease_path = path.join(ACTIVE_LOCK_FILE);
+        let file = File::open(&lease_path).map_err(|source| OvenStoreError::Io {
+            path: lease_path.clone(),
+            source,
+        })?;
+        file.lock_shared().map_err(|source| OvenStoreError::Io {
+            path: lease_path,
+            source,
+        })?;
+        selected.push((
+            path.clone(),
+            OvenStoreExecutionPayload {
+                manifest,
+                artifact_root: path.join(MATERIALIZED_DIRECTORY),
+                payload,
+                _lease: OvenStoreLease { file },
+            },
+        ));
+    }
+    Ok(selected)
 }
 
 /// Build one immutable artifact manifest from validated request input.
@@ -3318,6 +3392,144 @@ mod tests {
     };
     use std::fs::{self, OpenOptions};
     use std::path::Path;
+
+    /// Capture every directory and file, including mutable-store bookkeeping, without following links.
+    fn published_inventory(
+        root: &Path,
+    ) -> Result<std::collections::BTreeMap<std::path::PathBuf, Option<Vec<u8>>>, Box<dyn std::error::Error>> {
+        let mut inventory = std::collections::BTreeMap::new();
+        let mut pending = vec![root.to_path_buf()];
+        while let Some(directory) = pending.pop() {
+            for entry in fs::read_dir(directory)? {
+                let entry = entry?;
+                let path = entry.path();
+                let relative = path.strip_prefix(root)?.to_path_buf();
+                if entry.file_type()?.is_dir() {
+                    inventory.insert(relative, None);
+                    pending.push(path);
+                } else {
+                    assert!(entry.file_type()?.is_file(), "unexpected published entry: {path:?}");
+                    inventory.insert(relative, Some(fs::read(path)?));
+                }
+            }
+        }
+        Ok(inventory)
+    }
+
+    #[test]
+    fn published_reads_preserve_complete_inventory_and_active_leases() -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        let project = tempfile::tempdir()?;
+        write_project(project.path())?;
+        let store = OvenStore::new(temp.path(), OvenStoreLimits::new(1_000_000, 1_000_000, 1_000_000));
+        let manifest = store.publish(&request(project.path(), "published", b"native plan")?)?;
+        let entry = store.entry_root(&manifest.identity);
+        fs::write(entry.join(super::ACCESS_FILE), b"1\n")?;
+        let abandoned = temp.path().join(super::STAGING_DIRECTORY).join("retained-staging");
+        fs::create_dir_all(&abandoned)?;
+        fs::write(abandoned.join("evidence"), b"must remain untouched")?;
+        let mut originals = Vec::new();
+        for path in published_inventory(temp.path())?.keys() {
+            let path = temp.path().join(path);
+            if path.is_file() {
+                let original = fs::metadata(&path)?.permissions();
+                let mut readonly = original.clone();
+                readonly.set_readonly(true);
+                fs::set_permissions(&path, readonly)?;
+                originals.push((path, original));
+            }
+        }
+        let checked = (|| -> Result<(), Box<dyn std::error::Error>> {
+            let before = published_inventory(temp.path())?;
+            let published = super::PublishedOvenStore::new(temp.path());
+            for _ in 0..2 {
+                let selected =
+                    published.select_payloads_matching_for_execution(|item| item.identity == manifest.identity)?;
+                assert_eq!(selected.len(), 1);
+                assert_eq!(selected[0].payload, b"native plan");
+                selected[0].verify_materialized_files()?;
+                let contender = fs::File::open(entry.join(super::ACTIVE_LOCK_FILE))?;
+                let locked = contender.try_lock();
+                assert!(
+                    matches!(locked, Err(std::fs::TryLockError::WouldBlock)),
+                    "published read must retain an active lease: {locked:?}"
+                );
+                assert_eq!(published_inventory(temp.path())?, before);
+                drop(selected);
+                contender.try_lock()?;
+                contender.unlock()?;
+            }
+            assert_eq!(published_inventory(temp.path())?, before);
+            Ok(())
+        })();
+        for (path, permissions) in originals {
+            fs::set_permissions(path, permissions)?;
+        }
+        checked?;
+        Ok(())
+    }
+
+    #[test]
+    fn published_reads_refuse_missing_locks_without_creating_them() -> Result<(), Box<dyn std::error::Error>> {
+        for manager_missing in [true, false] {
+            let temp = tempfile::tempdir()?;
+            let project = tempfile::tempdir()?;
+            write_project(project.path())?;
+            let store = OvenStore::new(temp.path(), OvenStoreLimits::new(1_000_000, 1_000_000, 1_000_000));
+            let manifest = store.publish(&request(project.path(), "published", b"native plan")?)?;
+            let lock = if manager_missing {
+                temp.path().join(super::MANAGER_LOCK_FILE)
+            } else {
+                store.entry_root(&manifest.identity).join(super::ACTIVE_LOCK_FILE)
+            };
+            fs::remove_file(&lock)?;
+            let before = published_inventory(temp.path())?;
+            let result = super::PublishedOvenStore::new(temp.path()).select_payloads_matching_for_execution(|_| true);
+            assert!(matches!(result, Err(OvenStoreError::Io { path, .. }) if path == lock));
+            assert_eq!(published_inventory(temp.path())?, before);
+            assert!(!lock.exists());
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn published_reads_reject_payload_and_materialized_tampering() -> Result<(), Box<dyn std::error::Error>> {
+        for tamper_payload in [true, false] {
+            let temp = tempfile::tempdir()?;
+            let project = tempfile::tempdir()?;
+            write_project(project.path())?;
+            let source = project.path().join("native.rlib");
+            fs::write(&source, b"native artifact")?;
+            let mut publication = request(project.path(), "published", b"native plan")?;
+            publication.materialized_files.push(OvenArtifactMaterializedFile {
+                source_path: source,
+                relative_path: "lib/native.rlib".to_string(),
+            });
+            let store = OvenStore::new(temp.path(), OvenStoreLimits::new(1_000_000, 1_000_000, 1_000_000));
+            let manifest = store.publish(&publication)?;
+            let entry = store.entry_root(&manifest.identity);
+            let changed = if tamper_payload {
+                entry.join(super::PAYLOAD_FILE)
+            } else {
+                entry.join(super::MATERIALIZED_DIRECTORY).join("lib/native.rlib")
+            };
+            // Publication seals files read-only; replacing this test-owned entry models external corruption.
+            fs::remove_file(&changed)?;
+            fs::write(changed, b"changed content")?;
+            let before = published_inventory(temp.path())?;
+            let result = super::PublishedOvenStore::new(temp.path())
+                .select_payloads_matching_for_execution(|_| true)
+                .and_then(|selected| {
+                    for payload in selected {
+                        payload.verify_materialized_files()?;
+                    }
+                    Ok(())
+                });
+            assert!(matches!(result, Err(OvenStoreError::Integrity { .. })));
+            assert_eq!(published_inventory(temp.path())?, before);
+        }
+        Ok(())
+    }
 
     #[test]
     fn store_reports_distinct_logical_and_physical_bytes() -> Result<(), Box<dyn std::error::Error>> {

--- a/tests/package_boundary_facade_tests.rs
+++ b/tests/package_boundary_facade_tests.rs
@@ -10,10 +10,12 @@
 //! everything through a facade, consumed across a `[dependencies]` path package through `pub::`.
 
 use std::fs;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
 use incan::library_manifest::{ExportIdentityKind, ExportIdentityProjection, LibraryManifest};
+use sha2::{Digest, Sha256};
 
 mod support;
 
@@ -61,7 +63,9 @@ fn run_incan(current_dir: &Path, args: &[&str]) -> Result<Output, Box<dyn std::e
 
 /// Publish the producer closure through Oven's explicit project-bake boundary.
 fn run_explicit_oven_bake(current_dir: &Path) -> Result<Output, Box<dyn std::error::Error>> {
-    Ok(configured_incan_command(current_dir, &["oven", "bake", "--project", "."]).output()?)
+    let mut command = configured_incan_command(current_dir, &["oven", "bake", "--project", "."]);
+    support::configure_explicit_oven_bake_command(&mut command)?;
+    Ok(command.output()?)
 }
 
 /// Fail with the command's own output, which carries the diagnostic worth reading.
@@ -187,5 +191,119 @@ fn a_consumer_resolves_facade_published_declarations_across_a_dependency() -> Te
         stdout.contains("boundary") && stdout.contains('2') && stdout.contains("fast"),
         "the consumer must execute the facade's model, function and enum across the boundary, got:\n{stdout}"
     );
+    Ok(())
+}
+
+/// Hash every published file and retain empty directories, including store bookkeeping and lock files.
+fn artifact_inventory(
+    root: &Path,
+) -> Result<std::collections::BTreeMap<PathBuf, Option<String>>, Box<dyn std::error::Error>> {
+    let mut inventory = std::collections::BTreeMap::new();
+    let mut pending = vec![root.to_path_buf()];
+    let mut buffer = [0_u8; 64 * 1024];
+    while let Some(directory) = pending.pop() {
+        for entry in fs::read_dir(directory)? {
+            let entry = entry?;
+            let path = entry.path();
+            let relative = path.strip_prefix(root)?.to_path_buf();
+            if entry.file_type()?.is_dir() {
+                inventory.insert(relative, None);
+                pending.push(path);
+            } else {
+                assert!(entry.file_type()?.is_file(), "unexpected package entry: {path:?}");
+                let mut file = fs::File::open(path)?;
+                let mut digest = Sha256::new();
+                loop {
+                    let count = file.read(&mut buffer)?;
+                    if count == 0 {
+                        break;
+                    }
+                    digest.update(&buffer[..count]);
+                }
+                inventory.insert(relative, Some(format!("{:x}", digest.finalize())));
+            }
+        }
+    }
+    Ok(inventory)
+}
+
+#[test]
+fn source_free_native_diamond_preserves_published_store_inventory_issue1458() -> TestResult {
+    let fixture = tempfile::tempdir()?;
+    let catalog = fixture.path().join("catalog");
+    let pricing = fixture.path().join("pricing");
+    let home = fixture.path().join("incan-home");
+    write_fixture_file(
+        &catalog,
+        "loaf.toml",
+        "[project]\nname = \"immutable_catalog\"\nversion = \"0.1.0\"\n\n[rust-dependencies]\nbitflags = \"=1.3.2\"\n",
+    )?;
+    // The named Rust dependency forces a portable project entry, rather than an empty package store whose entire
+    // native closure happens to be supplied by the compiler's release envelope.
+    write_fixture_file(
+        &catalog,
+        "src/lib.incn",
+        "rust.module(\"bitflags\")\n\npub def answer() -> int:\n    return 42\n",
+    )?;
+    write_fixture_file(
+        &pricing,
+        "loaf.toml",
+        "[project]\nname = \"immutable_pricing\"\nversion = \"0.1.0\"\n\n[dependencies]\ncatalog = { path = \"../catalog\" }\n",
+    )?;
+    write_fixture_file(
+        &pricing,
+        "src/lib.incn",
+        "from pub::catalog import answer\n\npub def quote() -> int:\n    return answer()\n",
+    )?;
+    let bake = |project: &Path| -> Result<Output, Box<dyn std::error::Error>> {
+        let mut command = configured_incan_command(project, &["oven", "bake", "--project", "."]);
+        support::configure_explicit_oven_bake_command(&mut command)?;
+        command.env("INCAN_HOME", &home);
+        Ok(command.output()?)
+    };
+    assert_success(&bake(&catalog)?, "catalog publication with a packaged Rust dependency");
+    let catalog_artifact = catalog.join("target/lib");
+    let catalog_before = artifact_inventory(&catalog_artifact)?;
+    assert!(
+        catalog_before
+            .keys()
+            .any(|path| path.starts_with("oven/loafs/entries")
+                && path.file_name().is_some_and(|name| name == "loaf.json")),
+        "the regression requires actual packaged store entries"
+    );
+    assert_success(&bake(&pricing)?, "pricing publication through catalog");
+    assert_eq!(artifact_inventory(&catalog_artifact)?, catalog_before);
+    let pricing_artifact = pricing.join("target/lib");
+    let pricing_before = artifact_inventory(&pricing_artifact)?;
+    for project in [&catalog, &pricing] {
+        fs::remove_dir_all(project.join("src"))?;
+        fs::remove_file(project.join("loaf.toml"))?;
+    }
+    for name in ["first", "second"] {
+        let consumer = fixture.path().join(name);
+        write_fixture_file(
+            &consumer,
+            "loaf.toml",
+            &format!(
+                "[project]\nname = \"{name}\"\nversion = \"0.1.0\"\n\n[dependencies]\nstock = {{ path = \"../catalog\" }}\npricing = {{ path = \"../pricing\" }}\n"
+            ),
+        )?;
+        write_fixture_file(
+            &consumer,
+            "src/main.incn",
+            "from pub::stock import answer\nfrom pub::pricing import quote\n\ndef main() -> None:\n    println(answer() + quote())\n",
+        )?;
+        assert_success(
+            &bake(&consumer)?,
+            "fresh native diamond publication without provider sources",
+        );
+        let mut command = configured_incan_command(&consumer, &["run", "--locked", "src/main.incn"]);
+        command.env_remove("CARGO").env("INCAN_HOME", &home);
+        let output = command.output()?;
+        assert_success(&output, "source-free native diamond execution");
+        assert_eq!(String::from_utf8(output.stdout)?.trim(), "84");
+        assert_eq!(artifact_inventory(&catalog_artifact)?, catalog_before);
+        assert_eq!(artifact_inventory(&pricing_artifact)?, pricing_before);
+    }
     Ok(())
 }

--- a/workspaces/docs-site/docs/release_notes/0_6.md
+++ b/workspaces/docs-site/docs/release_notes/0_6.md
@@ -29,6 +29,7 @@ tags:
 
 The replacement backend will consume direct, compiler-owned lowering facts through Body IR. Backend selection and execution will be explicit and receipted, with no silent fallback to the legacy route. A corpus-based parity system will show which behavior is verified, which is intentionally migrated, and which is not yet acceptable.
 
+- **Tooling**: Native package imports read published Oven stores without changing access bookkeeping or cache files inside the package artifact. This keeps recorded dependency digests stable during import while retaining ordinary consumer-store reuse. (#1458)
 - **Tooling**: Oven compiler-suite replay reports live case durations, failures, and outstanding work; phase progress continues through cleanup, and every partition retains command and wrapper timing evidence plus diagnostic transcripts. Root-owned result records prevent nested test output from corrupting counts or timings, and incomplete accounting cannot claim suite success. (#1422, #1425)
 - **Tooling**: `make examples` prepares reusable dependencies and checks the frontend-only markform, scriptkit and styleforge consumers without running them; producer libraries remain part of the gate. (#1442)
 - **Compiler**: Source traits can inherit imported Rust trait bounds without synthesizing conflicting implementations of foreign parents. (#1427)


### PR DESCRIPTION
## Summary

Native package imports could update `last-used` inside a published dependency after its artifact digest was recorded, causing a later consumer to reject unchanged native code. Published stores now have a read-only access path that preserves their complete bytes and inventory. The physical digest remains strict, and existing consumer-store reuse remains fast.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: Importing a published native package preserves its recorded dependency digest. Missing published locks and corrupted contents refuse without repairing the source artifact.
- **Internals**: `PublishedOvenStore` opens existing manager/active locks read-only and retains execution leases. It shares manifest/payload verification with the writable cache, but performs no layout creation, staging reclamation, access updates or accounting writes. Cold imports verify the materialized closure; warm imports retain the existing admitted-destination return before rereading source files.
- **Risks**: Published packages with missing lock files now refuse explicitly. Writable cache publication and pruning retain their existing behavior. The separate same-alias extern collision found in the native fixture is tracked in #1459; it is not changed here.

This branch targets `0.6.0-dev.4` directly and is independent of #1426 and the Cargo-removal work.

## Testing / verification

- [x] `make test` / `cargo test` — focused tests below; full suite not run locally
- [ ] `make examples` (if relevant) — not relevant to this physical-store change
- [ ] `incan fmt --check .` (if relevant) — no authored Incan source files changed
- [x] Manual verification described below

- Rust 1.98.0, release profile, `lsp`: all 32 store tests pass, including read-only complete-inventory equality, missing-lock refusal, payload/materialized tamper rejection and active leases.
- The existing package-import test passes cold and warm. Its warm source materialized file is deliberately unreadable, proving the accepted destination avoids a full source rehash.
- The real native diamond test passes in 79.90s with actual packaged Loaf entries. Catalog and pricing sources/manifests are deleted before two fresh consumers are baked; both run and print `84`, and both complete provider inventories stay unchanged.
- Compiler/harness build passes. The corrected `cargo clippy --release --all-targets --all-features --locked --offline -- -D warnings` gate passes in 23.69s, including the library unit-test configuration. Rustfmt, changed Rustdoc and diff checks pass. The initial CI run caught two test-helper lints missed by the former local `--lib` plus integration-target selection; both are fixed without suppressions.
- The native gate uses compiler `4f76f507a48f` with an intact compatible revision-5 SDK from its original publisher. All 127 SDK files remain identical; no SDK/envelope was regenerated or retagged. This is a native correctness proof using explicit Oven preparation, not a Cargo-free preparation claim.
- Independent scope/store/reuse review is clean. Docs contracts and strict MkDocs pass with the retained local Python 3.14.4 toolstack.

The corrected-head [CI run 34266466009](https://github.com/encero-systems/incan/actions/runs/34266466009) passes all 11 selected jobs, including Clippy, docs, Rustdoc, formatting, dependency checks and emitted-symbol checks on Linux and macOS. Scope filtering skips the heavy SDK, native replay, ABI and shadow lanes. The native diamond and store results above are local acceptance; this is not a full-suite CI claim.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

Release note: `workspaces/docs-site/docs/release_notes/0_6.md`. No RFC lifecycle changes.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #1458
