### PR TITLE
bugfix - retain trait metadata for stdlib module imports (#1473)

### DIFF
--- a/src/frontend/typechecker/collect/stdlib_imports.rs
+++ b/src/frontend/typechecker/collect/stdlib_imports.rs
@@ -284,6 +284,7 @@ impl TypeChecker {
         let resolved_path = self.resolved_source_module_path(path);
         let target_identity = resolved_path.as_deref().and_then(SymbolTable::module_path_identity);
         let canonical_path = resolved_path.unwrap_or(normalized_path);
+        self.cache_stdlib_module_import_semantics(path);
         self.define_import_symbol(name, canonical_path, false, target_identity, span);
     }
 
@@ -406,6 +407,9 @@ impl TypeChecker {
             if self.materialize_bootstrap_source_dependency_import(module, item, span) {
                 continue;
             }
+            if self.materialize_stdlib_submodule_import(module, item, span) {
+                continue;
+            }
             if self.materialize_stdlib_from_import(&context, item, testing_semantics.as_ref(), span) {
                 continue;
             }
@@ -511,6 +515,19 @@ impl TypeChecker {
             )),
             ProviderModuleResolution::Active(_) | ProviderModuleResolution::Unknown => None,
         }
+    }
+
+    /// Retain a module import's hidden type and trait facts for its qualified signatures and derives.
+    ///
+    /// Checked providers keep authority over their own metadata. Only the existing inventoryless or source-bootstrap
+    /// adapters may seed source stub facts; this does not import those declarations into the consumer's namespace.
+    fn cache_stdlib_module_import_semantics(&mut self, module: &ImportPath) {
+        let provider_owned = matches!(
+            self.provider_plan.resolve_module(&module.segments),
+            ProviderModuleResolution::Active(provider) if provider.manifest.is_some()
+        );
+        let context = FromImportContext::new(module, self.is_known_stdlib_module(&module.segments), provider_owned);
+        self.cache_stdlib_stub_semantics(&context);
     }
 
     /// Cache all known top-level types and traits for a stub-backed stdlib module without making them source-visible.
@@ -1011,9 +1028,6 @@ impl TypeChecker {
             }
             return true;
         }
-        if self.materialize_stdlib_submodule_import(context.module, item, span) {
-            return true;
-        }
         if self.materialize_sdk_provider_import(context, item, testing_semantics, span) {
             return true;
         }
@@ -1074,9 +1088,13 @@ impl TypeChecker {
         true
     }
 
-    /// Materialize `from std.namespace import submodule` as a module binding when the submodule is registered.
+    /// Bind a registered submodule imported from `std` or `std.namespace`, retaining its hidden signature facts.
     fn materialize_stdlib_submodule_import(&mut self, module: &ImportPath, item: &ImportItem, span: Span) -> bool {
-        if module.segments.len() != 2 {
+        if module.parent_levels != 0
+            || module.is_absolute
+            || module.segments.first().map(String::as_str) != Some(stdlib::STDLIB_ROOT)
+            || !(1..=2).contains(&module.segments.len())
+        {
             return false;
         }
         let mut submodule_path = module.segments.clone();
@@ -1097,11 +1115,16 @@ impl TypeChecker {
         if !is_known_submodule {
             return false;
         }
+        if let Some(error) = self.sdk_provider_module_error(&submodule_path, span) {
+            self.errors.push(error);
+            return true;
+        }
 
         let local_name = Self::import_item_local_name(item);
         self.validate_root_namespace(&local_name, span);
         let path = canonicalize_source_module_segments(&submodule_path);
         let target_identity = SymbolTable::module_path_identity(&path);
+        self.cache_stdlib_module_import_semantics(&ImportPath::simple(submodule_path));
         self.define_import_symbol(local_name, path, false, target_identity, span);
         true
     }

--- a/tests/stdlib_module_trait_tests.rs
+++ b/tests/stdlib_module_trait_tests.rs
@@ -1,0 +1,130 @@
+//! Source-backed module imports retain the semantic traits used by their qualified codec bounds.
+
+use incan::frontend::api_metadata::{
+    CHECKED_API_METADATA_SCHEMA_VERSION, CheckedApiMetadataPackage, collect_checked_api_metadata,
+};
+use incan::frontend::ast::Program;
+use incan::frontend::typechecker::TypeChecker;
+use incan::frontend::{lexer, parser};
+use incan::library_manifest::LibraryManifest;
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+/// Parse a source-only consumer without loading a CLI session or an installed SDK.
+fn parsed(source: &str) -> Result<Program, Box<dyn std::error::Error>> {
+    let tokens = lexer::lex(source).map_err(|errors| format!("lex: {errors:?}"))?;
+    Ok(parser::parse(&tokens).map_err(|errors| format!("parse: {errors:?}"))?)
+}
+
+/// Exercise both directions of a module's codec bounds on the same nominal model.
+fn codec_consumer(import: &str, module: &str, derive: &str) -> String {
+    format!(
+        "{import}\n\n{derive}\nmodel Settings:\n    name: str\n\ndef codecs(source: str) -> None:\n    decoded = {module}.deserialize[Settings](source)\n    encoded = {module}.serialize(Settings(name=\"example\"))\n    pretty = {module}.serialize_pretty(Settings(name=\"example\"))\n"
+    )
+}
+
+/// Plain imports, root-module imports and aliases must use the module's declared derive contract.
+#[test]
+fn source_module_codec_bounds_accept_derived_models() -> TestResult {
+    for (import, module) in [
+        ("from std import toml", "toml"),
+        ("from std import toml as codec", "codec"),
+        ("import std.toml", "toml"),
+        ("import std.toml as codec", "codec"),
+    ] {
+        let source = codec_consumer(import, module, &format!("@derive({module})"));
+        TypeChecker::new()
+            .check_program(&parsed(&source)?)
+            .map_err(|errors| format!("{import}: {errors:?}"))?;
+    }
+    Ok(())
+}
+
+/// Loading semantic metadata must not make an ordinary model satisfy codec traits it never adopted.
+#[test]
+fn source_module_codec_bounds_reject_models_without_derives() -> TestResult {
+    for (import, module) in [
+        ("from std import toml", "toml"),
+        ("from std import toml as codec", "codec"),
+        ("import std.toml", "toml"),
+        ("import std.toml as codec", "codec"),
+    ] {
+        let source = codec_consumer(import, module, "");
+        let errors = TypeChecker::new()
+            .check_program(&parsed(&source)?)
+            .err()
+            .ok_or_else(|| format!("{import} accepted a model without codec traits"))?;
+        assert!(
+            errors.iter().any(|error| error.message.contains("TomlDeserialize")),
+            "{import}: {errors:?}"
+        );
+        assert!(
+            errors.iter().any(|error| error.message.contains("TomlSerialize")),
+            "{import}: {errors:?}"
+        );
+    }
+    Ok(())
+}
+
+/// Explicit item imports remain a control for the existing semantic-cache path.
+#[test]
+fn explicit_codec_trait_imports_remain_valid() -> TestResult {
+    let source = codec_consumer(
+        "from std import toml\nfrom std.toml import TomlSerialize, TomlDeserialize",
+        "toml",
+        "@derive(TomlSerialize, TomlDeserialize)",
+    );
+    TypeChecker::new()
+        .check_program(&parsed(&source)?)
+        .map_err(|errors| format!("explicit trait control: {errors:?}"))?;
+    Ok(())
+}
+
+/// Replay the exact source-only fixture that failed in the Linux integration root.
+#[test]
+fn original_toml_module_fixture_passes_bare_frontend_checking() -> TestResult {
+    let source = include_str!("fixtures/valid/std_toml_module_import.incn");
+    TypeChecker::new()
+        .check_program(&parsed(source)?)
+        .map_err(|errors| format!("original fixture: {errors:?}"))?;
+    Ok(())
+}
+
+/// A checked SDK module owns its empty requirements even when a richer source stub exists at that spelling.
+#[test]
+fn checked_sdk_module_imports_do_not_acquire_source_trait_requirements() -> TestResult {
+    let source = "const __derives__ = [TomlSerialize]\n\npub trait TomlSerialize:\n    pass\n";
+    let ast = parsed(source)?;
+    let module_path = vec!["toml".into()];
+    let mut producer = TypeChecker::new();
+    producer.set_current_module_path(Some(module_path.clone()));
+    producer
+        .check_program(&ast)
+        .map_err(|errors| format!("provider: {errors:?}"))?;
+    let metadata = collect_checked_api_metadata(&ast, &producer, module_path);
+    let mut manifest = LibraryManifest::new("codec_provider", "0.1.0");
+    manifest.contract_metadata.api = Some(CheckedApiMetadataPackage {
+        schema_version: CHECKED_API_METADATA_SCHEMA_VERSION,
+        package: None,
+        modules: vec![metadata],
+        public_namespaces: Vec::new(),
+    });
+    for import in ["from std import toml as codec", "import std.toml as codec"] {
+        let mut consumer = TypeChecker::new();
+        consumer.set_in_memory_sdk_manifest(manifest.clone());
+        let source = format!("{import}\n\n@derive(codec)\nmodel Record:\n    name: str\n");
+        consumer
+            .check_program(&parsed(&source)?)
+            .map_err(|errors| format!("{import}: {errors:?}"))?;
+        assert_eq!(
+            consumer
+                .type_info()
+                .derivations
+                .trait_rust_derive_paths
+                .get("std.toml.TomlSerialize"),
+            Some(&Vec::new()),
+            "{import} recovered source requirements for an artifact-owned trait"
+        );
+    }
+    Ok(())
+}

--- a/workspaces/docs-site/docs/release_notes/0_6.md
+++ b/workspaces/docs-site/docs/release_notes/0_6.md
@@ -106,6 +106,8 @@ The CLI, LSP, Architect, MCP tools, and Rust/Oven views will consume the same so
 
 0.6 is not released yet, so this list carries only fixes that are merged, regression-tested, and part of the release branch's supported behavior.
 
+- **Compiler**: Source-backed standard-library module imports retain the trait metadata required by their qualified codec functions. Models using `@derive(toml)` satisfy TOML codec bounds with either module import spelling and with aliases. (#1473)
+
 - **Compiler**: Reference-aware assignments preserve an existing borrow and materialize known borrowed values at owned destinations. Read-only nominal helpers and tree cursors can infer shared borrowing from complete local use and checked Rust receiver lifetimes, avoiding copies of ancestor subtrees. Crate-visible and inherent method entry points retain their callable ABI; mutation, escapes, overlapping call arguments, and unknown contracts keep owned behavior. (#1455)
 - **Language**: Plain assignment inside a nested block now reassigns the nearest enclosing binding — requiring `mut` and a compatible type — instead of silently creating a new block-local; `let` and `mut` remain the explicit shadowing forms, and `mut name = value` now declares a new binding over an active name rather than being rejected as mutation of an immutable one. This brings assignment behavior to the documented scoping contract. (#1072, #1248)
 - **Language**: `print` and `println` now render every argument, space-separated. Previously every argument after the first was silently dropped in generated Rust, with no diagnostic. (#1248)


### PR DESCRIPTION
## Summary

Source-backed standard-library module imports now retain the hidden trait metadata needed to check their qualified functions. A model using `@derive(toml)` satisfies TOML codec bounds through `from std import toml`, `import std.toml`, and their aliased forms. Models without the derives still fail the bounds, and an admitted compiled SDK continues to own its metadata.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [x] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior**: Module imports carry their declared codec traits without extra trait imports or Rust derive annotations.
- **Internals**: Confirmed root submodules use the existing module materializer. Both module import routes seed the existing guarded semantic cache for the target module; this does not introduce those traits as consumer namespace bindings.
- **Risks**: Module routing also covers registered `std.namespace` submodules. Checked-provider ownership, unavailable-module diagnostics and source-bootstrap restrictions remain in force. A regression supplies a checked SDK trait with deliberately empty requirements and verifies that richer source stubs cannot override it.

## Testing / verification

- [x] `make test` / `cargo test` — focused Rust regressions only; full suite not run
- [ ] `make examples` (not applicable to this frontend-only change)
- [ ] `incan fmt --check .` (no authored Incan files changed)
- [x] Manual verification described below

Manual verification notes:

- The original frontend produced the expected two failing and three passing regression tests; the repaired frontend passes all five. Positive and negative codec cases cover both module spellings and aliases, explicit trait imports remain valid, and the exact failing TOML fixture passes.
- The unchanged `test_valid_fixtures` implementation was replayed in a small harness against all 28 tracked valid fixtures, with a nonempty inventory assertion.
- Focused Clippy with warnings denied passed. Final validation on the merged dev.4 base includes the focused regressions, `make pre-commit-fast`, explicit-base changed Rustdocs and strict MkDocs.
- This is frontend acceptance. Native package execution, the full integration root and the original in-crate SDK test collection are not claimed.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

The [0.6 release notes](workspaces/docs-site/docs/release_notes/0_6.md) describe the corrected import behavior. No new API or procedure is introduced. The dev.3 version baseline is preserved; the PR targets dev.4 independently and includes no changes from unmerged PRs.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #1473
