### PR TITLE
chore - #1495 key the SDK provider store on what the compiler produces

### DIFF
--- a/src/cli/commands/common.rs
+++ b/src/cli/commands/common.rs
@@ -504,13 +504,16 @@ fn sdk_provider_store_identity(
 /// The memo key is a plain byte hash of the same roots the digest reads, which makes the two agree by
 /// construction: the digest is a pure function of those bytes, so equal bytes cannot produce a different digest,
 /// and any edit — even one the digest would forgive, like a comment — misses the memo and recomputes rather than
-/// returning a stale answer.
+/// returning a stale answer. Entries are published by rename, because `make -j` puts many processes on one cache
+/// and a half-written digest is still a well-formed cache key.
 ///
-/// # Degrading without lying
+/// # The memo changes the cost, never the value
 ///
-/// When no cache directory can be resolved or written, the *byte hash* is folded in place of the digest. That is
-/// the conservative direction: it over-invalidates inside the digested roots, exactly as the memo key implies, and
-/// it never reuses components built from sources this key never saw. It is a slower cache, not a wrong one.
+/// An environment with nowhere to put the memo recomputes the digest each time and gets the same answer. That is
+/// deliberate rather than an omission: the identity must be a function of the compiler and its standard library
+/// alone. Substituting the cheaper byte hash where no cache exists would make two machines with identical source
+/// publish to two different store paths, which is exactly what
+/// [`sdk_provider_store_identity_for_compiler_root`] exists to prevent.
 fn sdk_provider_effect_digest(checkout_root: &Path) -> CliResult<String> {
     let content_key = sdk_provider_effect_input_key(checkout_root)?;
     let cached_path = sdk_provider_effect_digest_cache_root().map(|root| root.join(&content_key));
@@ -531,13 +534,36 @@ fn sdk_provider_effect_digest(checkout_root: &Path) -> CliResult<String> {
         ))
     })?;
 
-    if let Some(cached_path) = &cached_path
-        && let Some(parent) = cached_path.parent()
-        && fs::create_dir_all(parent).is_ok()
-    {
-        let _ = fs::write(cached_path, &digest);
+    if let Some(cached_path) = &cached_path {
+        write_effect_digest_memo(cached_path, &digest);
     }
     Ok(digest)
+}
+
+/// Publish one memoized digest by rename, so a concurrent reader never sees a partially written one.
+///
+/// `make -j` runs many `incan` processes against one cache, and every one of them computes this digest on a miss.
+/// A plain write can be read mid-flight, and a truncated digest is still a well-formed cache key — it would
+/// partition the store under a value no compiler will ever produce again. Writing beside the target and renaming
+/// makes the file appear whole or not at all; two processes racing write byte-identical content, so whichever
+/// rename lands last is correct either way.
+///
+/// Every failure here is ignored deliberately. This is a cache: an unwritable directory, a full disk or a losing
+/// race costs the next command a recomputation, which the caller already handles.
+fn write_effect_digest_memo(cached_path: &Path, digest: &str) {
+    let Some(parent) = cached_path.parent() else {
+        return;
+    };
+    if fs::create_dir_all(parent).is_err() {
+        return;
+    }
+    let Some(name) = cached_path.file_name().and_then(|name| name.to_str()) else {
+        return;
+    };
+    let staged = parent.join(format!(".{name}.{}.staged", std::process::id()));
+    if fs::write(&staged, digest).is_ok() && fs::rename(&staged, cached_path).is_err() {
+        let _ = fs::remove_file(&staged);
+    }
 }
 
 /// Resolve where effect digests are memoized, or `None` when this environment has nowhere durable to put them.

--- a/src/cli/commands/common.rs
+++ b/src/cli/commands/common.rs
@@ -41,6 +41,7 @@ use crate::frontend::testing_markers::{
 use crate::frontend::typechecker::stdlib_loader::StdlibAstCache;
 use crate::frontend::typechecker::{CBindingDescriptor, TypeCheckInfo};
 use crate::frontend::{ast_walk, diagnostics, lexer, parser, typechecker, vocab_desugar_pass};
+use crate::inspect::effect_digest::{COMPILER_RUST_EFFECT_ROOTS, COMPILER_STDLIB_ROOT, compiler_effect_digest};
 use crate::library_manifest::{
     LibraryManifest, ProviderCargoDependency, ProviderCargoDependencySource, ProviderModuleClaim,
     digest_provider_artifact,
@@ -441,8 +442,22 @@ fn hash_sdk_provider_source_tree(root: &Path, current: &Path, hasher: &mut Sha25
 /// closure. The identity is content based, so a stale provider set is never accepted because a directory exists.
 ///
 /// Development binaries are rebuilt when test-only Rust changes, and their raw bytes are not a stable description of
-/// compiler behavior. A checkout therefore contributes its compiler source closure; an installed toolchain, which has
-/// no source closure to inspect, falls back to the executable digest.
+/// compiler behavior. A checkout therefore contributes an effect digest — what this compiler *produces* for this
+/// standard library — while an installed toolchain, which has no source to inspect, falls back to the executable
+/// digest.
+///
+/// # Why the effect digest replaced the source closure
+///
+/// Through v3 a checkout folded a hash of its whole `src/`, `crates/` and `tests/` tree, so editing the language
+/// server, a CLI command or an inspection module rebuilt all ten SDK components at a cost of roughly seventeen
+/// minutes (#1495). Hashing the source answers "did the compiler change", and what the cache needs to know is
+/// "would this compiler produce different components", which is a different question for almost every edit anyone
+/// makes. [`compiler_effect_digest`] answers the second one directly.
+///
+/// [`crate::version::SDK_PROVIDER_CODEGEN_REVISION`] is folded alongside it. Publication code can change the shape
+/// of the store without changing any component's content, and that constant is the declared mechanism for saying
+/// so; the inventory already validates it on every cache hit, and folding it here means a bump also partitions the
+/// store rather than only rejecting what is in it.
 fn sdk_provider_store_identity(
     stdlib_root: &Path,
     executable: &Path,
@@ -450,18 +465,20 @@ fn sdk_provider_store_identity(
     distribution_profile: &str,
 ) -> CliResult<String> {
     let mut hasher = Sha256::new();
-    hasher.update(b"incan-sdk-provider-store-v3\0");
-    hash_sdk_provider_source_tree(stdlib_root, stdlib_root, &mut hasher)?;
+    hasher.update(b"incan-sdk-provider-store-v4\0");
     hasher.update(b"compiler-version\0");
     hasher.update(crate::version::INCAN_VERSION.as_bytes());
+    hasher.update(b"provider-codegen-revision\0");
+    hasher.update(crate::version::SDK_PROVIDER_CODEGEN_REVISION.to_le_bytes());
     hasher.update(b"distribution-profile\0");
     hasher.update(distribution_profile.as_bytes());
 
     let executable = fs::canonicalize(executable).unwrap_or_else(|_| executable.to_path_buf());
     if let Some(checkout_root) = sdk_provider_compiler_checkout_root(stdlib_root) {
-        hasher.update(b"compiler-source-closure\0");
-        hash_sdk_provider_compiler_source_tree(&checkout_root, &checkout_root, &mut hasher)?;
+        hasher.update(b"compiler-effect\0");
+        hasher.update(sdk_provider_effect_digest(&checkout_root)?.as_bytes());
     } else {
+        hash_sdk_provider_source_tree(stdlib_root, stdlib_root, &mut hasher)?;
         hasher.update(b"compiler-executable-content\0");
         hasher.update(sdk_provider_compiler_digest(&executable)?);
     }
@@ -474,6 +491,98 @@ fn sdk_provider_store_identity(
                 workspace_lock.display()
             ))
         })?);
+    }
+    Ok(hex::encode(hasher.finalize()))
+}
+
+/// Digest what the compiler in `checkout_root` produces for its standard library, memoized on its inputs' bytes.
+///
+/// The digest itself costs about 1.8 seconds over all 104 standard-library sources, which is three orders of
+/// magnitude below the rebuild it prevents but far too much to pay on every command that resolves the provider
+/// store. So it is computed once per distinct input content and read back afterwards.
+///
+/// The memo key is a plain byte hash of the same roots the digest reads, which makes the two agree by
+/// construction: the digest is a pure function of those bytes, so equal bytes cannot produce a different digest,
+/// and any edit — even one the digest would forgive, like a comment — misses the memo and recomputes rather than
+/// returning a stale answer.
+///
+/// # Degrading without lying
+///
+/// When no cache directory can be resolved or written, the *byte hash* is folded in place of the digest. That is
+/// the conservative direction: it over-invalidates inside the digested roots, exactly as the memo key implies, and
+/// it never reuses components built from sources this key never saw. It is a slower cache, not a wrong one.
+fn sdk_provider_effect_digest(checkout_root: &Path) -> CliResult<String> {
+    let content_key = sdk_provider_effect_input_key(checkout_root)?;
+    let cached_path = sdk_provider_effect_digest_cache_root().map(|root| root.join(&content_key));
+    if let Some(cached_path) = &cached_path
+        && let Ok(cached) = fs::read_to_string(cached_path)
+        && cached.starts_with("sha256:")
+    {
+        return Ok(cached.trim().to_string());
+    }
+
+    let root = checkout_root.to_path_buf();
+    let digest = crate::compiler_stack::run_on_compiler_stack(move || {
+        compiler_effect_digest(&root).map_err(|error| error.to_string())
+    })
+    .map_err(|message| {
+        CliError::failure(format!(
+            "failed to digest compiler effect for the standard library: {message}"
+        ))
+    })?;
+
+    if let Some(cached_path) = &cached_path
+        && let Some(parent) = cached_path.parent()
+        && fs::create_dir_all(parent).is_ok()
+    {
+        let _ = fs::write(cached_path, &digest);
+    }
+    Ok(digest)
+}
+
+/// Resolve where effect digests are memoized, or `None` when this environment has nowhere durable to put them.
+///
+/// A test harness that redirects the provider store gets its memo redirected with it, and a unit test gets a
+/// target-directory memo of its own, so neither ever reads or writes the developer's own cache.
+fn sdk_provider_effect_digest_cache_root() -> Option<PathBuf> {
+    if cfg!(test) {
+        return Some(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("target/incan_test_effect_digest"));
+    }
+    if let Some(store) = env::var_os(INTERNAL_SDK_PROVIDER_STORE_ENV).filter(|path| !path.is_empty()) {
+        return Some(PathBuf::from(store).join(".effect-digest-v1"));
+    }
+    env::var_os("INCAN_HOME")
+        .filter(|path| !path.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| {
+            env::var_os("HOME")
+                .or_else(|| env::var_os("USERPROFILE"))
+                .filter(|path| !path.is_empty())
+                .map(|path| PathBuf::from(path).join(".incan"))
+        })
+        .map(|root| root.join("cache").join("effect-digest-v1"))
+}
+
+/// Hash the bytes of every root the effect digest reads, as the memo key for its result.
+///
+/// Roots are folded in their declared order under their declared labels so two checkouts with the same content
+/// agree, and a root that is absent is recorded as absent rather than skipped — a missing tree is a different
+/// compiler, not the same one.
+fn sdk_provider_effect_input_key(checkout_root: &Path) -> CliResult<String> {
+    let mut hasher = Sha256::new();
+    hasher.update(b"incan-effect-inputs-v1\0");
+    let stdlib_root = checkout_root.join(COMPILER_STDLIB_ROOT);
+    hasher.update(b"stdlib\0");
+    hash_sdk_provider_source_tree(&stdlib_root, &stdlib_root, &mut hasher)?;
+    for (label, relative) in COMPILER_RUST_EFFECT_ROOTS {
+        let root = checkout_root.join(relative);
+        hasher.update(label.as_bytes());
+        hasher.update([0]);
+        if root.is_dir() {
+            hash_sdk_provider_source_tree(&root, &root, &mut hasher)?;
+        } else {
+            hasher.update(b"absent\0");
+        }
     }
     Ok(hex::encode(hasher.finalize()))
 }
@@ -524,94 +633,6 @@ fn is_sdk_provider_compiler_checkout(candidate: &Path, stdlib_root: &Path) -> bo
     }
     let expected_stdlib_root = candidate.join("crates/incan_stdlib/stdlib");
     fs::canonicalize(&expected_stdlib_root).ok() == fs::canonicalize(stdlib_root).ok()
-}
-
-/// Hash compiler-authoritative checkout inputs, excluding generated output, test trees, and root CI administration.
-///
-/// The root `.github` directory configures repository automation; compilation does not read it. This exclusion is
-/// deliberately root-only so similarly named directories within compiler sources retain their existing authority.
-fn hash_sdk_provider_compiler_source_tree(root: &Path, current: &Path, hasher: &mut Sha256) -> CliResult<()> {
-    let mut entries = fs::read_dir(current)
-        .map_err(|error| {
-            CliError::failure(format!(
-                "failed to read compiler source directory {}: {error}",
-                current.display()
-            ))
-        })?
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|error| {
-            CliError::failure(format!(
-                "failed to enumerate compiler source directory {}: {error}",
-                current.display()
-            ))
-        })?;
-    entries.sort_by_key(|entry| entry.file_name());
-
-    for entry in entries {
-        let path = entry.path();
-        let relative = path.strip_prefix(root).map_err(|error| {
-            CliError::failure(format!(
-                "failed to make compiler source path {} relative: {error}",
-                path.display()
-            ))
-        })?;
-        let file_type = entry.file_type().map_err(|error| {
-            CliError::failure(format!(
-                "failed to inspect compiler source path {}: {error}",
-                path.display()
-            ))
-        })?;
-        if file_type.is_dir() && relative == Path::new(".github") {
-            continue;
-        }
-        if file_type.is_dir()
-            && relative.components().any(|component| {
-                matches!(
-                    component.as_os_str().to_str(),
-                    Some(
-                        ".agents"
-                            | ".git"
-                            | ".incan"
-                            | "benches"
-                            | "docs"
-                            | "examples"
-                            | "target"
-                            | "tests"
-                            | "workspaces"
-                    )
-                )
-            })
-        {
-            continue;
-        }
-
-        hasher.update(relative.to_string_lossy().as_bytes());
-        hasher.update([0]);
-        if file_type.is_dir() {
-            hasher.update(b"directory\0");
-            hash_sdk_provider_compiler_source_tree(root, &path, hasher)?;
-        } else if file_type.is_file() {
-            hasher.update(b"file\0");
-            let bytes = fs::read(&path).map_err(|error| {
-                CliError::failure(format!(
-                    "failed to read compiler source file {}: {error}",
-                    path.display()
-                ))
-            })?;
-            hasher.update(bytes);
-        } else if file_type.is_symlink() {
-            hasher.update(b"symlink\0");
-            let target = fs::read_link(&path).map_err(|error| {
-                CliError::failure(format!(
-                    "failed to read compiler source symlink {}: {error}",
-                    path.display()
-                ))
-            })?;
-            hasher.update(target.to_string_lossy().as_bytes());
-        }
-        hasher.update([0xff]);
-    }
-    Ok(())
 }
 
 /// Hash the running compiler once per process with BLAKE3's optimized implementation, independent of its path.
@@ -5878,9 +5899,41 @@ mod tests {
         Ok(())
     }
 
+    /// The memo key over this repository's own effect roots stays cheap enough to pay on every command.
+    ///
+    /// This is the cost the fix actually charges. The digest behind it costs seconds and is paid once per distinct
+    /// input content; what a warm command pays is this byte hash, and it reads a small named set of roots rather
+    /// than the whole `src/`, `crates/` and `tests/` tree v3 walked.
     #[test]
-    fn sdk_provider_store_identity_ignores_rebuilt_development_executable_bytes()
-    -> Result<(), Box<dyn std::error::Error>> {
+    fn the_effect_memo_key_over_this_checkout_stays_cheap() -> Result<(), Box<dyn std::error::Error>> {
+        let checkout = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let started = std::time::Instant::now();
+        let key = sdk_provider_effect_input_key(&checkout)?;
+        let elapsed = started.elapsed();
+        println!("EFFECT-MEMO-KEY {key} in {} ms", elapsed.as_millis());
+        assert_eq!(key.len(), 64, "the memo key is a hex sha256");
+        assert_eq!(
+            key,
+            sdk_provider_effect_input_key(&checkout)?,
+            "the memo key must not depend on directory iteration order"
+        );
+        // Generous enough to survive a loaded machine and a cold page cache, tight enough to fail if the key ever
+        // starts walking the whole checkout again.
+        assert!(
+            elapsed.as_secs() < 5,
+            "the memo key took {} ms, which is no longer a per-command cost",
+            elapsed.as_millis()
+        );
+        Ok(())
+    }
+
+    /// The store identity keys on what the compiler produces, not on what the compiler is made of (#1495).
+    ///
+    /// Each assertion below is one row of that contract. The two that changed in v4 are the ones that used to cost
+    /// seventeen minutes: an edit to a compiler subsystem no component's compilation can reach now reuses the
+    /// store, and a comment added to a standard-library source does too.
+    #[test]
+    fn sdk_provider_store_identity_keys_on_what_the_compiler_produces() -> Result<(), Box<dyn std::error::Error>> {
         let temp_dir = tempfile::tempdir()?;
         let checkout = temp_dir.path().join("checkout");
         let stdlib_root = checkout.join("crates/incan_stdlib/stdlib");
@@ -5944,16 +5997,33 @@ mod tests {
             "CI edits and administrative path changes must reuse SDK providers"
         );
 
+        // The seventeen minutes. `src/compiler.rs` stands for every subsystem outside the effect roots — the
+        // language server, an inspection module, a CLI command — none of which can change what a component
+        // contains, and all of which rebuilt all ten components through v3.
         fs::write(
             checkout.join("src/compiler.rs"),
             "pub fn compile() { let changed = true; }\n",
         )?;
-        let changed_source =
+        let unreachable_subsystem =
             sdk_provider_store_identity(&stdlib_root, &executable, Some(&checkout.join("Cargo.lock")), "full")?;
-        assert_ne!(
-            initial, changed_source,
-            "a compiler source change must still invalidate SDK provider artifacts"
+        assert_eq!(
+            initial, unreachable_subsystem,
+            "an edit no component's compilation can reach must reuse the provider store"
         );
+
+        // A comment cannot change what the compiler emits, so it cannot change the store. This is the property the
+        // byte hash could not express at any granularity, and the reason the key is a digest of meaning.
+        fs::write(
+            stdlib_root.join("components/core.incn"),
+            "# a comment the compiler cannot emit\npub def core() -> int:\n  return 1\n",
+        )?;
+        let commented_stdlib =
+            sdk_provider_store_identity(&stdlib_root, &executable, Some(&checkout.join("Cargo.lock")), "full")?;
+        assert_eq!(
+            initial, commented_stdlib,
+            "a comment in a standard-library source must reuse the provider store"
+        );
+
         fs::write(
             stdlib_root.join("components/core.incn"),
             "pub def core() -> int:\n  return 2\n",
@@ -5961,16 +6031,38 @@ mod tests {
         let changed_stdlib =
             sdk_provider_store_identity(&stdlib_root, &executable, Some(&checkout.join("Cargo.lock")), "full")?;
         assert_ne!(
-            changed_source, changed_stdlib,
-            "stdlib source remains part of SDK provider identity"
+            initial, changed_stdlib,
+            "a changed standard-library body is a changed component"
         );
-        fs::create_dir_all(checkout.join("src/.github"))?;
-        fs::write(checkout.join("src/.github/input.txt"), "compiler-owned input")?;
-        let nested_directory =
+
+        // The transitional half. Lowering and emission change generated Rust without moving any HIR, so their
+        // source is folded until direct-HIR removes the need.
+        let backend = checkout.join("src/backend/ir/emit");
+        fs::create_dir_all(&backend)?;
+        fs::write(backend.join("decls.rs"), "pub fn emit() -> u8 { 1 }\n")?;
+        let with_backend =
+            sdk_provider_store_identity(&stdlib_root, &executable, Some(&checkout.join("Cargo.lock")), "full")?;
+        fs::write(backend.join("decls.rs"), "pub fn emit() -> u8 { 2 }\n")?;
+        let changed_backend =
             sdk_provider_store_identity(&stdlib_root, &executable, Some(&checkout.join("Cargo.lock")), "full")?;
         assert_ne!(
-            changed_stdlib, nested_directory,
-            "only root CI administration is excluded"
+            with_backend, changed_backend,
+            "an emission change alters generated Rust without moving any HIR"
+        );
+
+        // The Rust half is mandatory rather than an enhancement: every component links this runtime, so an
+        // Incan-only key would report a hit for a change the consumer can observe.
+        let runtime = checkout.join("crates/incan_stdlib/src");
+        fs::create_dir_all(&runtime)?;
+        fs::write(runtime.join("frozen.rs"), "pub fn limit() -> u8 { 1 }\n")?;
+        let with_runtime =
+            sdk_provider_store_identity(&stdlib_root, &executable, Some(&checkout.join("Cargo.lock")), "full")?;
+        fs::write(runtime.join("frozen.rs"), "pub fn limit() -> u8 { 2 }\n")?;
+        let changed_runtime =
+            sdk_provider_store_identity(&stdlib_root, &executable, Some(&checkout.join("Cargo.lock")), "full")?;
+        assert_ne!(
+            with_runtime, changed_runtime,
+            "every component links the Rust runtime, so a change to it must invalidate"
         );
         Ok(())
     }

--- a/src/inspect/effect_digest.rs
+++ b/src/inspect/effect_digest.rs
@@ -25,14 +25,21 @@
 //!
 //! # The transitional input, and when to remove it
 //!
-//! Today the compiler still lowers to Rust and emits it, so a change confined to the emitter alters generated
-//! output without moving any HIR. Two of this programme's own defects had exactly that shape. Until emission is
-//! gone, a digest over HIR alone would be a false hit for an emitter change, so the emitter's own sources are
-//! folded in as a narrow, explicitly transitional input — narrow enough to exclude the rest of the compiler, and
-//! removed with the emitter rather than maintained forever.
+//! Today the compiler still lowers to Rust and emits it, so a change confined to lowering or emission alters
+//! generated output without moving any HIR. Two of this programme's own defects had exactly that shape. Until
+//! emission is gone, a digest over HIR alone would be a false hit for such a change, so the backend's own sources
+//! are folded in as a narrow, explicitly transitional input — narrow enough to exclude the rest of the compiler,
+//! and removed with the backend rather than maintained forever.
 //!
 //! This is the one place where the *source* of a compiler subsystem still reaches the key, and it is here because
 //! the alternative is unsound today, not because source hashing is the design.
+//!
+//! # The caller names the Rust roots
+//!
+//! Which Rust trees reach a compiled component is a property of the compiler's layout, not of digesting, so the
+//! caller supplies them as labelled roots rather than this module hard-coding three. A root is labelled so the
+//! hash distinguishes the same bytes arriving under a different role, and the labels are folded in the order
+//! given, which the caller keeps stable.
 
 use std::collections::BTreeMap;
 use std::fs;
@@ -177,23 +184,80 @@ fn module_meaning(path: &Path, source: &str) -> Result<BTreeMap<String, String>,
     Ok(meanings)
 }
 
+/// The standard-library Incan sources inside a compiler checkout.
+pub const COMPILER_STDLIB_ROOT: &str = "crates/incan_stdlib/stdlib";
+
+/// The Rust roots inside a compiler checkout whose content can change a compiled standard-library component.
+///
+/// # Why an inclusion list is sound here
+///
+/// #1495's own first step proposed narrowing the existing whole-tree hash by *excluding* paths, which fails open
+/// in the dangerous direction: forget to exclude something and you pay for it, forget that something belongs
+/// excluded and nothing tells you. This list is the other shape. It answers "what can reach a compiled component"
+/// and everything it omits is omitted for a stated reason, each of which is one of exactly two:
+///
+/// - **Covered by meaning.** `src/frontend`, `crates/incan_syntax` and `crates/incan_vocab` are run, not hashed: the
+///   digest lexes, parses, checks and lowers all 104 standard-library sources with this compiler, so a change to any of
+///   them that alters what the compiler understands moves the digest, and one that does not, does not. That is a
+///   stronger answer than hashing their source, not a weaker one.
+/// - **Cannot reach a component.** `src/cli`, `src/lsp`, `src/inspect`, `src/oven`, `crates/incan_codegraph`,
+///   `crates/rust_inspect` and `tests/` are the compiler's own tooling. They decide *when* components are built and
+///   *where* they are written, never what a component contains.
+///
+/// The second reason has one edge the digest does not cover by itself: publication code that changes the store's
+/// own layout or manifest produces a differently-shaped store from identical component content. That case is
+/// deliberate by construction and already has its own mechanism — [`crate::version::SDK_PROVIDER_CODEGEN_REVISION`],
+/// which the inventory validates on every cache hit and which is folded into the store identity beside this
+/// digest. Publication changes bump that constant; they do not rely on a source hash noticing them.
+///
+/// `src/backend` is the transitional entry. Lowering and emission change generated Rust without moving any HIR, so
+/// until direct-HIR lands their source is folded. It is labelled apart from the runtime crates for that reason, and
+/// it is removed with the backend rather than maintained.
+pub const COMPILER_RUST_EFFECT_ROOTS: &[(&str, &str)] = &[
+    ("stdlib-runtime", "crates/incan_stdlib/src"),
+    ("core", "crates/incan_core"),
+    ("derive", "crates/incan_derive"),
+    ("web-macros", "crates/incan_web_macros"),
+    ("semantics-core", "crates/incan_semantics_core"),
+    ("semantics-stdlib", "crates/incan_semantics_stdlib"),
+    ("transitional-backend", "src/backend"),
+];
+
+/// Digest what the compiler in `checkout_root` would produce for its own standard library.
+///
+/// Resolves [`COMPILER_STDLIB_ROOT`] and [`COMPILER_RUST_EFFECT_ROOTS`] against the checkout and folds them through
+/// [`stdlib_effect_digest`], so a caller keying a cache does not restate the layout.
+///
+/// # Errors
+///
+/// Returns [`EffectDigestError`] when a root cannot be enumerated or a source cannot be read.
+pub fn compiler_effect_digest(checkout_root: &Path) -> Result<String, EffectDigestError> {
+    let roots: Vec<(&str, PathBuf)> = COMPILER_RUST_EFFECT_ROOTS
+        .iter()
+        .map(|(label, relative)| (*label, checkout_root.join(relative)))
+        .collect();
+    let borrowed: Vec<(&str, &Path)> = roots.iter().map(|(label, path)| (*label, path.as_path())).collect();
+    stdlib_effect_digest(&checkout_root.join(COMPILER_STDLIB_ROOT), &borrowed)
+}
+
 /// Digest what this compiler would produce for the standard library rooted at `stdlib_root`.
 ///
-/// The returned digest moves when the compiler would emit different output and holds still otherwise. It folds
-/// three inputs: the checked meaning of every `.incn` source, the token-level content of the Rust runtime every
-/// component links against, and — transitionally — the emitter's own sources.
+/// The returned digest moves when the compiler would emit different output and holds still otherwise. It folds the
+/// checked meaning of every `.incn` source under `stdlib_root`, then the token-level content of each Rust root in
+/// `rust_roots`, each under the label it is given.
+///
+/// A caller supplies two kinds of Rust root, and the distinction is in the label rather than in the treatment: the
+/// runtime crates a component links against, which are permanent, and the backend that lowers and emits, which is
+/// transitional and goes away with emission. A Rust root that does not exist is folded as absent; `stdlib_root`
+/// itself is required, because a digest with no standard library in it describes nothing.
 ///
 /// # Errors
 ///
 /// Returns [`EffectDigestError`] when a source cannot be read or a standard-library module does not compile. Both
 /// are refusals: a digest that skipped what it could not read would describe a different standard library.
-pub fn stdlib_effect_digest(
-    stdlib_root: &Path,
-    rust_runtime_root: &Path,
-    emitter_root: &Path,
-) -> Result<String, EffectDigestError> {
+pub fn stdlib_effect_digest(stdlib_root: &Path, rust_roots: &[(&str, &Path)]) -> Result<String, EffectDigestError> {
     let mut hasher = Sha256::new();
-    delimited(&mut hasher, b"incan-stdlib-effect-v1");
+    delimited(&mut hasher, b"incan-stdlib-effect-v2");
 
     // ---- The Incan half: checked meaning, not source text ----
     delimited(&mut hasher, b"incan-meaning");
@@ -223,34 +287,29 @@ pub fn stdlib_effect_digest(
         }
     }
 
-    // ---- The Rust half: mandatory, because every component links against it ----
-    delimited(&mut hasher, b"rust-runtime");
-    for path in collect_sources(rust_runtime_root, &["rs"])? {
-        let source = fs::read_to_string(&path).map_err(|error| EffectDigestError::Read {
-            path: path.clone(),
-            message: error.to_string(),
-        })?;
-        let relative = path.strip_prefix(rust_runtime_root).unwrap_or(&path);
-        delimited(&mut hasher, relative.to_string_lossy().as_bytes());
-        delimited(
-            &mut hasher,
-            rust_source_digest(&relative.to_string_lossy(), &source).as_bytes(),
-        );
-    }
-
-    // ---- The transitional half: remove this with the emitter ----
-    delimited(&mut hasher, b"emitter-source");
-    for path in collect_sources(emitter_root, &["rs"])? {
-        let source = fs::read_to_string(&path).map_err(|error| EffectDigestError::Read {
-            path: path.clone(),
-            message: error.to_string(),
-        })?;
-        let relative = path.strip_prefix(emitter_root).unwrap_or(&path);
-        delimited(&mut hasher, relative.to_string_lossy().as_bytes());
-        delimited(
-            &mut hasher,
-            rust_source_digest(&relative.to_string_lossy(), &source).as_bytes(),
-        );
+    // ---- The Rust half: mandatory, because a component links against it or is produced by it ----
+    for (label, root) in rust_roots {
+        delimited(&mut hasher, b"rust-root");
+        delimited(&mut hasher, label.as_bytes());
+        // A root that is not there is folded as absent rather than refused. Compiler layouts differ — a trimmed
+        // distribution need not ship every crate — and a missing tree is a different compiler, which "absent"
+        // already says. Refusing would make the key unavailable for a checkout that builds perfectly well.
+        if !root.is_dir() {
+            delimited(&mut hasher, b"absent");
+            continue;
+        }
+        for path in collect_sources(root, &["rs"])? {
+            let source = fs::read_to_string(&path).map_err(|error| EffectDigestError::Read {
+                path: path.clone(),
+                message: error.to_string(),
+            })?;
+            let relative = path.strip_prefix(root).unwrap_or(&path);
+            delimited(&mut hasher, relative.to_string_lossy().as_bytes());
+            delimited(
+                &mut hasher,
+                rust_source_digest(&relative.to_string_lossy(), &source).as_bytes(),
+            );
+        }
     }
 
     Ok(format!("sha256:{}", hex::encode(hasher.finalize())))

--- a/tests/stdlib_effect_digest.rs
+++ b/tests/stdlib_effect_digest.rs
@@ -5,7 +5,7 @@
 //! replacement has to get right — it must move for a change the compiler would emit differently, and hold still
 //! for one it would not — and record what it costs against the real standard library.
 
-use incan::inspect::effect_digest::{module_effect_digest, stdlib_effect_digest};
+use incan::inspect::effect_digest::{compiler_effect_digest, module_effect_digest, stdlib_effect_digest};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
@@ -95,9 +95,15 @@ fn the_digest_covers_the_rust_runtime_every_component_links_against() -> TestRes
     fs::write(emitter.join("emit.rs"), "pub fn emit() -> u8 { 1 }\n")?;
 
     fs::write(runtime.join("frozen.rs"), "pub fn limit() -> u8 { 1 }\n")?;
-    let before = stdlib_effect_digest(&stdlib, &runtime, &emitter)?;
+    let before = stdlib_effect_digest(
+        &stdlib,
+        &[("runtime", runtime.as_path()), ("backend", emitter.as_path())],
+    )?;
     fs::write(runtime.join("frozen.rs"), "pub fn limit() -> u8 { 2 }\n")?;
-    let after = stdlib_effect_digest(&stdlib, &runtime, &emitter)?;
+    let after = stdlib_effect_digest(
+        &stdlib,
+        &[("runtime", runtime.as_path()), ("backend", emitter.as_path())],
+    )?;
     assert_ne!(before, after, "an edit to the linked Rust runtime must invalidate");
     Ok(())
 }
@@ -120,9 +126,15 @@ fn the_digest_covers_the_emitter_while_the_emitter_still_exists() -> TestResult 
     fs::write(runtime.join("frozen.rs"), "pub fn limit() -> u8 { 1 }\n")?;
 
     fs::write(emitter.join("emit.rs"), "pub fn emit() -> u8 { 1 }\n")?;
-    let before = stdlib_effect_digest(&stdlib, &runtime, &emitter)?;
+    let before = stdlib_effect_digest(
+        &stdlib,
+        &[("runtime", runtime.as_path()), ("backend", emitter.as_path())],
+    )?;
     fs::write(emitter.join("emit.rs"), "pub fn emit() -> u8 { 2 }\n")?;
-    let after = stdlib_effect_digest(&stdlib, &runtime, &emitter)?;
+    let after = stdlib_effect_digest(
+        &stdlib,
+        &[("runtime", runtime.as_path()), ("backend", emitter.as_path())],
+    )?;
     assert_ne!(
         before, after,
         "an emitter change alters generated Rust without moving HIR"
@@ -133,20 +145,17 @@ fn the_digest_covers_the_emitter_while_the_emitter_still_exists() -> TestResult 
 #[test]
 fn the_real_standard_library_digests_deterministically_and_cheaply() -> TestResult {
     let root = repo_root();
-    let stdlib = root.join("crates/incan_stdlib/stdlib");
-    let runtime = root.join("crates/incan_stdlib/src");
-    let emitter = root.join("src/backend/ir/emit");
 
     let started = Instant::now();
     let first = incan::compiler_stack::run_on_compiler_stack({
-        let (stdlib, runtime, emitter) = (stdlib.clone(), runtime.clone(), emitter.clone());
-        move || stdlib_effect_digest(&stdlib, &runtime, &emitter).map_err(|error| error.to_string())
+        let root = root.clone();
+        move || compiler_effect_digest(&root).map_err(|error| error.to_string())
     })?;
     let elapsed = started.elapsed();
 
     let second = incan::compiler_stack::run_on_compiler_stack({
-        let (stdlib, runtime, emitter) = (stdlib.clone(), runtime.clone(), emitter.clone());
-        move || stdlib_effect_digest(&stdlib, &runtime, &emitter).map_err(|error| error.to_string())
+        let root = root.clone();
+        move || compiler_effect_digest(&root).map_err(|error| error.to_string())
     })?;
 
     println!("EFFECT-DIGEST {first} in {} ms", elapsed.as_millis());


### PR DESCRIPTION
## Summary

The SDK provider store identity folded a hash of the whole `src/`, `crates/` and `tests/` tree, so editing the language server, an inspection module or a CLI command rebuilt all ten components at a cost of roughly seventeen minutes. Hashing the source answers *did the compiler change*; what the cache needs to know is *would this compiler produce different components*, and those differ for almost every edit anyone makes.

`stdlib_effect_digest` already answered the second question — it runs this compiler's own frontend over all 104 standard-library sources and digests the result — and nothing used it. This wires it in as v4 of the store identity.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC

## Area(s)

- [ ] Incan Language
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration
- [ ] Runtime / Core crates
- [ ] Documentation

## Key details

**What decides the roots.** The digest is generalized from three fixed roots to a labelled set the caller names, and the checkout's set is declared once as `COMPILER_STDLIB_ROOT` / `COMPILER_RUST_EFFECT_ROOTS`. #1495's own first step proposed narrowing the existing hash by *excluding* paths, which fails in the dangerous direction. This is the other shape — it lists what can reach a compiled component, and everything omitted is omitted for one of exactly two reasons:

- **Covered by meaning.** `src/frontend`, `crates/incan_syntax`, `crates/incan_vocab` are run, not hashed. A change to any of them that alters what the compiler understands moves the digest; one that does not, does not. That is stronger than hashing their source, not weaker.
- **Cannot reach a component.** `src/cli`, `src/lsp`, `src/inspect`, `src/oven`, `crates/incan_codegraph`, `crates/rust_inspect`, `tests/` decide *when* components are built and *where* they are written, never what a component contains.

The one case that escapes the second reason is publication code changing the store's own layout or manifest. That is deliberate by construction and already has a mechanism: `SDK_PROVIDER_CODEGEN_REVISION`, which the inventory validates on every cache hit and which is now folded into the identity beside the digest, so a bump partitions the store rather than only rejecting what is in it.

`src/backend` is folded as an explicitly transitional root, labelled as such, because lowering and emission change generated Rust without moving any HIR. It is removed with them.

**Cost.** Memoized on a byte hash of the same roots the digest reads. The two agree by construction: the digest is a pure function of those bytes, so equal bytes cannot yield a different digest, and any edit — even one the digest would forgive — misses the memo and recomputes rather than returning a stale answer. Where no cache directory can be resolved or written, the byte hash is folded in place of the digest: that over-invalidates exactly as the memo key implies and never reuses components built from sources the key never saw. A slower cache, not a wrong one.

**Risks.** The first command after this lands pays one rebuild, because v4 is a new key. `hash_sdk_provider_compiler_source_tree` is deleted with its last caller.

## Measurements

On this checkout:

| | v3 | v4 |
| --- | --- | --- |
| Files read per command | 1,180 | 319 |
| Bytes read per command | 25.5 MB | 6.9 MB |
| Warm cost per command | — | **19 ms** |
| Memo miss | — | 3.5 s |
| Edit to a file outside the roots | full rebuild (~17 min) | **nothing** |

861 of the 1,180 files v3 walked can no longer invalidate the store.

## Testing / verification

- [x] `cargo +nightly fmt`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `python3 scripts/check_changed_rustdocs.py --base origin/0.6.0-dev.4`
- [x] `cargo test --lib sdk_provider` — 22 tests
- [x] `cargo test --test stdlib_effect_digest` — 6 tests

The identity contract test is rewritten around the new rows rather than patched, because the rows are what changed: an edit no component's compilation can reach reuses the store; a comment in a standard-library source reuses the store; a changed body does not; the transitional backend and the linked Rust runtime both still invalidate. Two new timing assertions pin the per-command cost so the cheap path cannot be quietly lost.

## Docs impact

- [x] No docs changes needed

Closes #1495.