### PR TITLE
bugfix - retain verified project inspection authority owners (#1037)

### DIFF
--- a/src/cli/commands/lock.rs
+++ b/src/cli/commands/lock.rs
@@ -890,7 +890,7 @@ pub(crate) fn prepare_project_registry_source_authorities(
     for source in &authority.payload.registry_sources {
         let (root, catalog) = match source.owner {
             OvenProjectInspectionSourceOwner::Authority => {
-                (authority.artifact_root.as_path(), std::slice::from_ref(&source.package))
+                (authority.artifact_root(), std::slice::from_ref(&source.package))
             }
             OvenProjectInspectionSourceOwner::Constituent { index } => {
                 let owner = owners.get(index).ok_or_else(|| {
@@ -920,7 +920,7 @@ pub(crate) fn prepare_project_registry_source_authorities(
     let registry_lock_source = if sources.is_empty() {
         None
     } else {
-        let path = authority.artifact_root.join(OVEN_RUSTC_REGISTRY_LOCK_RELATIVE_PATH);
+        let path = authority.artifact_root().join(OVEN_RUSTC_REGISTRY_LOCK_RELATIVE_PATH);
         let metadata = fs::symlink_metadata(&path).map_err(|error| {
             CliError::failure(format!(
                 "project inspection authority lacks its sealed Cargo.lock at {}: {error}",
@@ -942,7 +942,7 @@ pub(crate) fn prepare_project_registry_source_authorities(
         .generated_out_dirs
         .iter()
         .map(|dir| crate::rust_inspect::SealedGeneratedOutDir {
-            out_dir: authority.artifact_root.join(&dir.relative_root),
+            out_dir: authority.artifact_root().join(&dir.relative_root),
             version: dir.version.clone(),
         })
         .collect::<Vec<_>>();
@@ -1036,7 +1036,7 @@ impl PreparedOvenProjectRegistrySourceAuthorities {
 
     /// Bind generated test receipts to the exact project authority selected once for this command.
     pub(crate) fn authority_identity(&self) -> &str {
-        &self.authority.identity
+        self.authority.identity()
     }
 
     /// Project the one complete exact authority for one generated test batch.

--- a/src/oven/rustc.rs
+++ b/src/oven/rustc.rs
@@ -1676,6 +1676,9 @@ pub enum OvenRustcError {
     /// Artifact plan intent differs from the selected Oven receipt.
     #[error("Oven direct-rustc artifact intent differs from the selected receipt")]
     IntentMismatch,
+    /// A project inspection authority uses a wire schema this executable cannot interpret.
+    #[error("unsupported Oven project inspection authority schema version {found}; expected {expected}")]
+    UnsupportedProjectInspectionAuthoritySchema { found: u32, expected: u32 },
     /// A request field is blank or does not obey the narrow Alpha spelling contract.
     #[error("invalid Oven direct-rustc {field}: {message}")]
     InvalidInput { field: &'static str, message: String },
@@ -4176,6 +4179,42 @@ pub fn select_direct_rustc_plan_identity(store: &OvenStore, receipt: &OvenReceip
         })
 }
 
+/// Minimal project-inspection header decoded before any version-specific authority fields.
+#[derive(Deserialize)]
+struct OvenProjectInspectionAuthorityHeader {
+    schema_version: u32,
+}
+
+/// Reject an unknown project-inspection wire version before decoding its version-specific body.
+fn preflight_project_inspection_authority_schema(identity: &str, bytes: &[u8]) -> Result<(), OvenRustcError> {
+    let header = serde_json::from_slice::<OvenProjectInspectionAuthorityHeader>(bytes).map_err(|error| {
+        OvenRustcError::InvalidStoredPlan {
+            identity: identity.to_string(),
+            message: format!("payload has no valid project inspection authority header: {error}"),
+        }
+    })?;
+    if header.schema_version != OVEN_PROJECT_INSPECTION_AUTHORITY_SCHEMA_VERSION {
+        return Err(OvenRustcError::UnsupportedProjectInspectionAuthoritySchema {
+            found: header.schema_version,
+            expected: OVEN_PROJECT_INSPECTION_AUTHORITY_SCHEMA_VERSION,
+        });
+    }
+    Ok(())
+}
+
+/// Decode one current project inspection authority after its schema and physical owner have been validated.
+fn decode_project_inspection_authority(
+    identity: &str,
+    bytes: &[u8],
+) -> Result<OvenProjectInspectionAuthorityPayload, OvenRustcError> {
+    serde_json::from_slice::<OvenProjectInspectionAuthorityPayload>(bytes).map_err(|error| {
+        OvenRustcError::InvalidStoredPlan {
+            identity: identity.to_string(),
+            message: format!("payload is not a project inspection authority: {error}"),
+        }
+    })
+}
+
 /// Load the one project inspection authority named by a source-current completed output.
 ///
 /// Selection never searches by dependency compatibility. The authority entry is exact, and all of its store-owned
@@ -4188,8 +4227,8 @@ pub(crate) fn load_project_inspection_authority(
     source_authority_digest: &str,
     compiler_version: &str,
 ) -> Result<OvenLoadedProjectInspectionAuthority, OvenRustcError> {
-    let (manifest, artifact_root, bytes, authority_lease) = store
-        .select_payload_for_execution(&authority_ref.identity)
+    let mut selected = store
+        .select_payloads_for_execution(std::slice::from_ref(&authority_ref.identity))
         .map_err(|error| OvenRustcError::PlanSelection {
             receipt_identity: authority_ref.receipt_identity.clone(),
             message: format!(
@@ -4197,35 +4236,41 @@ pub(crate) fn load_project_inspection_authority(
                 authority_ref.identity
             ),
         })?;
-    if manifest.kind != OvenArtifactKind::ProjectInspectionAuthority
+    let source_owner = selected.pop().ok_or_else(|| OvenRustcError::PlanSelection {
+        receipt_identity: authority_ref.receipt_identity.clone(),
+        message: format!(
+            "source-current project output could not retain exact project inspection authority `{}`",
+            authority_ref.identity
+        ),
+    })?;
+    let manifest = &source_owner.manifest;
+    if manifest.identity != authority_ref.identity
+        || manifest.kind != OvenArtifactKind::ProjectInspectionAuthority
         || manifest.receipt_identity != authority_ref.receipt_identity
         || manifest.build_unit_identity != authority_ref.build_unit_identity
     {
         return Err(OvenRustcError::InvalidStoredPlan {
-            identity: manifest.identity,
+            identity: manifest.identity.clone(),
             message: "project inspection authority differs from its exact kind, receipt, or build-unit reference"
                 .to_string(),
         });
     }
-    let payload = serde_json::from_slice::<OvenProjectInspectionAuthorityPayload>(&bytes).map_err(|error| {
-        OvenRustcError::InvalidStoredPlan {
-            identity: manifest.identity.clone(),
-            message: format!("payload is not a project inspection authority: {error}"),
-        }
-    })?;
+    preflight_project_inspection_authority_schema(&manifest.identity, &source_owner.payload)?;
+    source_owner.verify_materialized_files()?;
+    let payload = decode_project_inspection_authority(&manifest.identity, &source_owner.payload)?;
     validate_project_inspection_authority_payload(&payload)?;
     if payload.project_identity != project_identity
         || payload.source_authority_digest != source_authority_digest
         || payload.compiler_version != compiler_version
     {
         return Err(OvenRustcError::InvalidStoredPlan {
-            identity: manifest.identity,
+            identity: manifest.identity.clone(),
             message: "project inspection authority does not match the selected output's project, source, or compiler evidence"
                 .to_string(),
         });
     }
     if !payload.registry_sources.is_empty() {
-        let lock = artifact_root.join(OVEN_RUSTC_REGISTRY_LOCK_RELATIVE_PATH);
+        let lock = source_owner.artifact_root.join(OVEN_RUSTC_REGISTRY_LOCK_RELATIVE_PATH);
         let lock_bytes = fs::read(&lock).map_err(|source| OvenRustcError::Io {
             path: lock.clone(),
             source,
@@ -4329,14 +4374,11 @@ pub(crate) fn load_project_inspection_authority(
             }
         }
     }
-    Ok(OvenLoadedProjectInspectionAuthority {
-        identity: manifest.identity,
-        artifact_root,
+    Ok(OvenLoadedProjectInspectionAuthority::new(
+        source_owner,
         payload,
         stored_constituents,
-        _authority_lease: authority_lease,
-        lineage_leases: Vec::new(),
-    })
+    ))
 }
 
 /// Return whether one stored inspection constituent is authorized by its receiving project receipt.
@@ -6323,7 +6365,9 @@ mod tests {
         OVEN_PROJECT_EXTENSION_PAYLOAD_SCHEMA_VERSION, OvenProjectExtensionPayload, OvenProjectRegistrySourceDependency,
     };
     use crate::oven::native_test::run_native_test_batch_all;
-    use crate::oven::store::{OvenArtifactKind, OvenArtifactPublishRequest, OvenStore, OvenStoreLimits};
+    use crate::oven::store::{
+        OvenArtifactKind, OvenArtifactMaterializedFile, OvenArtifactPublishRequest, OvenStore, OvenStoreLimits,
+    };
     use crate::oven::{
         OVEN_COMPILER_TEST_PROFILE, OvenGeneratedProjectRequest, OvenImportRequest, digest_bytes,
         import_frozen_project, receipt_generated_project,
@@ -8935,7 +8979,7 @@ mod tests {
         let loaded = load_project_inspection_authority(
             &store,
             &OvenProjectInspectionAuthorityRef {
-                identity: authority.identity,
+                identity: authority.identity.clone(),
                 receipt_identity: second_receipt.identity.clone(),
                 build_unit_identity: second_receipt.build_unit_identity.clone(),
             },
@@ -8943,7 +8987,203 @@ mod tests {
             source_authority_digest,
             compiler_version,
         )?;
+        assert_eq!(loaded.identity(), authority.identity);
+        assert_eq!(
+            loaded.artifact_root(),
+            store.select(&authority.identity)?.0.materialized_root()
+        );
         assert_eq!(loaded.payload, authority_payload);
+        Ok(())
+    }
+
+    #[test]
+    fn project_inspection_authority_rejects_unknown_schema_before_decoding_its_body()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let project = tempfile::tempdir()?;
+        let store_root = tempfile::tempdir()?;
+        let materialized = tempfile::tempdir()?;
+        let receipt = intent(project.path())?;
+        let evidence = materialized.path().join("future-evidence.txt");
+        fs::write(&evidence, b"future evidence")?;
+        let store = OvenStore::new(
+            store_root.path(),
+            OvenStoreLimits::new(128 * 1024, 128 * 1024, 64 * 1024),
+        );
+        let future_schema = OVEN_PROJECT_INSPECTION_AUTHORITY_SCHEMA_VERSION + 1;
+        let authority = store.publish(&OvenArtifactPublishRequest {
+            receipt: receipt.clone(),
+            domain: "future-project-inspection-authority".to_string(),
+            kind: OvenArtifactKind::ProjectInspectionAuthority,
+            payload: serde_json::to_vec(&serde_json::json!({
+                "schema_version": future_schema,
+                "generated_out_dirs": [{"crate_name": 42}],
+            }))?,
+            materialized_files: vec![OvenArtifactMaterializedFile {
+                source_path: evidence,
+                relative_path: "authority/future-evidence.txt".to_string(),
+            }],
+        })?;
+        let (entry, lease) = store.select(&authority.identity)?;
+        drop(lease);
+        let stored_evidence = entry.materialized_root().join("authority/future-evidence.txt");
+        fs::remove_file(&stored_evidence)?;
+        fs::write(stored_evidence, b"corrupt evidence")?;
+
+        let result = load_project_inspection_authority(
+            &store,
+            &OvenProjectInspectionAuthorityRef {
+                identity: authority.identity,
+                receipt_identity: receipt.identity,
+                build_unit_identity: receipt.build_unit_identity,
+            },
+            "unused-project-identity",
+            "unused-source-authority",
+            "unused-compiler-version",
+        );
+        assert!(matches!(
+            result,
+            Err(OvenRustcError::UnsupportedProjectInspectionAuthoritySchema {
+                found,
+                expected: OVEN_PROJECT_INSPECTION_AUTHORITY_SCHEMA_VERSION,
+            }) if found == future_schema
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn project_inspection_authority_binds_the_requested_store_identity() -> Result<(), Box<dyn std::error::Error>> {
+        let project = tempfile::tempdir()?;
+        let store_root = tempfile::tempdir()?;
+        let receipt = intent(project.path())?;
+        let store = OvenStore::new(
+            store_root.path(),
+            OvenStoreLimits::new(128 * 1024, 128 * 1024, 64 * 1024),
+        );
+        let project_identity = "sha256:project";
+        let source_authority_digest = "sha256:source";
+        let compiler_version = "0.5.1-test";
+        let payload = OvenProjectInspectionAuthorityPayload {
+            schema_version: OVEN_PROJECT_INSPECTION_AUTHORITY_SCHEMA_VERSION,
+            project_identity: project_identity.to_string(),
+            source_authority_digest: source_authority_digest.to_string(),
+            compiler_version: compiler_version.to_string(),
+            registry_lock_digest: digest_bytes(b"registry lock"),
+            registry_source_dependencies: Vec::new(),
+            dev_registry_source_dependencies: Vec::new(),
+            test_dependency_envelope: None,
+            constituents: Vec::new(),
+            registry_sources: Vec::new(),
+            generated_out_dirs: Vec::new(),
+        };
+        let encoded_payload = serde_json::to_vec(&payload)?;
+        let publish = |domain: &str| {
+            store.publish(&OvenArtifactPublishRequest {
+                receipt: receipt.clone(),
+                domain: domain.to_string(),
+                kind: OvenArtifactKind::ProjectInspectionAuthority,
+                payload: encoded_payload.clone(),
+                materialized_files: Vec::new(),
+            })
+        };
+        let requested = publish("requested-project-inspection-authority")?;
+        let substitute = publish("substitute-project-inspection-authority")?;
+        assert_ne!(requested.identity, substitute.identity);
+        let (requested_entry, requested_lease) = store.select(&requested.identity)?;
+        let (substitute_entry, substitute_lease) = store.select(&substitute.identity)?;
+        drop(requested_lease);
+        drop(substitute_lease);
+        fs::remove_dir_all(&requested_entry.path)?;
+        fs::rename(&substitute_entry.path, &requested_entry.path)?;
+
+        let result = load_project_inspection_authority(
+            &store,
+            &OvenProjectInspectionAuthorityRef {
+                identity: requested.identity,
+                receipt_identity: receipt.identity,
+                build_unit_identity: receipt.build_unit_identity,
+            },
+            project_identity,
+            source_authority_digest,
+            compiler_version,
+        );
+        assert!(matches!(
+            result,
+            Err(OvenRustcError::InvalidStoredPlan { identity, .. }) if identity == substitute.identity
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn loaded_project_inspection_authority_retains_and_revalidates_its_store_owner()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let project = tempfile::tempdir()?;
+        let store_root = tempfile::tempdir()?;
+        let materialized = tempfile::tempdir()?;
+        let receipt = intent(project.path())?;
+        let evidence = materialized.path().join("authority-evidence.txt");
+        fs::write(&evidence, b"authority evidence")?;
+        let store = OvenStore::new(
+            store_root.path(),
+            OvenStoreLimits::new(128 * 1024, 128 * 1024, 64 * 1024),
+        );
+        let project_identity = "sha256:project";
+        let source_authority_digest = "sha256:source";
+        let compiler_version = "0.5.1-test";
+        let payload = OvenProjectInspectionAuthorityPayload {
+            schema_version: OVEN_PROJECT_INSPECTION_AUTHORITY_SCHEMA_VERSION,
+            project_identity: project_identity.to_string(),
+            source_authority_digest: source_authority_digest.to_string(),
+            compiler_version: compiler_version.to_string(),
+            registry_lock_digest: digest_bytes(b"registry lock"),
+            registry_source_dependencies: Vec::new(),
+            dev_registry_source_dependencies: Vec::new(),
+            test_dependency_envelope: None,
+            constituents: Vec::new(),
+            registry_sources: Vec::new(),
+            generated_out_dirs: Vec::new(),
+        };
+        let authority = store.publish(&OvenArtifactPublishRequest {
+            receipt: receipt.clone(),
+            domain: "retained-project-inspection-authority".to_string(),
+            kind: OvenArtifactKind::ProjectInspectionAuthority,
+            payload: serde_json::to_vec(&payload)?,
+            materialized_files: vec![OvenArtifactMaterializedFile {
+                source_path: evidence,
+                relative_path: "authority/evidence.txt".to_string(),
+            }],
+        })?;
+        let authority_ref = OvenProjectInspectionAuthorityRef {
+            identity: authority.identity.clone(),
+            receipt_identity: receipt.identity.clone(),
+            build_unit_identity: receipt.build_unit_identity.clone(),
+        };
+
+        let loaded = load_project_inspection_authority(
+            &store,
+            &authority_ref,
+            project_identity,
+            source_authority_digest,
+            compiler_version,
+        )?;
+        assert_eq!(loaded.identity(), authority.identity);
+        assert!(loaded.artifact_root().join("authority/evidence.txt").is_file());
+        assert!(store.inspect()?.active_lease_physical_bytes > 0);
+        drop(loaded);
+        assert_eq!(store.inspect()?.active_lease_physical_bytes, 0);
+
+        let (entry, lease) = store.select(&authority.identity)?;
+        drop(lease);
+        let stored_evidence = entry.materialized_root().join("authority/evidence.txt");
+        fs::remove_file(&stored_evidence)?;
+        fs::write(stored_evidence, b"authority evidencf")?;
+        let result = load_project_inspection_authority(
+            &store,
+            &authority_ref,
+            project_identity,
+            source_authority_digest,
+            compiler_version,
+        );
+        assert!(matches!(result, Err(OvenRustcError::Store(_))));
         Ok(())
     }
 

--- a/src/oven/rustc/inspection.rs
+++ b/src/oven/rustc/inspection.rs
@@ -4,7 +4,7 @@
 //! test dependencies, and generated output directory -- as recorded for one schema version.
 
 use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::path::Path;
 
 use super::super::OvenReceipt;
 use super::super::store::{OvenArtifactKind, OvenStoreExecutionPayload, OvenStoreLease};
@@ -153,15 +153,37 @@ pub(crate) struct OvenProjectInspectionAuthorityRef {
 
 /// Source-current singular project authority with every bounded-store constituent leased in one batch.
 pub(crate) struct OvenLoadedProjectInspectionAuthority {
-    pub(crate) identity: String,
-    pub(crate) artifact_root: PathBuf,
+    source_owner: OvenStoreExecutionPayload,
     pub(crate) payload: OvenProjectInspectionAuthorityPayload,
     pub(crate) stored_constituents: Vec<OvenStoreExecutionPayload>,
-    pub(super) _authority_lease: OvenStoreLease,
     pub(super) lineage_leases: Vec<OvenStoreLease>,
 }
 
 impl OvenLoadedProjectInspectionAuthority {
+    /// Retain one validated authority owner together with every store-owned constituent it names.
+    pub(super) fn new(
+        source_owner: OvenStoreExecutionPayload,
+        payload: OvenProjectInspectionAuthorityPayload,
+        stored_constituents: Vec<OvenStoreExecutionPayload>,
+    ) -> Self {
+        Self {
+            source_owner,
+            payload,
+            stored_constituents,
+            lineage_leases: Vec::new(),
+        }
+    }
+
+    /// Return the immutable Store identity that owns the authority payload and materialized files.
+    pub(crate) fn identity(&self) -> &str {
+        &self.source_owner.manifest.identity
+    }
+
+    /// Return the materialized root derived from the retained authority owner.
+    pub(crate) fn artifact_root(&self) -> &Path {
+        &self.source_owner.artifact_root
+    }
+
     /// Retain completed-output leases for the complete inspection command.
     pub(crate) fn retain_lineage_leases(&mut self, leases: Vec<OvenStoreLease>) {
         self.lineage_leases = leases;


### PR DESCRIPTION
## Summary

Project inspection now retains the exact verified Oven Store owner for its complete use. Loading binds the requested Store identity to the selected manifest, preflights the wire schema before decoding version-specific fields, verifies the materialized closure, and derives the authority identity and artifact root from the retained owner.

This closes three integrity gaps in the native Rust inspection path: a valid Store entry could be substituted at another identity path, future schemas could fail with misleading body-decoding errors, and authority data could outlive the object that owned its lease.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

Select the primary areas touched (used for review routing; labels are managed separately):

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: Corrupt or identity-substituted project inspection authorities now refuse before their files are consumed. Unsupported authority schemas report the schema mismatch before current-schema body decoding.
- **Internals**: `OvenLoadedProjectInspectionAuthority` owns one `OvenStoreExecutionPayload`; its identity, artifact root and lease can no longer drift apart. The existing cross-receipt compatible-plan rule remains unchanged.
- **Risks**: Loading an inspection authority now verifies its complete materialized file closure. This adds integrity-proportional I/O for a cold validation and should remain visible in Oven hot-path measurements.

## Testing / verification

- [x] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `cargo test --lib project_inspection_authority` — 5 passed, including whole-entry identity substitution, unsupported-schema ordering, same-length file corruption, owner lease lifetime, and compatible cross-receipt reuse.
- `cargo clippy --lib --tests -- -D warnings`
- `cargo fmt --all -- --check`
- `python3 scripts/check_changed_rustdocs.py --base 47e422e21393917d156d9d01c6f30e35e424a63b`
- `git diff --check`

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Refs #1037
