### PR TITLE
bugfix - #1037 project a provider's own native unions before seeding its exports

### DIFF
--- a/src/backend/ir/codegen.rs
+++ b/src/backend/ir/codegen.rs
@@ -1012,7 +1012,11 @@ impl<'a> IrCodegen<'a> {
             )?;
             for provider in plan.active_sdk_records() {
                 if let Some(manifest) = provider.manifest.as_deref() {
-                    emitter.seed_sdk_provider_manifest_metadata(manifest);
+                    emitter.seed_sdk_provider_manifest_metadata(
+                        manifest,
+                        Some(plan),
+                        foreign_type_routes.get(&manifest.name),
+                    )?;
                 }
             }
         }

--- a/src/backend/ir/emit/decls/mod.rs
+++ b/src/backend/ir/emit/decls/mod.rs
@@ -998,7 +998,8 @@ mod tests {
     };
 
     #[test]
-    fn stdlib_import_through_a_facade_finds_the_provider_by_the_declaring_module() {
+    fn stdlib_import_through_a_facade_finds_the_provider_by_the_declaring_module()
+    -> Result<(), Box<dyn std::error::Error>> {
         // A provider publishes the module that declares an item, not every facade re-exporting it. `from std.datetime
         // import utc` looks up `std.datetime.utc`, which the graph does not carry; the declaration lives at
         // `std.datetime.civil.naive.utc`, which it does.
@@ -1036,7 +1037,7 @@ mod tests {
 
         let registry = FunctionRegistry::new();
         let mut emitter = IrEmitter::new(&registry);
-        emitter.seed_sdk_provider_manifest_metadata(&manifest);
+        emitter.seed_sdk_provider_manifest_metadata(&manifest, None, None)?;
 
         // Import resolution proved the declaring module even though the facade path is not published.
         let item = IrImportItem {
@@ -1065,10 +1066,12 @@ mod tests {
             encode_incan_symbol_identity(&provider_identity),
             "a facade import must resolve to the provider's declaration, not a source-shaped stand-in"
         );
+        Ok(())
     }
 
     #[test]
-    fn stdlib_import_reexports_the_providers_identity_over_a_same_named_source_declaration() {
+    fn stdlib_import_reexports_the_providers_identity_over_a_same_named_source_declaration()
+    -> Result<(), Box<dyn std::error::Error>> {
         let provider_identity = CanonicalSymbolId {
             namespace: SymbolNamespace::OrdinaryLexical,
             origin: SymbolOrigin::Package {
@@ -1121,7 +1124,7 @@ mod tests {
         );
 
         let mut emitter = IrEmitter::new(&registry);
-        emitter.seed_sdk_provider_manifest_metadata(&manifest);
+        emitter.seed_sdk_provider_manifest_metadata(&manifest, None, None)?;
 
         let item = IrImportItem {
             name: "utc".to_string(),
@@ -1140,6 +1143,7 @@ mod tests {
             encode_incan_symbol_identity(&provider_identity),
             "a stdlib re-export must name the linked provider's declaration, not a same-named source one"
         );
+        Ok(())
     }
 
     #[test]

--- a/src/backend/ir/emit/mod.rs
+++ b/src/backend/ir/emit/mod.rs
@@ -1933,6 +1933,26 @@ impl<'a> IrEmitter<'a> {
         self.native_nominal_origins = origins;
     }
 
+    /// Bind one provider manifest's native carriers, nominal origins and type routes before its exports are read.
+    ///
+    /// Every path that reads a manifest's exported types has to do this first, because an unprojected native union
+    /// carries no physical projection and lowering has no error channel to complain through — it returns `Unknown`,
+    /// which the emitter then resolves to something unrelated or drops. The dependency path did it and the SDK
+    /// seeding path did not, which is the disagreement `ir_type_from_projected_manifest`'s debug assertion exists
+    /// to catch. Both call this now, so there is one order and one place to change it.
+    fn projected_provider_manifest(
+        &self,
+        manifest: &LibraryManifest,
+        library: &str,
+        plan: Option<&crate::provider::ProviderPlan>,
+        routes: Option<&HashMap<String, String>>,
+    ) -> Result<LibraryManifest, EmitError> {
+        let projected = crate::library_manifest::with_checked_native_unions(manifest.clone(), library, plan, routes)
+            .map_err(EmitError::InternalInvariant)?;
+        let projected = crate::library_manifest::with_native_nominal_origins(projected, &self.native_nominal_origins);
+        Ok(crate::library_manifest::with_checked_type_routes(projected, routes))
+    }
+
     /// Seed public dependency nominal metadata from `.incnlib` manifests.
     ///
     /// Package consumers do not have the provider's lowered IR available, but const validation and constructor emission
@@ -1961,18 +1981,9 @@ impl<'a> IrEmitter<'a> {
             let Some(LibraryManifestIndexEntry::Loaded { manifest, .. }) = index.get(&library) else {
                 continue;
             };
-            let projected = crate::library_manifest::with_checked_native_unions(
-                manifest.as_ref().clone(),
-                &library,
-                plan,
-                routes.get(&library),
-            )
-            .map_err(EmitError::InternalInvariant)?;
-            let projected =
-                crate::library_manifest::with_native_nominal_origins(projected, &self.native_nominal_origins);
             manifests.insert(
                 library.clone(),
-                crate::library_manifest::with_checked_type_routes(projected, routes.get(&library)),
+                self.projected_provider_manifest(manifest.as_ref(), &library, plan, routes.get(&library))?,
             );
         }
         let mut counts = HashMap::<String, usize>::new();
@@ -2435,8 +2446,29 @@ impl<'a> IrEmitter<'a> {
     /// Built-in stdlib consumers intentionally do not materialize provider source modules. The artifact manifest is
     /// therefore the sole metadata source for whether a receiver uses Incan call semantics and whether a member is an
     /// enum variant rather than a Rust field access.
-    pub(crate) fn seed_sdk_provider_manifest_metadata(&mut self, manifest: &LibraryManifest) {
+    ///
+    /// The manifest is projected before a single export is read. It was not, and that made this the seeding path
+    /// `ir_type_from_projected_manifest` names when it refuses: a native union arrived with no physical projection
+    /// and lowered to `Unknown`. The failure needed a component whose surface actually carries one to appear at all,
+    /// which is why it surfaced as an SDK preparation panic in `stdlib-codecs` rather than in any unit test.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EmitError::InternalInvariant`] when the manifest names a native union owned by some *other*
+    /// artifact that no admitted provider plan binds. That is a refusal rather than a fallback: emitting the union
+    /// unbound produces a type the generated Rust resolves to something else, with no diagnostic anywhere.
+    pub(crate) fn seed_sdk_provider_manifest_metadata(
+        &mut self,
+        manifest: &LibraryManifest,
+        plan: Option<&crate::provider::ProviderPlan>,
+        routes: Option<&HashMap<String, String>>,
+    ) -> Result<(), EmitError> {
         let provider_crate = manifest.name.replace('-', "_");
+        // A provider owns the unions its own surface publishes, and the admitted public-artifact graph is built
+        // from project dependencies, so it has no entry to look this provider up by. Bind those first; whatever is
+        // left names another artifact, which is the question the plan does answer.
+        let manifest = &crate::library_manifest::with_self_owned_native_unions(manifest.clone(), &provider_crate);
+        let manifest = &self.projected_provider_manifest(manifest, &manifest.name, plan, routes)?;
         for entry in &manifest.contract_metadata.identity_graph.exports {
             if entry.kind != ExportIdentityKind::Function || entry.public_path.first() != Some(&manifest.name) {
                 continue;
@@ -2478,7 +2510,7 @@ impl<'a> IrEmitter<'a> {
         // the public declarations of every `std.*` provider module. Consumers must use that artifact-owned API
         // instead of reopening the provider source modules.
         let Some(api) = manifest.contract_metadata.api.as_ref() else {
-            return;
+            return Ok(());
         };
         self.compiled_sdk_module_paths
             .extend(api.modules.iter().map(|module| module.module_path.clone()));
@@ -2514,6 +2546,7 @@ impl<'a> IrEmitter<'a> {
         }
         self.seed_compiled_provider_export_metadata(&provider_crate, &models, &classes, &enums, &newtypes);
         self.seed_compiled_provider_factory_metadata(&functions, &models, &classes);
+        Ok(())
     }
 
     /// Set provider module paths when a caller already derived them from the artifact entrypoint or manifest.
@@ -3649,7 +3682,7 @@ mod tests {
     }
 
     #[test]
-    fn compiled_sdk_manifest_seeds_exact_stdlib_function_identity() {
+    fn compiled_sdk_manifest_seeds_exact_stdlib_function_identity() -> Result<(), Box<dyn std::error::Error>> {
         let registry = FunctionRegistry::new();
         let identity = CanonicalSymbolId {
             namespace: SymbolNamespace::OrdinaryLexical,
@@ -3690,9 +3723,120 @@ mod tests {
         let mut emitter = IrEmitter::new(&registry);
         emitter.set_canonical_function_registry(canonical_registry);
 
-        emitter.seed_sdk_provider_manifest_metadata(&manifest);
+        emitter.seed_sdk_provider_manifest_metadata(&manifest, None, None)?;
 
         assert_eq!(emitter.canonical_stdlib_function_identity(&std_path), Some(&identity));
+        Ok(())
+    }
+
+    /// Build one SDK provider manifest whose exported enum variant carries a native union.
+    ///
+    /// `stdlib-system` publishes exactly this shape, and it is what made SDK preparation fail: the seeding path
+    /// read the union straight out of the manifest, where `checked_projection` is `#[serde(skip)]` and therefore
+    /// always absent on arrival.
+    fn manifest_exporting_a_native_union(
+        library: &str,
+        owner: crate::library_manifest::NativeUnionOwnerExport,
+    ) -> LibraryManifest {
+        let mut manifest = LibraryManifest::new(library, "0.6.0");
+        manifest.exports.enums.push(crate::library_manifest::EnumExport {
+            name: "Carrier".to_string(),
+            type_params: Vec::new(),
+            traits: Vec::new(),
+            trait_adoptions: Vec::new(),
+            value_type: None,
+            ordinal_type_identity: None,
+            variants: vec![crate::library_manifest::EnumVariantExport {
+                name: "Carried".to_string(),
+                canonical: None,
+                fields: vec![crate::library_manifest::TypeRef::NativeUnion(
+                    crate::library_manifest::NativeUnionExport {
+                        owner,
+                        rust_name: "__IncanUnionProbe".to_string(),
+                        members: vec![crate::library_manifest::TypeRef::Named {
+                            name: "int".to_string(),
+                            origin: None,
+                        }],
+                        local_nominals: Default::default(),
+                        checked_projection: None,
+                    },
+                )],
+                value: None,
+            }],
+            variant_aliases: Vec::new(),
+            methods: Vec::new(),
+            derives: Vec::new(),
+        });
+        manifest
+    }
+
+    /// A union an SDK provider owns itself binds to that provider's crate, with no admitted artifact graph.
+    ///
+    /// This is the defect that stopped SDK preparation at `stdlib-codecs`. The seeding path never projected, so
+    /// `ir_type_from_projected_manifest` saw a union with no physical projection and returned `Unknown` — silently
+    /// in release, and through a debug assertion in the prewarm. `Unknown` is the observable: the emitter resolves
+    /// it to something unrelated or drops it, with no diagnostic anywhere.
+    ///
+    /// The plan-based projection cannot answer this one. Its owner lookup goes through the admitted public-artifact
+    /// graph, which is built from project-dependency records and has no entry for an SDK provider, so it refuses
+    /// with "union import container is unavailable". A provider that owns its own union does not need to be looked
+    /// up: it is the owner.
+    #[test]
+    fn an_sdk_provider_binds_the_native_unions_it_owns() -> Result<(), Box<dyn std::error::Error>> {
+        let registry = FunctionRegistry::new();
+        let manifest = manifest_exporting_a_native_union(
+            "incan_stdlib_codecs",
+            crate::library_manifest::NativeUnionOwnerExport::ContainingArtifact,
+        );
+
+        let mut emitter = IrEmitter::new(&registry);
+        emitter.seed_sdk_provider_manifest_metadata(&manifest, None, None)?;
+
+        let key = ("Carrier".to_string(), "Carried".to_string());
+        let Some(super::VariantFields::Tuple(fields)) = emitter.enum_variant_fields.get(&key) else {
+            panic!(
+                "the variant should be recorded as a tuple, got {:?}",
+                emitter.enum_variant_fields.get(&key)
+            );
+        };
+        let [IrType::ExternalUnion { library, .. }] = fields.as_slice() else {
+            panic!("the variant field must lower to the carried union, got {fields:?}");
+        };
+        assert_eq!(
+            library, "::incan_stdlib_codecs",
+            "a provider owns the unions its own surface publishes, so its crate is the physical route"
+        );
+        Ok(())
+    }
+
+    /// A union owned by another artifact is still refused when nothing admits that artifact.
+    ///
+    /// The self-owned binding deliberately does not answer this case. `SelectedArtifact` names some other owner,
+    /// and which artifact that is, and whether its published representation agrees, is exactly what the admitted
+    /// graph exists to decide. Guessing would put the union in the wrong crate.
+    #[test]
+    fn sdk_provider_seeding_refuses_a_union_owned_by_an_unadmitted_artifact() {
+        let registry = FunctionRegistry::new();
+        let manifest = manifest_exporting_a_native_union(
+            "incan_stdlib_codecs",
+            crate::library_manifest::NativeUnionOwnerExport::SelectedArtifact(crate::provider::ProviderIdentity {
+                name: "incan_stdlib_system".to_string(),
+                version: "0.6.0".to_string(),
+                digest: "sha256:probe".to_string(),
+                feature_projection: Default::default(),
+            }),
+        );
+
+        let mut emitter = IrEmitter::new(&registry);
+        let seeded = emitter.seed_sdk_provider_manifest_metadata(&manifest, None, None);
+
+        let Err(super::EmitError::InternalInvariant(message)) = seeded else {
+            panic!("seeding must refuse a union it cannot place, got {seeded:?}");
+        };
+        assert!(
+            message.contains("__IncanUnionProbe"),
+            "the refusal must name the union it could not bind, got {message}"
+        );
     }
 
     #[test]

--- a/src/backend/ir/emit/mod.rs
+++ b/src/backend/ir/emit/mod.rs
@@ -1933,26 +1933,6 @@ impl<'a> IrEmitter<'a> {
         self.native_nominal_origins = origins;
     }
 
-    /// Bind one provider manifest's native carriers, nominal origins and type routes before its exports are read.
-    ///
-    /// Every path that reads a manifest's exported types has to do this first, because an unprojected native union
-    /// carries no physical projection and lowering has no error channel to complain through — it returns `Unknown`,
-    /// which the emitter then resolves to something unrelated or drops. The dependency path did it and the SDK
-    /// seeding path did not, which is the disagreement `ir_type_from_projected_manifest`'s debug assertion exists
-    /// to catch. Both call this now, so there is one order and one place to change it.
-    fn projected_provider_manifest(
-        &self,
-        manifest: &LibraryManifest,
-        library: &str,
-        plan: Option<&crate::provider::ProviderPlan>,
-        routes: Option<&HashMap<String, String>>,
-    ) -> Result<LibraryManifest, EmitError> {
-        let projected = crate::library_manifest::with_checked_native_unions(manifest.clone(), library, plan, routes)
-            .map_err(EmitError::InternalInvariant)?;
-        let projected = crate::library_manifest::with_native_nominal_origins(projected, &self.native_nominal_origins);
-        Ok(crate::library_manifest::with_checked_type_routes(projected, routes))
-    }
-
     /// Seed public dependency nominal metadata from `.incnlib` manifests.
     ///
     /// Package consumers do not have the provider's lowered IR available, but const validation and constructor emission
@@ -1981,9 +1961,18 @@ impl<'a> IrEmitter<'a> {
             let Some(LibraryManifestIndexEntry::Loaded { manifest, .. }) = index.get(&library) else {
                 continue;
             };
+            let projected = crate::library_manifest::with_checked_native_unions(
+                manifest.as_ref().clone(),
+                &library,
+                plan,
+                routes.get(&library),
+            )
+            .map_err(EmitError::InternalInvariant)?;
+            let projected =
+                crate::library_manifest::with_native_nominal_origins(projected, &self.native_nominal_origins);
             manifests.insert(
                 library.clone(),
-                self.projected_provider_manifest(manifest.as_ref(), &library, plan, routes.get(&library))?,
+                crate::library_manifest::with_checked_type_routes(projected, routes.get(&library)),
             );
         }
         let mut counts = HashMap::<String, usize>::new();
@@ -2464,11 +2453,19 @@ impl<'a> IrEmitter<'a> {
         routes: Option<&HashMap<String, String>>,
     ) -> Result<(), EmitError> {
         let provider_crate = manifest.name.replace('-', "_");
-        // A provider owns the unions its own surface publishes, and the admitted public-artifact graph is built
-        // from project dependencies, so it has no entry to look this provider up by. Bind those first; whatever is
-        // left names another artifact, which is the question the plan does answer.
+        // Only the union binding, and deliberately not the rest of the dependency path's projection. A provider
+        // owns the unions its own surface publishes, and the admitted public-artifact graph is built from project
+        // dependencies, so it has no entry to look this provider up by; bind those first, and leave whatever names
+        // another artifact to the plan, which is the question the plan answers.
+        //
+        // `with_checked_type_routes` must not run here. It rewrites every origin-carrying leaf to its route and
+        // replaces it with `Unknown` where no route matches, and an SDK provider has no foreign type routes — so
+        // applying it would erase the very metadata this function exists to seed. That is a dependency-path step
+        // for a dependency-path input, and the seeding path needs neither it nor the nominal-origin overlay.
         let manifest = &crate::library_manifest::with_self_owned_native_unions(manifest.clone(), &provider_crate);
-        let manifest = &self.projected_provider_manifest(manifest, &manifest.name, plan, routes)?;
+        let manifest =
+            &crate::library_manifest::with_checked_native_unions(manifest.clone(), &manifest.name, plan, routes)
+                .map_err(EmitError::InternalInvariant)?;
         for entry in &manifest.contract_metadata.identity_graph.exports {
             if entry.kind != ExportIdentityKind::Function || entry.public_path.first() != Some(&manifest.name) {
                 continue;

--- a/src/library_manifest/mod.rs
+++ b/src/library_manifest/mod.rs
@@ -26,7 +26,7 @@ pub(crate) use artifact::{
 pub use model::*;
 pub(crate) use type_projection::{
     VisitTypeRefs, contains_native_union, with_checked_native_unions, with_checked_type_origins,
-    with_checked_type_routes, with_native_nominal_origins,
+    with_checked_type_routes, with_native_nominal_origins, with_self_owned_native_unions,
 };
 pub use type_refs::resolved_type_from_manifest_type_ref;
 pub(crate) use type_refs::type_ref_from_resolved;

--- a/src/library_manifest/type_projection.rs
+++ b/src/library_manifest/type_projection.rs
@@ -287,6 +287,78 @@ pub(crate) fn contains_native_union(value: &(impl VisitTypeRefs + Clone)) -> boo
     found
 }
 
+/// Route one union's producer-local nominal leaves under the Rust owner already selected for it, and attach the
+/// resulting physical projection.
+///
+/// The leaf rewriting is the delicate half and it is written once here: a producer-local nominal is a name in the
+/// owner's crate, while a collection head, the union wrapper itself, `decimal`, and anything already absolute are
+/// not, so prefixing those would name a type that does not exist. Both owner-resolution strategies — the admitted
+/// provider graph, and a provider that owns its own unions — end here rather than each keeping a copy.
+fn attach_owner_projection(
+    bound: &mut crate::library_manifest::NativeUnionExport,
+    dependency_root: &str,
+    rust_owner: String,
+    mut members: Vec<TypeRef>,
+) {
+    members.visit_type_refs(&mut |member| match member {
+        TypeRef::Named { name, origin: None } if !name.starts_with("::") => {
+            if matches!(
+                super::resolved_type_from_manifest_type_ref(&TypeRef::Named {
+                    name: name.clone(),
+                    origin: None
+                }),
+                crate::frontend::symbols::ResolvedType::Named(_)
+            ) {
+                *name = format!("{rust_owner}::{name}");
+            }
+        }
+        TypeRef::Applied { name, origin: None, .. }
+            if !name.starts_with("::")
+                && incan_core::lang::types::collections::from_str(name).is_none()
+                && name != incan_core::lang::types::UNION_TYPE_NAME
+                && name != "decimal" =>
+        {
+            *name = format!("{rust_owner}::{name}");
+        }
+        _ => {}
+    });
+    bound.checked_projection = Some(Box::new(super::model::NativeUnionProjection {
+        dependency_root: dependency_root.to_string(),
+        rust_owner,
+        members,
+        nominal_origins: BTreeMap::new(),
+    }));
+}
+
+/// Bind the native unions a compiled SDK provider owns itself, whose physical owner is the provider's own crate.
+///
+/// [`with_checked_native_unions`] resolves an owner through the admitted public-artifact graph, and an SDK provider
+/// is not in it: that graph is built from project-dependency records, so looking one up fails with "union import
+/// container is unavailable". The lookup exists to answer *which* artifact owns a union that a consumer merely
+/// names. An SDK provider seeding its own manifest already knows: it is the owner, its crate is the physical route,
+/// and there is no second representation to reconcile against.
+///
+/// Unprojected unions are the only ones touched, so a manifest that has already been through the plan-based path is
+/// unchanged. A `SelectedArtifact` union names some *other* owner and is left alone here, because answering that is
+/// exactly what the artifact graph is for.
+pub(crate) fn with_self_owned_native_unions<T: VisitTypeRefs>(mut value: T, provider_crate: &str) -> T {
+    use crate::library_manifest::NativeUnionOwnerExport;
+    let rust_owner = format!("::{provider_crate}");
+    value.visit_type_refs(&mut |ty| {
+        let TypeRef::NativeUnion(native) = ty else {
+            return;
+        };
+        if native.checked_projection.is_some() || native.owner != NativeUnionOwnerExport::ContainingArtifact {
+            return;
+        }
+        let mut bound = native.for_publication();
+        let members = with_self_owned_native_unions(bound.members.clone(), provider_crate);
+        attach_owner_projection(&mut bound, provider_crate, rust_owner.clone(), members);
+        *native = bound;
+    });
+    value
+}
+
 /// Bind native carriers through the existing admitted provider graph before projecting a compiler-owned API copy.
 ///
 /// The original producer members stay immutable. Only the non-serialized physical projection is routed for emission;
@@ -324,41 +396,14 @@ pub(crate) fn with_checked_native_unions<T: VisitTypeRefs>(
         };
         let owner_path = crate::frontend::rust_type_display::provider_bridge_route(library, route);
         let rust_owner = format!("::{}", owner_path.join("::"));
-        let mut members = match with_checked_native_unions(bound.members.clone(), library, Some(plan), routes) {
+        let members = match with_checked_native_unions(bound.members.clone(), library, Some(plan), routes) {
             Ok(members) => with_checked_type_routes(members, routes),
             Err(error) => {
                 failure = Some(error);
                 return;
             }
         };
-        members.visit_type_refs(&mut |member| match member {
-            TypeRef::Named { name, origin: None } if !name.starts_with("::") => {
-                if matches!(
-                    super::resolved_type_from_manifest_type_ref(&TypeRef::Named {
-                        name: name.clone(),
-                        origin: None
-                    }),
-                    crate::frontend::symbols::ResolvedType::Named(_)
-                ) {
-                    *name = format!("{rust_owner}::{name}");
-                }
-            }
-            TypeRef::Applied { name, origin: None, .. }
-                if !name.starts_with("::")
-                    && incan_core::lang::types::collections::from_str(name).is_none()
-                    && name != incan_core::lang::types::UNION_TYPE_NAME
-                    && name != "decimal" =>
-            {
-                *name = format!("{rust_owner}::{name}");
-            }
-            _ => {}
-        });
-        bound.checked_projection = Some(Box::new(super::model::NativeUnionProjection {
-            dependency_root: library.to_string(),
-            rust_owner,
-            members,
-            nominal_origins: BTreeMap::new(),
-        }));
+        attach_owner_projection(&mut bound, library, rust_owner, members);
         *native = bound;
     });
     match failure {


### PR DESCRIPTION
## Summary

Preparing the `stdlib-codecs` SDK component panicked: a native union reached IR lowering with no checked projection.

`ir_type_from_projected_manifest` names the cause in its own comment — the dependency path runs `with_checked_native_unions` and the SDK seeding path does not, so the same construct arrives with nothing attached and becomes `Unknown`, a type the emitter then resolves to something unrelated or drops. The assertion that catches the disagreement is a `debug_assert!`, which is why this surfaced as a prewarm panic rather than a test failure, and why release builds have been lowering that union to `Unknown` silently. It also needed a component whose exported surface actually carries a union to appear at all.

Verified against plain `0.6.0-dev.4` before anything else: identical panic, same line. This is a dev-line defect that a warm provider store had been hiding, not one introduced alongside it.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC

## Area(s)

- [ ] Incan Language
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration
- [x] Runtime / Core crates
- [ ] Documentation

## Key details

**Wiring the existing projection in was not sufficient by itself.** The plan-based path resolves a `ContainingArtifact` union's owner through the admitted public-artifact graph, which is built from project-dependency records and has no entry for an SDK provider — so it refused with ``union import container `incan_stdlib_system` is unavailable``. That lookup exists to answer *which* artifact owns a union a consumer merely names. A provider seeding its own manifest already knows: it is the owner, its crate is the physical route, and there is no second representation to reconcile against. `with_self_owned_native_unions` binds those directly and leaves `SelectedArtifact` unions to the graph, which is the question the graph is for.

**The leaf routing is now written once.** Both owner-resolution strategies end in `attach_owner_projection` rather than each keeping a copy of the rule that a producer-local nominal takes the owner prefix while a collection head, the union wrapper, `decimal`, and anything already absolute do not.

**`seed_sdk_provider_manifest_metadata` is now fallible**, and takes the plan and routes its caller already had in hand. A union it cannot place is a refusal rather than a fallback: emitting it unbound produces a type the generated Rust resolves to something else, with no diagnostic anywhere.

**Risks.** A manifest carrying a `SelectedArtifact` union that no admitted plan binds now fails the build where it previously produced `Unknown` in release. That is the intended direction — the old behaviour was a wrong artifact, not a working one — but it is a behaviour change in release builds, not only in debug.

## Testing / verification

- [x] `cargo +nightly fmt`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `python3 scripts/check_changed_rustdocs.py --base origin/0.6.0-dev.4`
- [x] A cold SDK prewarm from an empty provider store, which is what found this and what proves it

Two new tests. One asserts the variant field lowers to the carried union under `::incan_stdlib_codecs` rather than to `Unknown` — the actual defect, at the level where it is observable. The other asserts a `SelectedArtifact` union nothing admits is still refused, so the self-owned binding cannot quietly grow into a guess.

## Docs impact

- [x] No docs changes needed

Toward #1037.
