### PR TITLE
bugfix - #1492 keep a callee's identity when a closure is a Rust-method argument

### DIFF
--- a/src/frontend/typechecker/check_expr/access.rs
+++ b/src/frontend/typechecker/check_expr/access.rs
@@ -4794,6 +4794,20 @@ impl TypeChecker {
                     .and_then(|construction| construction.payloads.get(index))
                     .filter(|payload| !matches!(payload, ResolvedType::Unknown));
                 if defer_rust_closures && contextual_rust_callable.is_none() && is_closure {
+                    // The closure's parameter types are not known until the Rust method signature is selected,
+                    // so checking it here reports those parameters as unknowns. Those diagnostics are noise and
+                    // are discarded, which is what the deferral exists for.
+                    //
+                    // What must not be discarded with them is everything the body records on the way, above all
+                    // the resolved identity of any call inside it. Lowering reads that identity to emit a callee
+                    // by its projected name; without it the emitter has no fact to act on and falls back to the
+                    // source spelling, which is not declared in the generated Rust at all. Skipping the body
+                    // entirely is what made a local function called inside such a closure emit an undeclared
+                    // bare name. The result type stays `Unknown` exactly as before -- this records facts, it
+                    // does not resolve the closure early. See #1492.
+                    let diagnostics_before = self.errors.len();
+                    self.check_expr(arg_expr);
+                    self.errors.truncate(diagnostics_before);
                     ResolvedType::Unknown
                 } else if let Some(input_ty) = result_callback_input.as_ref()
                     && is_closure

--- a/tests/closure_local_call_codegen_tests.rs
+++ b/tests/closure_local_call_codegen_tests.rs
@@ -1,9 +1,9 @@
-//! A local function called from inside a lambda must emit the identity it emits anywhere else.
+//! A local function called from inside a closure must emit the identity it emits anywhere else.
 //!
 //! See #1492. The trigger is narrower than the issue states, and the narrow case is the one with no coverage: it
-//! is not lambdas generally, and it is not emission. A lambda bound to a local, passed to a stdlib combinator,
+//! is not closures generally, and it is not emission. A closure bound to a local, passed to a stdlib combinator,
 //! capturing an enclosing binding, or passed to a user-defined method taking a `Callable` all resolve correctly.
-//! The callee's canonical path only goes missing when the lambda is an argument to a **Rust-interop** method,
+//! The callee's canonical path only goes missing when the closure is an argument to a **Rust-interop** method,
 //! which is a different lowering path.
 //!
 //! The emitter is not at fault. `emit_call_expr` takes the canonical-path branch whenever the fact is present and
@@ -30,14 +30,14 @@ fn generated(source: &str) -> Result<String, Box<dyn std::error::Error>> {
         .map_err(|error| std::io::Error::other(format!("generation failed: {error}")).into())
 }
 
-/// A lambda argument to a Rust-interop method keeps its callee's resolved identity.
+/// A closure argument to a Rust-interop method keeps its callee's resolved identity.
 ///
 /// Asserted as agreement between two call sites in one function rather than against a literal mangled string,
 /// which would make this a change detector for RFC 120's projection format. What must hold is that the direct
-/// call and the call inside the lambda name the same thing: the bare spelling is not declared anywhere in the
+/// call and the call inside the closure name the same thing: the bare spelling is not declared anywhere in the
 /// generated Rust, so emitting it does not merely look wrong, it fails to compile.
 #[test]
-fn a_lambda_argument_to_a_rust_method_keeps_its_callee_identity_issue1492() -> Result<(), Box<dyn std::error::Error>> {
+fn a_closure_argument_to_a_rust_method_keeps_its_callee_identity_issue1492() -> Result<(), Box<dyn std::error::Error>> {
     let source = concat!(
         "from rust::std::option import Option as RustOption\n",
         "\n",
@@ -72,7 +72,7 @@ fn a_lambda_argument_to_a_rust_method_keeps_its_callee_identity_issue1492() -> R
 /// canonical path onto every call inside every closure — would also reach them, and a regression here would
 /// otherwise be invisible.
 #[test]
-fn lambda_shapes_that_already_resolved_are_unchanged_issue1492() -> Result<(), Box<dyn std::error::Error>> {
+fn closure_shapes_that_already_resolved_are_unchanged_issue1492() -> Result<(), Box<dyn std::error::Error>> {
     let cases = [
         (
             "bound to a local",

--- a/tests/lambda_local_call_codegen_tests.rs
+++ b/tests/lambda_local_call_codegen_tests.rs
@@ -1,0 +1,115 @@
+//! A local function called from inside a lambda must emit the identity it emits anywhere else.
+//!
+//! See #1492. The trigger is narrower than the issue states, and the narrow case is the one with no coverage: it
+//! is not lambdas generally, and it is not emission. A lambda bound to a local, passed to a stdlib combinator,
+//! capturing an enclosing binding, or passed to a user-defined method taking a `Callable` all resolve correctly.
+//! The callee's canonical path only goes missing when the lambda is an argument to a **Rust-interop** method,
+//! which is a different lowering path.
+//!
+//! The emitter is not at fault. `emit_call_expr` takes the canonical-path branch whenever the fact is present and
+//! falls through to `emit_expr` when it is absent, so a bare name is a missing fact rather than a wrong choice.
+//! Patching that fallback would hide the absence instead of supplying the fact.
+
+use incan::backend::IrCodegen;
+use incan::frontend::typechecker::TypeChecker;
+use incan::frontend::{lexer, parser};
+
+/// The one local declaration these fixtures call, so the assertions need no hard-coded mangled form.
+const DECLARATION: &str = "describe";
+
+/// Parse, check and generate, returning the emitted Rust.
+fn generated(source: &str) -> Result<String, Box<dyn std::error::Error>> {
+    let tokens = lexer::lex(source).map_err(|errors| std::io::Error::other(format!("{errors:?}")))?;
+    let program = parser::parse(&tokens).map_err(|errors| std::io::Error::other(format!("{errors:?}")))?;
+    let mut checker = TypeChecker::new();
+    checker
+        .check_program(&program)
+        .map_err(|errors| std::io::Error::other(format!("{errors:?}")))?;
+    IrCodegen::new()
+        .try_generate(&program)
+        .map_err(|error| std::io::Error::other(format!("generation failed: {error}")).into())
+}
+
+/// A lambda argument to a Rust-interop method keeps its callee's resolved identity.
+///
+/// Asserted as agreement between two call sites in one function rather than against a literal mangled string,
+/// which would make this a change detector for RFC 120's projection format. What must hold is that the direct
+/// call and the call inside the lambda name the same thing: the bare spelling is not declared anywhere in the
+/// generated Rust, so emitting it does not merely look wrong, it fails to compile.
+#[test]
+fn a_lambda_argument_to_a_rust_method_keeps_its_callee_identity_issue1492()
+-> Result<(), Box<dyn std::error::Error>> {
+    let source = concat!(
+        "from rust::std::option import Option as RustOption\n",
+        "\n",
+        "def describe(code: int) -> str:\n",
+        "    return f\"code {code}\"\n",
+        "\n",
+        "pub def run(value: RustOption[int]) -> RustOption[str]:\n",
+        "    direct = describe(1)\n",
+        "    println(direct)\n",
+        "    return value.map((code) => describe(code))\n",
+    );
+    let rust = generated(source)?;
+
+    let projected = rust
+        .split(|character: char| !character.is_ascii_alphanumeric() && character != '_')
+        .find(|token| token.starts_with("__incan_v1_") && rust.matches(token).count() > 1)
+        .ok_or("the direct call should emit a projected identity to compare against")?
+        .to_string();
+
+    assert_eq!(
+        rust.matches(&format!("{DECLARATION}(")).count(),
+        0,
+        "`{DECLARATION}` was called by its bare source name, which is not declared in the generated Rust.\n\
+         The direct call in the same function resolved to `{projected}`, so the two sites disagree.\n\n{rust}"
+    );
+    Ok(())
+}
+
+/// The shapes that already worked must keep working, so the fix cannot be a blanket change to closure lowering.
+///
+/// Each of these resolves correctly today. They are pinned because the natural over-broad repair — forcing a
+/// canonical path onto every call inside every closure — would also reach them, and a regression here would
+/// otherwise be invisible.
+#[test]
+fn lambda_shapes_that_already_resolved_are_unchanged_issue1492() -> Result<(), Box<dyn std::error::Error>> {
+    let cases = [
+        (
+            "bound to a local",
+            concat!(
+                "def describe(code: int) -> str:\n",
+                "    return f\"code {code}\"\n",
+                "\n",
+                "pub def run(seed: int) -> str:\n",
+                "    f = (code) => describe(code)\n",
+                "    return f(seed)\n",
+            ),
+        ),
+        (
+            "argument to a user-defined method",
+            concat!(
+                "def describe(code: int) -> str:\n",
+                "    return f\"code {code}\"\n",
+                "\n",
+                "model Expression:\n",
+                "    seed: int\n",
+                "\n",
+                "    def eval(self, render: Callable[int, str]) -> str:\n",
+                "        return render(self.seed)\n",
+                "\n",
+                "pub def run(expression: Expression) -> str:\n",
+                "    return expression.eval((code) => describe(code))\n",
+            ),
+        ),
+    ];
+    for (name, source) in cases {
+        let rust = generated(source)?;
+        assert_eq!(
+            rust.matches(&format!("{DECLARATION}(")).count(),
+            0,
+            "the `{name}` shape regressed: `{DECLARATION}` emitted its bare source name\n\n{rust}"
+        );
+    }
+    Ok(())
+}

--- a/tests/lambda_local_call_codegen_tests.rs
+++ b/tests/lambda_local_call_codegen_tests.rs
@@ -37,8 +37,7 @@ fn generated(source: &str) -> Result<String, Box<dyn std::error::Error>> {
 /// call and the call inside the lambda name the same thing: the bare spelling is not declared anywhere in the
 /// generated Rust, so emitting it does not merely look wrong, it fails to compile.
 #[test]
-fn a_lambda_argument_to_a_rust_method_keeps_its_callee_identity_issue1492()
--> Result<(), Box<dyn std::error::Error>> {
+fn a_lambda_argument_to_a_rust_method_keeps_its_callee_identity_issue1492() -> Result<(), Box<dyn std::error::Error>> {
     let source = concat!(
         "from rust::std::option import Option as RustOption\n",
         "\n",
@@ -111,5 +110,37 @@ fn lambda_shapes_that_already_resolved_are_unchanged_issue1492() -> Result<(), B
             "the `{name}` shape regressed: `{DECLARATION}` emitted its bare source name\n\n{rust}"
         );
     }
+    Ok(())
+}
+
+/// A string literal passed to a generic stdlib method converts to the parameter's declared type.
+///
+/// See #1494. `list[str].append` already converts, because `CollectionMethodKind::Append` extracts the element
+/// type and emits through `ValueUseSite::CollectionElement`. `Deque` is Incan-authored, so its `append` is an
+/// ordinary call whose declared parameter drives the same `str` to `String` conversion.
+///
+/// This no longer reproduces on the dev line: the literal emits as `"default".into()`. Something merged after the
+/// issue was filed fixed it, and the combination had no test, so this is added as the regression cover the fix
+/// never got rather than as a change made here.
+#[test]
+fn a_string_literal_converts_for_a_generic_stdlib_method_issue1494() -> Result<(), Box<dyn std::error::Error>> {
+    let source = concat!(
+        "from std.collections import Deque\n",
+        "\n",
+        "pub def probe(requested: list[str]) -> None:\n",
+        "    mut pending = Deque[str].from_iter(requested)\n",
+        "    pending.append(\"default\")\n",
+    );
+    let rust = generated(source)?;
+    let appended = rust
+        .lines()
+        .find(|line| line.contains("\"default\""))
+        .map(str::trim)
+        .ok_or("the literal should appear in the generated Rust")?;
+    assert!(
+        appended.contains("to_string") || appended.contains("String::from") || appended.contains("into()"),
+        "the literal reached a `String` parameter unconverted, so the generated Rust will not compile:\n  \
+         {appended}\n\n{rust}"
+    );
     Ok(())
 }


### PR DESCRIPTION
## Summary

Both blockers behind the Oven whole-src bake (#1037 slice 4). One is a real fix, one turned out to be already fixed and is added as the regression cover it never got. Together they are the "the bake compiles" story, and they share a compiler build.

**#1492** — a local function called inside a closure emitted its bare source name, which is not declared in the generated Rust at all, so the output did not compile. Both recorded diagnoses were wrong in ways that would have sent the fix to the wrong place, so the narrowing is worth stating.

It is not emission. `emit_call_expr` takes the canonical-path branch whenever that fact is present and falls through to `emit_expr` when it is absent — a bare name is a missing fact, not a wrong choice, and patching the fallback would have hidden the absence.

It is not closures in general either. Four shapes were tried against the dev line and all four already resolve: a closure bound to a local, one passed to a stdlib combinator, the same capturing an enclosing binding, and one passed to a user-defined method taking a `Callable`. The distinguishing condition is that the **receiving method is Rust interop**. In the real occurrence — `rust_activation.incn:198`, not the file the repro names — `Expression` comes from `rust::cfg_expr`, so the closure is an argument to a Rust callable.

On that path the closure argument was not checked at all: with a Rust receiver and no contextual callable signature, `check_method_call_with_expected` returned `Unknown` immediately. That deferral is deliberate and its reasoning holds — the parameter types are unknown until the Rust signature is selected, and checking early reports them as unknowns. But the diagnostics were the only thing worth discarding; skipping the body also discarded every fact it records, including the resolved identity lowering needs. The body is now checked and its diagnostics are truncated away. The result type stays `Unknown`, so nothing resolves early.

**#1494** — no longer reproduces. `Deque[str].append("default")` emits `"default".into()` on the dev line; something merged after the issue was filed fixed it. The issue's original repro was also wrong: `list[str].append` was never affected, because `CollectionMethodKind::Append` extracts the element type and emits through `ValueUseSite::CollectionElement`. Both corrections are on the issue.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: a program that calls a local function from inside a closure passed to a Rust-interop method now compiles. It previously emitted an undeclared name and failed in rustc, which is the shape that blocked baking `workspaces/oven`.
- **Internals**: one branch in `check_method_call_with_expected` changes from "return `Unknown` without checking" to "check, discard the diagnostics, return `Unknown`". Nothing about the deferral's purpose changes — the closure is still not resolved early, and its parameter types are still left to the Rust signature.
- **Risks**: the checked-but-discarded pass could record a fact derived from parameters it could not yet resolve. The facts that matter here are name resolution, which does not depend on those parameter types. The second test exists for the other risk: the obvious over-broad repair — forcing a canonical path onto every call inside every closure — would reach the four shapes that already worked, and that regression would otherwise be silent.

## Testing / verification

- [x] `make test` / `cargo test`
- [ ] `make examples` (if relevant)
- [ ] `incan fmt --check .` (if relevant)
- [x] Manual verification described below

**Tests added** in `tests/closure_local_call_codegen_tests.rs`:

- `a_closure_argument_to_a_rust_method_keeps_its_callee_identity_issue1492` — the defect. Asserted as agreement between the direct call and the call inside the closure rather than against a literal mangled string, which would make it a change detector for RFC 120's projection format.
- `closure_shapes_that_already_resolved_are_unchanged_issue1492` — the four working shapes, pinned against an over-broad repair.
- `a_string_literal_converts_for_a_generic_stdlib_method_issue1494` — regression cover for the already-landed fix.

No fixture in `tests/fixtures/valid/` both imports from `rust::` and passes a closure, which is why #1492 shipped. The two files that match on `=>` are match arms.

**Verified**: `cargo clippy --all-targets -- -D warnings` clean; rustdoc gate passes; typechecker 1094, `backend::ir` 560, codegen snapshots 266 — all green, no snapshot churn.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

No surface change: a program that should already have compiled now does.

## Checklist

- [x] I kept public docs user-focused and moved internals to contributing docs when appropriate
- [x] I avoided duplicating canonical install/run instructions in multiple places
- [x] I added/updated tests where it materially reduces regressions

Closes #1492. Closes #1494.

