### PR TITLE
chore - #1495 scale the test cargo job cap to the host

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,14 @@
 # every target needing the compiler binary fails claiming the project's dependencies were never baked.
 TARGET_DIR := $(if $(CARGO_TARGET_DIR),$(CARGO_TARGET_DIR),$(CURDIR)/target)
 
-# Nested generated-project and named-publisher work is deliberately constrained so one local test command does not
-# consume every core. Override the cap for a specific machine with `make test INCAN_TEST_CARGO_BUILD_JOBS=<n>`.
-INCAN_TEST_CARGO_BUILD_JOBS ?= 2
+# Nested generated-project and named-publisher work is constrained so one local test command does not consume every
+# core. The cap used to be a flat 2 regardless of the machine, which meant the SDK prewarm compiled its ten
+# components serially on two cores -- about an eighth of an 18-core host, and the dominant share of the roughly 17
+# minutes that preparation takes. Scale with the machine instead, leaving a quarter of the cores as headroom rather
+# than taking all of them, with a floor of 2 so a small or unknown host behaves exactly as before. Override for a
+# specific machine with `make test INCAN_TEST_CARGO_BUILD_JOBS=<n>`.
+INCAN_HOST_CPUS := $(shell sysctl -n hw.logicalcpu 2>/dev/null || nproc 2>/dev/null || echo 4)
+INCAN_TEST_CARGO_BUILD_JOBS ?= $(shell n=$$(( $(INCAN_HOST_CPUS) * 3 / 4 )); if [ "$$n" -lt 2 ]; then n=2; fi; echo "$$n")
 INCAN_TEST_GENERATED_CARGO_TARGET_DIR ?= $(TARGET_DIR)/incan_generated_shared_target
 INCAN_TEST_SDK_PROVIDER_STORE ?= $(TARGET_DIR)/incan_test_sdk_provider_store
 INCAN_TEST_SDK_PROVIDER_PATH_FILE ?= $(TARGET_DIR)/incan_test_sdk_provider_path


### PR DESCRIPTION
## Summary

Preparing the SDK provider store takes about 17 minutes, and most of that was an artificial throttle. `INCAN_TEST_CARGO_BUILD_JOBS` was a flat `?= 2` regardless of the machine. Ten components are prepared serially, each compiling its own Rust dependency closure — 53 packages for `stdlib-web` alone — and every one of those closures was compiled two cores at a time. On an 18-core machine that is roughly an eighth of the host, held for the whole seventeen minutes. The cap now scales with the host.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [x] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: nothing changes for users of the toolchain. A contributor running `make test` gets the SDK prewarm compiled with a job count proportional to their machine instead of a fixed 2.
- **Internals**: `INCAN_HOST_CPUS` reads `sysctl -n hw.logicalcpu`, falling back to `nproc` and then to 4, so the expression is quiet on macOS, Linux, and anything else. The cap is three quarters of that, floored at 2.
- **Risks**: low, and the shape of the risk is worth stating plainly. The cap exists so a local `make test` does not take the whole machine, and that reason is preserved — a quarter of the cores stay free, which is a real fraction on a large host and matches the old behavior exactly on a small one. The floor of 2 means no machine gets *less* parallelism than before. An explicit `make test INCAN_TEST_CARGO_BUILD_JOBS=<n>` still wins, unchanged. A host that reports an implausible core count falls back to 4, not to something unbounded.

This is a throttle, not the cost itself. The cost is cargo compiling the same dependency closures repeatedly, which is what the direct-rustc work removes. #1495 also proposes per-component identities and building each dependency level concurrently; both are worth doing on their own terms, and the concurrency one needs a measurement first, because all ten components deliberately share one Cargo target directory and would otherwise serialize on its lock. This change trades nothing away and is a single line.

Two of #1495's three suggestions are worth re-reading against the current tree before anyone picks them up:

- Narrowing the compiler-source hash is **already done**. `hash_sdk_provider_compiler_source_tree` excludes `.agents`, `.git`, `.incan`, `benches`, `docs`, `examples`, `target`, `tests`, and `workspaces`, and the exclusion matches at any depth, so per-crate `tests/` directories are covered too.
- Per-component identity will not help a compiler-development loop. Emission is an input to every component, so an emitter edit correctly invalidates all ten however the identities are cut. It still helps a stdlib-only edit, which is a real case, but it is not the one that costs the seventeen minutes.

## Testing / verification

- [ ] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

Manual verification notes:

- On an 18-core host the cap resolves to 13, where it previously resolved to 2.
- `make test INCAN_TEST_CARGO_BUILD_JOBS=3` still resolves to 3, so the documented override is unaffected.
- The fallback chain was checked by expansion rather than by assertion: `sysctl` answers on macOS, `nproc` on Linux, and the literal 4 if neither does.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

The override instruction in the comment above the variable is preserved and still accurate.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Contributes to #1495.
