### PR TITLE
bugfix - accept inline model comparison assertions (#1470)

### DIFF
--- a/src/backend/ir/emit/expressions/calls.rs
+++ b/src/backend/ir/emit/expressions/calls.rs
@@ -1440,8 +1440,13 @@ impl<'a> IrEmitter<'a> {
         Ok(result_validation.apply(emitted))
     }
 
-    /// Return whether a nested binary operand must be parenthesized to preserve Incan precedence.
+    /// Group binary operands to preserve precedence and disambiguate named constructors from Rust control-flow blocks.
     fn binop_operand_needs_parens(parent: &BinOp, operand: &TypedExpr, is_right: bool) -> bool {
+        if let IrExprKind::Struct { fields, .. } = &operand.kind
+            && fields.iter().all(|(name, _)| !name.is_empty())
+        {
+            return true;
+        }
         let IrExprKind::BinOp { op: child, .. } = &operand.kind else {
             return false;
         };
@@ -2013,6 +2018,52 @@ mod tests {
             render(tokens),
             "ifincan_stdlib::strings::str_eq(&value,&target){panic!(\"AssertionError:left==right\");}"
         );
+        Ok(())
+    }
+
+    /// Inline named constructors must parse as operands rather than as the assertion's failure block.
+    #[test]
+    fn emit_canonical_assert_model_constructor_comparison_parses() -> Result<(), Box<dyn std::error::Error>> {
+        let registry = FunctionRegistry::new();
+        let emitter = IrEmitter::new(&registry);
+        let model_type = IrType::Struct("Pair".to_string());
+        let constructor = || {
+            TypedExpr::new(
+                IrExprKind::Struct {
+                    name: "Pair".to_string(),
+                    fields: vec![("x".to_string(), TypedExpr::new(IrExprKind::Int(1), IrType::Int))],
+                    fill_defaults: false,
+                },
+                model_type.clone(),
+            )
+        };
+
+        for helper in ["assert_eq", "assert_ne"] {
+            for (inline_left, inline_right) in [(false, true), (true, false), (true, true)] {
+                let left = if inline_left {
+                    constructor()
+                } else {
+                    local_arg("left", model_type.clone())
+                };
+                let right = if inline_right {
+                    constructor()
+                } else {
+                    local_arg("right", model_type.clone())
+                };
+                let tokens = emitter.emit_call_expr(
+                    &rust_call_target(helper),
+                    &[],
+                    &[pos_arg(left), pos_arg(right)],
+                    None,
+                    Some(&canonical_testing_path(helper)),
+                )?;
+                syn::parse2::<syn::Block>(quote! {{ #tokens }}).map_err(|error| {
+                    std::io::Error::other(format!(
+                        "{helper} with inline operands ({inline_left}, {inline_right}) must parse: {error}; {tokens}"
+                    ))
+                })?;
+            }
+        }
         Ok(())
     }
 

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -7028,6 +7028,109 @@ def main() -> None:
     Ok(())
 }
 
+/// Inline and bound model comparisons agree without moving operands or evaluating their fields twice.
+#[test]
+fn model_constructor_comparison_runs_equivalent_assertions() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    fs::create_dir_all(tmp.path().join("src"))?;
+    fs::write(
+        tmp.path().join("loaf.toml"),
+        "[project]\nname = \"model_constructor_comparison\"\nversion = \"0.1.0\"\n",
+    )?;
+    fs::write(
+        tmp.path().join("src/main.incn"),
+        r#"from std.testing import assert_eq, assert_ne, assert_false
+
+@derive(Eq)
+model Pair:
+    x: str
+
+def observed(tag: str) -> str:
+    println(tag)
+    return "same"
+
+def failure_message() -> str:
+    println("unexpected failure message")
+    return "model comparison failed"
+
+pub def main() -> None:
+    value = Pair(x="same")
+    expected = Pair(x="same")
+    assert value == Pair(x="same")
+    assert Pair(x="same") == value
+    assert Pair(x="same") == Pair(x="same")
+    assert value != Pair(x="different")
+    assert Pair(x="different") != value
+    assert (value == Pair(x="same")) == (Pair(x="same") == value)
+    assert not (value != Pair(x="same"))
+    assert_eq(value, Pair(x="same"))
+    assert_eq(Pair(x="same"), value)
+    assert_ne(value, Pair(x="different"))
+    assert_ne(Pair(x="different"), value)
+    assert_false(value != Pair(x="same"))
+    assert value == expected
+    assert value == Pair(x="same"), failure_message()
+    assert Pair(x=observed("left")) == Pair(x=observed("right"))
+    println(value.x)
+    println(expected.x)
+    println("ok")
+"#,
+    )?;
+
+    let bake = run_explicit_oven_bake(tmp.path())?;
+    assert_success(&bake, "prepare inline model comparison fixture");
+    let build = run_incan(tmp.path(), &["build", "src/main.incn"])?;
+    assert_success(&build, "build inline model comparison assertions");
+    let run = run_incan(tmp.path(), &["run", "src/main.incn"])?;
+    assert_success(&run, "run inline model comparison assertions");
+    assert_eq!(String::from_utf8(run.stdout)?, "left\nright\nsame\nsame\nok\n");
+    Ok(())
+}
+
+/// Unequal inline models still fail at runtime and evaluate the failure message exactly once.
+#[test]
+fn model_constructor_comparison_preserves_assertion_failure() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    fs::create_dir_all(tmp.path().join("src"))?;
+    fs::write(
+        tmp.path().join("loaf.toml"),
+        "[project]\nname = \"model_constructor_comparison_failure\"\nversion = \"0.1.0\"\n",
+    )?;
+    fs::write(
+        tmp.path().join("src/main.incn"),
+        r#"@derive(Eq)
+model Pair:
+    x: str
+
+def observed(tag: str) -> str:
+    println(tag)
+    return tag
+
+def failure_message() -> str:
+    println("failure message")
+    return "model comparison failed"
+
+pub def main() -> None:
+    assert Pair(x=observed("left")) == Pair(x=observed("right")), failure_message()
+    println("unreachable")
+"#,
+    )?;
+
+    let bake = run_explicit_oven_bake(tmp.path())?;
+    assert_success(&bake, "prepare failing inline model comparison fixture");
+    let build = run_incan(tmp.path(), &["build", "src/main.incn"])?;
+    assert_success(&build, "build failing inline model comparison assertion");
+    let run = run_incan(tmp.path(), &["run", "src/main.incn"])?;
+    assert_failure(&run, "unequal inline models must fail their assertion");
+    assert_eq!(String::from_utf8(run.stdout)?, "left\nright\nfailure message\n");
+    let stderr = String::from_utf8(run.stderr)?;
+    assert!(
+        stderr.contains("AssertionError: model comparison failed; left != right"),
+        "the normal assertion failure must survive native execution: {stderr}"
+    );
+    Ok(())
+}
+
 #[test]
 fn build_union_widening_converts_generated_wrappers_issue741() -> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir()?;

--- a/tests/codegen_snapshot_tests.rs
+++ b/tests/codegen_snapshot_tests.rs
@@ -5973,6 +5973,44 @@ fn test_assert_surface_codegen() {
     assert_codegen_snapshot!("assert_surface", rust_code);
 }
 
+/// Checked inline model comparisons and their equivalent assertion forms must survive Rust parsing.
+#[test]
+fn model_constructor_comparison_assertion_forms_codegen() -> TestResult {
+    for assertion in [
+        "assert value == Pair(x=1)",
+        "assert Pair(x=1) == value",
+        "assert Pair(x=1) == Pair(x=1)",
+        "assert value != Pair(x=2)",
+        "assert Pair(x=2) != value",
+        "assert (value == Pair(x=1)) == (Pair(x=1) == value)",
+        "assert not (value != Pair(x=1))",
+        "assert_eq(value, Pair(x=1))",
+        "assert_eq(Pair(x=1), value)",
+        "assert_ne(value, Pair(x=2))",
+        "assert_ne(Pair(x=2), value)",
+        "assert_false(value != Pair(x=1))",
+        "assert value == expected",
+    ] {
+        let source = format!(
+            r#"from std.testing import assert_eq, assert_ne, assert_false
+
+@derive(Eq)
+model Pair:
+    x: int
+
+pub def main() -> None:
+    value = Pair(x=1)
+    expected = Pair(x=1)
+    {assertion}
+"#,
+        );
+        let rust = generate_rust(&source);
+        syn::parse_file(&rust)
+            .map_err(|error| std::io::Error::other(format!("{assertion} must emit a valid Rust program: {error}")))?;
+    }
+    Ok(())
+}
+
 // ============================================================================
 /// RFC 057: Targeted Rust lint suppression.
 // ============================================================================

--- a/workspaces/docs-site/docs/release_notes/0_6.md
+++ b/workspaces/docs-site/docs/release_notes/0_6.md
@@ -106,6 +106,7 @@ The CLI, LSP, Architect, MCP tools, and Rust/Oven views will consume the same so
 
 0.6 is not released yet, so this list carries only fixes that are merged, regression-tested, and part of the release branch's supported behavior.
 
+- **Compiler**: Equality assertions accept inline model constructors on either side of the comparison without requiring an intermediate local binding. (#1470)
 - **Compiler**: Reference-aware assignments preserve an existing borrow and materialize known borrowed values at owned destinations. Read-only nominal helpers and tree cursors can infer shared borrowing from complete local use and checked Rust receiver lifetimes, avoiding copies of ancestor subtrees. Crate-visible and inherent method entry points retain their callable ABI; mutation, escapes, overlapping call arguments, and unknown contracts keep owned behavior. (#1455)
 - **Language**: Plain assignment inside a nested block now reassigns the nearest enclosing binding — requiring `mut` and a compatible type — instead of silently creating a new block-local; `let` and `mut` remain the explicit shadowing forms, and `mut name = value` now declares a new binding over an active name rather than being rejected as mutation of an immutable one. This brings assignment behavior to the documented scoping contract. (#1072, #1248)
 - **Language**: `print` and `println` now render every argument, space-separated. Previously every argument after the first was silently dropped in generated Rust, with no diagnostic. (#1248)


### PR DESCRIPTION
## Summary

Inline model constructors now work in equality assertions on either side: `assert value == Pair(x=1)` no longer fails during Rust emission with `unexpected token, expected ';'`. The existing binary-operand emitter groups named constructors so Rust parses them as comparison operands.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: Direct assertions and `assert_eq`/`assert_ne` accept inline model operands without an intermediate local variable.
- **Internals**: Extend the existing precedence helper to parenthesize named struct expressions on either side. Equality dispatch, borrowing and assertion-message handling are unchanged.
- **Risks**: The helper is shared by binary-expression emission. Regression coverage checks precedence, both operand positions, single evaluation, non-Copy operand reuse and lazy failure messages.
- **Scope**: Four files directly against `0.6.0-dev.4`; no dependency on the open package-boundary or RFC PRs.

## Testing / verification

- [ ] `make test` / `cargo test` — full suite not run; focused execution below
- [ ] `make examples` (if relevant) — not applicable
- [ ] `incan fmt --check .` (if relevant) — no standalone Incan files changed
- [x] Manual verification described below

Manual verification notes:

- Twelve emitter tests passed, including six inline-constructor/helper combinations and existing precedence/assertion controls.
- The checked-source regression passed all thirteen assertion forms; the existing assertion-surface test also passed. All fifteen retained programs emitted successfully with the patched compiler.
- Both actual CLI regression wrappers passed: explicit debug/release bake, release build, and debug execution. They verify exact stdout, operand reuse, one evaluation per operand, lazy message evaluation and the expected runtime assertion failure. Tests took 56.16s; the complete guarded native window took 96.064s.
- `cargo +1.98.0 clippy --locked --offline --release --workspace --all-targets --all-features -- -D warnings` passed. Production compiler build passed; SDK/provider/support inputs were reused unchanged.
- Scoped nightly formatting, explicit-base changed Rustdocs, version consistency, AGENTS-doc synchronization and whitespace checks passed. This is a warmed release-profile fast-gate equivalent; literal `make pre-commit-fast` and full CI were not run locally.
- Independent source review found no unresolved issue. Two fixture setup mistakes discovered by native execution were corrected: prepare both consumed profiles and supply the explicit run entrypoint. Compiler behavior did not change during those corrections.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

The 0.6 release notes describe the corrected assertion behavior.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #1470
