### PR TITLE
feature - #1037 emit RFC 106 namespace nodes over the module graph

### DIFF
--- a/crates/incan_codegraph/src/lib.rs
+++ b/crates/incan_codegraph/src/lib.rs
@@ -996,6 +996,27 @@ pub struct CodegraphRegistryReexportProjection {
     pub span: CodegraphSourceSpan,
 }
 
+/// Reachable namespace node, grouping the modules beneath it.
+///
+/// RFC 106 makes the namespace the graph's top-level unit of reachable surface, distinct from the module that
+/// declares a thing. One record is emitted per namespace an export contains, and `contains` edges relate it to its
+/// modules — including itself, when the namespace is also a module a consumer can import.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CodegraphNamespaceRecord {
+    /// Stable id unique within the export.
+    pub id: String,
+    /// Source language for this graph fact.
+    pub language: CodegraphLanguage,
+    /// Namespace path segments, as a consumer would name them.
+    pub namespace_path: Vec<String>,
+    /// Human-readable namespace name: the last path segment, or the crate root when the path is empty.
+    pub name: String,
+    /// Fact provenance.
+    pub provenance: CodegraphProvenance,
+    /// Whether this namespace is partial because a module beneath it is.
+    pub degraded: bool,
+}
+
 /// One newline-delimited codegraph record.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "record", rename_all = "snake_case")]
@@ -1004,6 +1025,8 @@ pub enum CodegraphRecord {
     Header(CodegraphHeaderRecord),
     /// Source file node.
     File(CodegraphFileRecord),
+    /// Reachable namespace node grouping the modules beneath it.
+    Namespace(CodegraphNamespaceRecord),
     /// Incan module node.
     Module(CodegraphModuleRecord),
     /// Top-level declaration node.
@@ -1096,8 +1119,8 @@ mod tests {
     use super::{
         CODEGRAPH_SCHEMA_VERSION, CodegraphCanonicalSymbolId, CodegraphDiagnosticRecord,
         CodegraphDiagnosticRelatedDeclaration, CodegraphFileRecord, CodegraphHeaderRecord, CodegraphIdentitySpan,
-        CodegraphLanguage, CodegraphMode, CodegraphProvenance, CodegraphRecord, CodegraphReferenceRecord,
-        CodegraphSourceSpan, CodegraphSymbolOrigin, to_jsonl,
+        CodegraphLanguage, CodegraphMode, CodegraphNamespaceRecord, CodegraphProvenance, CodegraphRecord,
+        CodegraphReferenceRecord, CodegraphSourceSpan, CodegraphSymbolOrigin, to_jsonl,
     };
 
     #[test]
@@ -1224,6 +1247,28 @@ mod tests {
             diagnostic.related_declarations[0].identity.declaration_name,
             "expected_value"
         );
+        Ok(())
+    }
+
+    /// The namespace record round-trips under its own `record` tag.
+    ///
+    /// The JSONL export is a published contract, so a new variant has to be checked at the wire rather than only
+    /// through the producer that builds it: the tag is what a consumer matches on, and nothing else in the schema
+    /// would fail if it were wrong.
+    #[test]
+    fn namespace_records_round_trip_under_their_own_tag() -> Result<(), Box<dyn std::error::Error>> {
+        let record = CodegraphRecord::Namespace(CodegraphNamespaceRecord {
+            id: "namespace:std.encoding".to_string(),
+            language: CodegraphLanguage::Incan,
+            namespace_path: vec!["std".to_string(), "encoding".to_string()],
+            name: "encoding".to_string(),
+            provenance: CodegraphProvenance::Syntax,
+            degraded: false,
+        });
+        let encoded = serde_json::to_value(&record)?;
+        assert_eq!(encoded["record"], "namespace");
+        assert_eq!(encoded["namespace_path"][1], "encoding");
+        assert_eq!(serde_json::from_value::<CodegraphRecord>(encoded)?, record);
         Ok(())
     }
 }

--- a/src/inspect/codegraph.rs
+++ b/src/inspect/codegraph.rs
@@ -22,11 +22,12 @@ use incan_codegraph::{
     CodegraphDiagnosticRecord, CodegraphDiagnosticRelatedDeclaration, CodegraphDiagnosticRelatedSpan,
     CodegraphExportRecord, CodegraphFeatureActivationReason, CodegraphFeatureReasonProjection, CodegraphFileRecord,
     CodegraphHeaderRecord, CodegraphIdentitySpan, CodegraphImportBinding, CodegraphImportRecord, CodegraphLanguage,
-    CodegraphMode, CodegraphModuleRecord, CodegraphPackage, CodegraphPackageFeatureProjection, CodegraphProvenance,
-    CodegraphProviderParticipation, CodegraphProviderProjection, CodegraphProviderProvenance, CodegraphRecord,
-    CodegraphReferenceRecord, CodegraphRegistryRecord, CodegraphRegistryReexportProjection,
-    CodegraphSdkComponentProjection, CodegraphSdkProjection, CodegraphSemanticContext, CodegraphSourceSpan,
-    CodegraphStableDeclarationId, CodegraphSymbolOrigin,
+    CodegraphMode, CodegraphModuleRecord, CodegraphNamespaceRecord, CodegraphPackage,
+    CodegraphPackageFeatureProjection, CodegraphProvenance, CodegraphProviderParticipation,
+    CodegraphProviderProjection, CodegraphProviderProvenance, CodegraphRecord, CodegraphReferenceRecord,
+    CodegraphRegistryRecord, CodegraphRegistryReexportProjection, CodegraphSdkComponentProjection,
+    CodegraphSdkProjection, CodegraphSemanticContext, CodegraphSourceSpan, CodegraphStableDeclarationId,
+    CodegraphSymbolOrigin,
 };
 use incan_core::lang::c_abi::{link_capability_as_str, scalar_type_as_str};
 use incan_semantics_core::namespace::{enclosing_namespace, is_namespace_root};
@@ -788,6 +789,8 @@ struct CodegraphBuilder {
     diagnostics: Vec<StableDiagnostic>,
     file_ids: BTreeMap<String, String>,
     module_ids: BTreeSet<String>,
+    /// Namespace ids already emitted, so one namespace yields one node however many modules sit beneath it.
+    namespace_ids: BTreeSet<String>,
     mode: CodegraphMode,
     root_path: String,
     root_path_buf: PathBuf,
@@ -815,6 +818,18 @@ struct DeclarationSummary {
     signature: Option<String>,
 }
 
+/// Stable record id for one namespace.
+///
+/// The crate root is a real namespace with an empty path, so it needs a spelling of its own rather than an empty
+/// suffix that would collide with a malformed id.
+fn namespace_id(namespace_path: &[String]) -> String {
+    if namespace_path.is_empty() {
+        "namespace:<root>".to_string()
+    } else {
+        format!("namespace:{}", namespace_path.join("."))
+    }
+}
+
 impl CodegraphBuilder {
     /// Create a record builder for one strict or tolerant export.
     fn new(root_path: &Path, package: Option<CodegraphPackage>, allow_errors: bool) -> Self {
@@ -824,6 +839,7 @@ impl CodegraphBuilder {
             signatures_by_identity: BTreeMap::new(),
             file_ids: BTreeMap::new(),
             module_ids: BTreeSet::new(),
+            namespace_ids: BTreeSet::new(),
             mode: if allow_errors {
                 CodegraphMode::AllowErrors
             } else {
@@ -1008,6 +1024,32 @@ impl CodegraphBuilder {
                 provenance: CodegraphProvenance::Syntax,
                 degraded,
             }));
+            // RFC 106: the namespace is the graph's unit of reachable surface, and a module is a detail of it
+            // unless it is one itself. Emitted once per namespace, with a `contains` edge per module beneath it,
+            // so a consumer can read the surface without reconstructing it from `namespace_path`.
+            let namespace_path = enclosing_namespace(&module.path_segments).to_vec();
+            let namespace_id = namespace_id(&namespace_path);
+            if self.namespace_ids.insert(namespace_id.clone()) {
+                self.records.push(CodegraphRecord::Namespace(CodegraphNamespaceRecord {
+                    id: namespace_id.clone(),
+                    language: CodegraphLanguage::Incan,
+                    name: namespace_path.last().cloned().unwrap_or_else(|| "crate".to_string()),
+                    namespace_path,
+                    provenance: CodegraphProvenance::Syntax,
+                    degraded,
+                }));
+            }
+            self.records
+                .push(CodegraphRecord::Containment(CodegraphContainmentRecord {
+                    id: format!("contains:{namespace_id}:{module_id}"),
+                    language: CodegraphLanguage::Incan,
+                    parent_id: namespace_id,
+                    child_id: module_id.clone(),
+                    kind: "namespace_contains_module".to_string(),
+                    span: None,
+                    provenance: CodegraphProvenance::Source,
+                    degraded,
+                }));
             self.records
                 .push(CodegraphRecord::Containment(CodegraphContainmentRecord {
                     id: format!("contains:{file_id}:{module_id}"),
@@ -2647,6 +2689,7 @@ fn record_degraded(record: &CodegraphRecord) -> bool {
     match record {
         CodegraphRecord::Header(record) => record.degraded,
         CodegraphRecord::File(record) => record.degraded,
+        CodegraphRecord::Namespace(record) => record.degraded,
         CodegraphRecord::Module(record) => record.degraded,
         CodegraphRecord::Declaration(record) => record.degraded,
         CodegraphRecord::Import(record) => record.degraded,
@@ -3686,6 +3729,59 @@ pub def pick(value: int, fallback: int) -> int:
             digests_for(documented)?.iter().all(|(_, doc)| doc.is_some()),
             "a documented one does"
         );
+        Ok(())
+    }
+
+    /// One namespace node per namespace, with its modules beneath it.
+    ///
+    /// RFC 106 makes the namespace the graph's unit of reachable surface. The property that matters is that an
+    /// internal module does not become a namespace of its own: `pkg/_internal` is a detail of `pkg`, so both it
+    /// and `pkg/api` hang off one node, and a consumer reading the surface sees `pkg` once rather than three
+    /// module paths it has to re-derive the grouping from.
+    #[test]
+    fn internal_modules_hang_off_their_enclosing_namespace() -> Result<(), Box<dyn std::error::Error>> {
+        let build = |segments: Vec<&str>| {
+            let path_segments: Vec<String> = segments.iter().map(|s| (*s).to_string()).collect();
+            ParsedModule {
+                name: path_segments.last().cloned().unwrap_or_default(),
+                path_segments,
+                file_path: PathBuf::from("m.incn"),
+                source: String::new(),
+                ast: crate::frontend::ast::Program::default(),
+            }
+        };
+
+        let mut collector = CodegraphBuilder::new(Path::new("."), None, false);
+        for module in [
+            build(vec!["pkg", "api"]),
+            build(vec!["pkg", "_internal"]),
+            build(vec!["pkg", "_other"]),
+        ] {
+            collector.collect_module_records_with_degraded(&module, "file:m", false);
+        }
+
+        let namespaces: Vec<Vec<String>> = collector
+            .records
+            .iter()
+            .filter_map(|record| match record {
+                CodegraphRecord::Namespace(namespace) => Some(namespace.namespace_path.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            namespaces,
+            vec![vec!["pkg".to_string(), "api".to_string()], vec!["pkg".to_string()]],
+            "a public module is its own namespace; two internal siblings share their parent's"
+        );
+
+        let edges = collector
+            .records
+            .iter()
+            .filter(|record| {
+                matches!(record, CodegraphRecord::Containment(edge) if edge.kind == "namespace_contains_module")
+            })
+            .count();
+        assert_eq!(edges, 3, "every module is contained by exactly one namespace");
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

RFC 106 landed the `namespace` node kind and the rule that a module whose name begins with a single underscore is a detail of its parent rather than a namespace of its own. Nothing emitted it, so a consumer wanting the reachable surface had to re-derive the grouping from `namespace_path` on every module record. This emits one `namespace` record per namespace, with a `namespace_contains_module` edge per module beneath it.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: `incan inspect codegraph --format jsonl` gains `namespace` records and `namespace_contains_module` containment edges. Additive; every existing record is unchanged, and a consumer that ignores unknown record kinds — which RFC 106 requires — is unaffected.
- **Internals**: `CodegraphNamespaceRecord` in the schema crate, emitted once per namespace by the producer as modules are collected. The crate root is a real namespace with an empty path, so it gets its own spelling (`namespace:<root>`) rather than an empty suffix that would collide with a malformed id.
- **Risks**: low. Nothing reads the new records yet, and the grouping they publish is already derivable from `namespace_path`, so a defect shows as a redundant fact disagreeing with an existing one rather than as a wrong build. The one judgement worth reviewing is the root spelling.

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

- `cargo clippy --all-targets -- -D warnings` — workspace-wide, clean.
- `python3 scripts/check_changed_rustdocs.py --base origin/0.6.0-dev.4` — clean.
- `incan_codegraph` 4/4; `inspect::codegraph` producer test passing.

Verified at two levels, deliberately. The **producer** test builds `pkg/api`, `pkg/_internal` and `pkg/_other` and asserts **two** namespaces rather than three — the public module is its own, the two internal siblings share their parent's — with exactly one containment edge per module. The **schema** test asserts the record round-trips under its own `record` tag, because the JSONL export is a published contract, the tag is what a consumer matches on, and nothing else in the schema would fail if it were wrong.

**Not verified end to end, and worth knowing before merge.** `incan inspect codegraph` on a scratch project times out in provider preparation on this machine, so I have not watched these records leave the CLI. The producer path the test drives is the one the CLI calls and the record enum is serde-tagged so a new variant needs no plumbing — but that is reasoning, not observation, and I would rather say so than imply a check I did not run.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

RFC 106 already specifies the node kind, the internal-module rule, and the two module-record fields; this implements what is written there.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Part of #1037.
