### PR TITLE
bugfix - infer string elements in empty-first nested lists (#1471)

### DIFF
--- a/src/frontend/typechecker/check_expr/collections.rs
+++ b/src/frontend/typechecker/check_expr/collections.rs
@@ -104,6 +104,35 @@ impl TypeChecker {
         self.merge_collection_member_type(member_ty, value_ty, span);
     }
 
+    /// Refine only list element holes originating in the first member's empty literal.
+    ///
+    /// Compatibility alone accepts `list[Unknown]` against `list[str]`, but retaining that hole loses the owned
+    /// string representation downstream. The source witness prevents peer observations from refining unrelated
+    /// unknown call results or nominal generic arguments. Existing concrete leaves are never widened here.
+    fn refine_empty_list_member(member: &mut ResolvedType, observed: &ResolvedType, seed: &Expr) {
+        let Expr::List(entries) = seed else {
+            return;
+        };
+        let (ResolvedType::Generic(name, args), ResolvedType::Generic(other_name, other_args)) = (member, observed)
+        else {
+            return;
+        };
+        if collection_type_id(name) != Some(CollectionTypeId::List)
+            || collection_type_id(other_name) != Some(CollectionTypeId::List)
+            || args.len() != 1
+            || other_args.len() != 1
+        {
+            return;
+        }
+        if entries.is_empty() {
+            if matches!(args[0], ResolvedType::Unknown) {
+                args[0] = other_args[0].clone();
+            }
+        } else if let Some(ListEntry::Element(first)) = entries.first() {
+            Self::refine_empty_list_member(&mut args[0], &other_args[0], &first.node);
+        }
+    }
+
     /// Type-check a list literal with an optional destination-type hint.
     ///
     /// When a surrounding context already expects `List[T]`, empty lists adopt `T` directly and non-empty lists
@@ -116,11 +145,21 @@ impl TypeChecker {
     ) -> ResolvedType {
         let hinted_elem_ty = Self::list_expected_element_type(expected);
         let mut elem_ty = hinted_elem_ty.clone().unwrap_or(ResolvedType::Unknown);
+        let first_member = match elems.first() {
+            Some(ListEntry::Element(value)) => Some(&value.node),
+            _ => None,
+        };
 
         for elem in elems {
             match elem {
                 ListEntry::Element(value) => {
                     let value_ty = self.check_expr_with_expected(value, hinted_elem_ty.as_ref());
+                    if hinted_elem_ty.is_none()
+                        && let Some(seed) = first_member
+                        && self.types_compatible(&value_ty, &elem_ty)
+                    {
+                        Self::refine_empty_list_member(&mut elem_ty, &value_ty, seed);
+                    }
                     self.check_collection_member_type(hinted_elem_ty.as_ref(), &mut elem_ty, value_ty, value.span);
                 }
                 ListEntry::Spread(value) => {

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -6994,6 +6994,24 @@ def test_smoke() -> None:
     Ok(())
 }
 
+/// Infer owned strings from later list members through a real build and runtime loop.
+#[test]
+fn nested_empty_first_list_runs_without_a_caller_annotation_issue1471() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    write_minimal_project(tmp.path(), "nested_empty_first_list", "")?;
+    fs::write(
+        tmp.path().join("src/main.incn"),
+        include_str!("fixtures/nested_list_loop_1471.incn"),
+    )?;
+    let bake = run_explicit_oven_bake(tmp.path())?;
+    assert_success(&bake, "prepare nested empty-first list fixture");
+    let build = run_incan(tmp.path(), &["build", "src/main.incn"])?;
+    assert_success(&build, "build inferred nested string lists");
+    let run = run_incan(tmp.path(), &["run", "src/main.incn"])?;
+    assert_success(&run, "run nested-list count and content assertions");
+    Ok(())
+}
+
 #[test]
 fn build_assert_string_inequality_in_list_loop_issue739() -> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir()?;

--- a/tests/fixtures/nested_list_loop_1471.incn
+++ b/tests/fixtures/nested_list_loop_1471.incn
@@ -1,0 +1,17 @@
+"""The first empty list must not erase the later string element type."""
+
+def size(values: list[str]) -> int:
+    """Validate nonempty content and return the element count."""
+    if len(values) > 0:
+        assert values[0] == "x"
+    return len(values)
+
+pub def main() -> None:
+    """Check both iterations and their total content without a caller annotation."""
+    mut count = 0
+    mut total = 0
+    for values in [[], ["x"]]:
+        count += 1
+        total += size(values)
+    assert count == 2
+    assert total == 1

--- a/tests/nested_list_loop_tests.rs
+++ b/tests/nested_list_loop_tests.rs
@@ -1,0 +1,147 @@
+//! Checked inference and native-emission regressions for empty-first nested lists (#1471).
+
+use incan::backend::IrCodegen;
+use incan::backend::ir::lower::AstLowering;
+use incan::backend::ir::types::IrType;
+use incan::frontend::ast::{Declaration, Span, Statement};
+use incan::frontend::symbols::ResolvedType;
+use incan::frontend::typechecker::TypeChecker;
+use incan::frontend::{lexer, parser};
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+/// Check the complete string-list type and its propagation into typed lowering.
+fn assert_literal_type(literal: &str, expected: &str) -> TestResult {
+    let source = format!("def run() -> None:\n    for values in {literal}:\n        pass\n");
+    let tokens = lexer::lex(&source).map_err(|errors| format!("{errors:?}"))?;
+    let program = parser::parse(&tokens).map_err(|errors| format!("{errors:?}"))?;
+    let mut checker = TypeChecker::new();
+    checker
+        .check_program(&program)
+        .map_err(|errors| format!("{errors:?}"))?;
+    let start = source.find(literal).ok_or("literal source span missing")?;
+    let span = Span {
+        start,
+        end: start + literal.len(),
+    };
+    let actual = checker
+        .type_info()
+        .expr_type(span)
+        .ok_or("literal checked type missing")?;
+    assert_eq!(actual.to_string(), expected);
+    let function = program
+        .declarations
+        .iter()
+        .find_map(|decl| match &decl.node {
+            Declaration::Function(function) => Some(function),
+            _ => None,
+        })
+        .ok_or("function missing")?;
+    let loop_stmt = function
+        .body
+        .iter()
+        .find_map(|stmt| match &stmt.node {
+            Statement::For(loop_stmt) => Some(loop_stmt),
+            _ => None,
+        })
+        .ok_or("loop missing")?;
+    let mut lowering = AstLowering::new_with_type_info(checker.type_info().clone());
+    let lowered = lowering.lower_expr_spanned(&loop_stmt.iter)?;
+    let mut leaf = &lowered.ty;
+    while let IrType::List(inner) = leaf {
+        leaf = inner;
+    }
+    assert_eq!(leaf, &IrType::String, "checked list leaf lost in typed IR");
+    Ok(())
+}
+
+/// String-list siblings refine empty literal holes, including an explicitly nested empty seed.
+#[test]
+fn nested_list_empty_holes_retain_checked_string_types() -> TestResult {
+    assert_literal_type("[[], [\"x\"]]", "List[List[str]]")?;
+    assert_literal_type("[[\"x\"], []]", "List[List[str]]")?;
+    assert_literal_type("[[[]], [[\"x\"]]]", "List[List[List[str]]]")?;
+    Ok(())
+}
+
+/// A concrete sibling must constrain later siblings instead of preserving an unknown acceptance hole.
+#[test]
+fn nested_list_empty_holes_do_not_accept_incompatible_later_members() -> TestResult {
+    let source = "def run() -> None:\n    values = [[], [\"x\"], [1]]\n";
+    let tokens = lexer::lex(source).map_err(|errors| format!("{errors:?}"))?;
+    let program = parser::parse(&tokens).map_err(|errors| format!("{errors:?}"))?;
+    let mut checker = TypeChecker::new();
+    let errors = checker
+        .check_program(&program)
+        .err()
+        .ok_or("mixed nested list was accepted")?;
+    assert!(
+        errors
+            .iter()
+            .any(|error| error.message.contains("str") && error.message.contains("int"))
+    );
+    Ok(())
+}
+
+/// All-empty lists retain unresolved leaf types rather than inventing a peer constraint.
+#[test]
+fn nested_list_all_empty_leaves_remain_unknown() -> TestResult {
+    let source = "def run() -> None:\n    values = [[], []]\n";
+    let tokens = lexer::lex(source).map_err(|errors| format!("{errors:?}"))?;
+    let program = parser::parse(&tokens).map_err(|errors| format!("{errors:?}"))?;
+    let mut checker = TypeChecker::new();
+    checker
+        .check_program(&program)
+        .map_err(|errors| format!("{errors:?}"))?;
+    let start = source.find("[[], []]").ok_or("literal missing")?;
+    let actual = checker
+        .type_info()
+        .expr_type(Span { start, end: start + 8 })
+        .ok_or("type missing")?;
+    let expected = ResolvedType::Generic(
+        "List".into(),
+        vec![ResolvedType::Generic("List".into(), vec![ResolvedType::Unknown])],
+    );
+    assert_eq!(actual, &expected);
+    Ok(())
+}
+
+/// Existing checked lowering must carry the inferred leaf into owned-string collection emission.
+#[test]
+fn nested_list_loop_emits_owned_strings_without_caller_annotation() -> TestResult {
+    let source = include_str!("fixtures/nested_list_loop_1471.incn");
+    let tokens = lexer::lex(source).map_err(|errors| format!("{errors:?}"))?;
+    let program = parser::parse(&tokens).map_err(|errors| format!("{errors:?}"))?;
+    let rust = IrCodegen::new().try_generate(&program)?;
+    let compact: String = rust.chars().filter(|character| !character.is_whitespace()).collect();
+    assert!(compact.contains("vec![vec![],vec![\"x\".to_string()]]"), "{rust}");
+    Ok(())
+}
+
+/// Explicit destinations and the existing numeric compatibility policy remain authoritative.
+#[test]
+fn nested_list_contextual_and_numeric_controls_typecheck() -> TestResult {
+    for source in [
+        "def run() -> None:\n    cases: list[list[str]] = [[], [\"x\"]]\n",
+        "def run() -> None:\n    cases: list[list[int | str]] = [[], [1], [\"x\"]]\n",
+    ] {
+        let tokens = lexer::lex(source).map_err(|errors| format!("{errors:?}"))?;
+        let program = parser::parse(&tokens).map_err(|errors| format!("{errors:?}"))?;
+        TypeChecker::new()
+            .check_program(&program)
+            .map_err(|errors| format!("{errors:?}"))?;
+    }
+    let numeric = "def run() -> None:\n    cases = [[1.0], [2]]\n";
+    let tokens = lexer::lex(numeric).map_err(|errors| format!("{errors:?}"))?;
+    let program = parser::parse(&tokens).map_err(|errors| format!("{errors:?}"))?;
+    let errors = TypeChecker::new()
+        .check_program(&program)
+        .err()
+        .ok_or("invariant nested numeric lists were widened")?;
+    assert!(
+        errors
+            .iter()
+            .any(|error| error.message.contains("List[float]") && error.message.contains("List[int]"))
+    );
+    Ok(())
+}

--- a/workspaces/docs-site/docs/release_notes/0_6.md
+++ b/workspaces/docs-site/docs/release_notes/0_6.md
@@ -106,6 +106,8 @@ The CLI, LSP, Architect, MCP tools, and Rust/Oven views will consume the same so
 
 0.6 is not released yet, so this list carries only fixes that are merged, regression-tested, and part of the release branch's supported behavior.
 
+- **Compiler**: Loops over nested literals such as `[[], ["x"]]` infer the string element type without an extra caller annotation. (#1471)
+
 - **Compiler**: Reference-aware assignments preserve an existing borrow and materialize known borrowed values at owned destinations. Read-only nominal helpers and tree cursors can infer shared borrowing from complete local use and checked Rust receiver lifetimes, avoiding copies of ancestor subtrees. Crate-visible and inherent method entry points retain their callable ABI; mutation, escapes, overlapping call arguments, and unknown contracts keep owned behavior. (#1455)
 - **Language**: Plain assignment inside a nested block now reassigns the nearest enclosing binding — requiring `mut` and a compatible type — instead of silently creating a new block-local; `let` and `mut` remain the explicit shadowing forms, and `mut name = value` now declares a new binding over an active name rather than being rejected as mutation of an immutable one. This brings assignment behavior to the documented scoping contract. (#1072, #1248)
 - **Language**: `print` and `println` now render every argument, space-separated. Previously every argument after the first was silently dropped in generated Rust, with no diagnostic. (#1248)


### PR DESCRIPTION
## Summary

A loop over `[[], ["x"]]` could retain an unknown element type from the first empty list and emit borrowed Rust strings where the called function needs owned strings. Infer that literal hole from the later string list so the original program builds and runs without a caller annotation.

Closes #1471. Targets `0.6.0-dev.4`; keeps the agreed `0.6.0-dev.3` workspace baseline.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [x] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [x] Documentation

## Key details

- **User-facing behavior:** unannotated nested string-list loops infer the owned string element type, including the reversed order and an explicitly nested empty seed.
- **Internals:** refine only unresolved list elements witnessed by the first member's empty list literal. Existing checked lowering then carries the element type into emission.
- **Risks:** collection inference affects later compatibility checks. Regressions preserve all-empty unknown leaves, reject incompatible later members, and retain explicit destination and invariant numeric-list behavior. This is a narrow literal-origin refinement, not general nested inference.

## Testing / verification

- [ ] `make test` / full `cargo test`
- [ ] `make examples` (not applicable to this focused fix)
- [ ] `incan fmt --check .` (not run across the repository)
- [x] Manual verification described below

On the merged dev.4 base at `ef247d9ac`:

- `nested_list_loop_tests`: 5 passed; `checked_empty_collection_constructor_tests`: 6 passed.
- Actual compiled `cli_integration` test `nested_empty_first_list_runs_without_a_caller_annotation_issue1471`: 1 passed. It performs explicit `oven bake --project .`, `build src/main.incn`, and `run src/main.incn`, checking loop count and content at runtime.
- Native test: 31.66 seconds in libtest; complete measured gate including observation and cleanup: 54.56 seconds. Bake took 30.11 seconds; ordinary build/run took 0.040/0.259 seconds and invoked no Cargo. Both reused the original baked dependency plans. Explicit bake used the existing Cargo compatibility publisher; this is regression proof, not a Jackhammer performance result.
- Scoped Clippy, formatting, `make pre-commit-fast`, and changed-rustdoc audit with explicit base `47e422e2` passed.
- `mkdocs build --strict` passed (8.04 seconds); authored docs inputs verified unchanged after generation.

The heavy full suite remains for integration CI; it is not represented by these focused results.

## Docs impact

- [ ] No docs changes needed
- [x] Docs updated
- [x] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

Updated the compiler bugfix entry in `workspaces/docs-site/docs/release_notes/0_6.md` and documented the changed inference boundary.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions
