### PR TITLE
bugfix - #1514 say when a command is waiting on the provider store lock

### DIFF
--- a/src/cli/commands/common.rs
+++ b/src/cli/commands/common.rs
@@ -365,12 +365,23 @@ fn acquire_sdk_provider_store_lock(store_root: &Path) -> CliResult<SdkProviderSt
         .truncate(false)
         .open(&lock_path)
         .map_err(|error| CliError::failure(format!("failed to open artifact lock {}: {error}", lock_path.display())))?;
-    file.lock().map_err(|error| {
-        CliError::failure(format!(
-            "failed to acquire artifact lock {}: {error}",
-            lock_path.display()
-        ))
-    })?;
+    // Try first, and say something before settling in to wait. Serializing the store is correct — two processes
+    // publishing providers at once is what this lock exists to prevent — but an unannounced block is
+    // indistinguishable from a hang, and preparing providers can take minutes. A command that has stopped printing
+    // for no stated reason gets misread as a compiler defect on whatever project happened to be open. See #1514.
+    if file.try_lock().is_err() {
+        eprintln!(
+            "Waiting for the SDK provider store at {}. Another Incan process holds its lock; this command \
+             continues as soon as that one releases it.",
+            store_root.display()
+        );
+        file.lock().map_err(|error| {
+            CliError::failure(format!(
+                "failed to acquire artifact lock {}: {error}",
+                lock_path.display()
+            ))
+        })?;
+    }
     Ok(SdkProviderStoreLock { _file: file })
 }
 
@@ -8686,6 +8697,58 @@ def main() -> None:
             relative,
             vec![PathBuf::from("nested/module.incn"), PathBuf::from("root.incn")]
         );
+        Ok(())
+    }
+
+    /// The store lock serializes, and a waiter is a waiter rather than a failure.
+    ///
+    /// This pins the behaviour the diagnostic sits on top of: a second acquirer blocks and then succeeds, instead
+    /// of failing or taking the lock. Timing distinguishes blocking from erroring; it does not assert a duration,
+    /// since the wait ends when the holder releases.
+    ///
+    /// It does **not** cover the message itself. Replacing the `try_lock` guard with `if false` leaves this test
+    /// passing, because the outer `lock()` blocks either way — so the diagnostic is verified by reading it, not by
+    /// this test. Covering it would mean routing one `eprintln!` through an injectable sink, which is more
+    /// structure than a single diagnostic earns. Recorded so the next reader does not assume otherwise.
+    #[test]
+    fn a_held_store_lock_makes_the_next_acquirer_wait_rather_than_fail() -> Result<(), Box<dyn std::error::Error>> {
+        let store = tempfile::tempdir()?;
+        let store_root = store.path().to_path_buf();
+
+        let held = acquire_sdk_provider_store_lock(&store_root)?;
+
+        let waiting_root = store_root.clone();
+        let (tx, rx) = std::sync::mpsc::channel();
+        let waiter = std::thread::spawn(move || {
+            let acquired = acquire_sdk_provider_store_lock(&waiting_root);
+            let _ = tx.send(acquired.is_ok());
+        });
+
+        assert!(
+            rx.recv_timeout(std::time::Duration::from_millis(250)).is_err(),
+            "a second acquirer must wait while the first holds the lock, not take it"
+        );
+
+        drop(held);
+        assert_eq!(
+            rx.recv_timeout(std::time::Duration::from_secs(10)),
+            Ok(true),
+            "releasing the lock must let the waiter through"
+        );
+        waiter
+            .join()
+            .map_err(|_| std::io::Error::other("lock waiter panicked"))?;
+        Ok(())
+    }
+
+    /// An uncontended lock is the common path and must stay silent and immediate.
+    #[test]
+    fn an_uncontended_store_lock_is_acquired_without_waiting() -> Result<(), Box<dyn std::error::Error>> {
+        let store = tempfile::tempdir()?;
+        let first = acquire_sdk_provider_store_lock(store.path())?;
+        drop(first);
+        let second = acquire_sdk_provider_store_lock(store.path())?;
+        drop(second);
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

Any command that prepares SDK providers blocked silently and indefinitely while another Incan process held the store lock — no message, no progress, no timeout. Contention is now announced before the command goes quiet. Serializing the store is unchanged and correct; the defect was that waiting and hanging looked identical.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: when another Incan process holds the provider-store lock, one line on stderr names the store and says the command continues once that process releases it. Nothing is printed when the lock is free.
- **Internals**: `acquire_sdk_provider_store_lock` tries `try_lock` first and only emits on contention, then blocks exactly as before. No change to what is locked, when, or for how long.
- **Risks**: minimal. The common path gains one `try_lock` and no output. The contention path gains a line on stderr, which could in principle surprise a caller parsing stderr strictly — worth a thought if any tooling does, though the same stream already carries the dependency-miss diagnostics.

## How it was found

Not by looking for it. `incan inspect codegraph src --format jsonl` on a **three-file** scratch project produced no output for 33 minutes while I was verifying an unrelated change. Sampling the process showed it was not looping:

```
inspect_codegraph → collect_codegraph_semantic_contexts → discover_with_selections
  → prepare_sdk_provider_inventory_in_store
    → acquire_sdk_provider_store_lock → File::lock → flock   ← blocked
```

A second `incan` process held `<store>/.incan.lock`. It presents as "the compiler hangs on a tiny project", which sends you hunting through analysis code for a cause that is another process doing ordinary work.

The contrast inside the same file is what makes it a defect rather than a preference: a few hundred lines away, finding no baked dependencies produces a long, specific, actionable diagnostic naming the project root, the build record, the receipt path, and the command to run. Waiting on a lock produced nothing.

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

- `cargo clippy --all-targets -- -D warnings` — workspace-wide, clean.
- `python3 scripts/check_changed_rustdocs.py --base origin/0.6.0-dev.4` — clean.
- Two tests added, 2/2.

**What the tests cover, and what they do not.** They pin that a second acquirer waits and then succeeds — rather than failing, or taking a lock someone else holds — and that the uncontended path still works. They do **not** cover the message: replacing the `try_lock` guard with `if false` leaves both passing, because the outer `lock()` blocks either way. I checked that rather than assuming it, and the limitation is recorded next to the tests instead of being implied away. Covering the message would mean routing one `eprintln!` through an injectable sink, which is more structure than a single diagnostic earns.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #1514
