### PR TITLE
feature - #1037 give the Oven control plane its library root

### DIFF
--- a/workspaces/oven/src/lib.incn
+++ b/workspaces/oven/src/lib.incn
@@ -1,0 +1,10 @@
+"""Public facade for the Incan-authored Oven control plane."""
+
+pub from manifest_errors import IntakeErrorKind
+pub from plan import select_native
+pub from plan_json import evaluate, evaluate_batch, decode_batch
+pub from native_compilation import evaluate_document, project
+pub from source_unit import select_source_units, SourceBatch, BatchSelection
+pub from rust_source import read_dependency_catalog
+pub from rust_activation import activate_unit, version_matches
+pub from invocation import decide_invocation


### PR DESCRIPTION
## Summary

`workspaces/oven/` has fourteen Incan modules and no library target. `incan test` discovers tests by filename, but `test_runner/execution.rs` will only treat a directory as a project — and so load its registry source authorities — once it finds `src/lib.incn` or `src/main.incn`. Without one, the control plane's test modules run outside the project context they are written against.

This adds the facade. It was authored during the control-plane work and deliberately withheld: with it present every `incan check` over the directory demands a passing project bake, and the bake failed on #1492. That fix is the base of this stack, so the reason to withhold it is gone.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC

## Area(s)

- [x] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration
- [ ] Runtime / Core crates
- [ ] Documentation

## Key details

- **User-facing behavior**: none outside the repository. This is a target for an in-repo workspace.
- **Internals**: ten `pub from` re-exports covering the fourteen modules that have a public surface. Every module named here and every symbol taken from it was checked against the dev line rather than assumed.
- **Risks**: the facade is what makes `incan check` over this directory demand a passing bake. That is the point — it is how the control plane stops drifting — but it also means a bake regression now surfaces here. Kept as its own commit so reverting is one revert.

## Testing / verification

- [x] `cargo +nightly fmt`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `python3 scripts/check_changed_rustdocs.py --base origin/0.6.0-dev.4`

Stacked on #1521; the diff against that branch is this one file.

## Docs impact

- [x] No docs changes needed

Part of #1037.