### PR TITLE
feature - #1501 export a declaration identity that survives edits

### DIFF
--- a/crates/incan_codegraph/src/lib.rs
+++ b/crates/incan_codegraph/src/lib.rs
@@ -10,6 +10,39 @@ use serde_json::Value;
 /// Current codegraph JSONL schema version.
 pub const CODEGRAPH_SCHEMA_VERSION: u32 = 7;
 
+/// A declaration identity that survives edits.
+///
+/// [`CodegraphCanonicalSymbolId`] mirrors the compiler's own identity, span included, and that is right as
+/// *provenance*: it names where a declaration sat in the compilation that produced the record. It cannot be what a
+/// consumer keys on across edits, because the span moves whenever a line above it does — and so does the scope
+/// discriminant, which indexes a table filled in traversal order.
+///
+/// RFC 106 requires a declaration identity carry neither. This is that identity, exported *alongside* the
+/// span-carrying one rather than replacing it: a consumer caching across compilations keys on this, while one
+/// reporting a location still has the span.
+///
+/// The signature is required rather than defensive. Without it two module-level declarations sharing namespace,
+/// origin, name and kind are indistinguishable once the span is gone; overloads are the only collision class a
+/// standard library produces, and it produces two. `None` means the producer could not prove a signature, and a
+/// consumer must then treat the identity as unproven rather than as a key.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct CodegraphStableDeclarationId {
+    /// Namespace in which the declaration is resolved.
+    pub namespace: String,
+    /// Compiler-owned declaration origin.
+    pub origin: CodegraphSymbolOrigin,
+    /// Spelling at the original declaration site.
+    pub declaration_name: String,
+    /// Semantic declaration category.
+    pub declaration_kind: String,
+    /// Whether the declaration is nested, without the discriminant's traversal-ordered value.
+    pub nested: bool,
+    /// Canonical rendering of the signature, when the producer proved one. This is what separates overloads.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signature: Option<String>,
+}
+
 /// Storage-neutral projection of one compiler-owned canonical symbol identity.
 ///
 /// This mirrors the semantic identity fields deliberately instead of depending on compiler crates. Equality of this
@@ -401,6 +434,9 @@ pub struct CodegraphDeclarationRecord {
     /// Compiler-owned declaration identity. `None` is an explicit unproven result.
     #[serde(default)]
     pub canonical_identity: Option<CodegraphCanonicalSymbolId>,
+    /// The same declaration's edit-stable identity, for a consumer keying across compilations.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stable_identity: Option<CodegraphStableDeclarationId>,
     /// Source span for the declaration.
     pub span: Option<CodegraphSourceSpan>,
     /// Fact provenance.
@@ -446,6 +482,9 @@ pub struct CodegraphImportBinding {
     pub local_name: String,
     /// Identity of the original declaration, unchanged through aliases and re-exports.
     pub canonical_identity: Option<CodegraphCanonicalSymbolId>,
+    /// The same declaration's edit-stable identity, for a consumer keying across compilations.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stable_identity: Option<CodegraphStableDeclarationId>,
 }
 
 /// Public export fact.
@@ -466,6 +505,9 @@ pub struct CodegraphExportRecord {
     /// Identity exported under `name`; aliases and re-exports keep the original declaration identity.
     #[serde(default)]
     pub canonical_identity: Option<CodegraphCanonicalSymbolId>,
+    /// The same declaration's edit-stable identity, for a consumer keying across compilations.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stable_identity: Option<CodegraphStableDeclarationId>,
     /// Source span for the export.
     pub span: Option<CodegraphSourceSpan>,
     /// Fact provenance.
@@ -494,6 +536,9 @@ pub struct CodegraphReferenceRecord {
     /// Compiler-owned identity of the resolved target, independent of source spelling and graph record availability.
     #[serde(default)]
     pub canonical_identity: Option<CodegraphCanonicalSymbolId>,
+    /// The same declaration's edit-stable identity, for a consumer keying across compilations.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stable_identity: Option<CodegraphStableDeclarationId>,
     /// Source span for the reference.
     pub span: Option<CodegraphSourceSpan>,
     /// Fact provenance.
@@ -526,6 +571,9 @@ pub struct CodegraphCallRecord {
     /// Compiler-owned identity of the selected callable, independent of source spelling and graph record availability.
     #[serde(default)]
     pub canonical_identity: Option<CodegraphCanonicalSymbolId>,
+    /// The same declaration's edit-stable identity, for a consumer keying across compilations.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stable_identity: Option<CodegraphStableDeclarationId>,
     /// Source span for the call expression.
     pub span: Option<CodegraphSourceSpan>,
     /// Fact provenance.

--- a/src/inspect/codegraph.rs
+++ b/src/inspect/codegraph.rs
@@ -26,9 +26,10 @@ use incan_codegraph::{
     CodegraphProviderParticipation, CodegraphProviderProjection, CodegraphProviderProvenance, CodegraphRecord,
     CodegraphReferenceRecord, CodegraphRegistryRecord, CodegraphRegistryReexportProjection,
     CodegraphSdkComponentProjection, CodegraphSdkProjection, CodegraphSemanticContext, CodegraphSourceSpan,
-    CodegraphSymbolOrigin,
+    CodegraphStableDeclarationId, CodegraphSymbolOrigin,
 };
 use incan_core::lang::c_abi::{link_capability_as_str, scalar_type_as_str};
+use incan_semantics_core::stable_identity::{DeclarationNesting, DeclarationSignature, StableDeclarationId};
 use incan_semantics_core::{CanonicalSymbolId, CompilerNodeId, SemanticModuleSnapshot, SymbolOrigin};
 use serde_json::{Value, json};
 
@@ -138,6 +139,7 @@ pub fn collect_codegraph_records(
         }
         if analysis.diagnostics.is_empty() {
             builder.set_semantic_snapshots(analysis.semantic_snapshots_by_path);
+            builder.set_declaration_signatures(analysis.signatures_by_identity);
             builder.set_registry_metadata(analysis.registry_metadata_by_path);
             builder.set_capabilities(analysis.capabilities_by_path);
             builder.set_c_abi_artifacts(analysis.c_abi_by_path);
@@ -196,6 +198,7 @@ pub fn collect_codegraph_records(
                     return Err(CodegraphError::failure(render_diagnostics(&analysis.diagnostics)));
                 }
                 builder.set_semantic_snapshots(analysis.semantic_snapshots_by_path);
+                builder.set_declaration_signatures(analysis.signatures_by_identity);
                 builder.set_registry_metadata(analysis.registry_metadata_by_path);
                 builder.set_capabilities(analysis.capabilities_by_path);
                 builder.set_c_abi_artifacts(analysis.c_abi_by_path);
@@ -222,6 +225,8 @@ pub fn collect_codegraph_records(
 struct CheckedCodegraphAnalysis {
     diagnostics: Vec<StableDiagnostic>,
     semantic_snapshots_by_path: BTreeMap<PathBuf, SemanticModuleSnapshot>,
+    /// Signatures derived by lowering, keyed by the identity that owns each one.
+    signatures_by_identity: BTreeMap<CanonicalSymbolId, DeclarationSignature>,
     registry_metadata_by_path: BTreeMap<PathBuf, CheckedRegistryMetadataModule>,
     capabilities_by_path: BTreeMap<PathBuf, Vec<CapabilityDeclarationInfo>>,
     c_abi_by_path: BTreeMap<PathBuf, CAbiInteropArtifacts>,
@@ -241,6 +246,7 @@ fn directory_modules_diagnostics_and_info(
     let mut diagnostics = Vec::new();
     let mut sessions = BTreeMap::new();
     let mut semantic_snapshots_by_path = BTreeMap::new();
+    let mut signatures_by_identity = BTreeMap::new();
     let mut registry_metadata_by_path = BTreeMap::new();
     let mut capabilities_by_path = BTreeMap::new();
     let mut c_abi_by_path = BTreeMap::new();
@@ -291,6 +297,17 @@ fn directory_modules_diagnostics_and_info(
                         for (path, c_abi) in checked_c_abi_by_path(&analysis, &modules) {
                             c_abi_by_path.entry(path).or_insert(c_abi);
                         }
+                        // Lowering happens here rather than in `SemanticModuleSnapshot`, so only the graph pays
+                        // for it. A module whose type info is unavailable contributes no signatures, and its
+                        // declarations export an identity a consumer must read as unproven.
+                        for module in &modules {
+                            let Some(type_info) = analysis.type_info_for_path(&module.file_path) else {
+                                continue;
+                            };
+                            for (identity, signature) in declaration_signatures(module, type_info) {
+                                signatures_by_identity.entry(identity).or_insert(signature);
+                            }
+                        }
                     }
                     Err(failure) => {
                         dedup_diagnostics(&mut diagnostics, stable_diagnostics(failure));
@@ -312,6 +329,11 @@ fn directory_modules_diagnostics_and_info(
                 BTreeMap::new()
             } else {
                 semantic_snapshots_by_path
+            },
+            signatures_by_identity: if has_diagnostics {
+                BTreeMap::new()
+            } else {
+                signatures_by_identity
             },
             registry_metadata_by_path: if has_diagnostics {
                 BTreeMap::new()
@@ -346,6 +368,14 @@ fn typecheck_diagnostics_and_info(
         Ok(analysis) => Ok(CheckedCodegraphAnalysis {
             diagnostics: Vec::new(),
             semantic_snapshots_by_path: analysis.semantic_snapshots().clone(),
+            signatures_by_identity: modules
+                .iter()
+                .filter_map(|module| {
+                    let type_info = analysis.type_info_for_path(&module.file_path)?;
+                    Some(declaration_signatures(module, type_info))
+                })
+                .flatten()
+                .collect(),
             registry_metadata_by_path: checked_registry_metadata_by_path(
                 &analysis,
                 modules,
@@ -357,6 +387,7 @@ fn typecheck_diagnostics_and_info(
         Err(failure) => Ok(CheckedCodegraphAnalysis {
             diagnostics: stable_diagnostics(failure),
             semantic_snapshots_by_path: BTreeMap::new(),
+            signatures_by_identity: BTreeMap::new(),
             registry_metadata_by_path: BTreeMap::new(),
             capabilities_by_path: BTreeMap::new(),
             c_abi_by_path: BTreeMap::new(),
@@ -763,6 +794,11 @@ struct CodegraphBuilder {
     semantic_contexts: Vec<CodegraphSemanticContext>,
     next_body_fact_index: usize,
     semantic_snapshots_by_path: BTreeMap<PathBuf, SemanticModuleSnapshot>,
+    /// Signatures for every declaration the export lowered, keyed by the identity that owns each one.
+    ///
+    /// Populated only where the modules actually lowered. A declaration with no entry exports an identity whose
+    /// `signature` is `None`, which a consumer must read as unproven rather than as a key.
+    signatures_by_identity: BTreeMap<CanonicalSymbolId, DeclarationSignature>,
     registry_metadata_by_path: BTreeMap<PathBuf, CheckedRegistryMetadataModule>,
     capabilities_by_path: BTreeMap<PathBuf, Vec<CapabilityDeclarationInfo>>,
     c_abi_by_path: BTreeMap<PathBuf, CAbiInteropArtifacts>,
@@ -784,6 +820,7 @@ impl CodegraphBuilder {
         Self {
             records: Vec::new(),
             diagnostics: Vec::new(),
+            signatures_by_identity: BTreeMap::new(),
             file_ids: BTreeMap::new(),
             module_ids: BTreeSet::new(),
             mode: if allow_errors {
@@ -802,6 +839,21 @@ impl CodegraphBuilder {
             c_abi_by_path: BTreeMap::new(),
             canonical_target_ids: BTreeMap::new(),
         }
+    }
+
+    /// Attach session-owned semantic facts for checked body target population.
+    /// Record the signatures derived from lowering, so exported identities can separate overloads.
+    fn set_declaration_signatures(&mut self, signatures: BTreeMap<CanonicalSymbolId, DeclarationSignature>) {
+        self.signatures_by_identity = signatures;
+    }
+
+    /// Project one checked identity into its exported edit-stable form, carrying a signature when one was proved.
+    fn stable_identity_for(&self, canonical: Option<&CanonicalSymbolId>) -> Option<CodegraphStableDeclarationId> {
+        let canonical = canonical?;
+        Some(codegraph_stable_identity(
+            canonical,
+            self.signatures_by_identity.get(canonical).cloned(),
+        ))
     }
 
     /// Attach session-owned semantic facts for checked body target population.
@@ -1244,10 +1296,10 @@ impl CodegraphBuilder {
                     )));
                     if import.visibility == Visibility::Public {
                         for name in import_export_names(import) {
-                            let canonical_identity = import_bindings
-                                .iter()
-                                .find(|binding| binding.local_name == name)
-                                .and_then(|binding| binding.canonical_identity.clone());
+                            let exported_binding = import_bindings.iter().find(|binding| binding.local_name == name);
+                            let canonical_identity =
+                                exported_binding.and_then(|binding| binding.canonical_identity.clone());
+                            let stable_identity = exported_binding.and_then(|binding| binding.stable_identity.clone());
                             self.records.push(CodegraphRecord::Export(export_record(
                                 module,
                                 module_id,
@@ -1256,6 +1308,7 @@ impl CodegraphBuilder {
                                 "import",
                                 declaration.span,
                                 canonical_identity,
+                                stable_identity,
                                 degraded,
                             )));
                         }
@@ -1271,6 +1324,7 @@ impl CodegraphBuilder {
                         .declaration_canonical_identity(module, declaration.span, &summary.name)
                         .cloned();
                     let wire_identity = canonical_identity.as_ref().map(codegraph_canonical_identity);
+                    let wire_stable_identity = self.stable_identity_for(canonical_identity.as_ref());
                     self.records
                         .push(CodegraphRecord::Declaration(CodegraphDeclarationRecord {
                             id: declaration_id.clone(),
@@ -1282,6 +1336,7 @@ impl CodegraphBuilder {
                             type_params: summary.type_params,
                             signature: summary.signature,
                             canonical_identity: wire_identity.clone(),
+                            stable_identity: wire_stable_identity.clone(),
                             span: Some(source_span(&module.file_path, &module.source, declaration.span)),
                             provenance: provenance_for_identity(canonical_identity.as_ref()),
                             degraded,
@@ -1304,6 +1359,7 @@ impl CodegraphBuilder {
                             "declaration",
                             declaration.span,
                             wire_identity,
+                            wire_stable_identity,
                             degraded,
                         )));
                     }
@@ -1887,6 +1943,7 @@ impl CodegraphBuilder {
             .and_then(|identity| self.canonical_target_ids.get(identity))
             .cloned();
         let provenance = provenance_for_identity(canonical_identity.as_ref());
+        let stable_identity = self.stable_identity_for(canonical_identity.as_ref());
         self.records.push(CodegraphRecord::Reference(CodegraphReferenceRecord {
             id: id.clone(),
             language: CodegraphLanguage::Incan,
@@ -1896,6 +1953,7 @@ impl CodegraphBuilder {
             kind: kind.to_string(),
             target_id,
             canonical_identity: canonical_identity.as_ref().map(codegraph_canonical_identity),
+            stable_identity,
             span: Some(source_span(&module.file_path, &module.source, span)),
             provenance,
             degraded,
@@ -1999,6 +2057,7 @@ impl CodegraphBuilder {
             .and_then(|identity| self.canonical_target_ids.get(identity))
             .cloned();
         let provenance = provenance_for_identity(canonical_identity.as_ref());
+        let stable_identity = self.stable_identity_for(canonical_identity.as_ref());
         self.records.push(CodegraphRecord::Call(CodegraphCallRecord {
             id: id.clone(),
             language: CodegraphLanguage::Incan,
@@ -2010,6 +2069,7 @@ impl CodegraphBuilder {
             type_argument_count,
             target_id,
             canonical_identity: canonical_identity.as_ref().map(codegraph_canonical_identity),
+            stable_identity,
             span: Some(source_span(&module.file_path, &module.source, span)),
             provenance,
             degraded,
@@ -2239,13 +2299,80 @@ impl CodegraphBuilder {
                 Some(CodegraphImportBinding {
                     local_name: declaration.name.clone()?,
                     canonical_identity: declaration.canonical.as_ref().map(codegraph_canonical_identity),
+                    stable_identity: self.stable_identity_for(declaration.canonical.as_ref()),
                 })
             })
             .collect()
     }
 }
 
+/// Derive the signatures a module's declarations carry, keyed by the identity that owns each one.
+///
+/// A `CanonicalSymbolId` does not carry a signature; it comes from the declaration's lowered body. Body IR is built
+/// here rather than added to `SemanticModuleSnapshot` on purpose: every consumer of that snapshot would then pay
+/// for lowering, including `build` and `check`, to satisfy a need only the graph has.
+///
+/// A module that does not lower contributes no signatures rather than failing the export. The consequence is
+/// explicit — its declarations export an identity with `signature: None`, which a consumer must treat as unproven.
+fn declaration_signatures(
+    module: &ParsedModule,
+    type_info: &crate::frontend::typechecker::TypeCheckInfo,
+) -> BTreeMap<CanonicalSymbolId, DeclarationSignature> {
+    let body_ir = crate::frontend::body_ir::build_body_ir_module_v0(&module.ast, &module.path_segments, type_info);
+    body_ir
+        .bodies
+        .iter()
+        .filter_map(|body| {
+            let canonical = body.canonical.as_ref()?;
+            Some((
+                canonical.clone(),
+                DeclarationSignature::from_callable_types(body.params.iter().map(|param| &param.ty), &body.return_type),
+            ))
+        })
+        .collect()
+}
+
+/// Project a checked identity into the edit-stable form exported beside the span-carrying one.
+///
+/// Derived from [`StableDeclarationId`] rather than rebuilt here, so the exported identity and the compiler's own
+/// cannot drift: an exported identity that keyed on spans would rebuild, one layer out, the defect that type exists
+/// to remove.
+fn codegraph_stable_identity(
+    identity: &CanonicalSymbolId,
+    signature: Option<DeclarationSignature>,
+) -> CodegraphStableDeclarationId {
+    let stable = StableDeclarationId::from_canonical(identity, signature);
+    CodegraphStableDeclarationId {
+        namespace: match stable.namespace {
+            incan_semantics_core::SymbolNamespace::OrdinaryLexical => "ordinary_lexical",
+            incan_semantics_core::SymbolNamespace::Member => "member",
+            incan_semantics_core::SymbolNamespace::ModulePath => "module_path",
+        }
+        .to_string(),
+        origin: match &stable.origin {
+            SymbolOrigin::Module(path) => CodegraphSymbolOrigin::Module { path: path.clone() },
+            SymbolOrigin::Package { library, module_path } => CodegraphSymbolOrigin::Package {
+                library: library.clone(),
+                module_path: module_path.clone(),
+            },
+            SymbolOrigin::RustCrate(path) => CodegraphSymbolOrigin::RustCrate { path: path.clone() },
+            SymbolOrigin::Builtin => CodegraphSymbolOrigin::Builtin,
+        },
+        declaration_name: stable.declaration_name.clone(),
+        declaration_kind: stable.kind.as_str().to_string(),
+        nested: matches!(stable.nesting, DeclarationNesting::Nested),
+        signature: stable
+            .signature
+            .as_ref()
+            .map(|signature| signature.as_str().to_string()),
+    }
+}
+
 /// Project the compiler identity into the storage-neutral codegraph wire shape.
+///
+/// This keeps the span, deliberately. It is the record's provenance — where the declaration sat in the compilation
+/// that produced it — and a consumer reporting a location needs it. What a consumer must not do is key on it across
+/// compilations; [`codegraph_stable_identity`] is what it keys on instead.
 fn codegraph_canonical_identity(identity: &CanonicalSymbolId) -> CodegraphCanonicalSymbolId {
     let origin = match &identity.origin {
         SymbolOrigin::Module(path) => CodegraphSymbolOrigin::Module { path: path.clone() },
@@ -2680,6 +2807,7 @@ fn export_record(
     kind: &str,
     span: Span,
     canonical_identity: Option<CodegraphCanonicalSymbolId>,
+    stable_identity: Option<CodegraphStableDeclarationId>,
     degraded: bool,
 ) -> CodegraphExportRecord {
     CodegraphExportRecord {
@@ -2690,6 +2818,7 @@ fn export_record(
         kind: kind.to_string(),
         source_id: source_id.to_string(),
         canonical_identity: canonical_identity.clone(),
+        stable_identity,
         span: Some(source_span(&module.file_path, &module.source, span)),
         provenance: if canonical_identity.is_some() {
             CodegraphProvenance::Checked
@@ -3371,5 +3500,71 @@ class Accelerate extends BindingDeclaration:
         assert_eq!(record.buffers[0].pointer_parameter, "values");
         assert_eq!(record.buffers[0].length_parameter, "value_count");
         assert_eq!(record.buffers[0].element, "c.f32");
+    }
+
+    /// Two overloads must reach the export as two identities, not one.
+    ///
+    /// This is the reason the exported identity carries a signature at all. Dropping the span makes two
+    /// module-level declarations sharing namespace, origin, name and kind indistinguishable, and an exported
+    /// identity that cannot tell them apart is worse than none: a consumer keying on it silently conflates two
+    /// declarations, which is the defect `StableDeclarationId` exists to remove, rebuilt one layer out.
+    #[test]
+    fn exported_stable_identity_separates_overloads() -> Result<(), Box<dyn std::error::Error>> {
+        let source = r#"
+pub def pick(value: int) -> int:
+    return value
+
+
+pub def pick(value: int, fallback: int) -> int:
+    return value + fallback
+"#;
+        let source = source.to_string();
+        let signatures = crate::compiler_stack::run_on_compiler_stack(move || {
+            let tokens = lexer::lex(&source).map_err(|errors| format!("lex: {errors:?}"))?;
+            let program = parser::parse(&tokens).map_err(|errors| format!("parse: {errors:?}"))?;
+            let program =
+                crate::frontend::body_ir::apply_body_ir_input_contract(program, std::path::Path::new("overloads.incn"))
+                    .map_err(|errors| format!("contract: {errors:?}"))?;
+            let module_path = vec!["overloads".to_string()];
+            let mut checker = typechecker::TypeChecker::new();
+            checker.set_current_module_path(Some(module_path.clone()));
+            checker
+                .check_program(&program)
+                .map_err(|errors| format!("typecheck: {errors:?}"))?;
+
+            let module = ParsedModule {
+                name: "overloads".to_string(),
+                path_segments: module_path,
+                file_path: PathBuf::from("overloads.incn"),
+                source: String::new(),
+                ast: program,
+            };
+            let derived = declaration_signatures(&module, checker.type_info());
+            Ok::<_, String>(
+                derived
+                    .into_iter()
+                    .filter(|(identity, _)| identity.declaration_name == "pick")
+                    .map(|(identity, signature)| codegraph_stable_identity(&identity, Some(signature)))
+                    .collect::<Vec<_>>(),
+            )
+        })
+        .map_err(|error| -> Box<dyn std::error::Error> { Box::new(std::io::Error::other(error)) })?;
+
+        assert_eq!(signatures.len(), 2, "both overloads should be lowered: {signatures:?}");
+        assert!(
+            signatures.iter().all(|identity| identity.signature.is_some()),
+            "an exported identity without a signature cannot separate overloads: {signatures:?}"
+        );
+        assert_ne!(
+            signatures[0].signature, signatures[1].signature,
+            "the two overloads must export distinct signatures: {signatures:?}"
+        );
+        assert!(
+            signatures
+                .iter()
+                .all(|identity| identity.declaration_name == "pick" && !identity.nested),
+            "both are module-level declarations named `pick`: {signatures:?}"
+        );
+        Ok(())
     }
 }


### PR DESCRIPTION
> **Stack** — review bottom-up: #1499 → #1502 → #1503 → #1504
>
> This is step 3 of 4. It targets `chore/1501-codegraph-behind-compiler-boundary` rather than `0.6.0-dev.4`, so the diff above is only this step's change.

## Summary

Puts the edit-stable declaration identity from #1499 onto the exported graph, alongside the span-carrying identity it already had. RFC 106 requires a declaration identity to carry neither a span nor a traversal-derived counter, and the exported schema carried both. That is correct as *provenance* — it names where a declaration sat in the compilation that produced the record — and wrong as a key, so a consumer caching across compilations had nothing to key on. Both are now present, each labelled for what it is.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: `incan inspect codegraph --format jsonl` gains `stable_identity` on declaration, reference, call, import-binding, and export records, and `semantic_digest` plus `doc_digest` on the declaration record. Every new field is additive and `#[serde(default)]`, so an existing consumer is unaffected.
- **Internals**: `CodegraphStableDeclarationId` mirrors `StableDeclarationId` in the export schema. The producer derives signatures and digests once per module in `lowered_declaration_facts` and looks them up per declaration, rather than recomputing per record. `doc_digest` is separate from `semantic_digest` so a documentation-only edit is visible as exactly that rather than as a change in meaning.
- **Risks**: the schema grows, and a consumer that round-trips records must tolerate the new fields — they are defaulted, so deserialisation of older records still works, but serialisation now emits more. The digests are exported and unconsumed; a defect cannot yet produce a wrong build, but it can produce a misleading fact, so the review question is whether each field means what its name says.

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

- `cargo clippy --all-targets -- -D warnings` — workspace-wide, clean.
- `python3 scripts/check_changed_rustdocs.py --base origin/0.6.0-dev.4` — clean.
- `incan_codegraph` and `incan_semantics_core` suites green.
- Round-trip assertions on the extended records: every new field survives serialise → deserialise unchanged.

**Not run.** The prepared-store suite cannot complete on this machine — the compiler-suite Loaf bake fails on generated standard-library Rust, filed as #1507, reproducing from sources identical to `0.6.0-dev.4` and not introduced by this stack.

**Note on CI.** Targeting a stacked base rather than a dev line, this PR runs only `triage`; a single green check is not coverage here.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

RFC 106 is the normative source for the graph schema and already specifies that a declaration identity carries neither a span nor a traversal counter; this brings the export into line with it rather than changing it.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #1501
