### PR TITLE
bugfix - #1516 substitute a generic enum's variant payload at its construction site

### DIFF
--- a/src/backend/ir/emit/expressions/methods.rs
+++ b/src/backend/ir/emit/expressions/methods.rs
@@ -1396,10 +1396,22 @@ impl<'a> IrEmitter<'a> {
                     .iter()
                     .zip(field_tys.iter())
                     .map(|(a, ty)| {
+                        // A declared payload type is usable as a target only when it is resolved at this construction
+                        // site. A variant payload is spelled in the enum's own vocabulary — `Items(list[Elem])` built
+                        // as a `Holder[Picked]` — and that names nothing bound here, so targeting it emits
+                        // `Vec::<Elem>::new()` against a type parameter that does not exist in scope. The typechecker
+                        // substituted the enum's arguments into the argument when it checked it, so prefer the
+                        // argument's own type whenever the declared payload is still unresolved and it is not. See
+                        // #1516, and #1507 for the model-field half of the same defect.
+                        let target_ty = if Self::is_unresolved_call_seed_type(ty) && !Self::is_unresolved_type(&a.ty) {
+                            &a.ty
+                        } else {
+                            ty
+                        };
                         self.emit_expr_for_use(
                             a,
                             ValueUseSite::IncanCallArg {
-                                target_ty: Some(ty),
+                                target_ty: Some(target_ty),
                                 callee_param: None,
                                 in_return: false,
                             },

--- a/src/backend/ir/lower/decl/enums.rs
+++ b/src/backend/ir/lower/decl/enums.rs
@@ -14,6 +14,13 @@ impl AstLowering {
             ast::ValueEnumType::Str => IrEnumValueType::String,
             ast::ValueEnumType::Int => IrEnumValueType::Int,
         });
+        // A variant payload naming one of the enum's own type parameters is a generic, not a nominal type. Lowering it
+        // without them in scope resolves `Elem` in `Items(list[Elem])` to `IrType::Struct("Elem")`, which every later
+        // stage reads as a concrete type that happens not to exist. This is the enum counterpart of the model field
+        // case fixed in #1507; see #1516.
+        let type_param_names: std::collections::HashSet<&str> =
+            e.type_params.iter().map(|param| param.name.as_str()).collect();
+
         let variants: Vec<EnumVariant> = e
             .variants
             .iter()
@@ -21,7 +28,13 @@ impl AstLowering {
                 let fields = if v.node.fields.is_empty() {
                     VariantFields::Unit
                 } else {
-                    VariantFields::Tuple(v.node.fields.iter().map(|t| self.lower_type(&t.node)).collect())
+                    VariantFields::Tuple(
+                        v.node
+                            .fields
+                            .iter()
+                            .map(|t| self.lower_type_with_type_params(&t.node, Some(&type_param_names)))
+                            .collect(),
+                    )
                 };
                 let raw_value = v.node.value.as_ref().map(|value| match &value.node {
                     ast::ValueEnumLiteral::Str(raw) => IrEnumValue::String(raw.clone()),

--- a/src/frontend/typechecker/check_expr/access.rs
+++ b/src/frontend/typechecker/check_expr/access.rs
@@ -51,6 +51,19 @@ use super::TypeChecker;
 /// before a following inspected inherent call can be resolved.
 const RUST_DEFAULT_ASSOCIATED_METHOD: &str = "default";
 
+/// One `Enum.Variant(...)` construction resolved against the destination type it is being built for.
+///
+/// Both halves are kept together because they are needed at different points of the same method-call pass: the
+/// substituted payload types must exist before the arguments are checked, since that is the only time they are
+/// checked, while the enum's own arguments are what the construction's result type reports afterwards.
+#[derive(Debug, Clone)]
+struct EnumVariantInstantiation {
+    /// The enum's type arguments, taken from the destination type.
+    arguments: Vec<ResolvedType>,
+    /// The variant's declared payload types, substituted through those arguments.
+    payloads: Vec<ResolvedType>,
+}
+
 #[derive(Debug, Clone)]
 struct MethodCandidate {
     info: MethodInfo,
@@ -4346,6 +4359,83 @@ impl TypeChecker {
     }
 
     /// Type-check a method call with an optional expected result type for overload disambiguation.
+    /// Resolve one `Enum.Variant(...)` construction against the destination type it is being built for.
+    ///
+    /// A variant payload is declared in the enum's own vocabulary — `Items(list[Elem])` — and that vocabulary is bound
+    /// nowhere at a construction site. A model constructor can recover from this by falling back to the supplied
+    /// value's own checked type, because the site inferred one. A variant payload has nothing to fall back to:
+    /// `Holder.Items([])` checks the literal as `Unknown`, and only the destination says what `Elem` is here. So the
+    /// declared payload must be substituted through the enum's arguments instead.
+    ///
+    /// The destination is the *immediate* expected type, never the enclosing function's return type read directly.
+    /// That distinction is what keeps this sound: a function returning `Holder[Picked]` may legitimately build a
+    /// `Holder[str]` for a local, and there the local's own annotation is the expectation. Only a same-name,
+    /// arity-matching instantiation is usable — anything else would substitute one declaration's parameters with
+    /// another's arguments — so every other shape yields `None` and leaves the unsubstituted behavior in place.
+    ///
+    /// See #1516, and #1507 for the model half of the same defect.
+    fn enum_variant_construction_instantiation(
+        &self,
+        base_ty: &ResolvedType,
+        method: &str,
+        expected_return_ty: Option<&ResolvedType>,
+    ) -> Option<EnumVariantInstantiation> {
+        let ResolvedType::Named(enum_name) = base_ty else {
+            return None;
+        };
+        let Some(TypeInfo::Enum(enum_info)) = self.lookup_semantic_type_info(enum_name) else {
+            return None;
+        };
+        if !enum_info.variants.iter().any(|variant| variant == method)
+            && !enum_info.variant_aliases.contains_key(method)
+        {
+            return None;
+        }
+        if enum_info.type_params.is_empty() {
+            return None;
+        }
+        let ResolvedType::Generic(expected_name, arguments) = expected_return_ty? else {
+            return None;
+        };
+        if expected_name != enum_name || arguments.len() != enum_info.type_params.len() {
+            return None;
+        }
+        // An alias shares its target's payload, and `variant_fields` is keyed by the canonical name only.
+        let canonical_variant = enum_info
+            .variant_aliases
+            .get(method)
+            .map(String::as_str)
+            .unwrap_or(method);
+        let substitutions = type_param_subst_map(&enum_info.type_params, arguments);
+        let payloads = enum_info
+            .variant_fields
+            .get(canonical_variant)
+            .map(|declared| {
+                declared
+                    .iter()
+                    .map(|payload| substitute_resolved_type(payload, &substitutions))
+                    .collect()
+            })
+            .unwrap_or_default();
+        Some(EnumVariantInstantiation {
+            arguments: arguments.clone(),
+            payloads,
+        })
+    }
+
+    /// Type-check `receiver.method(...)` once the receiver, method name, explicit type arguments, and value arguments
+    /// have been identified, against an optional type for the destination the result is being produced for.
+    ///
+    /// This is the shared arrival point for far more than ordinary user methods: C ABI constructors, `Result` and
+    /// `Option` combinators, string and collection surfaces, iterator protocol methods, Rust-receiver calls resolved
+    /// through inspected metadata, and `Enum.Variant(...)` construction all resolve here. Two consequences shape the
+    /// body. The receiver type is established first, because nearly every later decision keys off it; and the
+    /// arguments are checked exactly once, part-way through, so any contextual expectation an argument needs — a
+    /// closure's parameter types, an enum variant's substituted payload — must be resolved before that point rather
+    /// than corrected afterwards.
+    ///
+    /// `expected_return_ty` is the destination type, not the enclosing function's return type. Passing the immediate
+    /// destination is what lets a construction be checked against the instantiation it is actually built for.
     pub(in crate::frontend::typechecker::check_expr) fn check_method_call_with_expected(
         &mut self,
         base: &Spanned<Expr>,
@@ -4677,10 +4767,16 @@ impl TypeChecker {
         let rust_receiver_path = self.rust_canonical_path_for_receiver_type(&base_ty);
         let defer_rust_closures = rust_receiver_path.is_some();
 
+        // `Enum.Variant(payload)` reaches this shared method-call path, and this is the only place its arguments are
+        // checked, so the payload expectation has to be resolved before the loop below rather than corrected after it.
+        let enum_variant_construction =
+            self.enum_variant_construction_instantiation(&base_ty, method, expected_return_ty);
+
         // Collect arg types for method-specific validation.
         let arg_types: Vec<ResolvedType> = args
             .iter()
-            .map(|arg| {
+            .enumerate()
+            .map(|(index, arg)| {
                 let arg_expr = match arg {
                     CallArg::Positional(expr)
                     | CallArg::Named(_, expr)
@@ -4688,6 +4784,10 @@ impl TypeChecker {
                     | CallArg::KeywordUnpack(expr) => expr,
                 };
                 let is_closure = matches!(arg_expr.node, Expr::Closure(_, _));
+                let variant_payload_ty = enum_variant_construction
+                    .as_ref()
+                    .and_then(|construction| construction.payloads.get(index))
+                    .filter(|payload| !matches!(payload, ResolvedType::Unknown));
                 if defer_rust_closures && contextual_rust_callable.is_none() && is_closure {
                     ResolvedType::Unknown
                 } else if let Some(input_ty) = result_callback_input.as_ref()
@@ -4698,6 +4798,8 @@ impl TypeChecker {
                         Box::new(ResolvedType::Unknown),
                     );
                     self.check_expr_with_expected(arg_expr, Some(&expected))
+                } else if let Some(payload_ty) = variant_payload_ty {
+                    self.check_expr_with_expected(arg_expr, Some(payload_ty))
                 } else {
                     self.check_method_arg_with_rust_callable_alias(arg, contextual_rust_callable.as_ref())
                 }
@@ -4807,7 +4909,13 @@ impl TypeChecker {
             if let Some(identity) = variant_identity {
                 self.type_info.record_resolved_identity(span, identity);
             }
-            return ResolvedType::Named(enum_name.clone());
+            // Report the instantiation the destination supplied rather than the bare enum name. The bare name erases
+            // the arguments this construction was checked against, and every later stage then has to guess them. See
+            // #1516.
+            return match enum_variant_construction {
+                Some(construction) => ResolvedType::Generic(enum_name.clone(), construction.arguments),
+                None => ResolvedType::Named(enum_name.clone()),
+            };
         }
 
         // External/runtime-provided concurrency primitives: be permissive for surface types that have no local Incan

--- a/src/frontend/typechecker/check_expr/calls/args.rs
+++ b/src/frontend/typechecker/check_expr/calls/args.rs
@@ -109,6 +109,31 @@ impl TypeChecker {
         }
     }
 
+    /// Type-check call arguments against a purely positional list of expected types.
+    ///
+    /// This exists for callees whose parameters are positional payloads rather than named [`CallableParam`]s; enum
+    /// variant construction is the case that needs it. An argument with no corresponding expectation, or one whose
+    /// expectation is unresolved, is checked without a hint, so a missing expectation degrades to the unconstrained
+    /// behavior rather than asserting `Unknown` onto the argument.
+    pub(in crate::frontend::typechecker::check_expr) fn check_call_args_with_positional_expectations(
+        &mut self,
+        args: &[CallArg],
+        expected: &[ResolvedType],
+    ) {
+        for (index, arg) in args.iter().enumerate() {
+            self.call_argument_depth += 1;
+            match expected.get(index) {
+                Some(ty) if !matches!(ty, ResolvedType::Unknown) => {
+                    self.check_expr_with_expected(Self::call_arg_expr(arg), Some(ty));
+                }
+                _ => {
+                    self.check_expr(Self::call_arg_expr(arg));
+                }
+            }
+            self.call_argument_depth -= 1;
+        }
+    }
+
     /// Type-check all call arguments and collect their resolved types.
     pub(in crate::frontend::typechecker::check_expr::calls) fn check_call_arg_types(
         &mut self,

--- a/src/frontend/typechecker/check_expr/calls/args.rs
+++ b/src/frontend/typechecker/check_expr/calls/args.rs
@@ -109,31 +109,6 @@ impl TypeChecker {
         }
     }
 
-    /// Type-check call arguments against a purely positional list of expected types.
-    ///
-    /// This exists for callees whose parameters are positional payloads rather than named [`CallableParam`]s; enum
-    /// variant construction is the case that needs it. An argument with no corresponding expectation, or one whose
-    /// expectation is unresolved, is checked without a hint, so a missing expectation degrades to the unconstrained
-    /// behavior rather than asserting `Unknown` onto the argument.
-    pub(in crate::frontend::typechecker::check_expr) fn check_call_args_with_positional_expectations(
-        &mut self,
-        args: &[CallArg],
-        expected: &[ResolvedType],
-    ) {
-        for (index, arg) in args.iter().enumerate() {
-            self.call_argument_depth += 1;
-            match expected.get(index) {
-                Some(ty) if !matches!(ty, ResolvedType::Unknown) => {
-                    self.check_expr_with_expected(Self::call_arg_expr(arg), Some(ty));
-                }
-                _ => {
-                    self.check_expr(Self::call_arg_expr(arg));
-                }
-            }
-            self.call_argument_depth -= 1;
-        }
-    }
-
     /// Type-check all call arguments and collect their resolved types.
     pub(in crate::frontend::typechecker::check_expr::calls) fn check_call_arg_types(
         &mut self,

--- a/tests/checked_empty_collection_constructor_tests.rs
+++ b/tests/checked_empty_collection_constructor_tests.rs
@@ -456,3 +456,166 @@ fn empty_literal_keeps_a_concrete_declared_field_type_issue1507() -> Result<(), 
     }
     Ok(())
 }
+
+/// A generic enum's variant payload must be emitted with the enum's supplied type argument, not its own parameter.
+///
+/// This is the enum half of #1507's defect, filed as #1516. The model half could fall back to the supplied
+/// argument's own checked type because the typechecker inferred it at the construction site. A variant payload has
+/// no such inference to fall back on: `Holder.Items([])` inside a function returning `Holder[Picked]` checks the
+/// literal as `Unknown`, and the element type is determined only by the enclosing return type. The payload's
+/// declared type must therefore be substituted with the enum's resolved type arguments.
+#[test]
+fn enum_variant_payload_uses_the_enum_type_argument_not_the_declared_name_issue1516()
+-> Result<(), Box<dyn std::error::Error>> {
+    let source = concat!(
+        "@derive(Clone)\n",
+        "enum Holder[Elem with Clone]:\n",
+        "    Items(list[Elem])\n",
+        "    Empty\n",
+        "\n",
+        "@derive(Clone)\n",
+        "model Maker[T with Clone]:\n",
+        "    seed: T\n",
+        "\n",
+        "    def build[Picked with Clone](self) -> Holder[Picked]:\n",
+        "        return Holder.Items([])\n",
+        "\n",
+        "def main() -> None:\n",
+        "    m = Maker[int](seed=1)\n",
+        "    h: Holder[str] = m.build[str]()\n",
+        "    match h:\n",
+        "        case Holder.Items(values):\n",
+        "            println(f\"{len(values)}\")\n",
+        "        case Holder.Empty:\n",
+        "            println(\"empty\")\n",
+    );
+    let (program, _, _) = checked_source(source)?;
+    let generated = IrCodegen::new()
+        .try_generate(&program)
+        .map_err(|error| std::io::Error::other(format!("generic enum variant generation failed: {error}")))?;
+
+    if generated.contains("Vec::<Elem>::new()") {
+        return Err(format!(
+            "the variant payload kept the enum's own type-parameter name, which is bound nowhere at the \
+             construction site:\n{generated}"
+        )
+        .into());
+    }
+    if !generated.contains("Vec::<Picked>::new()") {
+        return Err(format!(
+            "expected the variant payload to carry the enum's supplied type argument, got:\n{generated}"
+        )
+        .into());
+    }
+    Ok(())
+}
+
+/// The matching-name case must keep working, since it is the only enum case that worked before.
+#[test]
+fn enum_variant_payload_still_emits_a_matching_type_parameter_name_issue1516() -> Result<(), Box<dyn std::error::Error>>
+{
+    let source = concat!(
+        "@derive(Clone)\n",
+        "enum Holder[U with Clone]:\n",
+        "    Items(list[U])\n",
+        "    Empty\n",
+        "\n",
+        "def build[U with Clone]() -> Holder[U]:\n",
+        "    return Holder.Items([])\n",
+        "\n",
+        "def main() -> None:\n",
+        "    h: Holder[str] = build[str]()\n",
+        "    match h:\n",
+        "        case Holder.Items(values):\n",
+        "            println(f\"{len(values)}\")\n",
+        "        case Holder.Empty:\n",
+        "            println(\"empty\")\n",
+    );
+    let (program, _, _) = checked_source(source)?;
+    let generated = IrCodegen::new()
+        .try_generate(&program)
+        .map_err(|error| std::io::Error::other(format!("matching-name enum generation failed: {error}")))?;
+    if !generated.contains("Vec::<U>::new()") {
+        return Err(format!("expected the shared name to survive, got:\n{generated}").into());
+    }
+    Ok(())
+}
+
+/// A concrete declared payload must still win: the substitution applies only to the enum's own parameters.
+#[test]
+fn enum_variant_payload_keeps_a_concrete_declared_payload_type_issue1516() -> Result<(), Box<dyn std::error::Error>> {
+    let source = concat!(
+        "@derive(Clone)\n",
+        "enum Holder[Elem with Clone]:\n",
+        "    Names(list[str])\n",
+        "    Items(list[Elem])\n",
+        "    Empty\n",
+        "\n",
+        "def build[Picked with Clone]() -> Holder[Picked]:\n",
+        "    return Holder.Names([])\n",
+        "\n",
+        "def main() -> None:\n",
+        "    h: Holder[int] = build[int]()\n",
+        "    match h:\n",
+        "        case Holder.Names(names):\n",
+        "            println(f\"{len(names)}\")\n",
+        "        case _:\n",
+        "            println(\"other\")\n",
+    );
+    let (program, _, _) = checked_source(source)?;
+    let generated = IrCodegen::new()
+        .try_generate(&program)
+        .map_err(|error| std::io::Error::other(format!("concrete payload enum generation failed: {error}")))?;
+    if !generated.contains("Vec::<String>::new()") {
+        return Err(format!("a concrete declared payload type must still drive emission, got:\n{generated}").into());
+    }
+    Ok(())
+}
+
+/// The instantiation comes from the destination the value is being built for, not the enclosing function's return.
+///
+/// This is what keeps the substitution sound. A function returning `Holder[Picked]` may legitimately build a
+/// `Holder[str]` for a local along the way; reading the enclosing return type directly would emit `Picked` there and
+/// produce Rust that compiles into the wrong type. The local's own annotation is the destination, so `str` wins.
+#[test]
+fn enum_variant_payload_follows_the_destination_not_the_enclosing_return_issue1516()
+-> Result<(), Box<dyn std::error::Error>> {
+    let source = concat!(
+        "@derive(Clone)\n",
+        "enum Holder[Elem with Clone]:\n",
+        "    Items(list[Elem])\n",
+        "    Empty\n",
+        "\n",
+        "def build[Picked with Clone]() -> Holder[Picked]:\n",
+        "    aside: Holder[str] = Holder.Items([])\n",
+        "    match aside:\n",
+        "        case Holder.Items(values):\n",
+        "            println(f\"{len(values)}\")\n",
+        "        case Holder.Empty:\n",
+        "            println(\"empty\")\n",
+        "    return Holder.Empty\n",
+        "\n",
+        "def main() -> None:\n",
+        "    h: Holder[int] = build[int]()\n",
+        "    match h:\n",
+        "        case Holder.Items(values):\n",
+        "            println(f\"{len(values)}\")\n",
+        "        case Holder.Empty:\n",
+        "            println(\"empty\")\n",
+    );
+    let (program, _, _) = checked_source(source)?;
+    let generated = IrCodegen::new()
+        .try_generate(&program)
+        .map_err(|error| std::io::Error::other(format!("destination-typed enum generation failed: {error}")))?;
+    if generated.contains("Vec::<Picked>::new()") {
+        return Err(format!(
+            "the local's own annotation is the destination; taking the enclosing return type instead emits the \
+             wrong element type:\n{generated}"
+        )
+        .into());
+    }
+    if !generated.contains("Vec::<String>::new()") {
+        return Err(format!("expected the local annotation to drive the payload type, got:\n{generated}").into());
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary

A generic enum's variant payload was emitted with the enum's own type-parameter name at every construction site. `Holder.Items([])`, inside a method returning `Holder[Picked]` where `Holder` declares `Items(list[Elem])`, emitted `Vec::<Elem>::new()` — naming a type parameter bound nowhere in that scope. The typechecker accepted the program and the generated Rust did not compile. This is the enum half of #1507, and it needs a different fix: the model half could fall back to the supplied value's own checked type because the construction site had inferred one, while a variant payload has nothing to fall back to. The payload is now substituted with the enum's type arguments taken from the destination type.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [x] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: constructing a generic enum's variant with an empty collection literal now compiles. Previously any such construction where the enum's parameter name differed from the one in scope produced Rust naming an unbound type parameter. The construction's checked type is now the instantiation it was built for (`Holder[Picked]`) rather than the bare enum name, so a genuinely mismatched payload is reported at the source rather than erased and surfaced later as a Rust type error.
- **Internals**: three changes, one per stage. The typechecker resolves the enum's instantiation from the destination type *before* the arguments are checked and checks each payload against the substituted type — `Enum.Variant(...)` arrives on the shared method-call path, where arguments are checked exactly once part-way through, so a later correction would come too late. Lowering puts the enum's type parameters in scope for variant payloads, so `Elem` lowers to `IrType::Generic` rather than `IrType::Struct`, a nominal type that happens not to exist and one the call-seed guard reads as already resolved. Emission then prefers the argument's checked type whenever the declared payload is still unresolved at the site; the two existing predicates turn out to be exactly the right pair, with the strict call-seed guard rejecting the callee's own vocabulary and the ordinary one accepting a generic that is genuinely bound here.
- **Risks**: the substitution reads the *immediate* destination type, never the enclosing function's return type. That distinction is what keeps it sound — a function returning `Holder[Picked]` may legitimately build a `Holder[str]` for a local, and there the local's own annotation is the destination. Only a same-name, arity-matching instantiation is used; every other shape leaves the previous behavior untouched, including when no destination type is known at all. The reported type changing from `Named` to `Generic` is the widest-reaching part: it is now more precise, so a payload that genuinely disagrees with its destination becomes a source error where it previously type-checked and failed in the generated Rust.

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

**Tests added** (in `tests/checked_empty_collection_constructor_tests.rs`, alongside #1507's):

- `enum_variant_payload_uses_the_enum_type_argument_not_the_declared_name_issue1516` — the defect itself; fails on the parent commit with `Vec::<Elem>::new()`.
- `enum_variant_payload_still_emits_a_matching_type_parameter_name_issue1516` — the matching-name case, which is the only one that worked before, still works.
- `enum_variant_payload_keeps_a_concrete_declared_payload_type_issue1516` — a concrete declared payload still drives emission, so the substitution reaches only the enum's own parameters.
- `enum_variant_payload_follows_the_destination_not_the_enclosing_return_issue1516` — the soundness guard: a local annotated `Holder[str]` inside a function returning `Holder[Picked]` emits `Vec::<String>::new()`, and the test fails if `Picked` appears.

**Verified locally**: the focused file passes 13/13; `codegen_snapshot_tests` passes 266/266 with no snapshot churn; the rustdoc gate passes. The remaining `cargo test --lib` failures in this tree are the known `collect_modules` / provider-store class that require `make test`'s SDK prewarm, and report "SDK provider publication requires the incan CLI executable"; CI runs the prepared path.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

No user-facing surface changed: this makes an already-valid program compile. `check_method_call_with_expected` gained the rustdoc the changed-function gate requires, describing why arguments are checked exactly once and what `expected_return_ty` means.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #1516
