### PR TITLE
bugfix - #1507 emit a generic constructor's supplied type argument

### DIFF
--- a/src/backend/ir/emit/expressions/calls.rs
+++ b/src/backend/ir/emit/expressions/calls.rs
@@ -117,7 +117,7 @@ impl<'a> IrEmitter<'a> {
     /// Generic placeholders coming from the callee signature (`Option[T]`, `Result[T, E]`) are not in scope at the
     /// caller, so they must still be treated as unresolved here even though they are perfectly valid inside the callee
     /// body or an enclosing generic impl/function.
-    pub(super) fn is_unresolved_call_seed_type(ty: &IrType) -> bool {
+    pub(in crate::backend::ir::emit) fn is_unresolved_call_seed_type(ty: &IrType) -> bool {
         match ty {
             IrType::Unknown | IrType::Generic(_) => true,
             IrType::Ref(inner) | IrType::RefMut(inner) | IrType::Option(inner) | IrType::List(inner) => {

--- a/src/backend/ir/emit/mod.rs
+++ b/src/backend/ir/emit/mod.rs
@@ -237,10 +237,43 @@ pub(super) struct StructConstructorMetadata {
     default_fields: HashSet<String>,
     field_aliases: HashMap<String, String>,
     type_private_fields: HashSet<String>,
+    /// The constructed declaration's own type parameters.
+    ///
+    /// A field type mentioning one of these is written in the declaration's vocabulary, not the construction
+    /// site's, so it must not be used as an emission target until it is substituted. See #1507.
+    owner_type_params: HashSet<String>,
     constructor_surface: StructConstructorSurface,
 }
 
 impl StructConstructorMetadata {
+    /// Whether a declared field type is written in the declaration's own type-parameter vocabulary.
+    ///
+    /// Such a type cannot be emitted at a construction site: `items: list[Elem]` on a `Holder[Picked](...)` names
+    /// `Elem`, which is bound in the declaration and nowhere at the call. The genericity of the type is not the
+    /// test — `Generic("Picked")` is generic and perfectly emittable, because the construction site binds it — so
+    /// the question is only whether the name belongs to this declaration. See #1507.
+    fn mentions_own_type_param(&self, ty: &IrType) -> bool {
+        if self.owner_type_params.is_empty() {
+            return false;
+        }
+        match ty {
+            IrType::Generic(name) | IrType::Struct(name) => self.owner_type_params.contains(name),
+            IrType::Ref(inner) | IrType::RefMut(inner) | IrType::Option(inner) | IrType::List(inner) => {
+                self.mentions_own_type_param(inner)
+            }
+            IrType::Set(inner) => self.mentions_own_type_param(inner),
+            IrType::Dict(key, value) | IrType::Result(key, value) => {
+                self.mentions_own_type_param(key) || self.mentions_own_type_param(value)
+            }
+            IrType::Tuple(items) => items.iter().any(|item| self.mentions_own_type_param(item)),
+            IrType::NamedGeneric(_, args) => args.iter().any(|arg| self.mentions_own_type_param(arg)),
+            IrType::Function { params, ret } => {
+                params.iter().any(|param| self.mentions_own_type_param(param)) || self.mentions_own_type_param(ret)
+            }
+            _ => false,
+        }
+    }
+
     /// Select the external Rust construction surface for one nominal declaration.
     ///
     /// Models seal private constructor inputs outside their owner. Classes retain their complete constructor input
@@ -267,6 +300,7 @@ impl StructConstructorMetadata {
     fn from_struct(s: &IrStruct) -> Self {
         Self {
             provider_identity: None,
+            owner_type_params: s.type_params.iter().map(|param| param.name.clone()).collect(),
             fields: s.fields.iter().map(|field| field.name.clone()).collect(),
             field_types: s
                 .fields
@@ -341,6 +375,7 @@ impl StructConstructorMetadata {
         let constructor_surface = Self::external_constructor_surface(kind, &type_private_fields, &default_fields);
         Self {
             provider_identity: Some(ConstructorProviderIdentity::PublicDependency(library.to_string())),
+            owner_type_params: HashSet::new(),
             fields: fields.iter().map(|field| field.name.clone()).collect(),
             field_types: fields
                 .iter()
@@ -784,8 +819,17 @@ impl<'a> IrEmitter<'a> {
         let mut planned = Vec::new();
         for field_name in metadata.constructor_fields() {
             let field_ident = Self::rust_ident(field_name);
-            let target_ty = metadata.field_types.get(field_name);
+            // A declared field type is usable as a target only when it is resolved at this construction site. A
+            // model's own type parameter is still spelled with the declaration's name — `items: list[Elem]` on a
+            // `Holder[Picked](...)` — and names nothing bound here, so targeting it emits `Vec::<Elem>::new()`
+            // against a type parameter that does not exist in scope. The supplied value's checked type carries the
+            // substitution this site made, so it is preferred whenever the declared type does not. See #1507.
+            let declared_ty = metadata.field_types.get(field_name);
             let value = if let Some(value) = provided.get(field_name.as_str()) {
+                let target_ty = match declared_ty {
+                    Some(declared) if metadata.mentions_own_type_param(declared) => Some(&value.ty),
+                    other => other,
+                };
                 let value = self.emit_expr_for_use(value, super::ownership::ValueUseSite::StructField { target_ty })?;
                 if metadata.uses_constructor_function() && metadata.default_fields.contains(field_name) {
                     quote! { Some(#value) }
@@ -793,6 +837,7 @@ impl<'a> IrEmitter<'a> {
                     value
                 }
             } else if metadata.default_fields.contains(field_name) {
+                let target_ty = declared_ty;
                 if metadata.uses_constructor_function() {
                     quote! { None }
                 } else {

--- a/src/backend/ir/lower/decl/models.rs
+++ b/src/backend/ir/lower/decl/models.rs
@@ -25,6 +25,15 @@ impl AstLowering {
                 span: Default::default(),
             })?;
 
+        // A field type naming one of the model's own type parameters is a generic, not a nominal type. Lowering it
+        // without them in scope resolves `Elem` in `items: list[Elem]` to `IrType::Struct("Elem")`, which every
+        // later stage reads as a concrete type that happens not to exist. The call-site seed guard
+        // (`is_unresolved_call_seed_type`) then cannot see that it needs substituting, because it treats `Struct`
+        // as resolved, and an empty collection literal is emitted as `Vec::<Elem>::new()` in a scope where `Elem`
+        // is not bound. See #1507.
+        let type_param_names: std::collections::HashSet<&str> =
+            m.type_params.iter().map(|param| param.name.as_str()).collect();
+
         let mut fields: Vec<StructField> = Vec::new();
         for f in &m.fields {
             let visibility = checked_visibilities
@@ -45,7 +54,7 @@ impl AstLowering {
                 .transpose()?;
             fields.push(StructField {
                 name: f.node.name.clone(),
-                ty: self.lower_type(&f.node.ty.node),
+                ty: self.lower_type_with_type_params(&f.node.ty.node, Some(&type_param_names)),
                 surface_type_name: None,
                 visibility: Self::map_visibility(visibility),
                 is_type_private: self.type_info.as_ref().is_some_and(|info| {

--- a/tests/checked_empty_collection_constructor_tests.rs
+++ b/tests/checked_empty_collection_constructor_tests.rs
@@ -354,3 +354,105 @@ fn nonempty_dict_conversion_does_not_gain_a_checked_constructor_fact_issue1247()
     }
     Ok(())
 }
+
+/// An empty collection literal in a generic constructor must use the type argument, not the declaration's name.
+///
+/// The declaration's own type parameters are a vocabulary of the declaration, not of the construction site. A field
+/// typed `list[Elem]` on `Holder[Picked](items=[])` must emit `Vec::<Picked>::new()`; emitting `Vec::<Elem>::new()`
+/// names a type parameter bound nowhere at the call.
+///
+/// The defect only surfaces when the two names differ. `Holder[U]` constructed with `U` emits the declaration's
+/// name and is accidentally correct, which is why this went unnoticed until the standard library hit the case with
+/// `FlatMapFallibleIterator`'s fourth parameter, `Output`. There the wrong name resolved silently to a same-named
+/// parameter on the enclosing trait implementation and failed as a type mismatch rather than an unknown type.
+/// See #1507.
+#[test]
+fn empty_literal_uses_the_supplied_type_argument_not_the_declared_name_issue1507()
+-> Result<(), Box<dyn std::error::Error>> {
+    let source = concat!(
+        "@derive(Clone)\n",
+        "model Holder[Elem with Clone]:\n",
+        "    items: list[Elem]\n",
+        "\n",
+        "@derive(Clone)\n",
+        "model Source[T with Clone]:\n",
+        "    value: T\n",
+        "\n",
+        "    def expand[Picked with Clone](self) -> Holder[Picked]:\n",
+        "        return Holder[Picked](items=[])\n",
+        "\n",
+        "def main() -> None:\n",
+        "    s = Source[int](value=1)\n",
+        "    h: Holder[str] = s.expand[str]()\n",
+        "    println(f\"{len(h.items)}\")\n",
+    );
+    let (program, _, _) = checked_source(source)?;
+    let generated = IrCodegen::new()
+        .try_generate(&program)
+        .map_err(|error| std::io::Error::other(format!("generic constructor generation failed: {error}")))?;
+
+    if generated.contains("Vec::<Elem>::new()") {
+        return Err(format!(
+            "the empty literal kept the declaration's own type-parameter name, which is bound nowhere at the \
+             construction site:\n{generated}"
+        )
+        .into());
+    }
+    if !generated.contains("Vec::<Picked>::new()") {
+        return Err(
+            format!("expected the empty literal to carry the supplied type argument, got:\n{generated}").into(),
+        );
+    }
+    Ok(())
+}
+
+/// The matching-name case must keep working, since it is the only one that worked before.
+#[test]
+fn empty_literal_still_emits_a_matching_type_parameter_name_issue1507() -> Result<(), Box<dyn std::error::Error>> {
+    let source = concat!(
+        "@derive(Clone)\n",
+        "model Holder[U with Clone]:\n",
+        "    items: list[U]\n",
+        "\n",
+        "def build[U with Clone]() -> Holder[U]:\n",
+        "    return Holder[U](items=[])\n",
+        "\n",
+        "def main() -> None:\n",
+        "    h: Holder[str] = build[str]()\n",
+        "    println(f\"{len(h.items)}\")\n",
+    );
+    let (program, _, _) = checked_source(source)?;
+    let generated = IrCodegen::new()
+        .try_generate(&program)
+        .map_err(|error| std::io::Error::other(format!("matching-name generation failed: {error}")))?;
+    if !generated.contains("Vec::<U>::new()") {
+        return Err(format!("expected the shared name to survive, got:\n{generated}").into());
+    }
+    Ok(())
+}
+
+/// A concrete field type must still win: the fallback applies only to the declaration's own parameters.
+#[test]
+fn empty_literal_keeps_a_concrete_declared_field_type_issue1507() -> Result<(), Box<dyn std::error::Error>> {
+    let source = concat!(
+        "@derive(Clone)\n",
+        "model Holder[Elem with Clone]:\n",
+        "    items: list[Elem]\n",
+        "    names: list[str]\n",
+        "\n",
+        "def build[Picked with Clone]() -> Holder[Picked]:\n",
+        "    return Holder[Picked](items=[], names=[])\n",
+        "\n",
+        "def main() -> None:\n",
+        "    h: Holder[int] = build[int]()\n",
+        "    println(f\"{len(h.names)}\")\n",
+    );
+    let (program, _, _) = checked_source(source)?;
+    let generated = IrCodegen::new()
+        .try_generate(&program)
+        .map_err(|error| std::io::Error::other(format!("concrete field generation failed: {error}")))?;
+    if !generated.contains("Vec::<String>::new()") {
+        return Err(format!("a concrete declared field type must still drive emission, got:\n{generated}").into());
+    }
+    Ok(())
+}

--- a/tests/snapshots/codegen_snapshot_tests__std_derives_collection_compiled.snap
+++ b/tests/snapshots/codegen_snapshot_tests__std_derives_collection_compiled.snap
@@ -624,7 +624,7 @@ for MapFallibleIterator<T, E, Source, Output, StoredMapFn> {
         return FlatMapFallibleIterator {
             source: self.clone(),
             f: f,
-            current: Vec::<Output>::new(),
+            current: Vec::<U>::new(),
             index: 0,
             input_marker: None::<_>,
             error_marker: None::<_>,
@@ -1071,7 +1071,7 @@ impl<
         return FlatMapFallibleIterator {
             source: self.clone(),
             f: f,
-            current: Vec::<Output>::new(),
+            current: Vec::<U>::new(),
             index: 0,
             input_marker: None::<_>,
             error_marker: None::<_>,
@@ -1572,7 +1572,7 @@ for FlatMapFallibleIterator<T, E, Source, Output, StoredExpand> {
         return FlatMapFallibleIterator {
             source: self.clone(),
             f: f,
-            current: Vec::<Output>::new(),
+            current: Vec::<U>::new(),
             index: 0,
             input_marker: None::<_>,
             error_marker: None::<_>,
@@ -1976,7 +1976,7 @@ for TakeFallibleIterator<T, E, Source> {
         return FlatMapFallibleIterator {
             source: self.clone(),
             f: f,
-            current: Vec::<Output>::new(),
+            current: Vec::<U>::new(),
             index: 0,
             input_marker: None::<_>,
             error_marker: None::<_>,
@@ -2385,7 +2385,7 @@ impl<
         return FlatMapFallibleIterator {
             source: self.clone(),
             f: f,
-            current: Vec::<Output>::new(),
+            current: Vec::<U>::new(),
             index: 0,
             input_marker: None::<_>,
             error_marker: None::<_>,
@@ -2844,7 +2844,7 @@ for MapErrFallibleIterator<T, E, Source, MappedError, StoredErrorMap> {
         return FlatMapFallibleIterator {
             source: self.clone(),
             f: f,
-            current: Vec::<Output>::new(),
+            current: Vec::<U>::new(),
             index: 0,
             input_marker: None::<_>,
             error_marker: None::<_>,
@@ -3296,7 +3296,7 @@ for InspectErrFallibleIterator<T, E, Source, StoredErrorObserver> {
         return FlatMapFallibleIterator {
             source: self.clone(),
             f: f,
-            current: Vec::<Output>::new(),
+            current: Vec::<U>::new(),
             index: 0,
             input_marker: None::<_>,
             error_marker: None::<_>,


### PR DESCRIPTION
## Summary

An empty collection literal in a generic constructor was emitted with the **declaration's** own type-parameter name instead of the type argument the call site supplied. `Holder[Picked](items=[])`, where `Holder` declares `items: list[Elem]`, emitted `Vec::<Elem>::new()` — naming a type parameter bound nowhere at the construction site. The typechecker accepted the program and the generated Rust did not compile. This is what stopped `stdlib-core` building and blocked baking the compiler-suite Loaf family, so the prepared-store test path could not run at all.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [x] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: generic models whose type-parameter names differ from the caller's now compile. Previously any such construction with an empty collection literal emitted invalid Rust.
- **Internals**: two causes, both fixed.

  Model field types were lowered with `lower_type` rather than `lower_type_with_type_params`, so the model's own parameters were never in scope and `Elem` resolved to `IrType::Struct("Elem")` — a nominal type that happens not to exist. Every later stage then treated it as resolved, including `is_unresolved_call_seed_type`, whose job is precisely to notice a declared type needing substitution.

  With that corrected the type is `Generic("Elem")`, which exposes the second cause: the construction site targeted the declared field type unconditionally. Genericity is the wrong test — `Generic("Picked")` is generic and perfectly emittable, because the call site binds it. The question is whether the name belongs to the declaration being constructed, so `StructConstructorMetadata` now carries its owner's type parameters and `mentions_own_type_param` answers it directly.

- **Risks**: the fallback changes which type drives emission for a constructor field, so the blast radius is every generic model construction. It is bounded by the predicate: the declared type is still used unless it names one of the constructed declaration's own parameters. A test pins that a concrete declared field type still wins. The snapshot suite is the other guard, and it moved in exactly the expected way.

## Testing / verification

- [ ] `make test` / `cargo test`
- [x] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

- `cargo clippy --all-targets -- -D warnings` — workspace-wide, clean.
- `python3 scripts/check_changed_rustdocs.py --base origin/0.6.0-dev.4` — clean.
- `cargo test --test codegen_snapshot_tests` — 266/266.
- `cargo test --test checked_empty_collection_constructor_tests` — 9/9, three of them new.

**The snapshot moved, and the move is the fix.** Five `Vec::<Output>::new()` in the standard library's `flat_map` became `Vec::<U>::new()`. Two others were deliberately left alone: they sit in `fn collect(&mut self) -> Result<Vec<Output>, E>`, where `Output` is in scope and correct. The snapshot had been recording the broken output all along, which is why 266 tests stayed green over a defect that stopped the standard library compiling — worth noting for anyone reviewing the snapshot diff.

**Regenerating the SDK components** with the fixed compiler produces zero occurrences of the broken pattern in `components/stdlib-core/src/derives/collection.rs`, where the original seven errors were.

**Three tests added**, covering the fix and both directions around it: the differing-name case that was broken, the matching-name case that was accidentally working and must keep working, and a concrete declared field type that must still drive emission rather than falling back.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #1507
