### PR TITLE
feature - #573 #777 cross-edit declaration identity, HIR visibility, and Rust declaration digests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1530,9 +1530,11 @@ dependencies = [
 name = "incan_semantics_core"
 version = "0.6.0-dev.3"
 dependencies = [
+ "hex",
  "incan_core",
  "serde",
  "serde_json",
+ "sha2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3153,6 +3153,8 @@ version = "0.6.0-dev.3"
 dependencies = [
  "hex",
  "incan_core",
+ "proc-macro2",
+ "quote",
  "ra_ap_hir",
  "ra_ap_ide_db",
  "ra_ap_load-cargo",
@@ -3164,6 +3166,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "syn",
  "tempfile",
  "thiserror 2.0.18",
  "toml",

--- a/crates/incan_core/src/errors.rs
+++ b/crates/incan_core/src/errors.rs
@@ -12,6 +12,7 @@
 //! - Allow dynamic details without heap allocations (borrowed `&str` + primitive fields).
 
 use core::fmt;
+use serde::Serialize;
 
 use crate::strings::StringAccessError;
 
@@ -21,7 +22,7 @@ use crate::strings::StringAccessError;
 /// - User-facing metadata (canonical spelling, description, examples) lives in the language registry:
 ///   `crate::lang::errors`.
 /// - Keep this enum focused on identity; avoid duplicating docs/meaning here.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
 pub enum ErrorKind {
     AssertionError,
     ValueError,

--- a/crates/incan_core/src/lang/builtins.rs
+++ b/crates/incan_core/src/lang/builtins.rs
@@ -18,9 +18,10 @@
 //! ```
 
 use super::registry::{LangItemInfo, RFC, RfcId, Since, Stability};
+use serde::Serialize;
 
 /// Stable identifier for a builtin function.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
 pub enum BuiltinFnId {
     Print,
     Len,

--- a/crates/incan_semantics_core/Cargo.toml
+++ b/crates/incan_semantics_core/Cargo.toml
@@ -12,6 +12,8 @@ authors.workspace = true
 [dependencies]
 incan_core = { path = "../incan_core" }
 serde = { version = "1.0", features = ["derive"] }
+sha2 = "0.10.9"
+hex = "0.4.3"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/crates/incan_semantics_core/src/body_ir.rs
+++ b/crates/incan_semantics_core/src/body_ir.rs
@@ -39,6 +39,7 @@
 //! ride on the callee target rather than the argument list, because they are part of which callable was selected
 //! rather than what it was passed.
 
+use serde::Serialize;
 use std::fmt::Write as _;
 
 use incan_core::errors::ErrorKind;
@@ -56,7 +57,7 @@ use crate::{
 // ============================================================================
 
 /// One module's lowered function/method bodies and direct-execution declaration facts.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct BodyIrModule {
     /// Identity of the owning module, matching [`crate::HirModule::id`].
     pub module_id: CompilerNodeId,
@@ -171,7 +172,7 @@ impl BodyIrModule {
 /// behavior-bearing models. Its field order is the checked constructor-slot order; a direct runtime must compare it
 /// with [`ConstructorTarget::canonical_field_layout`] before applying [`ConstructorTarget::binding`], rather than
 /// treating constructor argument spelling as layout evidence.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct NominalDeclaration {
     /// Exact source-local declaration identity, derived from the declaration source span.
     pub direct_declaration_id: CompilerNodeId,
@@ -196,7 +197,7 @@ pub struct NominalDeclaration {
 /// The record exists only for undecorated, non-generic declarations with no traits, methods, aliases, value backing,
 /// or payload variants. A runtime validates these records before materializing a carrier and never treats the enum
 /// spelling itself as an execution authority.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct FieldlessEnumDeclaration {
     /// Exact source-local enum declaration identity, derived from the declaration source span.
     pub direct_declaration_id: CompilerNodeId,
@@ -209,7 +210,7 @@ pub struct FieldlessEnumDeclaration {
 }
 
 /// One canonical zero-payload member of a retained fieldless normal enum.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct FieldlessEnumVariantDeclaration {
     /// Exact source-local variant declaration identity, derived from the declaration source span.
     pub direct_declaration_id: CompilerNodeId,
@@ -232,7 +233,7 @@ impl FieldlessEnumVariantDeclaration {
 }
 
 /// The scalar backing category a retained RFC 032 value enum exposes through `.value()`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum ValueEnumBacking {
     /// An integer-backed value enum.
     Int,
@@ -255,7 +256,7 @@ impl ValueEnumBacking {
 /// The record exists only for undecorated, non-generic declarations with no traits, methods, aliases, or payload
 /// variants. Each member has its own source-span identity, so a direct executor verifies the actual selected member
 /// without treating a qualified `Enum.Member` spelling as an identity.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct ValueEnumDeclaration {
     /// Exact source-local enum declaration identity, derived from its declaration span.
     pub direct_declaration_id: CompilerNodeId,
@@ -270,7 +271,7 @@ pub struct ValueEnumDeclaration {
 }
 
 /// One canonical scalar member of a retained source-local value enum.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct ValueEnumVariantDeclaration {
     /// Exact source-local variant declaration identity, derived from its declaration span.
     pub direct_declaration_id: CompilerNodeId,
@@ -296,7 +297,7 @@ impl ValueEnumVariantDeclaration {
 }
 
 /// Body IR v0 for a single function or method.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct Body {
     /// Identity of the owning declaration, matching the [`crate::HirDeclaration::id`] this body was lowered from.
     pub decl_id: CompilerNodeId,
@@ -484,7 +485,7 @@ fn render_runtime_requirement(req: &AbiV0RuntimeRequirement) -> String {
 // ============================================================================
 
 /// Stable index of one local within a [`Body`]'s `locals` vector.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 pub struct LocalId(pub u32);
 
 impl LocalId {
@@ -495,7 +496,7 @@ impl LocalId {
 }
 
 /// One explicit local or temporary value declared in a body.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct LocalDecl {
     pub id: LocalId,
     /// Source-level binding name, or `None` for a compiler-introduced temporary.
@@ -533,7 +534,7 @@ impl LocalDecl {
 }
 
 /// Where a local came from, for diagnostics and drop-planning purposes.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum LocalOrigin {
     /// Bound to a function/method parameter.
     Parameter,
@@ -584,11 +585,11 @@ impl LocalOrigin {
 }
 
 /// Stable index of one lexical scope within a [`Body`]'s `scopes` vector.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 pub struct ScopeId(pub u32);
 
 /// One lexical source scope, used to map statements and locals back to diagnostics-relevant source structure.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct ScopeInfo {
     pub id: ScopeId,
     /// Enclosing scope, or `None` for the body's root scope.
@@ -597,7 +598,7 @@ pub struct ScopeInfo {
 }
 
 /// Root storage selected for a Body IR place.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub enum PlaceRoot {
     /// A function-frame local selected by canonical source identity.
     Local(LocalId),
@@ -606,7 +607,7 @@ pub enum PlaceRoot {
 }
 
 /// Canonical module-level storage retained in a Body IR place.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct GlobalPlace {
     pub identity: CanonicalSymbolId,
     pub ty: IncanType,
@@ -614,7 +615,7 @@ pub struct GlobalPlace {
 }
 
 /// Which writes a global place permits after typechecking.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum GlobalWritePolicy {
     /// Constants cannot be written at either their root or through a projection.
     ReadOnly,
@@ -625,7 +626,7 @@ pub enum GlobalWritePolicy {
 }
 
 /// A place in memory: a canonical local/global root plus zero or more projections (field/index) into it.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct Place {
     pub root: PlaceRoot,
     pub projection: Vec<PlaceElem>,
@@ -709,7 +710,7 @@ impl Place {
 }
 
 /// One projection step applied to a place.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub enum PlaceElem {
     /// `.field` access, with the selected source member identity when the projection came from checked source.
     ///
@@ -760,7 +761,7 @@ impl PlaceElem {
 /// Every place-read carries its own [`OwnershipFact`] and last-use marker directly (see [`PlaceOperand`]) — this is
 /// the Duckborrower fact for that read, exposed as compiler-owned data rather than left for a backend to re-derive
 /// from generated Rust.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub enum Operand {
     /// A read of a place, annotated with its ownership decision.
     Place(PlaceOperand),
@@ -789,7 +790,7 @@ impl Operand {
 }
 
 /// A place-read operand paired with its Duckborrower ownership fact.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct PlaceOperand {
     pub place: Place,
     /// The ownership decision selected for this read.
@@ -802,7 +803,7 @@ pub struct PlaceOperand {
 }
 
 /// A literal constant operand value.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub enum Constant {
     Int(i64),
     Float(String),
@@ -832,7 +833,7 @@ pub enum Constant {
 }
 
 /// One exact numeric constant retained in Body IR without collapsing its checked type or value domain.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub enum TypedNumericConstant {
     /// An exact signed integer constant with its canonical checked identity.
     Signed {
@@ -917,7 +918,7 @@ impl Constant {
 /// move/clone split that a real Rust emission boundary needs, plus an explicit [`OwnershipFact::Unknown`] escape
 /// hatch for reads Body IR v0 cannot yet classify — per #653, ownership decisions must be represented "as
 /// Duckborrower facts or explicit unknowns," not silently defaulted.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum OwnershipFact {
     /// Trivial bitwise copy of a `Copy`-shaped type.
     Copy,
@@ -952,7 +953,7 @@ impl OwnershipFact {
 // ============================================================================
 
 /// The right-hand side of an [`StatementKind::Assign`].
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub enum Rvalue {
     /// Use an operand's value directly.
     Use(Operand),
@@ -1157,7 +1158,7 @@ impl Rvalue {
 }
 
 /// Exact checked target carried by a Body-IR `isinstance` operation.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct IsInstanceTarget {
     /// Alias-expanded semantic target type.
     pub ty: IncanType,
@@ -1188,7 +1189,7 @@ impl IsInstanceTarget {
 }
 
 /// Exact source-local enum/member identity selected for one value-enum member expression.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ValueEnumVariantTarget {
     /// Exact source-local owner enum declaration identity.
     pub enum_declaration_id: CompilerNodeId,
@@ -1220,7 +1221,7 @@ impl ValueEnumVariantTarget {
 }
 
 /// Exact source-local enum/member identity selected for one fieldless normal-enum member expression.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct FieldlessEnumVariantTarget {
     /// Exact source-local owner enum declaration identity.
     pub enum_declaration_id: CompilerNodeId,
@@ -1252,7 +1253,7 @@ impl FieldlessEnumVariantTarget {
 }
 
 /// One direct compiler-owned `Result` construction with its checked payload and error facts retained.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct ResultVariant {
     /// Which intrinsic Result constructor source checking selected.
     pub kind: ResultVariantKind,
@@ -1278,7 +1279,7 @@ impl ResultVariant {
 }
 
 /// Intrinsic source-level Result constructor selected by typechecking.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum ResultVariantKind {
     /// `Ok(payload)`.
     Ok,
@@ -1304,7 +1305,7 @@ impl ResultVariantKind {
 /// already evaluated when the callable was constructed. A consumer must visibly refuse
 /// [`CallableParamDefault::Unsupported`] at its stored source span instead of guessing from source structures or
 /// silently falling back.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct CallableParam {
     /// The local that receives this argument in the callable's execution frame.
     pub local: LocalId,
@@ -1343,7 +1344,7 @@ impl CallableParam {
 /// that contract. A partial preset instead names a closure-frame local populated from the partial's construction-time
 /// capture. These variants must remain distinct: treating a preset as a source computation would evaluate it again,
 /// while treating a source computation as a capture would evaluate it too early.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub enum CallableParamDefault {
     /// The caller must supply this argument.
     Required,
@@ -1396,7 +1397,7 @@ impl CallableParamDefault {
 /// omitted call site, before binding the callable frame's [`CallableParam::local`] argument. Any source read that
 /// would require a callable-local or otherwise unrepresented lexical binding is recorded instead as
 /// [`CallableParamDefault::Unsupported`].
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct DefaultComputation {
     /// Full source span of the default expression.
     pub span: HirSourceSpan,
@@ -1443,7 +1444,7 @@ impl DefaultComputation {
 /// unique and lets [`Rvalue::Closure`]'s [`CallableParam::local`] values and [`Self::capture_locals`] simply index
 /// into the same [`Body::locals`] the rest of the function uses, so a closure's own parameters and captures show up
 /// in the ordinary `locals:` listing like any other local.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct ClosureBody {
     /// The closure's own captured-binding locals, in the same order as [`Rvalue::Closure::captured_operands`] --
     /// `capture_locals[i]` is where a read of the `i`-th captured operand's value is durably bound inside the
@@ -1477,7 +1478,7 @@ impl ClosureBody {
 /// `captured_operands[i]` value, so no statement in `stmts` reaches back into the enclosing body's places when the
 /// generator is later polled. Clause bindings and iterator temporaries are ordinary locals in `stmts`; they become
 /// live only while the corresponding deferred loops execute.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct GeneratorBody {
     /// Local holding the eagerly evaluated first-clause source value.
     pub source_local: LocalId,
@@ -1512,7 +1513,7 @@ fn render_flattened_stmts(stmts: &[Statement]) -> Vec<String> {
 }
 
 /// One arm of a [`Rvalue::Match`].
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct MatchArm {
     /// The pattern tested against the match scrutinee.
     pub pattern: Pattern,
@@ -1588,7 +1589,7 @@ impl MatchArm {
 /// would need either still lowers structurally through the plain (non-narrowed) mapping, at the cost of the
 /// resulting field types sometimes falling back to [`IncanType::Unknown`] where the existing backend's richer
 /// resolution would have found something more precise.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub enum Pattern {
     /// `_`: matches anything, binds nothing.
     Wildcard,
@@ -1711,7 +1712,7 @@ impl Pattern {
 }
 
 /// Exact source-local plain-model declaration selected by one structural pattern.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct NominalPatternTarget {
     /// Exact source-local model declaration identity.
     pub direct_declaration_id: CompilerNodeId,
@@ -1735,7 +1736,7 @@ impl NominalPatternTarget {
 /// `Assign` statement copying out of the scrutinee: the actual value transfer happens as a side effect of the
 /// target backend's native pattern match, and this model only needs to record *how* that transfer should be
 /// treated (move/clone/borrow/copy) -- the same way [`PlaceOperand`] records it for an ordinary read.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct PatternBinding {
     pub local: LocalId,
     /// The ownership decision selected for this binding, computed the same way [`PlaceOperand::fact`] is: the
@@ -1766,7 +1767,7 @@ impl PatternBinding {
 /// carries an [`Operand`] rather than a full expression tree -- Body IR always lowers embedded expressions through
 /// the same [`Operand`]-producing path as any other read, so ownership facts and last-use tracking apply to
 /// f-string interpolations exactly like any other expression use.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub enum FormatPart {
     /// Literal text between interpolations, carried through unescaped -- brace/format-string escaping is an
     /// emission-target concern (see the existing Rust-emission backend's `escape_format_literal`), not something
@@ -1795,7 +1796,7 @@ impl FormatPart {
 /// Rust-emission backend's `FormatStyle` (`src/backend/ir/expr.rs`); unlike that backend's version, this one carries
 /// no `emits_rust_debug`-style target-representation logic, since Body IR v0 stays target-agnostic and leaves the
 /// decision of how a given style maps to a concrete formatting call to the consuming backend.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum FormatStyle {
     /// User-facing display formatting (`{value}`).
     Display,
@@ -1814,7 +1815,7 @@ impl FormatStyle {
 }
 
 /// Unary operator kind.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum UnOp {
     Neg,
     Not,
@@ -1844,7 +1845,7 @@ impl UnOp {
 /// existing Rust-emission backend currently emits both pairs the same way. Collapsing them here would discard which
 /// operator the source actually wrote, and Body IR is the representation a later identity/equality split would have
 /// to be decided against.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum BinOp {
     Add,
     Sub,
@@ -1929,7 +1930,7 @@ impl BinOp {
 /// sibling statement kind would re-fork exactly what [`ArgumentBinding`] unified. Changing the element type instead
 /// makes every reader of an element list a compile error at precisely the place a wrong answer would be produced,
 /// while readers that never inspect elements are untouched.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub enum ArgumentElement {
     /// Exactly one value at this position.
     One(Operand),
@@ -1977,7 +1978,7 @@ impl ArgumentElement {
 /// [`Operand::Place`] carries its own [`OwnershipFact`] and last-use marker. This type adds no separate ownership
 /// field; what it adds is that the read is *identified as a splice*, so a consumer distributing the source's
 /// elements can see that its length is a runtime fact rather than one value.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct SpreadElement {
     /// The sequence or mapping being spliced.
     pub source: Operand,
@@ -1997,7 +1998,7 @@ impl SpreadElement {
 }
 
 /// Which spread form a [`SpreadElement`] was spelled with.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum SpreadKind {
     /// `*source` — splices a sequence's elements positionally.
     Sequence,
@@ -2012,7 +2013,7 @@ pub enum SpreadKind {
 /// (a later entry overwrites an earlier one). That is why [`Rvalue::Dict`] carries this ordered list rather than a
 /// map — a map would have to collapse duplicates at construction, which is exactly the override semantics that
 /// must survive, and it could not hold a spread whose keys are unknown until runtime.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub enum DictEntry {
     /// A `key: value` pair. Both operands are evaluated, key first.
     Pair(Operand, Box<Operand>),
@@ -2031,7 +2032,7 @@ impl DictEntry {
 }
 
 /// Aggregate value shape built by [`Rvalue::Aggregate`].
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub enum AggregateKind {
     Tuple,
     List,
@@ -2117,7 +2118,7 @@ impl AggregateKind {
 /// This is the single binding mechanism for every call shape, replacing the per-target slot map #1124 introduced on
 /// [`LocalCallableTarget`]: local callables, direct named calls, method calls, and nominal construction all record
 /// their binding here, so a consumer learns the same fact the same way regardless of how the call was spelled.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub enum ArgumentBinding {
     /// No declared parameter slots were resolved for this call's arguments.
     ///
@@ -2211,7 +2212,7 @@ impl ArgumentBinding {
 }
 
 /// One call argument's resolved declaration slot and its position in written source order.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub struct BoundArgument {
     /// Declared parameter or field index this operand supplies.
     pub slot: usize,
@@ -2229,7 +2230,7 @@ fn render_type_arguments(type_args: &[IncanType]) -> String {
 }
 
 /// Call target for a [`StatementKind::Call`].
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub enum Callee {
     /// A direct named function or a locally held callable value.
     ///
@@ -2278,7 +2279,7 @@ impl Callee {
 /// ultimately invoke a callable. The alternatives themselves are intentionally distinct. In particular, a stored
 /// closure/partial is never represented as [`Self::Named`] with a fabricated source name; it is a
 /// [`Self::Local`] operand, carrying the lexical-environment ownership decision the caller made.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub enum CallableTarget {
     /// A direct call to a named Incan function.
     ///
@@ -2305,7 +2306,7 @@ pub enum CallableTarget {
 /// source identity and exact header token span. The body is a full [`Block`] plus a `result` operand, mirroring how
 /// [`ClosureBody`] carries a nested statement sequence with an explicit value instead of relying on a
 /// trailing-statement convention.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct RaceArm {
     /// This arm's awaitable, evaluated before selection along with every other arm's.
     pub awaitable: Operand,
@@ -2330,7 +2331,7 @@ impl RaceArm {
 /// The binding makes a local partial's two source-level call conventions explicit: positional arguments skip
 /// preset-default slots, while named arguments may override them. Callers that lower an ordinary local closure use
 /// [`ArgumentBinding::positional`].
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct LocalCallableTarget {
     /// The local read that owns the callable value and its lexical environment.
     pub operand: PlaceOperand,
@@ -2344,7 +2345,7 @@ pub struct LocalCallableTarget {
 /// and `decode_rows[Row](path)` are different calls, and a consumer that only saw the name could not tell them
 /// apart. `type_args` holds the *typechecker-resolved* arguments, so lowering never re-derives them from the source
 /// spelling.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct NamedCallableTarget {
     /// Source-level function name.
     pub name: String,
@@ -2380,7 +2381,7 @@ pub struct NamedCallableTarget {
 /// reason it keeps them apart: they have different remedies. A disabled provider is present but not selected by the
 /// project graph, while an unavailable one is selected but has no locally verified artifact. Collapsing them into a
 /// single "not usable" flag would leave a consumer unable to say which.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum ProviderActivationState {
     /// Enabled and locally available, so an admitted operation may be planned for execution.
     Active,
@@ -2407,7 +2408,7 @@ impl ProviderActivationState {
 /// branch on it: which operation was invoked is answered by [`ProviderOperationPlan::operation`], a canonical
 /// identity, and whether it may run is answered by [`Self::state`]. Recording the key anyway is what lets a receipt
 /// or a diagnostic say *which* provider without re-resolving the catalog.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ProviderActivation {
     /// Stable key of the catalog record this operation was admitted from.
     pub provider_key: String,
@@ -2437,7 +2438,7 @@ impl ProviderActivation {
 /// consumer cannot recover from the operand alone: which declared slot the value fills, where it was written (and so
 /// when it was evaluated relative to its siblings), its checked type, and its own source span — which is what lets an
 /// authority denial point at the argument that carried an out-of-scope value rather than at the whole call.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct ProviderOperationInput {
     /// Declared parameter slot this input supplies. Indexes the same slot space as [`BoundArgument::slot`].
     pub slot: usize,
@@ -2470,7 +2471,7 @@ impl ProviderOperationInput {
 /// capability identity does not name a capability, or whose inputs cannot all be represented is refused at its
 /// source span instead, so it has no plan to execute and no receipt to emit. Consumers must still validate a plan:
 /// constructed or corrupt IR is never evidence that source admission occurred.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct ProviderOperationPlan {
     /// RFC 120 canonical identity of the operation declaration this call selected.
     ///
@@ -2562,7 +2563,7 @@ fn render_symbol_path(symbol: &CanonicalSymbolId) -> String {
 /// Carries the same resolved type arguments and argument binding as [`NamedCallableTarget`]; the receiver itself
 /// stays `args[0]` of the surrounding [`StatementKind::Call`] and is deliberately *not* part of the binding, whose
 /// slots index the method's own declared parameters.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct MethodTarget {
     /// Source-level method name.
     pub name: String,
@@ -2627,7 +2628,7 @@ impl std::fmt::Display for MethodTarget {
 /// Source-level construction is named-only, so the binding is what records which declared field each operand fills.
 /// The surrounding [`Rvalue::Aggregate`] operand vector is in declared field order; the binding carries the written
 /// source order alongside it.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct ConstructorTarget {
     /// Source-level nominal type name.
     pub name: String,
@@ -2708,7 +2709,7 @@ impl std::fmt::Display for CallableTarget {
 /// is the inference this data model exists to replace; and one `Concat` would conflate a string join with a list
 /// concatenation. Negation likewise gets its own variant per collection rather than a wrapper, so one source
 /// operator stays one Body IR operation.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum HelperOp {
     StrConcat,
     StrEq,
@@ -2865,7 +2866,7 @@ impl HelperOp {
 // ============================================================================
 
 /// A normalized block of statements within a body, scoped to one [`ScopeId`].
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct Block {
     pub scope: ScopeId,
     pub stmts: Vec<Statement>,
@@ -3013,7 +3014,7 @@ fn render_statement(out: &mut String, stmt: &Statement, indent: &str, depth: usi
 /// arm, keyed by `TypeCheckInfo::protocol_iteration`): a builtin collection needs no named method dispatch at all,
 /// while a user-defined iterable resolves concrete `__iter__`/`__next__`-shaped method names through the
 /// typechecker's iteration-protocol resolution.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub enum IterProtocol {
     /// Iterate a builtin collection (`List`/`Dict`/`String`) or a range with no explicit method dispatch. How to
     /// concretely advance such an iterator is left to the consuming backend, matching how a plain `for` doesn't
@@ -3050,7 +3051,7 @@ impl IterProtocol {
 }
 
 /// One statement in a normalized Body IR block, carrying its own source span for diagnostics.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct Statement {
     pub kind: StatementKind,
     pub span: HirSourceSpan,
@@ -3060,7 +3061,7 @@ pub struct Statement {
 ///
 /// `while`/`for` source statements desugar into `Loop` + a conditional `Break` during lowering, rather than being
 /// represented as distinct statement kinds, so the canonical vocabulary has a single loop shape.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub enum StatementKind {
     /// Assign an rvalue into a place.
     Assign { place: Place, rvalue: Rvalue },
@@ -3215,7 +3216,7 @@ pub enum StatementKind {
 ///
 /// See [`StatementKind::Assert`] for why the three forms are one variant with this payload rather than three
 /// sibling statement kinds.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub enum AssertionKind {
     /// `assert cond`: panics when `cond` is false.
     Condition { cond: Operand },
@@ -3252,7 +3253,7 @@ impl AssertionKind {
 }
 
 /// Typechecker-proven error routing selected for one `?` operation.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub enum TryErrorRouting {
     /// The operand and enclosing Result have the same exact error type, so direct propagation needs no conversion.
     SameType { error_type: IncanType },
@@ -3287,7 +3288,7 @@ impl TryErrorRouting {
 /// One panic-interaction fact recorded for a body, without committing to a stable public panic strategy. This only
 /// exposes *that* a statement may panic and *why* — strategy decisions (unwind vs. abort, drop-on-unwind ordering)
 /// are left to later, target-specific work.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct PanicFact {
     pub span: HirSourceSpan,
     pub reason: PanicReason,
@@ -3301,7 +3302,7 @@ impl PanicFact {
 }
 
 /// Why a statement may panic at runtime.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub enum PanicReason {
     AssertFailure,
     DivisionOrModulo,

--- a/crates/incan_semantics_core/src/closure_digest.rs
+++ b/crates/incan_semantics_core/src/closure_digest.rs
@@ -1,0 +1,355 @@
+//! Folding per-declaration digests along dependency edges.
+//!
+//! A declaration's own [`crate::semantic_digest`] answers a narrow question. Consumers ask a wider one: has
+//! anything this declaration depends on changed. RFC 106 defines a **closure digest** for that — a digest over a
+//! declaration's own digest followed by the closure digests of its dependencies — and RFC 124 folds the same shape
+//! one level up, where a compiled unit's identity includes the identities of the units it links.
+//!
+//! Two properties are load-bearing and are what the tests here pin.
+//!
+//! **The fold must be order-free.** Dependencies are folded in a canonical order derived from their identities,
+//! never in traversal order. A fold sensitive to traversal reintroduces exactly the positional dependency that
+//! [`crate::stable_identity`] exists to remove: the graph would report a change because a declaration moved.
+//!
+//! **Cycles must fold deterministically.** Mutually recursive declarations have no well-founded order, so a naive
+//! recursive fold either loops forever or produces a different answer per entry point. Each strongly connected
+//! component is therefore folded as a single unit, over the sorted set of its members' own digests, so every member
+//! of a cycle shares one component contribution and the result does not depend on where the walk began.
+//!
+//! This module deliberately knows nothing about where edges come from. Body IR cannot supply them — it records the
+//! source-level callee spelling and defers full call-target resolution past v0 — so the resolved edges live in the
+//! RFC 106 graph, whose `target_id` and `canonical_identity` are `Option` precisely because resolution is partial.
+//! Keeping the fold independent of its edge source is what lets it be proven here rather than end-to-end.
+
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, BTreeSet};
+
+/// One node's contribution before folding: its own semantic digest and the nodes it depends on.
+#[derive(Debug, Clone, Default)]
+pub struct DependencyNode {
+    /// The declaration's own semantic digest.
+    pub digest: String,
+    /// Identities this declaration depends on, in any order.
+    pub dependencies: BTreeSet<String>,
+}
+
+/// Fold every node's digest with its dependencies', keyed by identity.
+///
+/// Returns a closure digest per input node. A dependency naming an identity absent from `nodes` is folded as an
+/// explicit unresolved marker rather than skipped: RFC 106 requires that an edge the graph could not resolve be
+/// treated as affected, and silently dropping it would let a closure claim to cover a dependency it never saw.
+pub fn closure_digests(nodes: &BTreeMap<String, DependencyNode>) -> BTreeMap<String, String> {
+    let components = strongly_connected_components(nodes);
+
+    // Component index per node, so a dependency edge can be classified as internal or external to the cycle.
+    let mut component_of: BTreeMap<&str, usize> = BTreeMap::new();
+    for (index, component) in components.iter().enumerate() {
+        for member in component {
+            component_of.insert(member.as_str(), index);
+        }
+    }
+
+    let mut component_digests: Vec<Option<String>> = vec![None; components.len()];
+    let mut resolved: BTreeMap<String, String> = BTreeMap::new();
+
+    // `strongly_connected_components` yields components in dependency order, so every external dependency of a
+    // component is already folded by the time the component is reached.
+    for (index, component) in components.iter().enumerate() {
+        let mut hasher = Sha256::new();
+        hasher.update(b"closure-v1");
+
+        // Members' own digests, sorted, so the component's contribution does not depend on traversal order.
+        for member in component {
+            let node = nodes.get(member.as_str());
+            hasher.update(b"\x01member\0");
+            update_delimited(&mut hasher, member.as_bytes());
+            update_delimited(
+                &mut hasher,
+                node.map(|node| node.digest.as_bytes()).unwrap_or(b"unresolved"),
+            );
+        }
+
+        // External dependencies, deduplicated and sorted by the identity they name.
+        let mut external: BTreeSet<(&str, String)> = BTreeSet::new();
+        for member in component {
+            let Some(node) = nodes.get(member.as_str()) else {
+                continue;
+            };
+            for dependency in &node.dependencies {
+                match component_of.get(dependency.as_str()) {
+                    Some(other) if *other == index => continue,
+                    Some(other) => {
+                        let digest = component_digests[*other]
+                            .clone()
+                            .unwrap_or_else(|| "pending".to_string());
+                        external.insert((dependency.as_str(), digest));
+                    }
+                    // An edge to an identity the graph does not contain. Recorded, never dropped.
+                    None => {
+                        external.insert((dependency.as_str(), "unresolved".to_string()));
+                    }
+                }
+            }
+        }
+        for (identity, digest) in external {
+            hasher.update(b"\x02dependency\0");
+            update_delimited(&mut hasher, identity.as_bytes());
+            update_delimited(&mut hasher, digest.as_bytes());
+        }
+
+        let digest = format!("sha256:{}", hex::encode(hasher.finalize()));
+        component_digests[index] = Some(digest.clone());
+        for member in component {
+            resolved.insert(member.clone(), digest.clone());
+        }
+    }
+    resolved
+}
+
+/// Write a length-delimited run, so adjacent values cannot run together.
+///
+/// Without a length, two identities differing only in where their boundary falls encode identically — the same
+/// collision [`crate::semantic_digest`] guards against.
+fn update_delimited(hasher: &mut Sha256, value: &[u8]) {
+    hasher.update((value.len() as u64).to_le_bytes());
+    hasher.update(value);
+}
+
+/// Group nodes into strongly connected components, returned in dependency order.
+///
+/// Iterative Tarjan: a recursive walk would blow the stack on a deep dependency chain, and a standard library's
+/// call graph is deep enough to care. Components come out with dependencies before dependents, which is the order
+/// the fold needs.
+fn strongly_connected_components(nodes: &BTreeMap<String, DependencyNode>) -> Vec<Vec<String>> {
+    #[derive(Default)]
+    struct State {
+        index: usize,
+        indices: BTreeMap<String, usize>,
+        lowlink: BTreeMap<String, usize>,
+        on_stack: BTreeSet<String>,
+        stack: Vec<String>,
+        components: Vec<Vec<String>>,
+    }
+
+    let mut state = State::default();
+
+    for root in nodes.keys() {
+        if state.indices.contains_key(root) {
+            continue;
+        }
+        // (node, index of the next dependency to visit)
+        let mut work: Vec<(String, usize)> = vec![(root.clone(), 0)];
+        while let Some((node, child)) = work.pop() {
+            if child == 0 {
+                state.indices.insert(node.clone(), state.index);
+                state.lowlink.insert(node.clone(), state.index);
+                state.index += 1;
+                state.stack.push(node.clone());
+                state.on_stack.insert(node.clone());
+            }
+
+            let dependencies: Vec<String> = nodes
+                .get(&node)
+                .map(|entry| entry.dependencies.iter().cloned().collect())
+                .unwrap_or_default();
+
+            if child < dependencies.len() {
+                let dependency = dependencies[child].clone();
+                work.push((node.clone(), child + 1));
+                if !nodes.contains_key(&dependency) {
+                    continue;
+                }
+                if !state.indices.contains_key(&dependency) {
+                    work.push((dependency, 0));
+                } else if state.on_stack.contains(&dependency) {
+                    let candidate = state.indices.get(&dependency).copied().unwrap_or_default();
+                    let current = state.lowlink.get(&node).copied().unwrap_or_default();
+                    state.lowlink.insert(node.clone(), current.min(candidate));
+                }
+                continue;
+            }
+
+            // Every dependency visited: propagate this node's lowlink into its parent, then close a root.
+            if let Some((parent, _)) = work.last() {
+                let child_low = state.lowlink.get(&node).copied().unwrap_or_default();
+                let parent_low = state.lowlink.get(parent.as_str()).copied().unwrap_or_default();
+                state.lowlink.insert(parent.clone(), parent_low.min(child_low));
+            }
+            if state.lowlink.get(&node) == state.indices.get(&node) {
+                let mut component = Vec::new();
+                while let Some(member) = state.stack.pop() {
+                    state.on_stack.remove(&member);
+                    let done = member == node;
+                    component.push(member);
+                    if done {
+                        break;
+                    }
+                }
+                // Defensive, and deliberately not test-covered: component discovery is already deterministic
+                // because `nodes` is a `BTreeMap`, so the same graph always yields the same stack order and no
+                // test can observe this sort. It stays because that determinism is a property of the container,
+                // not of this algorithm — swap the map and the sort is what keeps a cycle's digest stable.
+                component.sort();
+                state.components.push(component);
+            }
+        }
+    }
+    state.components
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn graph(entries: &[(&str, &str, &[&str])]) -> BTreeMap<String, DependencyNode> {
+        entries
+            .iter()
+            .map(|(name, digest, dependencies)| {
+                (
+                    (*name).to_string(),
+                    DependencyNode {
+                        digest: (*digest).to_string(),
+                        dependencies: dependencies.iter().map(|d| (*d).to_string()).collect(),
+                    },
+                )
+            })
+            .collect()
+    }
+
+    /// A change to a leaf must reach everything that depends on it, transitively, and nothing else.
+    #[test]
+    fn a_change_propagates_to_every_dependent_and_no_further() {
+        let before = graph(&[
+            ("leaf", "d1", &[]),
+            ("mid", "d2", &["leaf"]),
+            ("top", "d3", &["mid"]),
+            ("apart", "d4", &[]),
+        ]);
+        let after = graph(&[
+            ("leaf", "CHANGED", &[]),
+            ("mid", "d2", &["leaf"]),
+            ("top", "d3", &["mid"]),
+            ("apart", "d4", &[]),
+        ]);
+
+        let before = closure_digests(&before);
+        let after = closure_digests(&after);
+
+        assert_ne!(before["leaf"], after["leaf"], "the changed leaf");
+        assert_ne!(before["mid"], after["mid"], "its direct dependent");
+        assert_ne!(before["top"], after["top"], "its transitive dependent");
+        assert_eq!(
+            before["apart"], after["apart"],
+            "an unrelated declaration must not move"
+        );
+    }
+
+    /// A change must not propagate backwards. Depending on something does not make you part of it.
+    #[test]
+    fn a_change_does_not_reach_a_dependency() {
+        let before = graph(&[("leaf", "d1", &[]), ("top", "d2", &["leaf"])]);
+        let after = graph(&[("leaf", "d1", &[]), ("top", "CHANGED", &["leaf"])]);
+        assert_eq!(
+            closure_digests(&before)["leaf"],
+            closure_digests(&after)["leaf"],
+            "editing a dependent must not move its dependency"
+        );
+    }
+
+    /// The fold is over a set, not a sequence: the order dependencies were discovered in must not matter.
+    ///
+    /// This is the property that keeps traversal order out of the result. A fold sensitive to it would reintroduce
+    /// exactly the positional dependency the stable identity exists to remove.
+    #[test]
+    fn the_fold_is_order_free() {
+        let one = graph(&[("a", "d1", &[]), ("b", "d2", &[]), ("top", "d3", &["a", "b"])]);
+        let other = graph(&[("b", "d2", &[]), ("a", "d1", &[]), ("top", "d3", &["b", "a"])]);
+        assert_eq!(closure_digests(&one)["top"], closure_digests(&other)["top"]);
+    }
+
+    /// A cycle must fold to one answer regardless of which member the walk starts from.
+    #[test]
+    fn a_cycle_folds_deterministically() {
+        let forward = graph(&[("a", "d1", &["b"]), ("b", "d2", &["a"]), ("outside", "d3", &["a"])]);
+        let reversed = graph(&[("b", "d2", &["a"]), ("a", "d1", &["b"]), ("outside", "d3", &["a"])]);
+
+        let forward = closure_digests(&forward);
+        let reversed = closure_digests(&reversed);
+
+        assert_eq!(forward["a"], reversed["a"]);
+        assert_eq!(forward["b"], reversed["b"]);
+        assert_eq!(forward["outside"], reversed["outside"]);
+        assert_eq!(
+            forward["a"], forward["b"],
+            "members of one cycle share their component's digest"
+        );
+    }
+
+    /// A change inside a cycle must move every member of it, and its dependents.
+    #[test]
+    fn a_change_inside_a_cycle_moves_the_whole_cycle() {
+        let before = graph(&[("a", "d1", &["b"]), ("b", "d2", &["a"]), ("outside", "d3", &["a"])]);
+        let after = graph(&[("a", "CHANGED", &["b"]), ("b", "d2", &["a"]), ("outside", "d3", &["a"])]);
+
+        let before = closure_digests(&before);
+        let after = closure_digests(&after);
+
+        assert_ne!(before["a"], after["a"]);
+        assert_ne!(before["b"], after["b"], "the other member of the cycle moves too");
+        assert_ne!(before["outside"], after["outside"]);
+    }
+
+    /// An edge naming an identity the graph does not contain must be recorded, never silently dropped.
+    ///
+    /// RFC 106 requires an unresolved edge be treated as affected. Dropping it would let a closure claim to cover a
+    /// dependency it never saw — under-invalidation, and a wrong build.
+    #[test]
+    fn an_unresolved_edge_is_recorded_rather_than_ignored() {
+        let with_edge = graph(&[("top", "d1", &["missing"])]);
+        let without_edge = graph(&[("top", "d1", &[])]);
+        assert_ne!(
+            closure_digests(&with_edge)["top"],
+            closure_digests(&without_edge)["top"],
+            "a dependency on something unresolved is not the same as no dependency"
+        );
+    }
+
+    /// A deep chain must not overflow the stack; a recursive walk would.
+    #[test]
+    fn a_deep_chain_folds_without_recursion() {
+        let mut nodes = BTreeMap::new();
+        for index in 0..5_000 {
+            let dependencies = if index == 0 {
+                BTreeSet::new()
+            } else {
+                [format!("n{:05}", index - 1)].into_iter().collect()
+            };
+            nodes.insert(
+                format!("n{index:05}"),
+                DependencyNode {
+                    digest: format!("d{index}"),
+                    dependencies,
+                },
+            );
+        }
+        let digests = closure_digests(&nodes);
+        assert_eq!(digests.len(), 5_000);
+    }
+
+    /// An identity and the digest beside it must not be able to run together.
+    ///
+    /// Each member contributes its identity followed by its own digest. Without a length between them, a node
+    /// named `ab` with digest `cd` encodes byte-for-byte as one named `abc` with digest `d` — the boundary moves
+    /// and the encoding does not. Two genuinely different declarations would then share a closure digest, which
+    /// under-invalidates and yields a wrong build.
+    #[test]
+    fn identity_and_digest_are_length_delimited() {
+        let one = graph(&[("ab", "cd", &[])]);
+        let other = graph(&[("abc", "d", &[])]);
+        assert_ne!(
+            closure_digests(&one)["ab"],
+            closure_digests(&other)["abc"],
+            "the identity/digest boundary must be encoded, not implied"
+        );
+    }
+}

--- a/crates/incan_semantics_core/src/facts.rs
+++ b/crates/incan_semantics_core/src/facts.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use crate::IncanType;
 
 /// Kind of compiler-owned node that can receive semantic facts.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 pub enum CompilerNodeKind {
     /// A package selected at a command/session boundary.
     Package,
@@ -44,7 +44,7 @@ impl CompilerNodeKind {
 /// The `path` is intentionally semantic rather than Rust-shaped. Current bridge code may derive it from spans or
 /// source paths at first, but consumers should treat the rendered form as a compiler identity, not as an emitted Rust
 /// item path.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 pub struct CompilerNodeId {
     kind: CompilerNodeKind,
     path: String,

--- a/crates/incan_semantics_core/src/hir.rs
+++ b/crates/incan_semantics_core/src/hir.rs
@@ -77,6 +77,31 @@ impl SemanticModuleSnapshot {
     }
 }
 
+/// Whether a declaration is part of its module's public surface.
+///
+/// This mirrors the syntax-level visibility without depending on the syntax crate: `incan_semantics_core` sits below
+/// `incan_syntax`, and the frontend bridge translates. Visibility is a *semantic* fact here — it decides which
+/// declarations are roots of the external closure under RFC 106, and therefore whether a change to a declaration
+/// can be observed by a consumer at all.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Serialize, Deserialize)]
+pub enum DeclarationVisibility {
+    /// Not part of the module's public surface. Reachable from a public declaration only through its body.
+    #[default]
+    Private,
+    /// Exported from its module.
+    Public,
+}
+
+impl DeclarationVisibility {
+    /// Return the compact snapshot spelling.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Private => "private",
+            Self::Public => "public",
+        }
+    }
+}
+
 /// One top-level declaration in HIR v0.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HirDeclaration {
@@ -86,6 +111,12 @@ pub struct HirDeclaration {
     pub span: HirSourceSpan,
     /// Subject ID to query for a [`crate::SemanticFactKind::Type`] fact, when this declaration has one.
     pub type_fact_subject: Option<CompilerNodeId>,
+    /// Whether this declaration is part of its module's public surface.
+    ///
+    /// Present so a consumer can compute RFC 106's external closure without re-deriving visibility from syntax.
+    /// A binding that names another declaration — an import, alias, or re-export — records the visibility of the
+    /// *binding*, since that is what decides whether this module re-exports it.
+    pub visibility: DeclarationVisibility,
     /// RFC 120 canonical identity of this declaration, when the frontend proved one.
     ///
     /// For a local declaration this is the identity minted at its definition; for an import binding it is the
@@ -160,6 +191,7 @@ mod tests {
                 name: Some("run".to_string()),
                 span: HirSourceSpan::new(1, 24),
                 type_fact_subject: Some(type_fact_subject),
+                visibility: DeclarationVisibility::Public,
                 canonical: None,
             }],
         };
@@ -191,6 +223,7 @@ mod tests {
                     name: Some("run".to_string()),
                     span: HirSourceSpan::new(1, 24),
                     type_fact_subject: Some(type_fact_subject),
+                    visibility: DeclarationVisibility::Public,
                     canonical: None,
                 }],
             },

--- a/crates/incan_semantics_core/src/hir.rs
+++ b/crates/incan_semantics_core/src/hir.rs
@@ -128,7 +128,7 @@ pub struct HirDeclaration {
 }
 
 /// Top-level declaration categories represented by HIR v0.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum HirDeclarationKind {
     Import,
     Const,

--- a/crates/incan_semantics_core/src/lib.rs
+++ b/crates/incan_semantics_core/src/lib.rs
@@ -45,7 +45,9 @@ pub use facts::{
     SemanticRegistryValue, SemanticSourceTarget, SemanticSourceTargetKind, SymbolNamespace, SymbolOrigin,
     module_identity_for_path,
 };
-pub use hir::{HirDeclaration, HirDeclarationKind, HirModule, HirSourceSpan, SemanticModuleSnapshot};
+pub use hir::{
+    DeclarationVisibility, HirDeclaration, HirDeclarationKind, HirModule, HirSourceSpan, SemanticModuleSnapshot,
+};
 pub use types::{
     AbiV0Ownership, AbiV0Representation, AbiV0ReservedFacts, AbiV0RuntimeRequirement, AbiV0TypeFacts,
     AbiV0TypeIdentity, IncanCallableParam, IncanCallableParamKind, IncanPrimitiveType, IncanType, rust_tuple_arity,

--- a/crates/incan_semantics_core/src/lib.rs
+++ b/crates/incan_semantics_core/src/lib.rs
@@ -31,6 +31,7 @@ pub mod emitted_symbol;
 mod facts;
 mod hir;
 pub mod receipts;
+pub mod stable_identity;
 mod types;
 
 pub use emitted_symbol::{

--- a/crates/incan_semantics_core/src/lib.rs
+++ b/crates/incan_semantics_core/src/lib.rs
@@ -31,6 +31,7 @@ pub mod emitted_symbol;
 mod facts;
 mod hir;
 pub mod receipts;
+pub mod semantic_digest;
 pub mod stable_identity;
 mod types;
 

--- a/crates/incan_semantics_core/src/lib.rs
+++ b/crates/incan_semantics_core/src/lib.rs
@@ -27,6 +27,7 @@ use incan_core::lang::keywords::KeywordId;
 
 pub mod authority;
 pub mod body_ir;
+pub mod closure_digest;
 pub mod emitted_symbol;
 mod facts;
 mod hir;

--- a/crates/incan_semantics_core/src/semantic_digest.rs
+++ b/crates/incan_semantics_core/src/semantic_digest.rs
@@ -123,6 +123,7 @@ impl<'hasher> ser::Serializer for DigestSerializer<'hasher> {
     type SerializeStruct = StructDigest<'hasher>;
     type SerializeStructVariant = StructDigest<'hasher>;
 
+    /// Tag a boolean and write its single byte.
     fn serialize_bool(mut self, value: bool) -> Result<(), DigestError> {
         self.tag(0x01);
         self.hasher.update([u8::from(value)]);
@@ -145,39 +146,46 @@ impl<'hasher> ser::Serializer for DigestSerializer<'hasher> {
     digest_primitive!(serialize_i128, i128, 0x19);
     digest_primitive!(serialize_u128, u128, 0x1a);
 
+    /// Tag a character and write its UTF-8 encoding, length-delimited.
     fn serialize_char(mut self, value: char) -> Result<(), DigestError> {
         self.tag(0x0c);
         self.bytes(value.to_string().as_bytes());
         Ok(())
     }
 
+    /// Tag a string and write its bytes, length-delimited so adjacent values cannot run together.
     fn serialize_str(mut self, value: &str) -> Result<(), DigestError> {
         self.tag(0x0d);
         self.bytes(value.as_bytes());
         Ok(())
     }
 
+    /// Tag a byte string and write it, length-delimited.
     fn serialize_bytes(mut self, value: &[u8]) -> Result<(), DigestError> {
         self.tag(0x0e);
         self.bytes(value);
         Ok(())
     }
 
+    /// Tag an absent optional, so absence and a present empty value differ.
     fn serialize_none(mut self) -> Result<(), DigestError> {
         self.tag(0x0f);
         Ok(())
     }
 
+    /// Tag a present optional, then hash the value it wraps.
     fn serialize_some<T: ?Sized + Serialize>(mut self, value: &T) -> Result<(), DigestError> {
         self.tag(0x10);
         value.serialize(DigestSerializer { hasher: self.hasher })
     }
 
+    /// Tag the unit value.
     fn serialize_unit(mut self) -> Result<(), DigestError> {
         self.tag(0x11);
         Ok(())
     }
 
+    /// Hash a unit struct by name, since it carries nothing else to distinguish it.
     fn serialize_unit_struct(self, name: &'static str) -> Result<(), DigestError> {
         self.serialize_str(name)
     }
@@ -194,6 +202,7 @@ impl<'hasher> ser::Serializer for DigestSerializer<'hasher> {
         Ok(())
     }
 
+    /// Hash a newtype's inner value directly; the wrapper adds no meaning of its own.
     fn serialize_newtype_struct<T: ?Sized + Serialize>(
         self,
         _name: &'static str,
@@ -202,6 +211,7 @@ impl<'hasher> ser::Serializer for DigestSerializer<'hasher> {
         value.serialize(self)
     }
 
+    /// Tag a newtype variant by name, then hash the value it wraps.
     fn serialize_newtype_variant<T: ?Sized + Serialize>(
         mut self,
         _name: &'static str,
@@ -214,20 +224,24 @@ impl<'hasher> ser::Serializer for DigestSerializer<'hasher> {
         value.serialize(DigestSerializer { hasher: self.hasher })
     }
 
+    /// Tag a sequence and write its length, so two sequences cannot concatenate into one.
     fn serialize_seq(mut self, length: Option<usize>) -> Result<Self, DigestError> {
         self.tag(0x14);
         self.hasher.update((length.unwrap_or_default() as u64).to_le_bytes());
         Ok(self)
     }
 
+    /// Hash a tuple as a fixed-length sequence.
     fn serialize_tuple(self, length: usize) -> Result<Self, DigestError> {
         self.serialize_seq(Some(length))
     }
 
+    /// Hash a tuple struct as a fixed-length sequence; its name adds nothing the fields do not.
     fn serialize_tuple_struct(self, _name: &'static str, length: usize) -> Result<Self, DigestError> {
         self.serialize_seq(Some(length))
     }
 
+    /// Tag a tuple variant by name, then write its length and fields.
     fn serialize_tuple_variant(
         mut self,
         _name: &'static str,
@@ -241,17 +255,20 @@ impl<'hasher> ser::Serializer for DigestSerializer<'hasher> {
         Ok(self)
     }
 
+    /// Tag a map and write its length, then hash each key and value in turn.
     fn serialize_map(mut self, length: Option<usize>) -> Result<Self, DigestError> {
         self.tag(0x16);
         self.hasher.update((length.unwrap_or_default() as u64).to_le_bytes());
         Ok(self)
     }
 
+    /// Tag a struct; its fields are hashed by [`StructDigest`], which drops the positional ones.
     fn serialize_struct(mut self, _name: &'static str, _length: usize) -> Result<StructDigest<'hasher>, DigestError> {
         self.tag(0x17);
         Ok(StructDigest { hasher: self.hasher })
     }
 
+    /// Tag a struct variant by name; its fields are hashed by [`StructDigest`].
     fn serialize_struct_variant(
         mut self,
         _name: &'static str,

--- a/crates/incan_semantics_core/src/semantic_digest.rs
+++ b/crates/incan_semantics_core/src/semantic_digest.rs
@@ -140,6 +140,11 @@ impl<'hasher> ser::Serializer for DigestSerializer<'hasher> {
     digest_primitive!(serialize_f32, f32, 0x0a);
     digest_primitive!(serialize_f64, f64, 0x0b);
 
+    // `serde`'s defaults for these reject the value. Body IR carries 128-bit numeric constants, so without them
+    // the digest cannot cover a standard library at all -- a gap no fixture exercised and only a corpus found.
+    digest_primitive!(serialize_i128, i128, 0x19);
+    digest_primitive!(serialize_u128, u128, 0x1a);
+
     fn serialize_char(mut self, value: char) -> Result<(), DigestError> {
         self.tag(0x0c);
         self.bytes(value.to_string().as_bytes());

--- a/crates/incan_semantics_core/src/semantic_digest.rs
+++ b/crates/incan_semantics_core/src/semantic_digest.rs
@@ -1,0 +1,474 @@
+//! A digest over checked meaning, computed from values.
+//!
+//! RFC 106 requires the semantic digest be computed from checked values rather than by normalising a rendered
+//! form, and the rule is not stylistic. A rendering embeds positional data *inside* composite strings — an identity
+//! spelling carrying its own `@start..end`, for example — so scrubbing text after the fact reliably misses cases
+//! that omitting a field cannot. An earlier probe did exactly that, stripped `span=` and `#decl.`, and still leaked
+//! the offset through a nested identity rendering.
+//!
+//! The approach here is the one RFC 106 cites as prior art: normalise the structured value, then serialise.
+//! [`DigestSerializer`] walks a value through `serde` and feeds a hasher, dropping fields whose names are
+//! positional. Because it works field-by-field over the real value, a field added to Body IR later is included
+//! automatically — the drift that a hand-written visitor suffers, where a new field is silently omitted and the
+//! digest quietly under-invalidates, cannot happen here.
+//!
+//! Excluding a field is the *over*-invalidating direction when done wrong: a positional field left in makes an
+//! unrelated edit look like a change, which costs time. Omitting a meaningful field is the dangerous direction, and
+//! it is the one this design removes.
+
+use serde::{Serialize, ser};
+use sha2::{Digest, Sha256};
+use std::fmt::Display;
+
+/// Node-identifier fields excluded from every semantic digest.
+///
+/// Most are [`crate::CompilerNodeId`]s, which embed the declaration span in their own spelling and so carry
+/// position transitively even though their names do not say so.
+///
+/// `scope_discriminant` is the subtler one. It indexes a module-wide table filled in traversal order
+/// (`src/frontend/symbols.rs`: `self.current_scope = self.scopes.len() - 1`), so inserting or moving any
+/// declaration renumbers every declaration traversed after it. Its *presence* is meaningful — it separates a
+/// nested binding from a module-level namesake — and [`crate::stable_identity::StableDeclarationId`] keeps that
+/// in the identity. Its value is position and belongs nowhere.
+const POSITIONAL_ID_FIELDS: &[&str] = &["decl_id", "direct_call_id", "id", "module_id", "scope_discriminant"];
+
+/// Whether a struct field is positional and must not reach the digest.
+///
+/// The span rule is written structurally — `span` or any `*_span` — rather than as a list of known names. A list
+/// was the first attempt and it missed `CanonicalSymbolId::declaration_span`, which sits several levels down inside
+/// `Body::canonical`: every declaration in a module appeared to change when a comment was added anywhere in it.
+/// Matching the shape means a span field added later is excluded without anyone remembering to add it.
+///
+/// The failure directions are asymmetric. A positional field wrongly left in makes an unrelated edit look like a
+/// change, costing a rebuild. A meaningful field wrongly excluded makes a real change invisible, producing a wrong
+/// build. This rule can only ever over-match on names ending in `_span`, so it errs the safe way.
+fn is_positional_field(name: &str) -> bool {
+    name == "span" || name.ends_with("_span") || POSITIONAL_ID_FIELDS.contains(&name)
+}
+
+/// The error type for digest serialisation.
+///
+/// Serialising into a hasher cannot fail on I/O, so the only error is one `serde` itself raises.
+#[derive(Debug)]
+pub struct DigestError(String);
+
+impl Display for DigestError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "semantic digest serialization failed: {}", self.0)
+    }
+}
+
+impl std::error::Error for DigestError {}
+
+impl ser::Error for DigestError {
+    fn custom<T: Display>(message: T) -> Self {
+        Self(message.to_string())
+    }
+}
+
+/// Hash any checked value into a stable semantic digest, omitting positional fields.
+///
+/// The digest is `sha256:`-prefixed so a caller can tell one apart from a bare hex string in a receipt or a graph
+/// record, matching how RFC 124 spells payload digests.
+///
+/// # Errors
+///
+/// Returns [`DigestError`] only if the value's own `Serialize` implementation fails.
+pub fn semantic_digest<T: Serialize>(value: &T) -> Result<String, DigestError> {
+    let mut hasher = Sha256::new();
+    value.serialize(DigestSerializer { hasher: &mut hasher })?;
+    Ok(format!("sha256:{}", hex::encode(hasher.finalize())))
+}
+
+/// A `serde` serialiser that feeds a hasher instead of producing a document.
+///
+/// Every value is written with a type tag and, for anything variable-length, an explicit length. Both matter: a tag
+/// stops two differently-typed values with the same bytes from colliding, and a length stops adjacent values from
+/// running together — without one, the single identifier `aIb` and the pair `a` `b` hash identically.
+pub struct DigestSerializer<'hasher> {
+    hasher: &'hasher mut Sha256,
+}
+
+impl DigestSerializer<'_> {
+    /// Write a type tag, so values of different shapes cannot collide on identical payload bytes.
+    fn tag(&mut self, tag: u8) {
+        self.hasher.update([tag]);
+    }
+
+    /// Write a length-delimited byte run, so adjacent values cannot run together.
+    fn bytes(&mut self, value: &[u8]) {
+        self.hasher.update((value.len() as u64).to_le_bytes());
+        self.hasher.update(value);
+    }
+}
+
+macro_rules! digest_primitive {
+    ($method:ident, $ty:ty, $tag:expr) => {
+        fn $method(mut self, value: $ty) -> Result<(), DigestError> {
+            self.tag($tag);
+            self.hasher.update(value.to_le_bytes());
+            Ok(())
+        }
+    };
+}
+
+impl<'hasher> ser::Serializer for DigestSerializer<'hasher> {
+    type Ok = ();
+    type Error = DigestError;
+    type SerializeSeq = Self;
+    type SerializeTuple = Self;
+    type SerializeTupleStruct = Self;
+    type SerializeTupleVariant = Self;
+    type SerializeMap = Self;
+    type SerializeStruct = StructDigest<'hasher>;
+    type SerializeStructVariant = StructDigest<'hasher>;
+
+    fn serialize_bool(mut self, value: bool) -> Result<(), DigestError> {
+        self.tag(0x01);
+        self.hasher.update([u8::from(value)]);
+        Ok(())
+    }
+
+    digest_primitive!(serialize_i8, i8, 0x02);
+    digest_primitive!(serialize_i16, i16, 0x03);
+    digest_primitive!(serialize_i32, i32, 0x04);
+    digest_primitive!(serialize_i64, i64, 0x05);
+    digest_primitive!(serialize_u8, u8, 0x06);
+    digest_primitive!(serialize_u16, u16, 0x07);
+    digest_primitive!(serialize_u32, u32, 0x08);
+    digest_primitive!(serialize_u64, u64, 0x09);
+    digest_primitive!(serialize_f32, f32, 0x0a);
+    digest_primitive!(serialize_f64, f64, 0x0b);
+
+    fn serialize_char(mut self, value: char) -> Result<(), DigestError> {
+        self.tag(0x0c);
+        self.bytes(value.to_string().as_bytes());
+        Ok(())
+    }
+
+    fn serialize_str(mut self, value: &str) -> Result<(), DigestError> {
+        self.tag(0x0d);
+        self.bytes(value.as_bytes());
+        Ok(())
+    }
+
+    fn serialize_bytes(mut self, value: &[u8]) -> Result<(), DigestError> {
+        self.tag(0x0e);
+        self.bytes(value);
+        Ok(())
+    }
+
+    fn serialize_none(mut self) -> Result<(), DigestError> {
+        self.tag(0x0f);
+        Ok(())
+    }
+
+    fn serialize_some<T: ?Sized + Serialize>(mut self, value: &T) -> Result<(), DigestError> {
+        self.tag(0x10);
+        value.serialize(DigestSerializer { hasher: self.hasher })
+    }
+
+    fn serialize_unit(mut self) -> Result<(), DigestError> {
+        self.tag(0x11);
+        Ok(())
+    }
+
+    fn serialize_unit_struct(self, name: &'static str) -> Result<(), DigestError> {
+        self.serialize_str(name)
+    }
+
+    /// A unit variant contributes its *name*, never its index, so reordering an enum's variants is not a change.
+    fn serialize_unit_variant(
+        mut self,
+        _name: &'static str,
+        _index: u32,
+        variant: &'static str,
+    ) -> Result<(), DigestError> {
+        self.tag(0x12);
+        self.bytes(variant.as_bytes());
+        Ok(())
+    }
+
+    fn serialize_newtype_struct<T: ?Sized + Serialize>(
+        self,
+        _name: &'static str,
+        value: &T,
+    ) -> Result<(), DigestError> {
+        value.serialize(self)
+    }
+
+    fn serialize_newtype_variant<T: ?Sized + Serialize>(
+        mut self,
+        _name: &'static str,
+        _index: u32,
+        variant: &'static str,
+        value: &T,
+    ) -> Result<(), DigestError> {
+        self.tag(0x13);
+        self.bytes(variant.as_bytes());
+        value.serialize(DigestSerializer { hasher: self.hasher })
+    }
+
+    fn serialize_seq(mut self, length: Option<usize>) -> Result<Self, DigestError> {
+        self.tag(0x14);
+        self.hasher.update((length.unwrap_or_default() as u64).to_le_bytes());
+        Ok(self)
+    }
+
+    fn serialize_tuple(self, length: usize) -> Result<Self, DigestError> {
+        self.serialize_seq(Some(length))
+    }
+
+    fn serialize_tuple_struct(self, _name: &'static str, length: usize) -> Result<Self, DigestError> {
+        self.serialize_seq(Some(length))
+    }
+
+    fn serialize_tuple_variant(
+        mut self,
+        _name: &'static str,
+        _index: u32,
+        variant: &'static str,
+        length: usize,
+    ) -> Result<Self, DigestError> {
+        self.tag(0x15);
+        self.bytes(variant.as_bytes());
+        self.hasher.update((length as u64).to_le_bytes());
+        Ok(self)
+    }
+
+    fn serialize_map(mut self, length: Option<usize>) -> Result<Self, DigestError> {
+        self.tag(0x16);
+        self.hasher.update((length.unwrap_or_default() as u64).to_le_bytes());
+        Ok(self)
+    }
+
+    fn serialize_struct(mut self, _name: &'static str, _length: usize) -> Result<StructDigest<'hasher>, DigestError> {
+        self.tag(0x17);
+        Ok(StructDigest { hasher: self.hasher })
+    }
+
+    fn serialize_struct_variant(
+        mut self,
+        _name: &'static str,
+        _index: u32,
+        variant: &'static str,
+        _length: usize,
+    ) -> Result<StructDigest<'hasher>, DigestError> {
+        self.tag(0x18);
+        self.bytes(variant.as_bytes());
+        Ok(StructDigest { hasher: self.hasher })
+    }
+}
+
+macro_rules! digest_sequence {
+    ($trait_name:ident, $method:ident) => {
+        impl ser::$trait_name for DigestSerializer<'_> {
+            type Ok = ();
+            type Error = DigestError;
+
+            fn $method<T: ?Sized + Serialize>(&mut self, value: &T) -> Result<(), DigestError> {
+                value.serialize(DigestSerializer { hasher: self.hasher })
+            }
+
+            fn end(self) -> Result<(), DigestError> {
+                Ok(())
+            }
+        }
+    };
+}
+
+digest_sequence!(SerializeSeq, serialize_element);
+digest_sequence!(SerializeTuple, serialize_element);
+digest_sequence!(SerializeTupleStruct, serialize_field);
+digest_sequence!(SerializeTupleVariant, serialize_field);
+
+impl ser::SerializeMap for DigestSerializer<'_> {
+    type Ok = ();
+    type Error = DigestError;
+
+    fn serialize_key<T: ?Sized + Serialize>(&mut self, key: &T) -> Result<(), DigestError> {
+        key.serialize(DigestSerializer { hasher: self.hasher })
+    }
+
+    fn serialize_value<T: ?Sized + Serialize>(&mut self, value: &T) -> Result<(), DigestError> {
+        value.serialize(DigestSerializer { hasher: self.hasher })
+    }
+
+    fn end(self) -> Result<(), DigestError> {
+        Ok(())
+    }
+}
+
+/// Serialises a struct's fields, dropping the positional ones.
+///
+/// The field *name* is hashed alongside its value, so moving a value between two same-typed fields is a change
+/// rather than a coincidence.
+pub struct StructDigest<'hasher> {
+    hasher: &'hasher mut Sha256,
+}
+
+impl ser::SerializeStruct for StructDigest<'_> {
+    type Ok = ();
+    type Error = DigestError;
+
+    fn serialize_field<T: ?Sized + Serialize>(&mut self, key: &'static str, value: &T) -> Result<(), DigestError> {
+        if is_positional_field(key) {
+            return Ok(());
+        }
+        self.hasher.update((key.len() as u64).to_le_bytes());
+        self.hasher.update(key.as_bytes());
+        value.serialize(DigestSerializer { hasher: self.hasher })
+    }
+
+    fn end(self) -> Result<(), DigestError> {
+        Ok(())
+    }
+}
+
+impl ser::SerializeStructVariant for StructDigest<'_> {
+    type Ok = ();
+    type Error = DigestError;
+
+    fn serialize_field<T: ?Sized + Serialize>(&mut self, key: &'static str, value: &T) -> Result<(), DigestError> {
+        ser::SerializeStruct::serialize_field(self, key, value)
+    }
+
+    fn end(self) -> Result<(), DigestError> {
+        Ok(())
+    }
+}
+
+/// Return a body with its docstring removed, ready to digest.
+///
+/// An Incan docstring is a bare string expression at the head of a body, exactly as in Python, and it survives
+/// lowering as a leading `StatementKind::Expr` whose operand is a string constant. It reaches generated Rust as a
+/// `///` line, which cannot change a compiled artifact, so it must not change the semantic digest.
+///
+/// Documentation is still *output* — for published reference docs and for a manifest surface it is the product —
+/// which is why RFC 106 gives it a separate `doc_digest` rather than discarding it. This function only decides
+/// what the *semantic* digest covers.
+///
+/// The rule is deliberately narrow: only a leading bare string expression, only at the head of the body. A string
+/// expression anywhere else is a real statement, and dropping it would hide a change.
+pub fn body_without_docstring(body: &crate::body_ir::Body) -> crate::body_ir::Body {
+    use crate::body_ir::{Constant, Operand, StatementKind};
+
+    let mut projected = body.clone();
+    let is_docstring = projected
+        .block
+        .stmts
+        .first()
+        .map(|statement| {
+            matches!(
+                &statement.kind,
+                StatementKind::Expr {
+                    value: Operand::Constant(Constant::Str(_))
+                }
+            )
+        })
+        .unwrap_or(false);
+    if is_docstring {
+        projected.block.stmts.remove(0);
+    }
+    projected
+}
+
+/// Extract a body's docstring, if it has one.
+///
+/// The counterpart to [`body_without_docstring`]: what that removes, this returns, so a caller can compute RFC
+/// 106's separate `doc_digest` over the same definition of what documentation is.
+pub fn body_docstring(body: &crate::body_ir::Body) -> Option<&str> {
+    use crate::body_ir::{Constant, Operand, StatementKind};
+
+    match &body.block.stmts.first()?.kind {
+        StatementKind::Expr {
+            value: Operand::Constant(Constant::Str(text)),
+        } => Some(text),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Adjacent variable-length values must not be able to run together.
+    ///
+    /// Without a length between them, the pair `("ab", "c")` encodes to the same bytes as `("a", "bc")`: two
+    /// parameter names differing only in where the boundary falls would share a digest, and a rename that moved a
+    /// character across that boundary would be invisible. This is under-invalidation, which yields a wrong build.
+    #[test]
+    fn adjacent_values_are_length_delimited() -> Result<(), Box<dyn std::error::Error>> {
+        // The collision needs the string tag byte to appear *inside* the content, otherwise the tag itself
+        // happens to act as a delimiter and the case proves nothing. `\r` is 0x0d, the string tag, and a
+        // carriage return in a source literal or docstring is entirely ordinary.
+        //
+        // Without a length, both of these encode to the same six bytes:
+        //   0x0d 'a' 0x0d 'b' 0x0d 'c'
+        let split_late = vec!["a\rb".to_string(), "c".to_string()];
+        let split_early = vec!["a".to_string(), "b\rc".to_string()];
+        assert_ne!(
+            semantic_digest(&split_late)?,
+            semantic_digest(&split_early)?,
+            "two values differing only in where the boundary falls must not share a digest"
+        );
+        Ok(())
+    }
+
+    /// A field's name must reach the digest, so moving a value between two same-typed fields is a change.
+    ///
+    /// Without the name, a struct is just its values in order, and swapping two same-typed fields — a real
+    /// behavioural change — produces an identical digest.
+    #[test]
+    fn field_names_reach_the_digest() -> Result<(), Box<dyn std::error::Error>> {
+        #[derive(Serialize)]
+        struct Pair {
+            first: u32,
+            second: u32,
+        }
+        #[derive(Serialize)]
+        struct Renamed {
+            third: u32,
+            fourth: u32,
+        }
+        assert_ne!(
+            semantic_digest(&Pair { first: 1, second: 2 })?,
+            semantic_digest(&Renamed { third: 1, fourth: 2 })?,
+            "differently named fields holding the same values must differ"
+        );
+        assert_ne!(
+            semantic_digest(&Pair { first: 1, second: 2 })?,
+            semantic_digest(&Pair { first: 2, second: 1 })?,
+            "swapping two same-typed field values must be a change"
+        );
+        Ok(())
+    }
+
+    /// Differently shaped values holding identical payload bytes must not collide.
+    #[test]
+    fn type_tags_separate_same_bytes_in_different_shapes() -> Result<(), Box<dyn std::error::Error>> {
+        assert_ne!(semantic_digest(&Some("x"))?, semantic_digest(&"x")?);
+        assert_ne!(semantic_digest(&1u32)?, semantic_digest(&1i32)?);
+        assert_ne!(semantic_digest(&vec!["x"])?, semantic_digest(&"x")?);
+        Ok(())
+    }
+
+    /// An enum variant contributes its name, so reordering variants in the source is not a change.
+    #[test]
+    fn variant_identity_is_by_name_not_index() -> Result<(), Box<dyn std::error::Error>> {
+        #[derive(Serialize)]
+        enum First {
+            #[allow(dead_code)]
+            Alpha,
+            Beta,
+        }
+        #[derive(Serialize)]
+        enum Reordered {
+            Beta,
+            #[allow(dead_code)]
+            Alpha,
+        }
+        assert_eq!(semantic_digest(&First::Beta)?, semantic_digest(&Reordered::Beta)?);
+        Ok(())
+    }
+}

--- a/crates/incan_semantics_core/src/stable_identity.rs
+++ b/crates/incan_semantics_core/src/stable_identity.rs
@@ -1,0 +1,286 @@
+//! Declaration identity that survives edits.
+//!
+//! [`CanonicalSymbolId`] is the compiler's identity for a resolved reference, and it is correct for what it claims:
+//! its own documentation states it is stable across the stages of *one compilation, not across edits*, because
+//! [`CanonicalSymbolId::declaration_span`] participates in its equality and moves whenever a line above it does.
+//!
+//! A consumer that caches across edits needs a different guarantee. RFC 106 separates the two: identity answers
+//! *which declaration is this*, a digest answers *has its meaning changed*, and a single content-addressed value
+//! cannot answer both — if identity moved with content, an edited declaration would be indistinguishable from a
+//! deletion plus an addition. [`StableDeclarationId`] is that first half.
+//!
+//! Three positional channels have to be excluded, and each was found by measuring the compiler rather than by
+//! reasoning about it:
+//!
+//! - **The declaration span.** Removing it is necessary and is the obvious part.
+//! - **The signature, which removing the span makes necessary.** Two module-level declarations sharing namespace,
+//!   origin, name, and kind become indistinguishable once the span is gone. Measured across 2,078 checked
+//!   declarations of one standard library, overloads are the only class of collision that arises — and they arise
+//!   reliably, so a signature discriminant is required rather than defensive.
+//! - **The scope discriminant's value.** [`ScopeDiscriminant`] indexes a module-wide table filled in traversal
+//!   order, so inserting or moving any declaration renumbers every declaration traversed after it and untouched
+//!   siblings appear to change. Only whether a declaration is nested may enter the identity, never where its scope
+//!   sat in the traversal.
+
+use serde::{Deserialize, Serialize};
+
+use crate::facts::{CanonicalSymbolId, SemanticSourceTargetKind, SymbolNamespace, SymbolOrigin};
+use crate::types::IncanType;
+
+/// Whether a declaration is module-level or introduced inside an enclosing scope.
+///
+/// This records only what [`crate::facts::ScopeDiscriminant`] is *for* — separating same-named bindings in sibling
+/// scopes from a module-level declaration of that name — while discarding the discriminant's numeric value, which
+/// is an index into a traversal-ordered table and therefore positional.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum DeclarationNesting {
+    /// Unique within its origin without needing a scope to disambiguate it.
+    ModuleLevel,
+    /// Introduced inside an enclosing scope, such as a local, parameter, receiver, or generic binder.
+    Nested,
+}
+
+/// A canonical rendering of a declaration's signature, used to separate overloads.
+///
+/// The rendering is an identity input, so it must be derived from checked types and never from source spelling: two
+/// declarations that differ only in how their types are written are the same declaration, and two that differ in the
+/// types themselves are not. It carries no span, no parameter name, and no ordering beyond the parameters' own.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct DeclarationSignature(String);
+
+impl DeclarationSignature {
+    /// Build a signature from a callable's checked parameter and return types.
+    ///
+    /// Parameter *names* are deliberately excluded. Renaming a parameter does not produce a different declaration,
+    /// and including the name would make a rename look like a new declaration to every consumer keyed on identity.
+    pub fn from_callable_types<'a>(
+        parameters: impl IntoIterator<Item = &'a IncanType>,
+        return_type: &IncanType,
+    ) -> Self {
+        let rendered = parameters
+            .into_iter()
+            .map(render_type)
+            .collect::<Vec<_>>()
+            .join(",");
+        Self(format!("({rendered})->{}", render_type(return_type)))
+    }
+
+    /// Build a signature from an already-canonical rendering.
+    ///
+    /// For declarations that are not callables but still need separating, and for callers holding a rendering this
+    /// module did not produce. The caller owns the guarantee that the rendering is derived from checked types.
+    pub fn from_rendering(rendering: impl Into<String>) -> Self {
+        Self(rendering.into())
+    }
+
+    /// The canonical rendering.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Render one checked type into the signature alphabet.
+///
+/// This is deliberately a total function over [`IncanType`] rather than a `Display` implementation: the rendering is
+/// an identity input, so it must change only when the type changes, and keeping it local stops an unrelated
+/// formatting change elsewhere from silently rekeying every declaration in the workspace.
+fn render_type(value: &IncanType) -> String {
+    match value {
+        IncanType::Never => "!".to_string(),
+        IncanType::Primitive(primitive) => format!("{primitive:?}"),
+        IncanType::Named(name) => name.clone(),
+        IncanType::Generic { base, args } => {
+            let rendered = args.iter().map(render_type).collect::<Vec<_>>().join(",");
+            format!("{base}[{rendered}]")
+        }
+        other => format!("{other:?}"),
+    }
+}
+
+/// A declaration identity that is stable across edits.
+///
+/// Equality answers *is this the same declaration* and must survive a comment, a reformat, a reordering, an
+/// insertion above, and a move between files. It deliberately holds no span, no byte offset, and no traversal
+/// counter; see the module documentation for why each is excluded.
+///
+/// This does **not** replace [`CanonicalSymbolId`], which remains correct within one compilation and is what the
+/// compiler resolves references against. The two are joined by construction: a caller resolves with the canonical
+/// identity, then derives this one for anything that has to outlive the compilation.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct StableDeclarationId {
+    /// Which namespace the binding lives in.
+    pub namespace: SymbolNamespace,
+    /// The module, package, crate, or registry owning the declaration.
+    pub origin: SymbolOrigin,
+    /// The spelling at the declaration site.
+    pub declaration_name: String,
+    /// Declaration category.
+    pub kind: SemanticSourceTargetKind,
+    /// Whether the declaration is module-level or nested, without the discriminant's positional value.
+    pub nesting: DeclarationNesting,
+    /// Separates declarations that share every field above, which in practice means overloads.
+    pub signature: Option<DeclarationSignature>,
+}
+
+impl StableDeclarationId {
+    /// Derive a stable identity from the compilation's canonical identity.
+    ///
+    /// The span is dropped and the scope discriminant is reduced to [`DeclarationNesting`]. `signature` separates
+    /// overloads and may be `None` for a declaration that cannot collide — but a caller that has a signature
+    /// available should pass it, because absence is only safe where the declaration kind admits no overloading.
+    pub fn from_canonical(canonical: &CanonicalSymbolId, signature: Option<DeclarationSignature>) -> Self {
+        Self {
+            namespace: canonical.namespace,
+            origin: canonical.origin.clone(),
+            declaration_name: canonical.declaration_name.clone(),
+            kind: canonical.kind.clone(),
+            nesting: match canonical.scope_discriminant {
+                Some(_) => DeclarationNesting::Nested,
+                None => DeclarationNesting::ModuleLevel,
+            },
+            signature,
+        }
+    }
+
+    /// Render a deterministic, span-free spelling for snapshots, digests, and diagnostics.
+    ///
+    /// Unlike [`CanonicalSymbolId::render_compact`] this ends at the signature rather than at `@start..end`, which
+    /// is the whole point: the rendering is safe to persist and to compare across edits.
+    pub fn render_compact(&self) -> String {
+        let origin = match &self.origin {
+            SymbolOrigin::Module(path) => path.join("::"),
+            SymbolOrigin::Package { library, module_path } => {
+                let mut parts = vec![format!("pub::{library}")];
+                parts.extend(module_path.iter().cloned());
+                parts.join("::")
+            }
+            SymbolOrigin::RustCrate(path) => format!("rust::{}", path.join("::")),
+            SymbolOrigin::Builtin => "builtin".to_string(),
+        };
+        let namespace = match self.namespace {
+            SymbolNamespace::OrdinaryLexical => "",
+            SymbolNamespace::Member => "member/",
+            SymbolNamespace::ModulePath => "path/",
+        };
+        let nesting = match self.nesting {
+            DeclarationNesting::ModuleLevel => "",
+            DeclarationNesting::Nested => "#nested",
+        };
+        let signature = self
+            .signature
+            .as_ref()
+            .map(|signature| format!("|{}", signature.as_str()))
+            .unwrap_or_default();
+        format!(
+            "{namespace}{}:{origin}::{}{nesting}{signature}",
+            self.kind.as_str(),
+            self.declaration_name
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::facts::ScopeDiscriminant;
+    use crate::hir::HirSourceSpan;
+    use crate::types::IncanPrimitiveType;
+
+    fn canonical(name: &str, span: (usize, usize), scope: Option<usize>) -> CanonicalSymbolId {
+        CanonicalSymbolId {
+            namespace: SymbolNamespace::OrdinaryLexical,
+            origin: SymbolOrigin::Module(vec!["environ".to_string()]),
+            declaration_name: name.to_string(),
+            kind: SemanticSourceTargetKind::Function,
+            scope_discriminant: scope.map(ScopeDiscriminant),
+            declaration_span: HirSourceSpan::new(span.0, span.1),
+        }
+    }
+
+    /// The defining property: the same declaration at a different offset is the same declaration.
+    #[test]
+    fn identity_survives_a_moved_declaration() {
+        let before = StableDeclarationId::from_canonical(&canonical("read", (100, 200), None), None);
+        let after = StableDeclarationId::from_canonical(&canonical("read", (900, 1000), None), None);
+        assert_eq!(before, after);
+        assert_eq!(before.render_compact(), after.render_compact());
+    }
+
+    /// A scope discriminant is an index into a traversal-ordered table, so its value must not reach identity.
+    /// Its presence must, or a nested binding would collide with a module-level declaration of the same name.
+    #[test]
+    fn nesting_is_recorded_without_its_positional_value() {
+        let first = StableDeclarationId::from_canonical(&canonical("value", (10, 20), Some(2)), None);
+        let renumbered = StableDeclarationId::from_canonical(&canonical("value", (10, 20), Some(97)), None);
+        assert_eq!(first, renumbered, "a renumbered scope is the same declaration");
+
+        let module_level = StableDeclarationId::from_canonical(&canonical("value", (10, 20), None), None);
+        assert_ne!(first, module_level, "a nested binding is not its module-level namesake");
+    }
+
+    /// Dropping the span alone is not sufficient: overloads then collide. This is the case measured in
+    /// `environ.incn`, where `get_as` is declared twice and separated only by `declaration_span`.
+    #[test]
+    fn overloads_collide_without_a_signature_and_separate_with_one() {
+        let one_argument = canonical("get_as", (195, 400), None);
+        let two_arguments = canonical("get_as", (218, 500), None);
+
+        let without = (
+            StableDeclarationId::from_canonical(&one_argument, None),
+            StableDeclarationId::from_canonical(&two_arguments, None),
+        );
+        assert_eq!(without.0, without.1, "without a signature the overloads are indistinguishable");
+
+        let str_type = IncanType::Primitive(IncanPrimitiveType::Str);
+        let result = IncanType::Named("Result".to_string());
+        let with = (
+            StableDeclarationId::from_canonical(
+                &one_argument,
+                Some(DeclarationSignature::from_callable_types([&str_type], &result)),
+            ),
+            StableDeclarationId::from_canonical(
+                &two_arguments,
+                Some(DeclarationSignature::from_callable_types([&str_type, &str_type], &result)),
+            ),
+        );
+        assert_ne!(with.0, with.1, "the signature separates them");
+    }
+
+    /// Renaming a parameter does not produce a different declaration, so names must stay out of the signature.
+    #[test]
+    fn signature_ignores_parameter_names_by_construction() {
+        let str_type = IncanType::Primitive(IncanPrimitiveType::Str);
+        let int_type = IncanType::Primitive(IncanPrimitiveType::Int);
+        let unit = IncanType::Named("None".to_string());
+        let signature = DeclarationSignature::from_callable_types([&str_type, &int_type], &unit);
+        assert!(!signature.as_str().contains("key"), "no parameter name reaches the rendering");
+        assert_eq!(
+            signature,
+            DeclarationSignature::from_callable_types([&str_type, &int_type], &unit),
+            "the rendering is deterministic"
+        );
+    }
+
+    /// A differing parameter type is a differing declaration; a differing return type is too.
+    #[test]
+    fn signature_tracks_types_in_both_positions() {
+        let str_type = IncanType::Primitive(IncanPrimitiveType::Str);
+        let int_type = IncanType::Primitive(IncanPrimitiveType::Int);
+        assert_ne!(
+            DeclarationSignature::from_callable_types([&str_type], &int_type),
+            DeclarationSignature::from_callable_types([&int_type], &int_type)
+        );
+        assert_ne!(
+            DeclarationSignature::from_callable_types([&str_type], &int_type),
+            DeclarationSignature::from_callable_types([&str_type], &str_type)
+        );
+    }
+
+    /// The rendering is persisted and compared across edits, so it must carry no offset at all.
+    #[test]
+    fn rendering_carries_no_offset() {
+        let rendered = StableDeclarationId::from_canonical(&canonical("read", (1234, 5678), None), None).render_compact();
+        assert!(!rendered.contains("1234") && !rendered.contains("5678"), "rendered: {rendered}");
+        assert!(!rendered.contains('@'), "an `@start..end` suffix would defeat the purpose: {rendered}");
+    }
+}

--- a/crates/incan_semantics_core/src/stable_identity.rs
+++ b/crates/incan_semantics_core/src/stable_identity.rs
@@ -14,9 +14,10 @@
 //!
 //! - **The declaration span.** Removing it is necessary and is the obvious part.
 //! - **The signature, which removing the span makes necessary.** Two module-level declarations sharing namespace,
-//!   origin, name, and kind become indistinguishable once the span is gone. Measured across 2,078 checked
-//!   declarations of one standard library, overloads are the only class of collision that arises — and they arise
-//!   reliably, so a signature discriminant is required rather than defensive.
+//!   origin, name, and kind become indistinguishable once the span is gone. Measured across the 1,252 declarations
+//!   one standard library actually declares — imports, aliases, and re-exports share their target's identity by
+//!   design and cannot collide — overloads are the only collision class that arises, and it arises twice. A
+//!   signature discriminant is therefore required rather than defensive.
 //! - **The scope discriminant's value.** [`ScopeDiscriminant`] indexes a module-wide table filled in traversal
 //!   order, so inserting or moving any declaration renumbers every declaration traversed after it and untouched
 //!   siblings appear to change. Only whether a declaration is nested may enter the identity, never where its scope

--- a/crates/incan_semantics_core/src/stable_identity.rs
+++ b/crates/incan_semantics_core/src/stable_identity.rs
@@ -14,14 +14,14 @@
 //!
 //! - **The declaration span.** Removing it is necessary and is the obvious part.
 //! - **The signature, which removing the span makes necessary.** Two module-level declarations sharing namespace,
-//!   origin, name, and kind become indistinguishable once the span is gone. Measured across the 1,252 declarations
-//!   one standard library actually declares — imports, aliases, and re-exports share their target's identity by
-//!   design and cannot collide — overloads are the only collision class that arises, and it arises twice. A
-//!   signature discriminant is therefore required rather than defensive.
-//! - **The scope discriminant's value.** [`ScopeDiscriminant`] indexes a module-wide table filled in traversal
-//!   order, so inserting or moving any declaration renumbers every declaration traversed after it and untouched
-//!   siblings appear to change. Only whether a declaration is nested may enter the identity, never where its scope
-//!   sat in the traversal.
+//!   origin, name, and kind become indistinguishable once the span is gone. Measured across the 1,252 declarations one
+//!   standard library actually declares — imports, aliases, and re-exports share their target's identity by design and
+//!   cannot collide — overloads are the only collision class that arises, and it arises twice. A signature discriminant
+//!   is therefore required rather than defensive.
+//! - **The scope discriminant's value.** [`ScopeDiscriminant`] indexes a module-wide table filled in traversal order,
+//!   so inserting or moving any declaration renumbers every declaration traversed after it and untouched siblings
+//!   appear to change. Only whether a declaration is nested may enter the identity, never where its scope sat in the
+//!   traversal.
 
 use serde::{Deserialize, Serialize};
 
@@ -58,11 +58,7 @@ impl DeclarationSignature {
         parameters: impl IntoIterator<Item = &'a IncanType>,
         return_type: &IncanType,
     ) -> Self {
-        let rendered = parameters
-            .into_iter()
-            .map(render_type)
-            .collect::<Vec<_>>()
-            .join(",");
+        let rendered = parameters.into_iter().map(render_type).collect::<Vec<_>>().join(",");
         Self(format!("({rendered})->{}", render_type(return_type)))
     }
 
@@ -230,7 +226,10 @@ mod tests {
             StableDeclarationId::from_canonical(&one_argument, None),
             StableDeclarationId::from_canonical(&two_arguments, None),
         );
-        assert_eq!(without.0, without.1, "without a signature the overloads are indistinguishable");
+        assert_eq!(
+            without.0, without.1,
+            "without a signature the overloads are indistinguishable"
+        );
 
         let str_type = IncanType::Primitive(IncanPrimitiveType::Str);
         let result = IncanType::Named("Result".to_string());
@@ -241,7 +240,10 @@ mod tests {
             ),
             StableDeclarationId::from_canonical(
                 &two_arguments,
-                Some(DeclarationSignature::from_callable_types([&str_type, &str_type], &result)),
+                Some(DeclarationSignature::from_callable_types(
+                    [&str_type, &str_type],
+                    &result,
+                )),
             ),
         );
         assert_ne!(with.0, with.1, "the signature separates them");
@@ -254,7 +256,10 @@ mod tests {
         let int_type = IncanType::Primitive(IncanPrimitiveType::Int);
         let unit = IncanType::Named("None".to_string());
         let signature = DeclarationSignature::from_callable_types([&str_type, &int_type], &unit);
-        assert!(!signature.as_str().contains("key"), "no parameter name reaches the rendering");
+        assert!(
+            !signature.as_str().contains("key"),
+            "no parameter name reaches the rendering"
+        );
         assert_eq!(
             signature,
             DeclarationSignature::from_callable_types([&str_type, &int_type], &unit),
@@ -280,8 +285,15 @@ mod tests {
     /// The rendering is persisted and compared across edits, so it must carry no offset at all.
     #[test]
     fn rendering_carries_no_offset() {
-        let rendered = StableDeclarationId::from_canonical(&canonical("read", (1234, 5678), None), None).render_compact();
-        assert!(!rendered.contains("1234") && !rendered.contains("5678"), "rendered: {rendered}");
-        assert!(!rendered.contains('@'), "an `@start..end` suffix would defeat the purpose: {rendered}");
+        let rendered =
+            StableDeclarationId::from_canonical(&canonical("read", (1234, 5678), None), None).render_compact();
+        assert!(
+            !rendered.contains("1234") && !rendered.contains("5678"),
+            "rendered: {rendered}"
+        );
+        assert!(
+            !rendered.contains('@'),
+            "an `@start..end` suffix would defeat the purpose: {rendered}"
+        );
     }
 }

--- a/crates/incan_semantics_core/src/types.rs
+++ b/crates/incan_semantics_core/src/types.rs
@@ -61,7 +61,7 @@ pub fn rust_tuple_arity(path: &str) -> Option<usize> {
 }
 
 /// Backend-neutral Incan type universe used by v0.5 middle-end facts.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 pub enum IncanType {
     /// Compiler-internal bottom type used for diverging interop expressions.
     Never,
@@ -192,7 +192,7 @@ fn write_joined_type_args(f: &mut fmt::Formatter<'_>, base: &str, args: &[IncanT
 }
 
 /// Primitive and primitive-like Incan types with compiler-owned semantics.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 pub enum IncanPrimitiveType {
     Int,
     Float,
@@ -222,7 +222,7 @@ impl fmt::Display for IncanPrimitiveType {
 }
 
 /// Callable parameter metadata preserved in semantic function types.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 pub struct IncanCallableParam {
     pub name: Option<String>,
     pub ty: IncanType,
@@ -246,7 +246,7 @@ impl fmt::Display for IncanCallableParam {
 }
 
 /// Source-level parameter shape for semantic callable types.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 pub enum IncanCallableParamKind {
     Normal,
     RestPositional,

--- a/crates/rust_inspect/Cargo.toml
+++ b/crates/rust_inspect/Cargo.toml
@@ -30,6 +30,11 @@ ra_ap_paths = "0.0.325"
 ra_ap_project_model = "0.0.325"
 ra_ap_syntax = "0.0.325"
 ra_ap_vfs = "0.0.325"
+# Token-level Rust parsing for the declaration digest, pinned to the versions the compiler crate already builds so
+# the digest sees the same token model the Rust code generator emits against.
+syn = { version = "2.0", features = ["full", "parsing", "printing"] }
+proc-macro2 = "1.0"
+quote = "1.0"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/rust_inspect/src/digest.rs
+++ b/crates/rust_inspect/src/digest.rs
@@ -1,0 +1,566 @@
+//! Semantic digests for the Rust declarations an Incan build links against.
+//!
+//! A build-identity closure that folds only Incan declarations is not partially correct, it is unsound: a change to
+//! the Rust runtime an Incan component links against produces a cache hit for a change the consumer could not see.
+//! This module closes that gap for Rust source by giving every declaration a digest that moves whenever any token in
+//! it moves.
+//!
+//! # What this is, and what it is not
+//!
+//! This is the token-stream stopgap, chosen deliberately over waiting for body lowering. It over-invalidates inside a
+//! file — reordering a function's local statements moves that function's digest even when the compiled output is
+//! identical — and it under-invalidates nowhere. Over-invalidating costs build time; under-invalidating yields a
+//! wrong binary, so the asymmetry decides the design.
+//!
+//! It is a digest of a *source file's tokens*. It does not resolve names, expand macros, or read anything the file
+//! does not contain. A change reaching this file only through a macro defined elsewhere, through an `include!`, or
+//! through a build script is invisible here and must be covered by digesting those inputs too.
+//!
+//! # Keys
+//!
+//! A digest is only useful next to a stable name for what it digests. [`RustItemDigestKey`] pairs the declaration's
+//! module path, owner, kind, and name with a *signature discriminant*: the digest of the declaration's header. The
+//! discriminant is what stops `Alpha::tail` and `Omega::tail`, or two `#[cfg]`-gated spellings of one function, from
+//! sharing a key. Because the header excludes a trailing brace-delimited body where one exists, an item's key
+//! survives edits to its body, which is what lets a consumer say "this item changed" rather than "an item vanished
+//! and another appeared".
+
+use proc_macro2::{Delimiter, TokenStream, TokenTree};
+use quote::ToTokens;
+use serde::{Deserialize, Serialize};
+use syn::{ForeignItem, ImplItem, Item, ItemForeignMod, ItemImpl, ItemMod, ItemTrait, TraitItem};
+
+use crate::digest_tokens::digest_tokens;
+
+/// Failure modes for Rust declaration digesting.
+#[derive(Debug, thiserror::Error)]
+pub enum RustDigestError {
+    /// The supplied text is not a parseable Rust source file.
+    ///
+    /// Digesting is all-or-nothing per file on purpose. A partial digest of a file that failed to parse would look
+    /// like a complete one to a consumer and would silently hide whatever followed the syntax error.
+    #[error("failed to parse Rust source for digesting: {message}")]
+    Parse {
+        /// The parser's message, without position information.
+        message: String,
+    },
+}
+
+/// The kind of Rust declaration a digest describes.
+///
+/// The kind is part of the key because Rust keeps types and values in separate namespaces, so `struct Handle` and
+/// `fn Handle` can coexist in one module and must not share an entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum RustDigestItemKind {
+    /// A free, associated, trait, or `extern` block function.
+    Function,
+    /// A `struct` declaration.
+    Struct,
+    /// An `enum` declaration.
+    Enum,
+    /// A `union` declaration.
+    Union,
+    /// A `type` alias, including an associated type in a trait or `impl`.
+    TypeAlias,
+    /// A `const` item, including an associated constant.
+    Const,
+    /// A `static` item, including one declared in an `extern` block.
+    Static,
+    /// A `trait` declaration's header; its associated items get their own entries.
+    Trait,
+    /// A `trait` alias.
+    TraitAlias,
+    /// An `impl` block's header; its associated items get their own entries.
+    Impl,
+    /// A module's header and inner attributes; its items get their own entries.
+    Module,
+    /// A `use` declaration.
+    Use,
+    /// A macro definition or an item-position macro invocation.
+    Macro,
+    /// An `extern crate` declaration.
+    ExternCrate,
+    /// An `extern` block's header; its items get their own entries.
+    ForeignBlock,
+    /// A declaration this crate does not model individually, digested as raw tokens.
+    Verbatim,
+}
+
+/// A stable identity for one Rust declaration.
+///
+/// Ordering is defined so a whole file's entries can be compared as a sorted sequence, which is what makes reordering
+/// declarations in a file a no-op for the digest set.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct RustItemDigestKey {
+    /// The module path containing this declaration, as supplied by the caller and extended by inline `mod` blocks.
+    pub module_path: String,
+    /// The `impl`, `trait`, or `extern` block owning this declaration, rendered from tokens; `None` at module level.
+    pub owner: Option<String>,
+    /// Which kind of declaration this is.
+    pub kind: RustDigestItemKind,
+    /// The declaration's name, or a rendered stand-in for the declarations that have none.
+    pub name: String,
+    /// Digest of the declaration's header, distinguishing same-named declarations that differ before their body.
+    pub signature_discriminant: String,
+}
+
+impl RustItemDigestKey {
+    /// Render the key as one line, for diagnostics and for use as a map key.
+    ///
+    /// The rendering is lossless with respect to the key's fields, so two keys render identically only when they are
+    /// equal.
+    pub fn render(&self) -> String {
+        let owner = self.owner.as_deref().unwrap_or("");
+        format!(
+            "{}|{}|{:?}|{}|{}",
+            self.module_path, owner, self.kind, self.name, self.signature_discriminant
+        )
+    }
+}
+
+/// One Rust declaration's identity and semantic digest.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RustItemDigest {
+    /// Stable identity for this declaration.
+    pub key: RustItemDigestKey,
+    /// Lowercase hexadecimal SHA-256 over the declaration's tokens, doc attributes excluded.
+    pub digest: String,
+}
+
+/// Every declaration digest extracted from one Rust source file.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RustSourceDigest {
+    items: Vec<RustItemDigest>,
+}
+
+impl RustSourceDigest {
+    /// All declarations, in a deterministic order that does not depend on their order in the source file.
+    pub fn items(&self) -> &[RustItemDigest] {
+        &self.items
+    }
+
+    /// Take ownership of the declarations.
+    pub fn into_items(self) -> Vec<RustItemDigest> {
+        self.items
+    }
+
+    /// Find the declarations matching an identity, ignoring only the signature discriminant.
+    ///
+    /// Callers look declarations up by the part of the key that survives an edit, so a signature change reads as "the
+    /// same declaration, different digest" rather than as a removal plus an addition. The kind is part of the lookup
+    /// because a type and its `impl` block legitimately share a name; more than one match after that means the name
+    /// is genuinely repeated, as `#[cfg]`-gated spellings of one declaration are, and the caller decides what that
+    /// means.
+    pub fn find(
+        &self,
+        module_path: &str,
+        owner: Option<&str>,
+        kind: RustDigestItemKind,
+        name: &str,
+    ) -> Vec<&RustItemDigest> {
+        self.items
+            .iter()
+            .filter(|item| {
+                item.key.module_path == module_path
+                    && item.key.owner.as_deref() == owner
+                    && item.key.kind == kind
+                    && item.key.name == name
+            })
+            .collect()
+    }
+}
+
+/// Digest every declaration in one Rust source file.
+///
+/// `module_path` names the module the file *is*, for example `incan_stdlib::runtime`; it seeds the module path of
+/// every declaration and is not otherwise interpreted. Inline `mod` blocks extend it.
+///
+/// The file itself contributes a [`RustDigestItemKind::Module`] entry carrying its inner attributes, so a change to
+/// `#![no_std]` or `#![feature(…)]` is visible even though it belongs to no declaration.
+pub fn digest_rust_source(module_path: &str, source: &str) -> Result<RustSourceDigest, RustDigestError> {
+    let file = syn::parse_file(source).map_err(|error| RustDigestError::Parse {
+        message: error.to_string(),
+    })?;
+    let mut walker = DigestWalker::default();
+    walker.walk_file(module_path, &file);
+    let mut items = walker.items;
+    items.sort_by(|left, right| left.key.cmp(&right.key));
+    Ok(RustSourceDigest { items })
+}
+
+/// Accumulator threaded through the declaration walk.
+#[derive(Default)]
+struct DigestWalker {
+    items: Vec<RustItemDigest>,
+}
+
+impl DigestWalker {
+    /// Record one declaration's key and digest.
+    fn record(
+        &mut self,
+        module_path: &str,
+        owner: Option<&str>,
+        kind: RustDigestItemKind,
+        name: impl Into<String>,
+        tokens: TokenStream,
+    ) {
+        let header = header_tokens(&tokens);
+        self.items.push(RustItemDigest {
+            key: RustItemDigestKey {
+                module_path: module_path.to_string(),
+                owner: owner.map(str::to_string),
+                kind,
+                name: name.into(),
+                signature_discriminant: digest_tokens(header),
+            },
+            digest: digest_tokens(tokens),
+        });
+    }
+
+    /// Walk a parsed file, recording its inner attributes as a module entry before descending into its items.
+    fn walk_file(&mut self, module_path: &str, file: &syn::File) {
+        let (parent, name) = split_module_path(module_path);
+        let mut attrs = TokenStream::new();
+        for attr in &file.attrs {
+            attr.to_tokens(&mut attrs);
+        }
+        self.record(parent, None, RustDigestItemKind::Module, name, attrs);
+        self.walk_items(module_path, &file.items);
+    }
+
+    /// Walk the items of one module scope.
+    fn walk_items(&mut self, module_path: &str, items: &[Item]) {
+        for item in items {
+            self.walk_item(module_path, item);
+        }
+    }
+
+    /// Record one module-level item, descending into the scopes that contain further declarations.
+    ///
+    /// `Item` is `#[non_exhaustive]`, so an unrecognized future variant falls back to a verbatim token digest rather
+    /// than being dropped; dropping it would be the under-invalidation this module exists to avoid.
+    fn walk_item(&mut self, module_path: &str, item: &Item) {
+        use RustDigestItemKind as Kind;
+        match item {
+            Item::Fn(item) => self.record(
+                module_path,
+                None,
+                Kind::Function,
+                item.sig.ident.to_string(),
+                item.to_token_stream(),
+            ),
+            Item::Struct(item) => self.record(
+                module_path,
+                None,
+                Kind::Struct,
+                item.ident.to_string(),
+                item.to_token_stream(),
+            ),
+            Item::Enum(item) => self.record(
+                module_path,
+                None,
+                Kind::Enum,
+                item.ident.to_string(),
+                item.to_token_stream(),
+            ),
+            Item::Union(item) => self.record(
+                module_path,
+                None,
+                Kind::Union,
+                item.ident.to_string(),
+                item.to_token_stream(),
+            ),
+            Item::Type(item) => self.record(
+                module_path,
+                None,
+                Kind::TypeAlias,
+                item.ident.to_string(),
+                item.to_token_stream(),
+            ),
+            Item::Const(item) => self.record(
+                module_path,
+                None,
+                Kind::Const,
+                item.ident.to_string(),
+                item.to_token_stream(),
+            ),
+            Item::Static(item) => self.record(
+                module_path,
+                None,
+                Kind::Static,
+                item.ident.to_string(),
+                item.to_token_stream(),
+            ),
+            Item::TraitAlias(item) => self.record(
+                module_path,
+                None,
+                Kind::TraitAlias,
+                item.ident.to_string(),
+                item.to_token_stream(),
+            ),
+            Item::ExternCrate(item) => self.record(
+                module_path,
+                None,
+                Kind::ExternCrate,
+                item.ident.to_string(),
+                item.to_token_stream(),
+            ),
+            Item::Use(item) => self.record(module_path, None, Kind::Use, "use", item.to_token_stream()),
+            Item::Macro(item) => {
+                let name = item
+                    .ident
+                    .as_ref()
+                    .map_or_else(|| render_tokens(&item.mac.path), ToString::to_string);
+                self.record(module_path, None, Kind::Macro, name, item.to_token_stream());
+            }
+            Item::Mod(item) => self.walk_module(module_path, item),
+            Item::Trait(item) => self.walk_trait(module_path, item),
+            Item::Impl(item) => self.walk_impl(module_path, item),
+            Item::ForeignMod(item) => self.walk_foreign_mod(module_path, item),
+            other => self.record(module_path, None, Kind::Verbatim, "", other.to_token_stream()),
+        }
+    }
+
+    /// Record a module's header and inner attributes, then descend into its items.
+    ///
+    /// The module's own entry deliberately excludes its items: they are recorded individually, and folding them in
+    /// twice would make every entry in a file move whenever any one of them did.
+    fn walk_module(&mut self, module_path: &str, item: &ItemMod) {
+        let name = item.ident.to_string();
+        let mut shell = item.clone();
+        shell.content = shell.content.map(|(brace, _)| (brace, Vec::new()));
+        self.record(
+            module_path,
+            None,
+            RustDigestItemKind::Module,
+            name.clone(),
+            shell.to_token_stream(),
+        );
+        if let Some((_, items)) = &item.content {
+            self.walk_items(&join_module_path(module_path, &name), items);
+        }
+    }
+
+    /// Record a trait's header, then each of its associated items under the trait as owner.
+    fn walk_trait(&mut self, module_path: &str, item: &ItemTrait) {
+        let name = item.ident.to_string();
+        let mut shell = item.clone();
+        shell.items = Vec::new();
+        self.record(
+            module_path,
+            None,
+            RustDigestItemKind::Trait,
+            name.clone(),
+            shell.to_token_stream(),
+        );
+        for assoc in &item.items {
+            self.walk_trait_item(module_path, &name, assoc);
+        }
+    }
+
+    /// Record one associated item of a trait.
+    fn walk_trait_item(&mut self, module_path: &str, owner: &str, item: &TraitItem) {
+        use RustDigestItemKind as Kind;
+        let owner = Some(owner);
+        match item {
+            TraitItem::Fn(item) => self.record(
+                module_path,
+                owner,
+                Kind::Function,
+                item.sig.ident.to_string(),
+                item.to_token_stream(),
+            ),
+            TraitItem::Const(item) => self.record(
+                module_path,
+                owner,
+                Kind::Const,
+                item.ident.to_string(),
+                item.to_token_stream(),
+            ),
+            TraitItem::Type(item) => self.record(
+                module_path,
+                owner,
+                Kind::TypeAlias,
+                item.ident.to_string(),
+                item.to_token_stream(),
+            ),
+            TraitItem::Macro(item) => self.record(
+                module_path,
+                owner,
+                Kind::Macro,
+                render_tokens(&item.mac.path),
+                item.to_token_stream(),
+            ),
+            other => self.record(module_path, owner, Kind::Verbatim, "", other.to_token_stream()),
+        }
+    }
+
+    /// Record an `impl` block's header, then each of its associated items under the impl target as owner.
+    fn walk_impl(&mut self, module_path: &str, item: &ItemImpl) {
+        let owner = impl_owner(item);
+        let mut shell = item.clone();
+        shell.items = Vec::new();
+        self.record(
+            module_path,
+            None,
+            RustDigestItemKind::Impl,
+            owner.clone(),
+            shell.to_token_stream(),
+        );
+        for assoc in &item.items {
+            self.walk_impl_item(module_path, &owner, assoc);
+        }
+    }
+
+    /// Record one associated item of an `impl` block.
+    fn walk_impl_item(&mut self, module_path: &str, owner: &str, item: &ImplItem) {
+        use RustDigestItemKind as Kind;
+        let owner = Some(owner);
+        match item {
+            ImplItem::Fn(item) => self.record(
+                module_path,
+                owner,
+                Kind::Function,
+                item.sig.ident.to_string(),
+                item.to_token_stream(),
+            ),
+            ImplItem::Const(item) => self.record(
+                module_path,
+                owner,
+                Kind::Const,
+                item.ident.to_string(),
+                item.to_token_stream(),
+            ),
+            ImplItem::Type(item) => self.record(
+                module_path,
+                owner,
+                Kind::TypeAlias,
+                item.ident.to_string(),
+                item.to_token_stream(),
+            ),
+            ImplItem::Macro(item) => self.record(
+                module_path,
+                owner,
+                Kind::Macro,
+                render_tokens(&item.mac.path),
+                item.to_token_stream(),
+            ),
+            other => self.record(module_path, owner, Kind::Verbatim, "", other.to_token_stream()),
+        }
+    }
+
+    /// Record an `extern` block's header, then each of its declarations under that block as owner.
+    fn walk_foreign_mod(&mut self, module_path: &str, item: &ItemForeignMod) {
+        let owner = render_tokens(&item.abi);
+        let mut shell = item.clone();
+        shell.items = Vec::new();
+        self.record(
+            module_path,
+            None,
+            RustDigestItemKind::ForeignBlock,
+            owner.clone(),
+            shell.to_token_stream(),
+        );
+        for foreign in &item.items {
+            self.walk_foreign_item(module_path, &owner, foreign);
+        }
+    }
+
+    /// Record one declaration inside an `extern` block.
+    fn walk_foreign_item(&mut self, module_path: &str, owner: &str, item: &ForeignItem) {
+        use RustDigestItemKind as Kind;
+        let owner = Some(owner);
+        match item {
+            ForeignItem::Fn(item) => self.record(
+                module_path,
+                owner,
+                Kind::Function,
+                item.sig.ident.to_string(),
+                item.to_token_stream(),
+            ),
+            ForeignItem::Static(item) => self.record(
+                module_path,
+                owner,
+                Kind::Static,
+                item.ident.to_string(),
+                item.to_token_stream(),
+            ),
+            ForeignItem::Type(item) => self.record(
+                module_path,
+                owner,
+                Kind::TypeAlias,
+                item.ident.to_string(),
+                item.to_token_stream(),
+            ),
+            ForeignItem::Macro(item) => self.record(
+                module_path,
+                owner,
+                Kind::Macro,
+                render_tokens(&item.mac.path),
+                item.to_token_stream(),
+            ),
+            other => self.record(module_path, owner, Kind::Verbatim, "", other.to_token_stream()),
+        }
+    }
+}
+
+/// Split a declaration's header from its brace-delimited body.
+///
+/// Functions, named structs, enums, unions, traits, `impl` blocks, and inline modules all end in a braced body, so
+/// dropping the final brace group leaves exactly the header a reader would call the declaration's signature. Items
+/// that end in `;` instead — constants, statics, aliases, tuple structs, `use` — have no body to separate, so their
+/// header is the whole item and their key moves when their value does. That is over-invalidation, and for a constant
+/// it is arguably the truth: its value is part of what callers compile against.
+fn header_tokens(tokens: &TokenStream) -> TokenStream {
+    let trees: Vec<TokenTree> = tokens.clone().into_iter().collect();
+    match trees.last() {
+        Some(TokenTree::Group(group)) if group.delimiter() == Delimiter::Brace => {
+            trees.iter().take(trees.len() - 1).cloned().collect()
+        }
+        _ => tokens.clone(),
+    }
+}
+
+/// Render an `impl` block's target as the owner string its associated items are keyed under.
+///
+/// A trait implementation renders as `<SelfType as Trait>` so that inherent and trait methods of the same name stay
+/// distinct, and so that two traits contributing the same method name to one type do too. A negative implementation
+/// keeps its `!`, because `impl !Send for X` and `impl Send for X` are different facts.
+fn impl_owner(item: &ItemImpl) -> String {
+    let self_ty = render_tokens(&item.self_ty);
+    match &item.trait_ {
+        Some((negation, path, _)) => {
+            let negation = if negation.is_some() { "!" } else { "" };
+            format!("<{self_ty} as {negation}{}>", render_tokens(path))
+        }
+        None => self_ty,
+    }
+}
+
+/// Render syntax as its token text, for the parts of a key that must read back to a human.
+///
+/// Rendering goes through tokens rather than source text so that `Vec<T>` and `Vec < T >` produce the same owner, in
+/// keeping with the rest of the digest. This feeds keys only, never digests, so its exact spelling is a readability
+/// concern rather than a correctness one.
+fn render_tokens(value: &impl ToTokens) -> String {
+    value.to_token_stream().to_string()
+}
+
+/// Split a module path into its parent path and its own final segment.
+fn split_module_path(module_path: &str) -> (&str, &str) {
+    module_path.rsplit_once("::").unwrap_or(("", module_path))
+}
+
+/// Join a parent module path with a child segment, tolerating an empty parent.
+fn join_module_path(parent: &str, child: &str) -> String {
+    if parent.is_empty() {
+        child.to_string()
+    } else {
+        format!("{parent}::{child}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    include!("digest/tests.rs");
+}

--- a/crates/rust_inspect/src/digest/tests.rs
+++ b/crates/rust_inspect/src/digest/tests.rs
@@ -1,0 +1,577 @@
+use std::collections::BTreeMap;
+use std::error::Error;
+
+use super::*;
+
+/// Module path every fixture in this file is digested under.
+const MODULE: &str = "probe";
+
+/// The baseline fixture every invariant is measured against.
+///
+/// Its shape is deliberate rather than incidental. Each declaration an invariant edits has at least one further
+/// declaration positioned *after* it — `Omega` and its `impl` come last and are never the edit target — because
+/// positional leakage only contaminates what a parser reaches later. A fixture whose edit sits at the end cannot
+/// detect a span reaching the digest, and would report a passing invariant it never exercised.
+const BASE: &str = r#"#![allow(dead_code)]
+
+pub struct Alpha {
+    pub left: u8,
+}
+
+pub fn middle(value: u8) -> u8 {
+    value + 1
+}
+
+pub struct Omega {
+    pub right: u8,
+}
+
+impl Omega {
+    pub fn tail(&self) -> u8 {
+        self.right
+    }
+}
+"#;
+
+/// Digest a fixture into a rendered-key to digest map.
+///
+/// A repeated rendered key is reported as an error rather than silently overwritten, so every fixture in this file
+/// doubles as a check that distinct declarations receive distinct keys.
+fn digest_map(source: &str) -> Result<BTreeMap<String, String>, Box<dyn Error>> {
+    let digest = digest_rust_source(MODULE, source)?;
+    let mut map = BTreeMap::new();
+    for item in digest.items() {
+        if map.insert(item.key.render(), item.digest.clone()).is_some() {
+            return Err(format!("two declarations share the key `{}`", item.key.render()).into());
+        }
+    }
+    Ok(map)
+}
+
+/// Digest a fixture into a rendered-key to digest map, omitting declarations with the named identifiers.
+///
+/// Invariants that expect one declaration to move use this for everything else, so "other items unchanged" is
+/// checked against complete keys and not only against digests.
+fn digest_map_excluding(source: &str, excluded: &[&str]) -> Result<BTreeMap<String, String>, Box<dyn Error>> {
+    let mut map = digest_map(source)?;
+    map.retain(|key, _| !excluded.iter().any(|name| key.contains(&format!("|{name}|"))));
+    Ok(map)
+}
+
+/// Return the single declaration matching an identity, failing when the fixture is ambiguous.
+fn single<'a>(
+    digest: &'a RustSourceDigest,
+    owner: Option<&str>,
+    kind: RustDigestItemKind,
+    name: &str,
+) -> Result<&'a RustItemDigest, Box<dyn Error>> {
+    match digest.find(MODULE, owner, kind, name).as_slice() {
+        [only] => Ok(only),
+        found => Err(format!("expected exactly one `{name}` {kind:?}, found {}", found.len()).into()),
+    }
+}
+
+/// Return the single declaration matching an identity in a freshly digested fixture.
+fn single_of(
+    source: &str,
+    owner: Option<&str>,
+    kind: RustDigestItemKind,
+    name: &str,
+) -> Result<RustItemDigest, Box<dyn Error>> {
+    let digest = digest_rust_source(MODULE, source)?;
+    Ok(single(&digest, owner, kind, name)?.clone())
+}
+
+/// Adding or removing `///` and `//!` documentation must move nothing.
+///
+/// Doc comments lex to `#[doc]` and `#![doc]` attributes, so they survive tokenization and have to be excluded
+/// explicitly. The fixture documents an item, a struct field, a crate root, and an `impl` method, each with further
+/// declarations after it.
+#[test]
+fn doc_comments_do_not_move_any_digest() -> Result<(), Box<dyn Error>> {
+    let documented = r#"#![allow(dead_code)]
+//! Crate prose that no compiled output depends on.
+
+/// Alpha carries the left byte.
+pub struct Alpha {
+    /// The left byte itself.
+    pub left: u8,
+}
+
+/// Middle adds one.
+///
+/// A second paragraph, to make the attribute count differ as well as its content.
+pub fn middle(value: u8) -> u8 {
+    value + 1
+}
+
+pub struct Omega {
+    pub right: u8,
+}
+
+impl Omega {
+    /// Tail reads the right byte.
+    pub fn tail(&self) -> u8 {
+        self.right
+    }
+}
+"#;
+
+    assert_eq!(
+        digest_map(documented)?,
+        digest_map(BASE)?,
+        "documentation cannot change compiled output and must not reach any digest"
+    );
+    Ok(())
+}
+
+/// Documentation must be stripped at any nesting depth, not only on top-level declarations.
+///
+/// A doc comment on an item declared inside a function body is the case an attribute walker over the item AST
+/// misses, because it never descends into bodies. Stripping at the token level has no depth to miss.
+#[test]
+fn doc_comments_are_stripped_at_any_nesting_depth() -> Result<(), Box<dyn Error>> {
+    let plain = r#"pub fn holder() -> u8 {
+    struct Inner;
+    let _ = Inner;
+    1
+}
+
+pub struct After;
+"#;
+    let documented = r#"pub fn holder() -> u8 {
+    /// Documentation on an item nested inside a function body.
+    struct Inner;
+    let _ = Inner;
+    1
+}
+
+pub struct After;
+"#;
+
+    assert_eq!(
+        digest_map(documented)?,
+        digest_map(plain)?,
+        "doc attributes nested inside a function body must be stripped too"
+    );
+    Ok(())
+}
+
+/// Adding or removing `//` and `/* */` comments must move nothing.
+///
+/// The tokenizer drops comments before this crate sees them, so this invariant documents a property rather than
+/// guarding an implementation choice. It still earns its place: it would fail immediately if the digest were ever
+/// rebuilt over source text instead of tokens.
+#[test]
+fn line_comments_do_not_move_any_digest() -> Result<(), Box<dyn Error>> {
+    let commented = r#"#![allow(dead_code)]
+// A remark before anything is declared.
+
+pub struct Alpha {
+    // Inside the struct body.
+    pub left: u8,
+}
+
+pub fn middle(value: u8) -> u8 {
+    // Inside a function body, ahead of the expression that matters.
+    value + 1 // and after it
+}
+
+/* a block comment between two declarations */
+
+pub struct Omega {
+    pub right: u8,
+}
+
+impl Omega {
+    pub fn tail(&self) -> u8 {
+        self.right
+    }
+}
+"#;
+
+    assert_eq!(
+        digest_map(commented)?,
+        digest_map(BASE)?,
+        "comments never reach a token stream and must not reach any digest"
+    );
+    Ok(())
+}
+
+/// Reformatting must move nothing.
+///
+/// Collapsing the fixture onto one line changes every line number and byte offset in the file while leaving the
+/// token sequence intact, which is the strongest cheap evidence that no span reaches a digest.
+#[test]
+fn reformatting_does_not_move_any_digest() -> Result<(), Box<dyn Error>> {
+    let reformatted = concat!(
+        "#![allow(dead_code)] pub struct Alpha { pub left : u8 , } ",
+        "pub fn middle ( value : u8 ) -> u8 { value + 1 } ",
+        "pub struct Omega { pub right : u8 , } ",
+        "impl Omega { pub fn tail ( & self ) -> u8 { self . right } }",
+    );
+
+    assert_eq!(
+        digest_map(reformatted)?,
+        digest_map(BASE)?,
+        "whitespace and line breaks must not reach any digest"
+    );
+    Ok(())
+}
+
+/// Reordering two declarations must move nothing.
+///
+/// `Alpha` and `middle` swap places while `Omega` and its `impl` stay put behind them, so any positional
+/// contribution to the digest would show up in the two declarations that were never touched.
+#[test]
+fn reordering_declarations_does_not_move_any_digest() -> Result<(), Box<dyn Error>> {
+    let reordered = r#"#![allow(dead_code)]
+
+pub fn middle(value: u8) -> u8 {
+    value + 1
+}
+
+pub struct Alpha {
+    pub left: u8,
+}
+
+pub struct Omega {
+    pub right: u8,
+}
+
+impl Omega {
+    pub fn tail(&self) -> u8 {
+        self.right
+    }
+}
+"#;
+
+    assert_eq!(
+        digest_map(reordered)?,
+        digest_map(BASE)?,
+        "a declaration's position in its file must not reach any digest"
+    );
+    Ok(())
+}
+
+/// Inserting a declaration in the middle of a file must add one entry and disturb no other.
+///
+/// The insertion goes between `middle` and `Omega` rather than at the end, so the two declarations that follow it
+/// are pushed to new lines. An insertion appended at the end would move nothing and would prove nothing.
+#[test]
+fn inserting_a_declaration_in_the_middle_leaves_every_other_digest_unchanged() -> Result<(), Box<dyn Error>> {
+    let inserted = r#"#![allow(dead_code)]
+
+pub struct Alpha {
+    pub left: u8,
+}
+
+pub fn middle(value: u8) -> u8 {
+    value + 1
+}
+
+pub const INSERTED: u8 = 7;
+
+pub struct Omega {
+    pub right: u8,
+}
+
+impl Omega {
+    pub fn tail(&self) -> u8 {
+        self.right
+    }
+}
+"#;
+
+    let before = digest_map(BASE)?;
+    let after = digest_map(inserted)?;
+
+    for (key, digest) in &before {
+        assert_eq!(
+            after.get(key),
+            Some(digest),
+            "inserting a declaration must not move `{key}`"
+        );
+    }
+    let added: Vec<&String> = after.keys().filter(|key| !before.contains_key(*key)).collect();
+    assert_eq!(added.len(), 1, "expected exactly one new entry, got {added:?}");
+    assert!(
+        added.iter().any(|key| key.contains("|INSERTED|")),
+        "the new entry should be the inserted constant, got {added:?}"
+    );
+    Ok(())
+}
+
+/// Changing a function body must move that function's digest and nothing else, keeping its key intact.
+///
+/// The key has to survive a body change: a consumer needs to read this as "the same declaration, different digest"
+/// rather than as a removal plus an addition.
+#[test]
+fn changing_a_function_body_moves_only_that_function() -> Result<(), Box<dyn Error>> {
+    let changed = BASE.replace("value + 1", "value + 2");
+
+    let before = single_of(BASE, None, RustDigestItemKind::Function, "middle")?;
+    let after = single_of(&changed, None, RustDigestItemKind::Function, "middle")?;
+
+    assert_ne!(
+        before.digest, after.digest,
+        "a body change must move the declaration's digest"
+    );
+    assert_eq!(
+        before.key, after.key,
+        "a body change must leave the declaration's key intact"
+    );
+    assert_eq!(
+        digest_map_excluding(&changed, &["middle"])?,
+        digest_map_excluding(BASE, &["middle"])?,
+        "a body change must not move any other declaration"
+    );
+    Ok(())
+}
+
+/// Changing an associated function's body must leave its `impl` block's own entry alone.
+///
+/// The `impl` header entry exists so that a change to the block's generics or trait reference is visible; it must
+/// not also absorb every method body, or every method in a block would appear to change together.
+#[test]
+fn changing_an_associated_function_body_leaves_the_impl_header_untouched() -> Result<(), Box<dyn Error>> {
+    let changed = BASE.replace("self.right\n", "self.right.wrapping_add(0)\n");
+
+    let before = single_of(BASE, Some("Omega"), RustDigestItemKind::Function, "tail")?;
+    let after = single_of(&changed, Some("Omega"), RustDigestItemKind::Function, "tail")?;
+    assert_ne!(before.digest, after.digest, "the method's digest must move");
+    assert_eq!(before.key, after.key, "the method's key must survive a body change");
+
+    let header_before = single_of(BASE, None, RustDigestItemKind::Impl, "Omega")?;
+    let header_after = single_of(&changed, None, RustDigestItemKind::Impl, "Omega")?;
+    assert_eq!(
+        header_before, header_after,
+        "the impl header entry must not absorb its methods' bodies"
+    );
+    Ok(())
+}
+
+/// Changing a struct's fields must move that struct's digest while keeping its key intact.
+///
+/// A named struct's braced field list is its body for keying purposes, so the key survives while the digest moves.
+#[test]
+fn changing_a_struct_field_moves_only_that_struct() -> Result<(), Box<dyn Error>> {
+    let changed = BASE.replace("pub left: u8", "pub left: u16");
+
+    let before = single_of(BASE, None, RustDigestItemKind::Struct, "Alpha")?;
+    let after = single_of(&changed, None, RustDigestItemKind::Struct, "Alpha")?;
+
+    assert_ne!(before.digest, after.digest, "a field type change must move the digest");
+    assert_eq!(before.key, after.key, "a field type change must leave the key intact");
+    assert_eq!(
+        digest_map_excluding(&changed, &["Alpha"])?,
+        digest_map_excluding(BASE, &["Alpha"])?,
+        "a field type change must not move any other declaration"
+    );
+    Ok(())
+}
+
+/// Changing a function signature must move its digest and its discriminant, and nothing else.
+///
+/// Unlike a body change, the signature discriminant is expected to move here; the stable part of the key must not,
+/// so the declaration remains findable.
+#[test]
+fn changing_a_function_signature_moves_only_that_function() -> Result<(), Box<dyn Error>> {
+    let changed = BASE.replace("pub fn middle(value: u8)", "pub fn middle(value: u8, extra: u8)");
+
+    let before = single_of(BASE, None, RustDigestItemKind::Function, "middle")?;
+    let after = single_of(&changed, None, RustDigestItemKind::Function, "middle")?;
+
+    assert_ne!(
+        before.digest, after.digest,
+        "a signature change must move the declaration's digest"
+    );
+    assert_ne!(
+        before.key.signature_discriminant, after.key.signature_discriminant,
+        "a signature change must move the discriminant that distinguishes same-named declarations"
+    );
+    assert_eq!(
+        (
+            &before.key.module_path,
+            &before.key.owner,
+            before.key.kind,
+            &before.key.name
+        ),
+        (
+            &after.key.module_path,
+            &after.key.owner,
+            after.key.kind,
+            &after.key.name
+        ),
+        "a signature change must leave the findable part of the key intact"
+    );
+    assert_eq!(
+        digest_map_excluding(&changed, &["middle"])?,
+        digest_map_excluding(BASE, &["middle"])?,
+        "a signature change must not move any other declaration"
+    );
+    Ok(())
+}
+
+/// Same-named methods on different owners must receive distinct keys and distinct digests.
+///
+/// Rust has no free-function overloading, but method names collide constantly across `impl` blocks, and an inherent
+/// method and a trait method of one type collide on the same type. Without an owner in the key these would share an
+/// entry and one would silently mask the other.
+#[test]
+fn same_named_methods_on_different_owners_stay_distinct() -> Result<(), Box<dyn Error>> {
+    let source = r#"pub struct Alpha;
+pub struct Omega;
+
+pub trait Tailed {
+    fn tail(&self) -> u8;
+}
+
+impl Alpha {
+    pub fn tail(&self) -> u8 {
+        1
+    }
+}
+
+impl Tailed for Alpha {
+    fn tail(&self) -> u8 {
+        2
+    }
+}
+
+impl Omega {
+    pub fn tail(&self) -> u8 {
+        3
+    }
+}
+
+pub struct After;
+"#;
+
+    let digest = digest_rust_source(MODULE, source)?;
+    let inherent = single(&digest, Some("Alpha"), RustDigestItemKind::Function, "tail")?;
+    let via_trait = single(&digest, Some("<Alpha as Tailed>"), RustDigestItemKind::Function, "tail")?;
+    let other_owner = single(&digest, Some("Omega"), RustDigestItemKind::Function, "tail")?;
+
+    let digests = [&inherent.digest, &via_trait.digest, &other_owner.digest];
+    let unique: BTreeMap<&String, ()> = digests.iter().map(|digest| (*digest, ())).collect();
+    assert_eq!(unique.len(), 3, "three distinct method bodies must produce three digests");
+    Ok(())
+}
+
+/// A module's inner attributes must reach its digest.
+///
+/// `#![deny(…)]`, `#![no_std]`, and `#![feature(…)]` change compiled output while belonging to no declaration. If
+/// the crate-root entry did not carry them, editing one would be invisible, which is the under-invalidation this
+/// module exists to prevent.
+#[test]
+fn inner_attributes_reach_the_module_digest() -> Result<(), Box<dyn Error>> {
+    let changed = BASE.replace("#![allow(dead_code)]", "#![deny(dead_code)]");
+
+    let before = digest_rust_source(MODULE, BASE)?;
+    let after = digest_rust_source(MODULE, &changed)?;
+    let root_before = before
+        .find("", None, RustDigestItemKind::Module, MODULE)
+        .first()
+        .map(|item| item.digest.clone())
+        .ok_or("expected a crate-root module entry")?;
+    let root_after = after
+        .find("", None, RustDigestItemKind::Module, MODULE)
+        .first()
+        .map(|item| item.digest.clone())
+        .ok_or("expected a crate-root module entry")?;
+
+    assert_ne!(
+        root_before, root_after,
+        "a non-doc inner attribute change must move the module digest"
+    );
+    assert_eq!(
+        digest_map_excluding(&changed, &[MODULE])?,
+        digest_map_excluding(BASE, &[MODULE])?,
+        "an inner attribute change must not move any declaration"
+    );
+    Ok(())
+}
+
+/// Punctuation spacing must follow meaning, not layout.
+///
+/// Spacing is the only thing separating `a && b`, a conjunction, from `a & &b`, a bitwise `and` against a
+/// reference, so it cannot be discarded without under-invalidating. It also cannot be taken from the lexer, which
+/// would make `&&u8` and `& &u8` — one type, two layouts — digest differently. Both halves hold here because the
+/// digest runs over the stream `syn` re-emits from the parsed item, and that round trip normalizes spacing onto
+/// meaning rather than onto how the author typed it. Both halves are asserted, because an implementation that
+/// hashed the lexed stream instead would still satisfy the second one alone.
+#[test]
+fn punctuation_spacing_follows_meaning_not_layout() -> Result<(), Box<dyn Error>> {
+    // ---- Layout: one type, written two ways ----
+    let tight = "pub fn probe(x: &&u8) -> u8 {\n    **x\n}\n\npub struct After;\n";
+    let loose = "pub fn probe(x: & &u8) -> u8 {\n    **x\n}\n\npub struct After;\n";
+    assert_eq!(
+        digest_map(tight)?,
+        digest_map(loose)?,
+        "a double reference must digest the same however its ampersands are spaced"
+    );
+
+    // ---- Meaning: two operations, separated by nothing but spacing ----
+    let conjunction = "pub fn probe(a: bool, b: bool) -> bool {\n    a && b\n}\n\npub struct After;\n";
+    let bitand_ref = "pub fn probe(a: bool, b: bool) -> bool {\n    a & &b\n}\n\npub struct After;\n";
+    assert_ne!(
+        single_of(conjunction, None, RustDigestItemKind::Function, "probe")?.digest,
+        single_of(bitand_ref, None, RustDigestItemKind::Function, "probe")?.digest,
+        "`a && b` and `a & &b` are different operations and must not share a digest"
+    );
+    assert_eq!(
+        single_of(conjunction, None, RustDigestItemKind::Struct, "After")?,
+        single_of(bitand_ref, None, RustDigestItemKind::Struct, "After")?,
+        "the declaration after the edit must be untouched by it"
+    );
+    Ok(())
+}
+
+/// Doc attributes inside a macro body are retained, because there they may not be documentation at all.
+///
+/// Outside macro token soup a `#[…]` is always an attribute, which is what makes recognizing doc attributes by shape
+/// exact. Inside a macro body that guarantee is gone, so the body is hashed verbatim and editing a doc comment there
+/// over-invalidates. That is the safe direction and is asserted here so the carve-out cannot be removed unnoticed.
+#[test]
+fn doc_attributes_inside_macro_bodies_are_retained() -> Result<(), Box<dyn Error>> {
+    let original = r#"macro_rules! declare {
+    () => {
+        /// original documentation
+        pub struct Generated;
+    };
+}
+
+pub struct After;
+"#;
+    let revised = original.replace("original documentation", "revised documentation");
+
+    let before = single_of(original, None, RustDigestItemKind::Macro, "declare")?;
+    let after = single_of(&revised, None, RustDigestItemKind::Macro, "declare")?;
+    assert_ne!(
+        before.digest, after.digest,
+        "macro bodies are hashed verbatim, so a doc comment inside one is expected to move the digest"
+    );
+
+    assert_eq!(
+        single_of(original, None, RustDigestItemKind::Struct, "After")?,
+        single_of(&revised, None, RustDigestItemKind::Struct, "After")?,
+        "the declaration after the macro must be untouched by it"
+    );
+    Ok(())
+}
+
+/// A file that does not parse is reported, never partially digested.
+///
+/// A partial digest of a broken file is indistinguishable from a complete one to a consumer and would hide whatever
+/// followed the syntax error.
+#[test]
+fn unparseable_source_is_reported_rather_than_partially_digested() -> Result<(), Box<dyn Error>> {
+    let outcome = digest_rust_source(MODULE, "pub fn broken( {");
+    assert!(
+        matches!(outcome, Err(RustDigestError::Parse { .. })),
+        "expected a parse error, got {outcome:?}"
+    );
+    Ok(())
+}
+

--- a/crates/rust_inspect/src/digest/tests.rs
+++ b/crates/rust_inspect/src/digest/tests.rs
@@ -460,7 +460,11 @@ pub struct After;
 
     let digests = [&inherent.digest, &via_trait.digest, &other_owner.digest];
     let unique: BTreeMap<&String, ()> = digests.iter().map(|digest| (*digest, ())).collect();
-    assert_eq!(unique.len(), 3, "three distinct method bodies must produce three digests");
+    assert_eq!(
+        unique.len(),
+        3,
+        "three distinct method bodies must produce three digests"
+    );
     Ok(())
 }
 
@@ -627,4 +631,3 @@ fn unparseable_source_is_reported_rather_than_partially_digested() -> Result<(),
     );
     Ok(())
 }
-

--- a/crates/rust_inspect/src/digest/tests.rs
+++ b/crates/rust_inspect/src/digest/tests.rs
@@ -251,6 +251,11 @@ impl Omega {
         digest_map(BASE)?,
         "a declaration's position in its file must not reach any digest"
     );
+    assert_eq!(
+        digest_rust_source(MODULE, reordered)?.items(),
+        digest_rust_source(MODULE, BASE)?.items(),
+        "entries must come back in an order derived from their keys, not from the file"
+    );
     Ok(())
 }
 
@@ -557,6 +562,54 @@ pub struct After;
         single_of(original, None, RustDigestItemKind::Struct, "After")?,
         single_of(&revised, None, RustDigestItemKind::Struct, "After")?,
         "the declaration after the macro must be untouched by it"
+    );
+    Ok(())
+}
+
+/// Group delimiters must reach the digest, because they carry meaning on their own.
+///
+/// `(1, 2)` and `[1, 2]` are a tuple and an array. Their tokens are identical — `1`, `,`, `2` — and only the
+/// delimiter around them differs, so an encoding that recorded a group's contents without its delimiter would hash
+/// two different types the same. That is under-invalidation, so it gets its own test rather than relying on some
+/// other fixture happening to vary a delimiter.
+#[test]
+fn group_delimiters_reach_the_digest() -> Result<(), Box<dyn Error>> {
+    let tuple = "pub fn probe() {\n    let value = (1, 2);\n    let _ = value;\n}\n\npub struct After;\n";
+    let array = "pub fn probe() {\n    let value = [1, 2];\n    let _ = value;\n}\n\npub struct After;\n";
+
+    assert_ne!(
+        single_of(tuple, None, RustDigestItemKind::Function, "probe")?.digest,
+        single_of(array, None, RustDigestItemKind::Function, "probe")?.digest,
+        "a tuple and an array differ only by delimiter and must not share a digest"
+    );
+    assert_eq!(
+        single_of(tuple, None, RustDigestItemKind::Struct, "After")?,
+        single_of(array, None, RustDigestItemKind::Struct, "After")?,
+        "the declaration after the edit must be untouched by it"
+    );
+    Ok(())
+}
+
+/// Encoded tokens must be length-delimited, so a token boundary cannot be forged.
+///
+/// Each token contributes a kind tag followed by its text. Without a length between them, the single identifier
+/// `aIb` encodes as `I` `a` `I` `b` — byte for byte what the two identifiers `a` and `b` encode as, because `I` is
+/// the identifier tag. Macro token soup is where two adjacent identifiers and one longer identifier are both
+/// ordinary, so that is where the collision would actually be reachable.
+#[test]
+fn encoded_tokens_are_length_delimited() -> Result<(), Box<dyn Error>> {
+    let joined = "pub fn probe() {\n    stub!(aIb);\n}\n\npub struct After;\n";
+    let split = "pub fn probe() {\n    stub!(a b);\n}\n\npub struct After;\n";
+
+    assert_ne!(
+        single_of(joined, None, RustDigestItemKind::Function, "probe")?.digest,
+        single_of(split, None, RustDigestItemKind::Function, "probe")?.digest,
+        "one identifier and two identifiers must not encode to the same bytes"
+    );
+    assert_eq!(
+        single_of(joined, None, RustDigestItemKind::Struct, "After")?,
+        single_of(split, None, RustDigestItemKind::Struct, "After")?,
+        "the declaration after the edit must be untouched by it"
     );
     Ok(())
 }

--- a/crates/rust_inspect/src/digest_tokens.rs
+++ b/crates/rust_inspect/src/digest_tokens.rs
@@ -1,0 +1,217 @@
+//! Canonical, span-free hashing of Rust token streams.
+//!
+//! The Rust-side declaration digest answers one question: did anything that can change compiled output move? Token
+//! streams are the cheapest representation that answers it honestly. They survive reformatting, they carry no byte
+//! offsets, and they retain every construct the compiler will actually see, including macro invocations that this
+//! crate cannot expand. This module turns a [`proc_macro2::TokenStream`] into a stable hexadecimal digest.
+//!
+//! Two things are excluded because they provably cannot reach compiled output. Comments are dropped by the tokenizer
+//! before this module ever sees them, so `//` and `/* */` cost nothing. Doc attributes survive tokenization as
+//! `#[doc = …]` (that is what `///` and `//!` lex to), so they are dropped here explicitly, at every nesting level.
+//!
+//! # Why spacing is part of the digest
+//!
+//! [`proc_macro2::Spacing`] records whether a punctuation token was written flush against the next one, and it is
+//! semantically load-bearing: `a && b` is a logical conjunction while `a & &b` is a bitwise `and` against a
+//! reference, and the two differ in nothing else. Discarding spacing would hash those equal, which is exactly the
+//! under-invalidation this digest exists to prevent, so it is retained.
+//!
+//! Retaining it does not cost formatting stability, because callers hash the stream `syn` re-emits from a parsed
+//! item rather than the stream the lexer produced. That round trip normalizes spacing onto meaning: a double
+//! reference emits two `Alone` ampersands whether it was written `&&u8` or `& &u8`, while the `&&` operator emits a
+//! `Joint` one. Layout is normalized, meaning is preserved. The exception is a macro invocation's argument tokens,
+//! which `syn` stores exactly as lexed, so spacing inside macro soup remains source-faithful and over-invalidates
+//! in the same direction as everything else in that soup.
+//!
+//! # Why macro bodies are absorbed verbatim
+//!
+//! Outside a macro invocation, a `#` followed by a bracket group is always an attribute, so recognizing doc
+//! attributes by shape is exact. Inside macro token soup that guarantee is gone: `#[doc = $d]` may be a matcher
+//! fragment or a substitution whose edit really does change what the macro expands to. Macro bodies are therefore
+//! hashed exactly as written, doc attributes included. The failure direction is over-invalidation, and detecting a
+//! macro invocation by shape can only ever over-trigger (`return !(x)` looks like one), so both halves of the
+//! heuristic fail safe.
+
+use proc_macro2::{Delimiter, Spacing, TokenStream, TokenTree};
+use sha2::{Digest, Sha256};
+
+// ============================================================================
+// Encoding tags
+// ============================================================================
+//
+// Every token contributes a one-byte kind tag so that a token stream cannot be confused with a differently shaped one
+// that happens to concatenate to the same bytes. Variable-length payloads are length-delimited for the same reason.
+
+/// Tag introducing an identifier's text.
+const TAG_IDENT: u8 = b'I';
+/// Tag introducing a punctuation character.
+const TAG_PUNCT: u8 = b'P';
+/// Tag introducing a literal's source text.
+const TAG_LITERAL: u8 = b'L';
+/// Tag closing a delimited group, so nesting depth cannot be forged by a flat token run.
+const TAG_GROUP_END: u8 = b'}';
+
+/// Hash a token stream into this crate's canonical digest, dropping doc attributes at every nesting level.
+///
+/// The returned string is lowercase hexadecimal SHA-256. It depends only on the token sequence, never on where those
+/// tokens sat in a file.
+pub(crate) fn digest_tokens(tokens: TokenStream) -> String {
+    let mut hasher = Sha256::new();
+    absorb_stripped(&mut hasher, tokens);
+    hex::encode(hasher.finalize())
+}
+
+/// Absorb a token stream with doc attributes removed and macro bodies left verbatim.
+///
+/// The stream is materialized into a slice because recognizing an attribute needs lookahead across two or three
+/// token trees, which an iterator alone cannot offer without buffering anyway.
+fn absorb_stripped(hasher: &mut Sha256, tokens: TokenStream) {
+    let trees: Vec<TokenTree> = tokens.into_iter().collect();
+    let mut index = 0;
+    while index < trees.len() {
+        // ---- Doc attributes contribute nothing ----
+        if let Some(resume) = doc_attribute_end(&trees, index) {
+            index = resume;
+            continue;
+        }
+
+        // ---- Macro invocations are hashed exactly as written ----
+        if let Some(resume) = macro_invocation_end(&trees, index) {
+            for tree in trees.iter().take(resume).skip(index) {
+                absorb_verbatim(hasher, tree);
+            }
+            index = resume;
+            continue;
+        }
+
+        // ---- Ordinary tokens, recursing into groups so nested attributes are reached ----
+        match &trees[index] {
+            TokenTree::Group(group) => {
+                absorb_delimiter(hasher, group.delimiter());
+                absorb_stripped(hasher, group.stream());
+                hasher.update([TAG_GROUP_END]);
+            }
+            leaf => absorb_verbatim(hasher, leaf),
+        }
+        index += 1;
+    }
+}
+
+/// Absorb one token tree exactly as written, including any doc attributes nested inside it.
+///
+/// This is the encoding that defines the digest. It is deliberately structural rather than textual: it never calls
+/// `TokenStream::to_string`, so no rendering decision of an upstream crate can silently change what a digest means,
+/// and it never touches [`proc_macro2::Span`], so an item's position in its file cannot reach the hash.
+fn absorb_verbatim(hasher: &mut Sha256, tree: &TokenTree) {
+    match tree {
+        TokenTree::Group(group) => {
+            absorb_delimiter(hasher, group.delimiter());
+            for inner in group.stream() {
+                absorb_verbatim(hasher, &inner);
+            }
+            hasher.update([TAG_GROUP_END]);
+        }
+        TokenTree::Ident(ident) => absorb_field(hasher, TAG_IDENT, ident.to_string().as_bytes()),
+        TokenTree::Punct(punct) => {
+            absorb_field(hasher, TAG_PUNCT, punct.as_char().to_string().as_bytes());
+            hasher.update([spacing_tag(punct.spacing())]);
+        }
+        TokenTree::Literal(literal) => absorb_field(hasher, TAG_LITERAL, literal.to_string().as_bytes()),
+    }
+}
+
+/// Absorb one length-delimited, tagged field so adjacent payloads cannot be mistaken for one another.
+///
+/// The length is written as decimal digits followed by `:` rather than as fixed-width native-endian bytes, so a digest
+/// computed on a 32-bit host matches one computed on a 64-bit host.
+fn absorb_field(hasher: &mut Sha256, tag: u8, bytes: &[u8]) {
+    hasher.update([tag]);
+    hasher.update(bytes.len().to_string().as_bytes());
+    hasher.update(b":");
+    hasher.update(bytes);
+}
+
+/// Absorb a group's opening delimiter.
+///
+/// An invisible (`Delimiter::None`) group is real grouping produced by macro expansion and changes how the tokens
+/// parse, so it gets its own tag rather than being treated as absent.
+fn absorb_delimiter(hasher: &mut Sha256, delimiter: Delimiter) {
+    let tag = match delimiter {
+        Delimiter::Parenthesis => b'(',
+        Delimiter::Brace => b'{',
+        Delimiter::Bracket => b'[',
+        Delimiter::None => b'N',
+    };
+    hasher.update([tag]);
+}
+
+/// Map punctuation spacing onto its encoding tag.
+fn spacing_tag(spacing: Spacing) -> u8 {
+    match spacing {
+        Spacing::Joint => b'J',
+        Spacing::Alone => b'A',
+    }
+}
+
+/// Report where a doc attribute starting at `index` ends, or `None` when no doc attribute starts there.
+///
+/// Both the outer form (`#[doc = "…"]`, which `///` lexes to) and the inner form (`#![doc = "…"]`, which `//!` lexes
+/// to) are recognized, as is the call form `#[doc(hidden)]`. Every `doc` attribute is rustdoc-only: none of them can
+/// change compiled output, so all of them are excluded rather than only the comment-derived spellings.
+fn doc_attribute_end(trees: &[TokenTree], index: usize) -> Option<usize> {
+    let TokenTree::Punct(pound) = trees.get(index)? else {
+        return None;
+    };
+    if pound.as_char() != '#' {
+        return None;
+    }
+    let mut cursor = index + 1;
+    if let Some(TokenTree::Punct(bang)) = trees.get(cursor)
+        && bang.as_char() == '!'
+    {
+        cursor += 1;
+    }
+    let TokenTree::Group(group) = trees.get(cursor)? else {
+        return None;
+    };
+    if group.delimiter() != Delimiter::Bracket {
+        return None;
+    }
+    let Some(TokenTree::Ident(name)) = group.stream().into_iter().next() else {
+        return None;
+    };
+    if name != "doc" {
+        return None;
+    }
+    Some(cursor + 1)
+}
+
+/// Report where a macro invocation starting at `index` ends, or `None` when none starts there.
+///
+/// Two shapes count: `name ! <group>` for an ordinary invocation, and `macro_rules ! name <group>` for a definition,
+/// whose body is token soup for the same reason. The check is intentionally shape-based and therefore approximate;
+/// because a false positive only suppresses doc-stripping inside the group, it costs an extra invalidation and never
+/// a missed one.
+fn macro_invocation_end(trees: &[TokenTree], index: usize) -> Option<usize> {
+    let TokenTree::Ident(name) = trees.get(index)? else {
+        return None;
+    };
+    let TokenTree::Punct(bang) = trees.get(index + 1)? else {
+        return None;
+    };
+    if bang.as_char() != '!' {
+        return None;
+    }
+    let body = if name == "macro_rules" {
+        if !matches!(trees.get(index + 2), Some(TokenTree::Ident(_))) {
+            return None;
+        }
+        index + 3
+    } else {
+        index + 2
+    };
+    match trees.get(body) {
+        Some(TokenTree::Group(_)) => Some(body + 1),
+        _ => None,
+    }
+}

--- a/crates/rust_inspect/src/lib.rs
+++ b/crates/rust_inspect/src/lib.rs
@@ -17,6 +17,8 @@ use incan_core::interop::RustItemMetadata;
 mod cache;
 mod cache_resolve;
 mod cache_timing;
+mod digest;
+mod digest_tokens;
 mod error;
 mod extractor;
 mod generic_params;
@@ -24,6 +26,9 @@ mod loader;
 mod receiver_contract;
 
 pub use cache::RustMetadataCache;
+pub use digest::{
+    RustDigestError, RustDigestItemKind, RustItemDigest, RustItemDigestKey, RustSourceDigest, digest_rust_source,
+};
 pub use error::RustMetadataError;
 pub use extractor::{extract_rust_item, rust_type_implements_trait};
 pub use loader::{

--- a/src/frontend/hir.rs
+++ b/src/frontend/hir.rs
@@ -6,8 +6,8 @@
 use crate::frontend::ast::{self, Declaration};
 use crate::frontend::typechecker::TypeCheckInfo;
 use incan_semantics_core::{
-    CompilerNodeId, HirDeclaration, HirDeclarationKind, HirModule, HirSourceSpan, SemanticFactStore,
-    SemanticModuleSnapshot,
+    CompilerNodeId, DeclarationVisibility, HirDeclaration, HirDeclarationKind, HirModule, HirSourceSpan,
+    SemanticFactStore, SemanticModuleSnapshot,
 };
 
 /// Build declaration-level HIR v0 for a typechecked module.
@@ -79,6 +79,7 @@ fn hir_declarations_for(
                 name: Some(binding.local_name.clone()),
                 span,
                 type_fact_subject: hir_type_fact_subject(facts, module_identity, &binding.local_name),
+                visibility: hir_visibility(&decl.node),
                 canonical: binding.canonical.clone(),
             })
             .collect();
@@ -105,8 +106,40 @@ fn hir_declarations_for(
         name,
         span,
         type_fact_subject,
+        visibility: hir_visibility(&decl.node),
         canonical,
     }]
+}
+
+/// Translate a syntax declaration's visibility into the semantic vocabulary.
+///
+/// `incan_semantics_core` sits below `incan_syntax` and must not depend on it, so the mapping lives here at the
+/// bridge rather than as a `From` implementation on either side. Declarations that carry no visibility of their own
+/// are private: a docstring or a vocab block exports nothing, and treating an unknown as public would make the
+/// external closure larger than the source justifies, which under-reports what a change can reach.
+fn hir_visibility(decl: &Declaration) -> DeclarationVisibility {
+    let visibility = match decl {
+        Declaration::Import(decl) => decl.visibility,
+        Declaration::Const(decl) => decl.visibility,
+        Declaration::Static(decl) => decl.visibility,
+        Declaration::Model(decl) => decl.visibility,
+        Declaration::Capability(decl) => decl.visibility,
+        Declaration::Class(decl) => decl.visibility,
+        Declaration::Trait(decl) => decl.visibility,
+        Declaration::Alias(decl) => decl.visibility,
+        Declaration::Partial(decl) => decl.visibility,
+        Declaration::TypeAlias(decl) => decl.visibility,
+        Declaration::Newtype(decl) => decl.visibility,
+        Declaration::Enum(decl) => decl.visibility,
+        Declaration::Function(decl) => decl.visibility,
+        Declaration::TestModule(_) | Declaration::VocabBlock(_) | Declaration::Docstring(_) => {
+            return DeclarationVisibility::Private;
+        }
+    };
+    match visibility {
+        ast::Visibility::Public => DeclarationVisibility::Public,
+        ast::Visibility::Private => DeclarationVisibility::Private,
+    }
 }
 
 /// Return the compatibility semantic-fact subject for one checked local spelling, when a type fact exists.

--- a/tests/declaration_identity_corpus.rs
+++ b/tests/declaration_identity_corpus.rs
@@ -153,3 +153,61 @@ fn stable_declaration_identity_is_unique_across_the_standard_library() -> TestRe
     }
     Ok(())
 }
+
+/// Visibility must reach HIR, because it is what roots RFC 106's external closure.
+///
+/// Without it a consumer cannot tell which declarations a dependent can observe, so it cannot distinguish an
+/// internal-only change from one that propagates — the distinction RFC 124 relies on to avoid rebaking dependents.
+#[test]
+fn hir_records_declaration_visibility() -> TestResult {
+    use incan_semantics_core::DeclarationVisibility;
+
+    let source = r#"
+pub def exported(value: int) -> int:
+    return value
+
+
+def internal(value: int) -> int:
+    return value
+"#;
+    let source = source.to_string();
+    let declarations = incan::compiler_stack::run_on_compiler_stack(move || {
+        let tokens = lexer::lex(&source).map_err(|errors| format!("lex: {errors:?}"))?;
+        let program = parser::parse(&tokens).map_err(|errors| format!("parse: {errors:?}"))?;
+        let program = apply_body_ir_input_contract(program, Path::new("visibility.incn"))
+            .map_err(|errors| format!("contract: {errors:?}"))?;
+        let module_path = vec!["visibility".to_string()];
+        let mut checker = TypeChecker::new();
+        checker.set_current_module_path(Some(module_path.clone()));
+        checker
+            .check_program(&program)
+            .map_err(|errors| format!("typecheck: {errors:?}"))?;
+        let hir = build_hir_v0(&program, &module_path, checker.type_info());
+        Ok::<_, String>(
+            hir.declarations
+                .iter()
+                .filter_map(|declaration| {
+                    declaration
+                        .name
+                        .clone()
+                        .map(|name| (name, declaration.visibility))
+                })
+                .collect::<Vec<_>>(),
+        )
+    })
+    .map_err(|error| Box::<dyn std::error::Error>::from(error))?;
+
+    let exported = declarations.iter().find(|(name, _)| name == "exported");
+    let internal = declarations.iter().find(|(name, _)| name == "internal");
+    assert_eq!(
+        exported.map(|(_, visibility)| *visibility),
+        Some(DeclarationVisibility::Public),
+        "in {declarations:?}"
+    );
+    assert_eq!(
+        internal.map(|(_, visibility)| *visibility),
+        Some(DeclarationVisibility::Private),
+        "in {declarations:?}"
+    );
+    Ok(())
+}

--- a/tests/declaration_identity_corpus.rs
+++ b/tests/declaration_identity_corpus.rs
@@ -132,7 +132,11 @@ fn stable_declaration_identity_is_unique_across_the_standard_library() -> TestRe
     let collisions: Vec<_> = claims.iter().filter(|(_, claimants)| claimants.len() > 1).collect();
 
     println!("CORPUS modules_checked={modules_checked} modules_skipped={modules_skipped} declarations={total}");
-    println!("CORPUS distinct_identities={} colliding={}", claims.len(), collisions.len());
+    println!(
+        "CORPUS distinct_identities={} colliding={}",
+        claims.len(),
+        collisions.len()
+    );
 
     if !collisions.is_empty() {
         let detail = collisions
@@ -186,12 +190,7 @@ def internal(value: int) -> int:
         Ok::<_, String>(
             hir.declarations
                 .iter()
-                .filter_map(|declaration| {
-                    declaration
-                        .name
-                        .clone()
-                        .map(|name| (name, declaration.visibility))
-                })
+                .filter_map(|declaration| declaration.name.clone().map(|name| (name, declaration.visibility)))
                 .collect::<Vec<_>>(),
         )
     })

--- a/tests/declaration_identity_corpus.rs
+++ b/tests/declaration_identity_corpus.rs
@@ -210,3 +210,130 @@ def internal(value: int) -> int:
     );
     Ok(())
 }
+
+/// Measure the conformant digest over a real standard library.
+///
+/// The figure quoted while this was being designed — 1.80 s — was measured on a *text-substitution* prototype,
+/// which RFC 106 then ruled non-conformant. That number was never evidence for the approach actually shipped, so
+/// this measures the value-level digest instead, and asserts the properties a corpus can check that fixtures
+/// cannot: every declaration digests, and no two distinct declarations share a digest by accident.
+#[test]
+fn conformant_digest_covers_the_standard_library() -> TestResult {
+    use incan_semantics_core::semantic_digest::{body_without_docstring, semantic_digest};
+    use std::time::Instant;
+
+    let stdlib_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("crates/incan_stdlib/stdlib");
+    let mut sources = Vec::new();
+    collect_sources(&stdlib_root, &mut sources)?;
+    sources.sort();
+
+    let started = Instant::now();
+    let outcome = incan::compiler_stack::run_on_compiler_stack(move || {
+        let mut digested = 0usize;
+        let mut modules = 0usize;
+        let mut skipped = 0usize;
+        let mut bodies_digested = 0usize;
+        // Digest -> the identities that produced it, to spot accidental sharing.
+        let mut by_digest: BTreeMap<String, Vec<String>> = BTreeMap::new();
+
+        for path in &sources {
+            let Ok(source) = fs::read_to_string(path) else {
+                skipped += 1;
+                continue;
+            };
+            let tokens = match lexer::lex(&source) {
+                Ok(tokens) => tokens,
+                Err(_) => {
+                    skipped += 1;
+                    continue;
+                }
+            };
+            let Ok(program) = parser::parse(&tokens) else {
+                skipped += 1;
+                continue;
+            };
+            let Ok(program) = apply_body_ir_input_contract(program, path) else {
+                skipped += 1;
+                continue;
+            };
+            let module_path = vec![path.file_stem().unwrap_or_default().to_string_lossy().to_string()];
+            let mut checker = TypeChecker::new();
+            checker.set_current_module_path(Some(module_path.clone()));
+            if checker.check_program(&program).is_err() {
+                skipped += 1;
+                continue;
+            }
+            modules += 1;
+
+            let hir = build_hir_v0(&program, &module_path, checker.type_info());
+            let body_ir = build_body_ir_module_v0(&program, &module_path, checker.type_info());
+            let mut bodies: BTreeMap<CanonicalSymbolId, &Body> = BTreeMap::new();
+            for body in &body_ir.bodies {
+                if let Some(canonical) = body.canonical.as_ref() {
+                    bodies.insert(canonical.clone(), body);
+                }
+            }
+
+            for declaration in &hir.declarations {
+                let Some(canonical) = declaration.canonical.as_ref() else {
+                    continue;
+                };
+                if !matches!(&canonical.origin, SymbolOrigin::Module(path) if path == &module_path) {
+                    continue;
+                }
+                let body = bodies.get(canonical).copied();
+                let signature = signature_of(body);
+                let identity = StableDeclarationId::from_canonical(canonical, signature);
+                let body_digest = match body {
+                    Some(body) => {
+                        bodies_digested += 1;
+                        semantic_digest(&body_without_docstring(body)).map_err(|error| error.to_string())?
+                    }
+                    None => "sha256:none".to_string(),
+                };
+                let digest = semantic_digest(&(
+                    declaration.kind,
+                    &declaration.name,
+                    declaration.visibility,
+                    &body_digest,
+                ))
+                .map_err(|error| error.to_string())?;
+                by_digest.entry(digest).or_default().push(identity.render_compact());
+                digested += 1;
+            }
+        }
+        Ok::<_, String>((digested, modules, skipped, bodies_digested, by_digest))
+    })
+    .map_err(|error| Box::<dyn std::error::Error>::from(error))?;
+
+    let elapsed = started.elapsed();
+    let (digested, modules, skipped, bodies_digested, by_digest) = outcome;
+
+    println!("CONFORMANT modules={modules} skipped={skipped}");
+    println!("CONFORMANT declarations_digested={digested} bodies_digested={bodies_digested}");
+    println!("CONFORMANT distinct_digests={}", by_digest.len());
+    println!("CONFORMANT elapsed_ms={}", elapsed.as_millis());
+
+    // Two declarations sharing a digest is not a collision and must not be read as one. Identity is the key and
+    // the digest is the value: a consumer looks a declaration up by identity, then compares digests. A shared
+    // digest says only "these two happen to mean the same thing", which in this corpus is simply true — the same
+    // constant is declared in several modules (`_SECONDS_PER_DAY` across three datetime modules, `_BYTE_TABLE`
+    // across four base-N encoders). The digest deliberately excludes the owning module, because a constant moved
+    // between modules with its value unchanged has not changed meaning.
+    //
+    // Reported rather than asserted, so a sudden jump is visible without pinning a number that legitimately moves
+    // as the standard library grows.
+    let shared: usize = by_digest.values().filter(|claims| claims.len() > 1).count();
+    println!("CONFORMANT digests_shared_by_more_than_one_declaration={shared}");
+    for claims in by_digest.values().filter(|claims| claims.len() > 1).take(5) {
+        println!("CONFORMANT shared (identical meaning, not a collision): {claims:?}");
+    }
+
+    if modules < 90 {
+        return Err(format!("corpus too small to be evidence: {modules} modules").into());
+    }
+    if bodies_digested == 0 {
+        return Err("no bodies were digested, so the measurement covers signatures only".into());
+    }
+    Ok(())
+}

--- a/tests/declaration_identity_corpus.rs
+++ b/tests/declaration_identity_corpus.rs
@@ -125,7 +125,7 @@ fn stable_declaration_identity_is_unique_across_the_standard_library() -> TestRe
         }
         Ok::<_, String>((claims, modules_checked, modules_skipped))
     })
-    .map_err(|error| Box::<dyn std::error::Error>::from(error))?;
+    .map_err(Box::<dyn std::error::Error>::from)?;
 
     let (claims, modules_checked, modules_skipped) = outcome;
     let total: usize = claims.values().map(Vec::len).sum();
@@ -194,7 +194,7 @@ def internal(value: int) -> int:
                 .collect::<Vec<_>>(),
         )
     })
-    .map_err(|error| Box::<dyn std::error::Error>::from(error))?;
+    .map_err(Box::<dyn std::error::Error>::from)?;
 
     let exported = declarations.iter().find(|(name, _)| name == "exported");
     let internal = declarations.iter().find(|(name, _)| name == "internal");
@@ -304,7 +304,7 @@ fn conformant_digest_covers_the_standard_library() -> TestResult {
         }
         Ok::<_, String>((digested, modules, skipped, bodies_digested, by_digest))
     })
-    .map_err(|error| Box::<dyn std::error::Error>::from(error))?;
+    .map_err(Box::<dyn std::error::Error>::from)?;
 
     let elapsed = started.elapsed();
     let (digested, modules, skipped, bodies_digested, by_digest) = outcome;

--- a/tests/declaration_identity_corpus.rs
+++ b/tests/declaration_identity_corpus.rs
@@ -1,0 +1,155 @@
+//! Corpus proof that a declaration identity is unique once it stops carrying position.
+//!
+//! The unit tests beside `StableDeclarationId` prove the rules in isolation. This proves the property that actually
+//! matters and cannot be reasoned about: that across a real standard library, no two distinct declarations claim one
+//! identity. Collision classes are found by measuring a corpus, not by predicting them — the overload case this
+//! guards was discovered exactly that way, and it was the only one in 2,078 declarations.
+
+use incan::frontend::body_ir::{apply_body_ir_input_contract, build_body_ir_module_v0};
+use incan::frontend::hir::build_hir_v0;
+use incan::frontend::typechecker::TypeChecker;
+use incan::frontend::{lexer, parser};
+use incan_semantics_core::body_ir::Body;
+use incan_semantics_core::stable_identity::{DeclarationSignature, StableDeclarationId};
+use incan_semantics_core::{CanonicalSymbolId, SymbolOrigin};
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+/// Collect every Incan source under a root, skipping build output.
+fn collect_sources(root: &Path, out: &mut Vec<PathBuf>) -> TestResult {
+    for entry in fs::read_dir(root)? {
+        let entry = entry?;
+        let path = entry.path();
+        if entry.file_type()?.is_dir() {
+            if path.file_name().map(|name| name == "target").unwrap_or(false) {
+                continue;
+            }
+            collect_sources(&path, out)?;
+        } else if path.extension().map(|extension| extension == "incn").unwrap_or(false) {
+            out.push(path);
+        }
+    }
+    Ok(())
+}
+
+/// Derive the signature discriminant for a declaration from its lowered body.
+///
+/// A declaration with no body cannot be a callable and therefore cannot be overloaded, so `None` is correct there
+/// rather than merely convenient.
+fn signature_of(body: Option<&Body>) -> Option<DeclarationSignature> {
+    body.map(|body| {
+        DeclarationSignature::from_callable_types(body.params.iter().map(|param| &param.ty), &body.return_type)
+    })
+}
+
+/// Mint every stable identity one module contributes, paired with the declaration name that claimed it.
+///
+/// Declaration and body are joined on the full span-carrying `CanonicalSymbolId`, which is exactly what that type is
+/// valid for: unique within one compilation. The span is used for the join and excluded from the identity.
+fn identities_in_module(path: &Path, source: &str) -> Result<Vec<(StableDeclarationId, String)>, String> {
+    let tokens = lexer::lex(source).map_err(|errors| format!("lex: {errors:?}"))?;
+    let program = parser::parse(&tokens).map_err(|errors| format!("parse: {errors:?}"))?;
+    let program = apply_body_ir_input_contract(program, path).map_err(|errors| format!("contract: {errors:?}"))?;
+    let module_path = vec![path.file_stem().unwrap_or_default().to_string_lossy().to_string()];
+    let mut checker = TypeChecker::new();
+    checker.set_current_module_path(Some(module_path.clone()));
+    checker
+        .check_program(&program)
+        .map_err(|errors| format!("typecheck: {errors:?}"))?;
+
+    let hir = build_hir_v0(&program, &module_path, checker.type_info());
+    let body_ir = build_body_ir_module_v0(&program, &module_path, checker.type_info());
+
+    let mut body_by_identity: BTreeMap<CanonicalSymbolId, &Body> = BTreeMap::new();
+    for body in &body_ir.bodies {
+        if let Some(canonical) = body.canonical.as_ref() {
+            body_by_identity.insert(canonical.clone(), body);
+        }
+    }
+
+    let mut identities = Vec::new();
+    for declaration in &hir.declarations {
+        let Some(canonical) = declaration.canonical.as_ref() else {
+            continue;
+        };
+        // Only declarations this module *declares*. An import, alias, or re-export carries the declaring module's
+        // identity on purpose (RFC 120: "an import, an alias, and a re-export of one declaration all carry this
+        // same value"), so counting those as claimants would measure how often a declaration is referenced, not
+        // whether two declarations collide.
+        let declared_here = matches!(&canonical.origin, SymbolOrigin::Module(path) if path == &module_path);
+        if !declared_here {
+            continue;
+        }
+        let signature = signature_of(body_by_identity.get(canonical).copied());
+        identities.push((
+            StableDeclarationId::from_canonical(canonical, signature),
+            declaration.name.clone().unwrap_or_else(|| "<anonymous>".to_string()),
+        ));
+    }
+    Ok(identities)
+}
+
+#[test]
+fn stable_declaration_identity_is_unique_across_the_standard_library() -> TestResult {
+    let stdlib_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("crates/incan_stdlib/stdlib");
+    let mut sources = Vec::new();
+    collect_sources(&stdlib_root, &mut sources)?;
+    sources.sort();
+
+    let outcome = incan::compiler_stack::run_on_compiler_stack(move || {
+        let mut claims: BTreeMap<String, Vec<String>> = BTreeMap::new();
+        let mut modules_checked = 0usize;
+        let mut modules_skipped = 0usize;
+        for path in &sources {
+            let Ok(source) = fs::read_to_string(path) else {
+                modules_skipped += 1;
+                continue;
+            };
+            // A module that does not compile standalone contributes no identities. That is a limitation of
+            // per-file corpus evaluation, not a defect under test, so it is counted and skipped rather than failing.
+            let Ok(identities) = identities_in_module(path, &source) else {
+                modules_skipped += 1;
+                continue;
+            };
+            modules_checked += 1;
+            let module = path.file_name().unwrap_or_default().to_string_lossy().to_string();
+            for (identity, name) in identities {
+                claims
+                    .entry(identity.render_compact())
+                    .or_default()
+                    .push(format!("{module}::{name}"));
+            }
+        }
+        Ok::<_, String>((claims, modules_checked, modules_skipped))
+    })
+    .map_err(|error| Box::<dyn std::error::Error>::from(error))?;
+
+    let (claims, modules_checked, modules_skipped) = outcome;
+    let total: usize = claims.values().map(Vec::len).sum();
+    let collisions: Vec<_> = claims.iter().filter(|(_, claimants)| claimants.len() > 1).collect();
+
+    println!("CORPUS modules_checked={modules_checked} modules_skipped={modules_skipped} declarations={total}");
+    println!("CORPUS distinct_identities={} colliding={}", claims.len(), collisions.len());
+
+    if !collisions.is_empty() {
+        let detail = collisions
+            .iter()
+            .map(|(identity, claimants)| format!("  {identity}\n    claimed by {claimants:?}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        return Err(format!(
+            "{} identities are claimed by more than one declaration:\n{detail}",
+            collisions.len()
+        )
+        .into());
+    }
+
+    // A corpus that checked almost nothing would pass vacuously.
+    if modules_checked < 90 {
+        return Err(format!("corpus too small to be evidence: only {modules_checked} modules checked").into());
+    }
+    Ok(())
+}

--- a/tests/semantic_digest_invariants.rs
+++ b/tests/semantic_digest_invariants.rs
@@ -27,6 +27,9 @@ use std::path::Path;
 
 type TestResult = Result<(), Box<dyn std::error::Error>>;
 
+/// The before-and-after digests of one fixture pair, keyed by declaration identity.
+type DigestPair = (BTreeMap<String, String>, BTreeMap<String, String>);
+
 /// Digest every declaration in one module, keyed by its edit-stable identity.
 fn digest_declarations(source: &str) -> Result<BTreeMap<String, String>, String> {
     let tokens = lexer::lex(source).map_err(|errors| format!("lex: {errors:?}"))?;
@@ -75,10 +78,7 @@ fn digest_declarations(source: &str) -> Result<BTreeMap<String, String>, String>
     Ok(digests)
 }
 
-fn digest_pair(
-    before: &str,
-    after: &str,
-) -> Result<(BTreeMap<String, String>, BTreeMap<String, String>), Box<dyn std::error::Error>> {
+fn digest_pair(before: &str, after: &str) -> Result<DigestPair, Box<dyn std::error::Error>> {
     let before = before.to_string();
     let after = after.to_string();
     incan::compiler_stack::run_on_compiler_stack(move || {

--- a/tests/semantic_digest_invariants.rs
+++ b/tests/semantic_digest_invariants.rs
@@ -1,0 +1,277 @@
+//! Behavioural invariants for the semantic digest.
+//!
+//! These are the acceptance contract from RFC 106, asserted at **declaration granularity**. That granularity is
+//! deliberate and was learned the hard way: an implementation leaking traversal order still moves the digest of the
+//! declaration actually edited, so a test asserting only "the module digest changed" passes a broken digest. Only
+//! the count of *untouched* declarations that also moved exposes it.
+//!
+//! Two fixture conditions are mandatory, and a fixture omitting them is untested rather than passing:
+//!
+//! - every fixture keeps a declaration positioned **after** the edit, because positional leakage contaminates only what
+//!   is traversed later;
+//! - that trailing declaration owns a **nested scope**, because a declaration with no scope discriminant cannot detect
+//!   traversal-order renumbering;
+//! - a body-change fixture additionally **introduces a scope**, since an edit leaving the scope count unchanged shifts
+//!   no later index and cannot detect the leak at all.
+
+use incan::frontend::body_ir::{apply_body_ir_input_contract, build_body_ir_module_v0};
+use incan::frontend::hir::build_hir_v0;
+use incan::frontend::typechecker::TypeChecker;
+use incan::frontend::{lexer, parser};
+use incan_semantics_core::CanonicalSymbolId;
+use incan_semantics_core::body_ir::Body;
+use incan_semantics_core::semantic_digest::{body_without_docstring, semantic_digest};
+use incan_semantics_core::stable_identity::{DeclarationSignature, StableDeclarationId};
+use std::collections::BTreeMap;
+use std::path::Path;
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+/// Digest every declaration in one module, keyed by its edit-stable identity.
+fn digest_declarations(source: &str) -> Result<BTreeMap<String, String>, String> {
+    let tokens = lexer::lex(source).map_err(|errors| format!("lex: {errors:?}"))?;
+    let program = parser::parse(&tokens).map_err(|errors| format!("parse: {errors:?}"))?;
+    let program =
+        apply_body_ir_input_contract(program, Path::new("fixture.incn")).map_err(|errors| format!("{errors:?}"))?;
+    let module_path = vec!["fixture".to_string()];
+    let mut checker = TypeChecker::new();
+    checker.set_current_module_path(Some(module_path.clone()));
+    checker
+        .check_program(&program)
+        .map_err(|errors| format!("{errors:?}"))?;
+
+    let hir = build_hir_v0(&program, &module_path, checker.type_info());
+    let body_ir = build_body_ir_module_v0(&program, &module_path, checker.type_info());
+
+    let mut bodies: BTreeMap<CanonicalSymbolId, &Body> = BTreeMap::new();
+    for body in &body_ir.bodies {
+        if let Some(canonical) = body.canonical.as_ref() {
+            bodies.insert(canonical.clone(), body);
+        }
+    }
+
+    let mut digests = BTreeMap::new();
+    for declaration in &hir.declarations {
+        let Some(canonical) = declaration.canonical.as_ref() else {
+            continue;
+        };
+        let body = bodies.get(canonical).copied();
+        let signature = body.map(|body| {
+            DeclarationSignature::from_callable_types(body.params.iter().map(|param| &param.ty), &body.return_type)
+        });
+        let identity = StableDeclarationId::from_canonical(canonical, signature);
+        // Digest the declaration record and its body together, both from checked values.
+        let declaration_digest = semantic_digest(&(declaration.kind, &declaration.name, declaration.visibility))
+            .map_err(|error| error.to_string())?;
+        let body_digest = match body {
+            Some(body) => semantic_digest(&body_without_docstring(body)).map_err(|error| error.to_string())?,
+            None => "sha256:none".to_string(),
+        };
+        digests.insert(
+            identity.render_compact(),
+            semantic_digest(&(declaration_digest, body_digest)).map_err(|error| error.to_string())?,
+        );
+    }
+    Ok(digests)
+}
+
+fn digest_pair(
+    before: &str,
+    after: &str,
+) -> Result<(BTreeMap<String, String>, BTreeMap<String, String>), Box<dyn std::error::Error>> {
+    let before = before.to_string();
+    let after = after.to_string();
+    incan::compiler_stack::run_on_compiler_stack(move || {
+        Ok::<_, String>((digest_declarations(&before)?, digest_declarations(&after)?))
+    })
+    .map_err(Box::<dyn std::error::Error>::from)
+}
+
+/// Assert not one declaration moved.
+fn assert_nothing_moved(before: &str, after: &str) -> TestResult {
+    let (before, after) = digest_pair(before, after)?;
+    let moved: Vec<_> = after
+        .iter()
+        .filter(|(key, digest)| before.get(*key).map(|old| old != *digest).unwrap_or(true))
+        .map(|(key, _)| key.as_str())
+        .collect();
+    if !moved.is_empty() {
+        return Err(format!("expected nothing to move, these did: {moved:?}").into());
+    }
+    if before.len() != after.len() {
+        return Err(format!("declaration count changed: {} -> {}", before.len(), after.len()).into());
+    }
+    Ok(())
+}
+
+/// Assert exactly the named declarations moved and no others.
+fn assert_only_these_moved(before: &str, after: &str, expected: &[&str]) -> TestResult {
+    let (before, after) = digest_pair(before, after)?;
+    let moved: Vec<String> = after
+        .iter()
+        .filter(|(key, digest)| before.get(*key).map(|old| old != *digest).unwrap_or(false))
+        .map(|(key, _)| key.clone())
+        .collect();
+    let unexpected: Vec<_> = moved
+        .iter()
+        .filter(|m| !expected.iter().any(|e| m.contains(e)))
+        .collect();
+    let missing: Vec<_> = expected
+        .iter()
+        .filter(|e| !moved.iter().any(|m| m.contains(*e)))
+        .collect();
+    if !unexpected.is_empty() {
+        return Err(format!("untouched declarations moved: {unexpected:?}").into());
+    }
+    if !missing.is_empty() {
+        return Err(format!("expected to move but did not: {missing:?}").into());
+    }
+    Ok(())
+}
+
+/// `tail_helper` sits after every edit and owns a nested scope, so traversal-order leakage is detectable.
+const BASE: &str = r#"
+def head_helper(value: int) -> int:
+    return value + 1
+
+
+def edited(value: int) -> int:
+    return value * 2
+
+
+def tail_helper(value: int) -> int:
+    if value > 0:
+        inner = value + 1
+        return inner
+    other = value - 1
+    return other
+"#;
+
+#[test]
+fn adding_documentation_moves_nothing() -> TestResult {
+    let after = BASE.replace(
+        "def edited(value: int) -> int:\n    return value * 2",
+        "def edited(value: int) -> int:\n    \"\"\"\n    Added documentation.\n    \"\"\"\n    return value * 2",
+    );
+    assert_nothing_moved(BASE, &after)
+}
+
+#[test]
+fn removing_documentation_moves_nothing() -> TestResult {
+    let documented = BASE.replace(
+        "def edited(value: int) -> int:\n    return value * 2",
+        "def edited(value: int) -> int:\n    \"\"\"\n    Present here, absent in the pair.\n    \"\"\"\n    return value * 2",
+    );
+    assert_nothing_moved(&documented, BASE)
+}
+
+#[test]
+fn adding_a_comment_moves_nothing() -> TestResult {
+    let after = BASE.replace("def edited", "# a standalone comment\ndef edited");
+    assert_nothing_moved(BASE, &after)
+}
+
+#[test]
+fn reordering_declarations_moves_nothing() -> TestResult {
+    let after = r#"
+def edited(value: int) -> int:
+    return value * 2
+
+
+def head_helper(value: int) -> int:
+    return value + 1
+
+
+def tail_helper(value: int) -> int:
+    if value > 0:
+        inner = value + 1
+        return inner
+    other = value - 1
+    return other
+"#;
+    assert_nothing_moved(BASE, after)
+}
+
+#[test]
+fn reformatting_moves_nothing() -> TestResult {
+    let after = BASE.replace(
+        "    if value > 0:\n        inner = value + 1",
+        "    if value > 0:\n\n        inner = value + 1",
+    );
+    assert_nothing_moved(BASE, &after)
+}
+
+#[test]
+fn inserting_a_declaration_moves_no_existing_declaration() -> TestResult {
+    let after = BASE.replace(
+        "def edited",
+        "def inserted_helper(value: int) -> int:\n    return value\n\n\ndef edited",
+    );
+    assert_only_these_moved(BASE, &after, &[])
+}
+
+#[test]
+fn changing_a_body_moves_only_that_declaration() -> TestResult {
+    // The edit introduces a scope. A body change that adds none shifts no later scope index and therefore cannot
+    // detect traversal-order leakage at all.
+    let after = BASE.replace(
+        "def edited(value: int) -> int:\n    return value * 2",
+        "def edited(value: int) -> int:\n    if value > 1:\n        doubled = value * 2\n        return doubled\n    return value * 4",
+    );
+    assert_only_these_moved(BASE, &after, &["edited"])
+}
+
+/// A signature change replaces a declaration's identity rather than moving its digest.
+///
+/// The signature is part of the identity, because without it overloads collide — a corpus of one standard library
+/// has two such pairs. The consequence is that changing a signature is a *delete plus an add*, not a modification:
+/// the old identity disappears and a new one appears.
+///
+/// For invalidation that is exactly right; both are "changed". For a consumer tracing one declaration across
+/// versions it is a real limitation, and it is the price of separating overloads. This test pins the behaviour so
+/// the trade-off is visible rather than discovered.
+#[test]
+fn changing_a_signature_replaces_the_identity_and_leaves_siblings_alone() -> TestResult {
+    let after = BASE.replace(
+        "def edited(value: int) -> int:\n    return value * 2",
+        "def edited(value: int) -> str:\n    return \"changed\"",
+    );
+    let (before, after) = digest_pair(BASE, &after)?;
+
+    let gone: Vec<_> = before.keys().filter(|key| !after.contains_key(*key)).collect();
+    let appeared: Vec<_> = after.keys().filter(|key| !before.contains_key(*key)).collect();
+    assert_eq!(gone.len(), 1, "exactly one identity should disappear, got {gone:?}");
+    assert_eq!(
+        appeared.len(),
+        1,
+        "exactly one identity should appear, got {appeared:?}"
+    );
+    assert!(
+        gone[0].contains("edited") && appeared[0].contains("edited"),
+        "{gone:?} -> {appeared:?}"
+    );
+
+    // Every declaration that kept its identity must also have kept its digest.
+    let moved: Vec<_> = after
+        .iter()
+        .filter(|(key, digest)| before.get(*key).map(|old| old != *digest).unwrap_or(false))
+        .map(|(key, _)| key.as_str())
+        .collect();
+    assert!(moved.is_empty(), "siblings must be untouched, these moved: {moved:?}");
+    Ok(())
+}
+
+/// A digest that is not deterministic for identical input is not a digest.
+#[test]
+fn digest_is_deterministic_for_identical_source() -> TestResult {
+    let (first, second) = digest_pair(BASE, BASE)?;
+    let differing: Vec<_> = first
+        .iter()
+        .filter(|(key, digest)| second.get(*key) != Some(*digest))
+        .map(|(key, _)| key.as_str())
+        .collect();
+    if !differing.is_empty() {
+        return Err(format!("identical source produced different digests for: {differing:?}").into());
+    }
+    Ok(())
+}


### PR DESCRIPTION
> **Stack** — review bottom-up: #1499 → #1502 → #1503 → #1504
>
> This is the base of the stack. It targets `0.6.0-dev.4`; the three above target each other in turn, so each shows only its own step.

## Summary

Gives a declaration an identity that survives an ordinary edit, and a digest that reflects its checked meaning rather than its source text. RFC 120's canonical identity carries a declaration span and a traversal-derived scope counter, which is correct as provenance and unusable as a cache key: a comment added above a declaration moves both. `StableDeclarationId` keeps what names a declaration and drops what records where it sat, and the semantic digest is computed from checked values through a `serde::Serializer` rather than from rendered text. A parallel digest covers the Rust sources an Incan build links against, so a closure folding only Incan declarations can no longer report a hit for a change in the Rust runtime beneath it.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [x] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: none. No CLI surface, diagnostic, or emitted output changes. The new types are additive and nothing consumes them yet.
- **Internals**: `StableDeclarationId` excludes the span and the scope discriminant's *value* while keeping its presence, and adds a signature discriminant so overloads stay distinct. `semantic_digest` serialises values into a hasher and excludes positional fields structurally — `span` or any `*_span` — rather than by a name list; a list was the first attempt and it missed `CanonicalSymbolId::declaration_span` nested inside `Body::canonical`, so every declaration in a module appeared to change when a comment was added anywhere in it. `closure_digest` folds declaration digests along dependency edges with strongly connected components folded as units. `HirDeclaration` gains a visibility field, declared in `incan_semantics_core` rather than reused from `incan_syntax` because semantics_core sits below syntax. The Rust half digests token streams, which survives reformatting and retains macro invocations the crate cannot expand.
- **Risks**: the digests are new and unconsumed, so a defect cannot yet produce a wrong build. The direction of error is the thing to review: every design choice here errs toward over-invalidating, because under-invalidating ships a stale artifact. The signature discriminant and the per-body scope renumbering were both found by corpus measurement rather than predicted, which is a reason to treat the remaining edge cases as unmeasured rather than absent.

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

`make test` was **not** run to completion on this branch; see the note below. What was run:

- `cargo clippy --all-targets -- -D warnings` — workspace-wide, clean.
- `python3 scripts/check_changed_rustdocs.py --base origin/0.6.0-dev.4` — clean.
- Owning crate suites green, including `rust_inspect` 95 tests for the token digest.
- CI on this PR: 15 passed, 8 skipped.

**Corpus measurement.** 1,252 standard-library declarations, 1,252 distinct stable identities. An earlier figure of "1 collision in 2,078" counted import bindings, which RFC 120 requires to share their target's identity and which therefore cannot collide; the corrected denominator is declarations whose origin matches the compiling module.

**Mutation testing.** Each digest was checked by mutating it and confirming the suite notices, with every mutation verified to have reached disk before a survivor was believed. Four guard tests were found to be defeated by their own fixtures and rewritten — most instructively, a length-delimiting guard that passed only because the type tag happened to act as a separator, where a real collision needs the tag byte inside the content. The Rust token digest takes 15 mutants with 0 survivors.

**Not run.** The prepared-store suite cannot complete on this machine: the compiler-suite Loaf bake fails to compile generated standard-library Rust, filed as #1507 and reproducing from sources identical to `0.6.0-dev.4`. It is not introduced by this branch — nothing here touches `src/backend/` or the standard library.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

No user-facing surface changes. RFC 120 remains the normative source for canonical identity; this adds a derived identity beside it rather than altering it.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #573
Closes #777
