### PR TITLE
chore - #1037 mutation-test the closure fold and close its encoding gaps

### DIFF
--- a/crates/incan_semantics_core/src/closure_digest.rs
+++ b/crates/incan_semantics_core/src/closure_digest.rs
@@ -355,4 +355,74 @@ mod tests {
             "the identity/digest boundary must be encoded, not implied"
         );
     }
+
+    // ---- Encoding soundness ----
+    //
+    // The tests above prove the fold *propagates* correctly. These prove it *encodes* correctly, which is a
+    // different property and the one that fails silently: a propagation bug shows up as a rebuild that did not
+    // happen, while an encoding bug shows up as two different graphs sharing one digest, which is a reused
+    // artifact that should not have been. Each test below was written against a specific mutation of the fold
+    // that the propagation tests did not notice.
+
+    /// Two declarations with the same digest are not the same declaration.
+    ///
+    /// Dropping the member identity from the component hash leaves only the digests, so a graph containing `alpha`
+    /// and a graph containing `beta` with the same body fold identically. Their dependents would then share a
+    /// closure digest across a rename.
+    #[test]
+    fn the_member_identity_is_part_of_its_own_closure_digest() {
+        let alpha = closure_digests(&graph(&[("alpha", "d1", &[])]));
+        let beta = closure_digests(&graph(&[("beta", "d1", &[])]));
+        assert_ne!(alpha.get("alpha"), beta.get("beta"));
+    }
+
+    /// A dependency is named, not merely counted.
+    ///
+    /// Note this passes for a reason narrower than it looks: removing the dependency identity from the fold does
+    /// *not* fail, because what gets folded is the dependency's closure digest, which already carries that
+    /// identity. The field is redundant given the member run, and is kept as one hash update rather than removed.
+    ///
+    /// Folding only a dependency's digest and not its identity makes two different dependencies interchangeable
+    /// whenever their bodies agree, so a declaration that switched which of two identical helpers it calls would
+    /// keep its closure digest.
+    #[test]
+    fn a_dependency_identity_is_part_of_the_digest_that_folds_it() {
+        let calls_left = closure_digests(&graph(&[("caller", "c", &["left"]), ("left", "same", &[])]));
+        let calls_right = closure_digests(&graph(&[("caller", "c", &["right"]), ("right", "same", &[])]));
+        assert_ne!(calls_left.get("caller"), calls_right.get("caller"));
+    }
+
+    /// A declaration's digest must not depend on where its component landed in the walk.
+    ///
+    /// `the_fold_is_order_free` pins insertion order and does not move a node between component indices. Adding an
+    /// unrelated declaration that sorts earlier does exactly that, so folding the component index — the most
+    /// natural way to accidentally reintroduce traversal dependence — survives that test and fails this one.
+    #[test]
+    fn an_unrelated_declaration_does_not_move_a_digest_by_shifting_component_indices() {
+        let alone = closure_digests(&graph(&[("target", "d", &[])]));
+        let with_earlier_neighbour = closure_digests(&graph(&[("0_sorts_first", "other", &[]), ("target", "d", &[])]));
+        assert_eq!(alone.get("target"), with_earlier_neighbour.get("target"));
+    }
+
+    /// A digest must not be able to forge a second member out of its own text.
+    ///
+    /// Each member writes a `\x01member\0` tag, its length-delimited identity, and its length-delimited digest.
+    /// Drop the digest's length and a single member whose digest happens to spell the tag, an eight-byte little-
+    /// endian length, and another identity and digest produces byte-for-byte the same hash input as two genuine
+    /// members. The fixture below is that forgery, built against the real encoding rather than against a plausible
+    /// one — an earlier attempt used a digest containing only the tag, which cannot collide because the identity
+    /// that follows is still delimited, and so passed while the delimiter was removed.
+    #[test]
+    fn a_digest_cannot_forge_a_second_member_out_of_its_own_text() {
+        // `\x01member\0` + little-endian u64 `1` + identity "b" + digest "y".
+        let forged_tail = "\u{1}member\u{0}\u{1}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}by";
+        let forged = closure_digests(&graph(&[("a", forged_tail, &[])]));
+        // Two members of one component: a cycle, so neither edge leaves the component and no dependency is written.
+        let genuine = closure_digests(&graph(&[("a", "", &["b"]), ("b", "y", &["a"])]));
+        assert_ne!(
+            forged.get("a"),
+            genuine.get("a"),
+            "a digest spelling the member encoding must not hash the same as two real members"
+        );
+    }
 }

--- a/src/inspect/closure.rs
+++ b/src/inspect/closure.rs
@@ -348,4 +348,54 @@ mod tests {
             |public_digest: &str| external_digest(&[declaration_with("d:api", "api", Some(public_digest), "public")]);
         assert_ne!(build("d1"), build("CHANGED"));
     }
+
+    // ---- Encoding soundness ----
+    //
+    // The tests above prove the external surface is computed from the right roots and extended along the right
+    // edges. These prove the surface is *encoded* soundly, which fails differently: not as a rebuild that did not
+    // happen, but as two different units sharing one external digest, so a dependent is not rebaked when it should
+    // be. Each was written against a mutation the tests above did not notice.
+
+    /// Two overloads are two declarations, and the surface must keep them apart.
+    ///
+    /// `identity_key` folds the signature discriminant precisely because a name and kind do not distinguish
+    /// overloads. Dropping it merges them into one key, so a change to either would move a digest the other shares
+    /// and a change to both would move one entry rather than two.
+    #[test]
+    fn two_overloads_do_not_share_one_external_entry() {
+        let overload = |signature: &str, digest: &str| {
+            let mut record = declaration("d:same", "same", Some(digest));
+            if let CodegraphRecord::Declaration(declaration) = &mut record
+                && let Some(identity) = declaration.stable_identity.as_mut()
+            {
+                identity.signature = Some(signature.to_string());
+            }
+            record
+        };
+        let records = vec![overload("(Int)->Unit", "d1"), overload("(Str)->Unit", "d2")];
+        let digests = closure_digests_for_export(&records);
+        assert_eq!(
+            digests.len(),
+            2,
+            "two overloads must hold two closure entries, got {digests:?}"
+        );
+    }
+
+    /// An edge the graph could not resolve still reaches the external digest.
+    ///
+    /// Named for what it proves. It does *not* isolate the `unwrap_or("unresolved")` fallback in `external_digest`:
+    /// replacing that with a skip leaves this passing, because introducing an unresolved edge also moves its
+    /// owner's closure digest, and the owner's entry already folds both the dependency identity and its unresolved
+    /// state. That fallback is therefore redundant rather than untested — kept because an entry absent from the
+    /// surface is the failure this whole model exists to avoid, and the cost of keeping it is one hash update.
+    #[test]
+    fn an_unresolved_edge_reaches_the_external_digest() {
+        let with_unresolved = vec![declaration("d:pub", "pub_fn", Some("d1")), call("d:pub", None)];
+        let without = vec![declaration("d:pub", "pub_fn", Some("d1"))];
+        assert_ne!(
+            external_digest(&with_unresolved),
+            external_digest(&without),
+            "an edge the graph could not resolve must reach the external digest"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

The closure fold shipped with tests that prove it *propagates* correctly and none that prove it *encodes* correctly. Those two fail differently: a propagation bug is a rebuild that did not happen, while an encoding bug is two different graphs sharing one digest — a reused artifact that should not have been. Ten mutations were applied to the fold and six survived. Four are now caught; the remaining two are provably redundant and say so where they are written.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [x] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: none. Tests and documentation only; no production logic changed.
- **Internals**: six tests added across `closure_digest.rs` and `src/inspect/closure.rs`, each named for the mutation it was written against, under an `Encoding soundness` banner that says why the section exists separately from the propagation tests above it.
- **Risks**: none to behaviour. The risk this reduces is the one the fold exists to prevent — two units sharing an identity.

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

- `cargo clippy --all-targets -- -D warnings` — workspace-wide, clean.
- `python3 scripts/check_changed_rustdocs.py --base origin/0.6.0-dev.4` — clean.
- `incan_semantics_core` closure tests 12/12; `inspect::closure` 8/8.

**Mutations now caught**, each re-run against the new tests to confirm it dies:

| Mutation | Caught by |
| --- | --- |
| Fold only digests, dropping the member identity | two declarations with one body no longer share a digest across a rename |
| Fold the component index into the hash | an unrelated declaration that sorts earlier no longer moves a digest |
| Drop the signature discriminant | two overloads no longer collapse into one external entry |
| Drop the digest's length delimiter | a forged member built from the real encoding |

**The delimiting test took two attempts, and the first attempt is the point.** A digest containing only the `\x01member\0` tag cannot collide, because the identity that follows it is still length-delimited — so that fixture passed *with the delimiter removed*. A guard test that passes against its own mutation is worse than no test, because it implies coverage it does not have. The working fixture spells the tag, an eight-byte little-endian length, and a second identity and digest, which hashes byte-for-byte the same as two genuine members.

**Two survivors are deliberate.** The dependency identity is already carried by the dependency's closure digest; the unresolved-member fallback in `external_digest` is already carried by its owner's entry, which folds both the identity and its unresolved state. Both are one hash update each and are kept, because an entry missing from the external surface is exactly the failure this model exists to avoid. Both now carry that reasoning in the source.

One existing test was renamed to what it proves rather than what it was meant to prove.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Part of #1037.
