### PR TITLE
bugfix - verify native output digests before reuse (#1463)

### DIFF
--- a/src/oven/rustc.rs
+++ b/src/oven/rustc.rs
@@ -9138,7 +9138,7 @@ mod tests {
         assert!(!bake.cargo_process_started);
         assert!(!bake.reused);
         assert!(bake.output.is_file());
-        let sidecar = caller_output_receipt_path(&bake.output)?;
+        let sidecar = super::caller_output_receipt_path(&bake.output)?;
         let original_output = fs::read(&bake.output)?;
         let original_sidecar = fs::read(&sidecar)?;
         let output_modified = fs::metadata(&bake.output)?.modified()?;
@@ -9163,7 +9163,7 @@ mod tests {
         assert_eq!(record["output_digest"], rebuilt.output_digest);
         assert_eq!(
             record["schema_version"],
-            OVEN_DIRECT_RUSTC_OUTPUT_RECEIPT_SCHEMA_VERSION
+            super::OVEN_DIRECT_RUSTC_OUTPUT_RECEIPT_SCHEMA_VERSION
         );
 
         let mut missing_digest = record.clone();

--- a/src/oven/rustc.rs
+++ b/src/oven/rustc.rs
@@ -48,7 +48,7 @@ pub const OVEN_RUSTC_REGISTRY_LOCK_RELATIVE_PATH: &str = "registry-sources/Cargo
 /// Crate-name prefix reserved for the runtime family owned by one Incan release Loaf.
 pub const OVEN_COMPILER_RUNTIME_CRATE_PREFIX: &str = "incan_";
 /// Schema version for caller-owned native-output reuse evidence.
-const OVEN_DIRECT_RUSTC_OUTPUT_RECEIPT_SCHEMA_VERSION: u32 = 2;
+const OVEN_DIRECT_RUSTC_OUTPUT_RECEIPT_SCHEMA_VERSION: u32 = 3;
 
 /// One registry leaf and the immutable Loaf root that seals its relative artifact path.
 #[derive(Debug, Clone)]
@@ -1631,10 +1631,10 @@ fn default_direct_rustc_output_kind() -> String {
     OvenDirectRustcOutputKind::Binary.receipt_value().to_string()
 }
 
-/// Small sidecar persisted beside a caller-owned native output so an unchanged normal command does not rebuild it.
+/// Complete input binding retained beside a caller-owned native output.
 ///
-/// The sidecar is not Oven store state and never authorizes execution by itself: the caller still verifies the
-/// receipt, compiler identity, source digest, and immutable plan before this record can admit a reuse.
+/// This is not Oven store state and never authorizes execution by itself: the caller still verifies the receipt,
+/// compiler identity, source digest, and immutable plan before matching these inputs and the persisted output digest.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct OvenDirectRustcOutputReceipt {
     schema_version: u32,
@@ -1651,6 +1651,17 @@ struct OvenDirectRustcOutputReceipt {
     output_kind: String,
     #[serde(default)]
     caller_owned_library_digests: BTreeMap<String, String>,
+}
+
+/// Successful compilation evidence binding the complete verified inputs to the exact produced output bytes.
+///
+/// Flattening preserves the sidecar's input field names. The schema bump and required digest ensure readers cannot
+/// reuse older evidence that never bound the output; a malformed or interrupted record is a cache miss.
+#[derive(Debug, Serialize, Deserialize)]
+struct OvenDirectRustcOutputRecord {
+    #[serde(flatten)]
+    inputs: OvenDirectRustcOutputReceipt,
+    output_digest: String,
 }
 
 /// Backwards-compatible name for a direct-rustc libtest bake.
@@ -5059,8 +5070,7 @@ fn bake_direct_rustc(
             .map(|plan| plan.caller_owned_library_digests.clone())
             .unwrap_or_default(),
     };
-    if caller_output_is_reusable(&output, &output_receipt) {
-        let output_digest = digest_regular_file(&output, "output")?;
+    if let Some(output_digest) = caller_output_reusable_digest(&output, &output_receipt) {
         return Ok(OvenDirectRustcBake {
             source_digest,
             output,
@@ -5150,7 +5160,13 @@ fn bake_direct_rustc(
     }
     verified_regular_file(&output, "output")?;
     let output_digest = digest_regular_file(&output, "output")?;
-    write_caller_output_receipt(&output, &output_receipt)?;
+    write_caller_output_record(
+        &output,
+        &OvenDirectRustcOutputRecord {
+            inputs: output_receipt,
+            output_digest: output_digest.clone(),
+        },
+    )?;
     Ok(OvenDirectRustcBake {
         source_digest,
         output,
@@ -5201,31 +5217,29 @@ fn caller_output_receipt_path(output: &Path) -> Result<PathBuf, OvenRustcError> 
     Ok(output.with_file_name(format!("{name}.oven-output.json")))
 }
 
-/// Check only a fully matching regular output/sidecar pair; malformed or interrupted sidecars trigger a rebuild.
-fn caller_output_is_reusable(output: &Path, expected: &OvenDirectRustcOutputReceipt) -> bool {
-    if verified_regular_file(output, "output").is_err() {
-        return false;
+/// Verify complete input evidence and hash the current regular output once, returning the digest only on a match.
+///
+/// Missing, malformed, old or mismatched evidence is a cache miss. Returning the verified digest lets the caller
+/// report reuse without rereading the output. The caller must perform receipt/compiler/input admission first.
+fn caller_output_reusable_digest(output: &Path, expected: &OvenDirectRustcOutputReceipt) -> Option<String> {
+    let receipt_path = caller_output_receipt_path(output).ok()?;
+    let bytes = fs::read(&receipt_path).ok()?;
+    let record: OvenDirectRustcOutputRecord = serde_json::from_slice(&bytes).ok()?;
+    if record.inputs != *expected {
+        return None;
     }
-    let Ok(receipt_path) = caller_output_receipt_path(output) else {
-        return false;
-    };
-    let Ok(bytes) = fs::read(&receipt_path) else {
-        return false;
-    };
-    serde_json::from_slice::<OvenDirectRustcOutputReceipt>(&bytes)
-        .ok()
-        .as_ref()
-        == Some(expected)
+    let output_digest = digest_regular_file(output, "output").ok()?;
+    (output_digest == record.output_digest).then_some(output_digest)
 }
 
-/// Atomically publish reuse evidence only after rustc has produced and verified its regular caller-owned output.
-fn write_caller_output_receipt(output: &Path, receipt: &OvenDirectRustcOutputReceipt) -> Result<(), OvenRustcError> {
+/// Atomically publish the input/output binding only after rustc has produced and verified its regular output.
+fn write_caller_output_record(output: &Path, record: &OvenDirectRustcOutputRecord) -> Result<(), OvenRustcError> {
     let path = caller_output_receipt_path(output)?;
     let parent = path.parent().ok_or_else(|| OvenRustcError::InvalidInput {
         field: "output",
         message: "reuse evidence has no parent directory".to_string(),
     })?;
-    let bytes = serde_json::to_vec(receipt).map_err(|error| OvenRustcError::InvalidInput {
+    let bytes = serde_json::to_vec(record).map_err(|error| OvenRustcError::InvalidInput {
         field: "output receipt",
         message: format!("cannot serialize reuse evidence: {error}"),
     })?;
@@ -9084,6 +9098,7 @@ mod tests {
         Ok(())
     }
 
+    /// A real native library rebuilds changed output or invalid evidence and preserves an unchanged warm result.
     #[test]
     fn trusted_direct_rustc_materializes_a_reusable_library_without_cargo() -> Result<(), Box<dyn std::error::Error>> {
         let project = tempfile::tempdir()?;
@@ -9123,9 +9138,64 @@ mod tests {
         assert!(!bake.cargo_process_started);
         assert!(!bake.reused);
         assert!(bake.output.is_file());
+        let sidecar = caller_output_receipt_path(&bake.output)?;
+        let original_output = fs::read(&bake.output)?;
+        let original_sidecar = fs::read(&sidecar)?;
+        let output_modified = fs::metadata(&bake.output)?.modified()?;
+        let sidecar_modified = fs::metadata(&sidecar)?.modified()?;
         let reused = bake_trusted_direct_rustc_library(&request)?;
         assert!(reused.reused);
         assert_eq!(reused.output, bake.output);
+        assert_eq!(reused.output_digest, bake.output_digest);
+        assert_eq!(fs::read(&bake.output)?, original_output);
+        assert_eq!(fs::read(&sidecar)?, original_sidecar);
+        assert_eq!(fs::metadata(&bake.output)?.modified()?, output_modified);
+        assert_eq!(fs::metadata(&sidecar)?.modified()?, sidecar_modified);
+
+        // A still-valid input sidecar cannot authorize replacement output bytes.
+        fs::write(&bake.output, b"changed output bytes")?;
+        let rebuilt = bake_trusted_direct_rustc_library(&request)?;
+        assert!(!rebuilt.reused);
+        assert!(!rebuilt.cargo_process_started);
+        assert_eq!(rebuilt.output_digest, bake.output_digest);
+        assert_eq!(rebuilt.output_digest, digest_bytes(&fs::read(&rebuilt.output)?));
+        let record: serde_json::Value = serde_json::from_slice(&fs::read(&sidecar)?)?;
+        assert_eq!(record["output_digest"], rebuilt.output_digest);
+        assert_eq!(
+            record["schema_version"],
+            OVEN_DIRECT_RUSTC_OUTPUT_RECEIPT_SCHEMA_VERSION
+        );
+
+        let mut missing_digest = record.clone();
+        missing_digest
+            .as_object_mut()
+            .ok_or("output sidecar must be an object")?
+            .remove("output_digest");
+        let mut legacy = missing_digest.clone();
+        legacy["schema_version"] = serde_json::json!(2);
+        let mut malformed_digest = record.clone();
+        malformed_digest["output_digest"] = serde_json::json!(42);
+        let mut wrong_digest = record.clone();
+        wrong_digest["output_digest"] = serde_json::json!(digest_bytes(b"another output"));
+        let mut wrong_inputs = record.clone();
+        wrong_inputs["receipt_identity"] = serde_json::json!(digest_bytes(b"another receipt"));
+        for (case, invalid_record) in [
+            ("legacy sidecar", legacy),
+            ("missing digest", missing_digest),
+            ("malformed digest", malformed_digest),
+            ("wrong digest", wrong_digest),
+            ("wrong input receipt", wrong_inputs),
+        ] {
+            fs::write(&sidecar, serde_json::to_vec(&invalid_record)?)?;
+            let rebuilt = bake_trusted_direct_rustc_library(&request)?;
+            assert!(!rebuilt.reused, "{case} must rebuild");
+            assert_eq!(rebuilt.output_digest, bake.output_digest, "{case}");
+            let warm = bake_trusted_direct_rustc_library(&request)?;
+            assert!(warm.reused, "{case} must publish reusable repaired evidence");
+            assert_eq!(warm.output_digest, rebuilt.output_digest, "{case}");
+        }
+        fs::write(&sidecar, b"{interrupted sidecar")?;
+        assert!(!bake_trusted_direct_rustc_library(&request)?.reused);
         Ok(())
     }
 

--- a/workspaces/docs-site/docs/release_notes/0_6.md
+++ b/workspaces/docs-site/docs/release_notes/0_6.md
@@ -29,6 +29,7 @@ tags:
 
 The replacement backend will consume direct, compiler-owned lowering facts through Body IR. Backend selection and execution will be explicit and receipted, with no silent fallback to the legacy route. A corpus-based parity system will show which behavior is verified, which is intentionally migrated, and which is not yet acceptable.
 
+- **Tooling**: Oven validates caller-owned native output bytes against the digest recorded after compilation before reusing them. Changed outputs and old or malformed reuse evidence trigger a rebuild. (#1463)
 - **Tooling**: Oven compiler-suite replay reports live case durations, failures, and outstanding work; phase progress continues through cleanup, and every partition retains command and wrapper timing evidence plus diagnostic transcripts. Root-owned result records prevent nested test output from corrupting counts or timings, and incomplete accounting cannot claim suite success. (#1422, #1425)
 - **Tooling**: `make examples` prepares reusable dependencies and checks the frontend-only markform, scriptkit and styleforge consumers without running them; producer libraries remain part of the gate. (#1442)
 - **Compiler**: Source traits can inherit imported Rust trait bounds without synthesizing conflicting implementations of foreign parents. (#1427)


### PR DESCRIPTION
## Summary

Oven could report a caller-owned native output as reused after its bytes changed, because the sidecar bound only compilation inputs. Reuse now requires the current output digest to match the digest recorded after successful compilation, as well as the complete existing input receipt. Changed output or invalid evidence causes a rebuild.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: Modified native output, missing or malformed output bindings, and incompatible input records rebuild instead of claiming reuse. Unchanged output remains reusable.
- **Internals**: The schema-3 sidecar pairs the complete input receipt with the digest produced by compilation. The reuse check returns its verified digest directly, so a warm output is hashed once. Existing receipt, compiler, source and artifact admission remain intact.
- **Compatibility**: Prior sidecars lack an output binding and cause one rebuild. This change makes no new concurrent-writer or crash-transaction guarantee.

## Testing / verification

- [x] Focused native library test — 1 passed; full suite not run.
- [ ] `make examples` — not applicable to this physical output-sidecar change.
- [ ] `incan fmt --check .` — not applicable; no Incan source changed.
- [x] Manual source verification described below.

Completed with pinned Rust 1.98.0, a warm release target and offline source inputs:

- `cargo check --locked --release --features lsp --lib --tests` — passed.
- `cargo clippy --locked --release --features lsp --lib --tests -- -D warnings` — passed.
- `cargo check --workspace --all-features --release --locked --offline` — passed; the release-profile equivalent of the workspace/all-features fast compile check. Literal `make pre-commit-fast` was not run.
- Actual `trusted_direct_rustc_materializes_a_reusable_library_without_cargo` native library regression — passed. It compiles and rebuilds with rustc, checks corruption-triggered rebuilding and restored digest, unchanged warm bytes/mtime, and old/missing/malformed/wrong sidecars. Final clean-source rerun: 1 passed in 0.32s; 3475 unrelated tests filtered.
- Nightly Rust formatting check, changed Rustdoc coverage against the dev.4 base, whitespace checks and independent source review — passed. Version-consistency and agent-documentation checks also passed.

After merging current dev.4 `423ab6014`, the only conflict was adjacent release-note entries; both were retained. The changed Rust file is byte-identical to the compiled and linted version. Changed Rustdoc, whitespace, version and agent-documentation checks passed again, and the retained native executable passed the focused test again. The full workspace compilation and Clippy results above precede that base merge; they are not claimed as a new compilation of the merged head.

The original defect was reproduced using the exact production receipt, path helpers and reuse predicate from dev.4 `6c3fc2170`, with only the supporting error enum reduced. Replacing a regular output while keeping its input sidecar unchanged still returned `true` and failed the expected rejection assertion. This source-reduced red proof is distinct from the passing actual native compilation/rebuild regression.

No SDK or release-envelope preparation was needed. Full compiler-suite and example runs were not performed.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

Updated `workspaces/docs-site/docs/release_notes/0_6.md` and sidecar boundary Rustdoc. No tutorial, how-to, reference or explanation page changes are needed.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #1463