### PR TITLE
bugfix - refresh stdlib snapshots stale since #1493

### DIFF
--- a/tests/snapshots/stdlib_generated_rust_snapshot_tests__std_io_source.snap
+++ b/tests/snapshots/stdlib_generated_rust_snapshot_tests__std_io_source.snap
@@ -446,7 +446,7 @@ impl<R: BinaryReader + Clone> FallibleIterator<Vec<u8>, IoError> for ReaderChunk
         return crate::__incan_std::derives::collection::FlatMapFallibleIterator {
             source: self.clone(),
             f: f,
-            current: vec![],
+            current: Vec::<_>::new(),
             index: 0,
             input_marker: None::<_>,
             error_marker: None::<_>,
@@ -502,7 +502,7 @@ impl<R: BinaryReader + Clone> FallibleIterator<Vec<u8>, IoError> for ReaderChunk
     }
     fn collect(&mut self) -> Result<Vec<Vec<u8>>, IoError> {
         let _ = "\n        Consume successful items into a list or return the first source error.\n\n        Items retain source order. A failure discards the partial list and returns only the error; ordinary exhaustion\n        returns every collected item in `Ok`.\n        ";
-        let mut items: Vec<Vec<u8>> = vec![];
+        let mut items: Vec<Vec<u8>> = Vec::<_>::new();
         loop {
             let _ = match self.__next__() {
                 Ok(Some(item)) => items.push(item.clone()),

--- a/tests/snapshots/stdlib_generated_rust_snapshot_tests__std_telemetry_core_source.snap
+++ b/tests/snapshots/stdlib_generated_rust_snapshot_tests__std_telemetry_core_source.snap
@@ -310,7 +310,7 @@ impl TelemetryValue {
             int_value: None::<_>,
             float_value: None::<_>,
             bytes_value: None::<_>,
-            array_value: vec![],
+            array_value: Vec::<TelemetryValue>::new(),
             map_value: std::collections::HashMap::new(),
         };
     }
@@ -326,7 +326,7 @@ impl TelemetryValue {
             int_value: None::<_>,
             float_value: None::<_>,
             bytes_value: None::<_>,
-            array_value: vec![],
+            array_value: Vec::<TelemetryValue>::new(),
             map_value: std::collections::HashMap::new(),
         };
     }
@@ -342,7 +342,7 @@ impl TelemetryValue {
             int_value: None::<_>,
             float_value: None::<_>,
             bytes_value: None::<_>,
-            array_value: vec![],
+            array_value: Vec::<TelemetryValue>::new(),
             map_value: std::collections::HashMap::new(),
         };
     }
@@ -358,7 +358,7 @@ impl TelemetryValue {
             int_value: Some(value),
             float_value: None::<_>,
             bytes_value: None::<_>,
-            array_value: vec![],
+            array_value: Vec::<TelemetryValue>::new(),
             map_value: std::collections::HashMap::new(),
         };
     }
@@ -374,7 +374,7 @@ impl TelemetryValue {
             int_value: None::<_>,
             float_value: Some(value),
             bytes_value: None::<_>,
-            array_value: vec![],
+            array_value: Vec::<TelemetryValue>::new(),
             map_value: std::collections::HashMap::new(),
         };
     }
@@ -392,7 +392,7 @@ impl TelemetryValue {
             int_value: None::<_>,
             float_value: None::<_>,
             bytes_value: Some(value),
-            array_value: vec![],
+            array_value: Vec::<TelemetryValue>::new(),
             map_value: std::collections::HashMap::new(),
         };
     }
@@ -424,7 +424,7 @@ impl TelemetryValue {
             int_value: None::<_>,
             float_value: None::<_>,
             bytes_value: None::<_>,
-            array_value: vec![],
+            array_value: Vec::<TelemetryValue>::new(),
             map_value: values,
         };
     }


### PR DESCRIPTION
## Summary

`stdlib_generated_rust_snapshot_tests` has been failing on `0.6.0-dev.4` since #1493 merged. Two stdlib sources contain an empty list literal whose element type is known, so they now emit `Vec::<T>::new()` where they previously emitted `vec![]`, and their snapshots went stale.

This refreshes those two snapshots. Emitted values are unchanged; the element type is written down where it was previously inferred.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [x] Compiler (frontend/backend/codegen)
- [ ] Incan Language (syntax/semantics)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: none. `Vec::<TelemetryValue>::new()` and `vec![]` construct the same empty vector; the difference is that the element type is explicit, which is the point of #1493 — an untyped `vec![]` as a comparison operand leaves `PartialEq` ambiguous.
- **Scope**: 9 lines across two snapshot files, `std_io_source` and `std_telemetry_core_source`. Verified to contain nothing but that shape by filtering the diff for any line not matching `vec![]` or `Vec::<` and finding none.
- **Risks**: none beyond accepting the new expected output, which is why the diff was checked line-shape by line-shape rather than accepted wholesale.

### How this was missed

Worth recording, since the process gap matters more than the fix. Verifying #1493 I ran `cargo test --test codegen_snapshot_tests` (266 passing) and `cargo test --lib`, comparing the lib counts against a reverse-patch baseline of pristine dev.4 to establish no regressions. Both were sound as far as they went. `stdlib_generated_rust_snapshot_tests` is a separate test binary that neither command reaches, so a suite that would have caught this in 0.15 seconds was simply never run.

## Testing / verification

- [x] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- `cargo test --test stdlib_generated_rust_snapshot_tests` — **13 passed, 0 failed** (was 11 passed, 2 failed).
- `cargo test --test codegen_snapshot_tests` — **266 passed, 0 failed**, unchanged.
- Both snapshot suites were swept this time rather than one.

Refs #1493.
