### PR TITLE
feature - #1037 carry one selected unit's provider intake evidence

### DIFF
--- a/workspaces/oven/src/lib.incn
+++ b/workspaces/oven/src/lib.incn
@@ -8,3 +8,4 @@ pub from source_unit import select_source_units, SourceBatch, BatchSelection
 pub from rust_source import read_dependency_catalog
 pub from rust_activation import activate_unit, version_matches
 pub from invocation import decide_invocation
+pub from provider_intake import provider_intake_evidence, ProviderIntakeEvidence, SelectedBuildSlot

--- a/workspaces/oven/src/provider_intake.incn
+++ b/workspaces/oven/src/provider_intake.incn
@@ -1,0 +1,160 @@
+"""Companion evidence for one selected unit, assembled only from what the source authority already retained."""
+
+from std.hash import sha256
+from manifest_errors import IntakeError, IntakeErrorKind
+from intake import ManifestEvidence
+from rust_source import RustDependencyCatalog, RustDependencyDeclaration, RustDependencyRole
+from rust_activation import ActivationContext, RustActivation, SlotActivation
+
+
+@derive(Eq)
+pub model SelectedBuildSlot:
+    """
+    One original build-dependency slot, named by where it was declared rather than by what it resolved to.
+
+    The index is the declaration's position in the authored catalog, which is the only identity a slot has before
+    a child source is admitted. The alias is what the manifest wrote, not a package name: an aliased dependency
+    keeps the spelling its host compiles against. The host unit is supplied by the caller because a build
+    dependency activates in the host domain, and which host that is, is a property of the activation context
+    rather than of the declaration.
+    """
+
+    pub index: int
+    pub alias: str
+    pub host_unit: str
+
+
+pub model ProviderIntakeEvidence:
+    """
+    What one selected unit's provider intake retained, beside the unit rather than inside it.
+
+    A selected unit deliberately carries no manifest slot and no member inventory: it names what was chosen, not
+    what was read. Those facts still have to survive, because a later producer has to show that the thing it
+    compiled is the thing the manifest described. Keeping them in a companion record is what stops the unit's
+    identity absorbing physical evidence that would make two identical units compare unequal.
+
+    Every field here is carried, never derived. See [`provider_intake_evidence`] for the refusals that enforce it.
+
+    Deliberately not `Eq`. It holds a `ManifestEvidence`, which is physical evidence rather than identity, and
+    comparing two of these would invite exactly the confusion the separation exists to prevent: whether two units
+    are the same is a question about their identity, not about whether they were read from identical bytes.
+    """
+
+    pub owner: str
+    pub package_root: str
+    pub manifest: ManifestEvidence
+    pub members: list[str]
+    pub build_slots: list[SelectedBuildSlot]
+    pub build_unit_present: bool
+    pub effective_features: list[str]
+
+
+def refusal(manifest: str, field: list[str], kind: IntakeErrorKind, detail: str) -> IntakeError:
+    """Reuse the source-located intake vocabulary so a companion refusal reads like any other manifest refusal."""
+    return IntakeError(kind=kind, manifest=manifest, field=field, location=None, detail=detail)
+
+
+def members_excluding_manifest(members: list[str], manifest_path: str) -> list[str]:
+    """
+    Drop the manifest from the member inventory, preserving the order the authority supplied.
+
+    The manifest is evidence in its own right and is carried separately with its digest. Leaving it in the
+    inventory too would let a consumer digest it twice and disagree with itself about what the package contains.
+    """
+    mut kept: list[str] = []
+    for member in members:
+        if member != manifest_path:
+            kept.append(member)
+    return kept
+
+
+def declaration_at(catalog: RustDependencyCatalog, index: int) -> Option[RustDependencyDeclaration]:
+    """Find the authored declaration an activation slot refers to, by its original catalog position."""
+    for declaration in catalog.dependencies:
+        if declaration.index == index:
+            return Some(declaration)
+    return None
+
+
+def slot_is_active(activation: SlotActivation) -> bool:
+    """Report whether one slot activated, without inspecting why an inactive one did not."""
+    match activation:
+        SlotActivation.Active(_, _, _) => return true
+        SlotActivation.Inactive(_) => return false
+
+
+pub def provider_intake_evidence(
+    owner: str,
+    package_root: str,
+    manifest: ManifestEvidence,
+    members: list[str],
+    catalog: RustDependencyCatalog,
+    context: ActivationContext,
+    activation: RustActivation,
+) -> Result[ProviderIntakeEvidence, IntakeError]:
+    """
+    Build one unit's companion evidence from the retained authority, refusing rather than reconstructing.
+
+        Nothing here inspects a filesystem, re-parses a manifest, or reads a selected graph. Every fact is either
+        handed in by the caller that already held it or read out of `catalog` and `activation`, which are the
+        authored declarations and their activation outcome. That is the whole property this function exists to
+        have: an implementation that satisfied the same shape by re-deriving the data would pass the same value
+        assertions and lose the guarantee.
+
+        `build_unit_present` is carried from the context rather than inferred from whether any build slot
+        activated. They are different facts: a package can declare build dependencies and have no build unit, and
+        the inventory is what knows. Deriving it from the slot list would be the reconstruction this gate forbids,
+        arrived at by an accident of the two usually agreeing.
+
+        Two refusals keep it honest. Evidence whose digest does not match its own bytes is rejected, because a
+        companion record that disagrees with itself proves nothing about the compiled artifact. An activation slot
+        naming a build declaration the catalog does not contain is also rejected, rather than filled in from the
+        alias or the package name, because guessing there is exactly the reconstruction the gate forbids.
+
+        Args:
+            owner: Identity of the provider that retained this source, supplied by the retaining caller.
+            package_root: Package root under that owner, as the authority recorded it.
+            manifest: Byte snapshot of the unit's `Cargo.toml` with its digest, from the original read.
+            members: Package member inventory from the authority, manifest included; it is removed here.
+            catalog: Authored dependency declarations; the only source of slot indices and aliases.
+            context: The activation context this unit was activated under; supplies the host triple the build
+                slots activate against, and `build_unit_present`, which the checked source-unit inventory owns.
+            activation: Per-slot activation outcome for this unit.
+
+        Returns:
+            The companion evidence, or a structured refusal naming the manifest and field.
+    """
+    if sha256.digest(manifest.raw_bytes) != manifest.sha256_digest:
+        return Err(refusal(
+            manifest.path,
+            ["sha256_digest"],
+            IntakeErrorKind.Invalid,
+            "manifest evidence digest does not match its own bytes; the retained source is not self-consistent",
+        ))
+
+    mut build_slots: list[SelectedBuildSlot] = []
+    for slot in activation.slots:
+        match declaration_at(catalog, slot.index):
+            None => return Err(refusal(
+                manifest.path,
+                ["dependencies"],
+                IntakeErrorKind.Invalid,
+                f"activation slot {slot.index} has no declaration in the retained catalog",
+            ))
+            Some(declaration) =>
+                if declaration.role == RustDependencyRole.Build and slot_is_active(slot.activation):
+                    build_slots.append(
+                        SelectedBuildSlot(
+                            index=slot.index, alias=declaration.alias, host_unit=context.host.triple
+                        )
+                    )
+
+    return Ok(ProviderIntakeEvidence(
+        owner=owner,
+        package_root=package_root,
+        manifest=manifest,
+        members=members_excluding_manifest(members, manifest.path),
+        build_slots=build_slots,
+        build_unit_present=context.build_unit_present,
+        effective_features=activation.effective_features,
+    ))

--- a/workspaces/oven/src/provider_intake.incn
+++ b/workspaces/oven/src/provider_intake.incn
@@ -4,7 +4,7 @@ from std.hash import sha256
 from manifest_errors import IntakeError, IntakeErrorKind
 from intake import ManifestEvidence
 from rust_source import RustDependencyCatalog, RustDependencyDeclaration, RustDependencyRole
-from rust_activation import ActivationContext, RustActivation, SlotActivation
+from rust_activation import ActivationContext, InactiveReason, RustActivation, SlotActivation
 
 
 @derive(Eq)
@@ -76,11 +76,19 @@ def declaration_at(catalog: RustDependencyCatalog, index: int) -> Option[RustDep
     return None
 
 
-def slot_is_active(activation: SlotActivation) -> bool:
-    """Report whether one slot activated, without inspecting why an inactive one did not."""
+def build_slot_is_declared_here(activation: SlotActivation) -> bool:
+    """
+    Report whether a build-role slot belongs in this unit's evidence.
+
+    Whether a build dependency was declared and whether the unit has a build unit are different facts that
+    usually agree. Activation folds them together — a build slot in a unit with no build unit is `BuildUnitAbsent`
+    — so reading activation alone would make `build_slots` a mirror of `build_unit_present` and lose the
+    disagreement the evidence exists to record. Every other exclusion is a genuine deselection for this target or
+    feature selection, and those slots stay out.
+    """
     match activation:
         SlotActivation.Active(_, _, _) => return true
-        SlotActivation.Inactive(_) => return false
+        SlotActivation.Inactive(reason) => return reason == InactiveReason.BuildUnitAbsent
 
 
 pub def provider_intake_evidence(
@@ -142,7 +150,7 @@ pub def provider_intake_evidence(
                 f"activation slot {slot.index} has no declaration in the retained catalog",
             ))
             Some(declaration) =>
-                if declaration.role == RustDependencyRole.Build and slot_is_active(slot.activation):
+                if declaration.role == RustDependencyRole.Build and build_slot_is_declared_here(slot.activation):
                     build_slots.append(
                         SelectedBuildSlot(
                             index=slot.index, alias=declaration.alias, host_unit=context.host.triple

--- a/workspaces/oven/src/test_provider_intake.incn
+++ b/workspaces/oven/src/test_provider_intake.incn
@@ -1,0 +1,167 @@
+"""Companion evidence is carried from the retained authority; reconstructing it is what these tests forbid."""
+
+from std.hash import sha256
+from rust::std::str import from_utf8
+from std.testing import fail, fail_t
+from manifest_errors import IntakeError, IntakeErrorKind
+from intake import ManifestEvidence
+from rust_source import read_dependency_catalog, RustDependencyCatalog
+from rust_activation import (
+    activate_unit,
+    ActivationContext,
+    ActivationPurpose,
+    CfgSnapshot,
+    RustActivation,
+    TargetConfiguration,
+)
+from provider_intake import provider_intake_evidence, ProviderIntakeEvidence
+
+
+def require_ok[T](result: Result[T, IntakeError]) -> T:
+    """Keep fixture setup shallow while reporting the original intake diagnostic on failure."""
+    match result:
+        Ok(value) => return value
+        Err(error) => return fail_t[T](error.message())
+
+
+def manifest_bytes() -> bytes:
+    """
+    One authored manifest carrying both roles, so a build slot can be told from a normal one.
+
+    A bytes literal rather than a string, because bytes are what the authority retains: the str is derived from
+    them exactly as `parse_document` derives it, and deriving it the other way round would let the fixture agree
+    with itself for the wrong reason.
+    """
+    return b"[package]\x0aname = 'probe'\x0aversion = '0.1.0'\x0a\x0a[dependencies]\x0aserde = '1'\x0a\x0a[build-dependencies]\x0acc = { version = '1', package = 'cc' }\x0a"
+
+
+def decoded(raw: bytes) -> str:
+    """Decode the retained bytes the way the intake boundary does."""
+    match from_utf8(raw):
+        Ok(text) => return str(text)
+        Err(error) => return fail_t[str](str(error))
+
+
+def evidence_for(raw: bytes) -> ManifestEvidence:
+    """Build evidence the way a retaining caller would: exact bytes, and the digest of those bytes."""
+    return ManifestEvidence(
+        path="Cargo.toml", raw_bytes=raw, source=decoded(raw), sha256_digest=sha256.digest(raw)
+    )
+
+
+def host_context(build_unit: bool) -> ActivationContext:
+    """A concrete host and target, because activation refuses an empty triple."""
+    snapshot = CfgSnapshot(flags=[], values={})
+    unit = TargetConfiguration(triple="x86_64-unknown-linux-gnu", cfg=Some(snapshot))
+    return ActivationContext(
+        host=unit,
+        target=unit,
+        purpose=ActivationPurpose.Normal,
+        requested_features=[],
+        default_features=true,
+        build_unit_present=build_unit,
+    )
+
+
+def catalog_and_activation(raw: bytes, build_unit: bool) -> (RustDependencyCatalog, RustActivation):
+    """Read the authored catalog and activate it once, which is all the authority a producer gets."""
+    catalog = require_ok(read_dependency_catalog(decoded(raw), "Cargo.toml"))
+    activation = require_ok(activate_unit(catalog, host_context(build_unit), "Cargo.toml"))
+    return (catalog, activation)
+
+
+def produced(raw: bytes, members: list[str], build_unit: bool) -> ProviderIntakeEvidence:
+    """Run the producer over one manifest, failing the test with its refusal rather than swallowing it."""
+    catalog, activation = catalog_and_activation(raw, build_unit)
+    return require_ok(
+        provider_intake_evidence(
+            "incan-oven",
+            "packages/probe",
+            evidence_for(raw),
+            members,
+            catalog,
+            host_context(build_unit),
+            activation,
+        )
+    )
+
+
+pub def test_manifest_digest_is_the_digest_of_the_retained_bytes() -> None:
+    """
+    The evidence a unit carries must digest the bytes it also carries, not a re-read of the file.
+
+    This is the property that makes the record worth keeping: a later producer can show the thing it compiled is
+    the thing the manifest described. If the digest came from a fresh filesystem read it would agree with the
+    file and say nothing about the snapshot.
+    """
+    raw = manifest_bytes()
+    evidence = produced(raw, ["Cargo.toml", "src/lib.rs"], true)
+    if evidence.manifest.sha256_digest != sha256.digest(raw):
+        fail("the carried digest must be the digest of the carried bytes")
+    if evidence.manifest.raw_bytes != raw:
+        fail("the exact source bytes must survive into the evidence")
+
+
+pub def test_the_manifest_is_removed_from_the_member_inventory() -> None:
+    """The manifest is carried once, as evidence; leaving it in the inventory would digest it twice."""
+    evidence = produced(manifest_bytes(), ["Cargo.toml", "src/lib.rs", "build.rs"], true)
+    if "Cargo.toml" in evidence.members:
+        fail("the manifest must not appear in the member inventory")
+    if evidence.members != ["src/lib.rs", "build.rs"]:
+        fail(f"the remaining members must keep the authority's order, got {evidence.members}")
+
+
+pub def test_a_build_dependency_is_recorded_by_its_declaration_index_and_alias() -> None:
+    """
+    A build slot is named by where it was declared and what the manifest called it.
+
+    Both are properties of the authored catalog. A producer that reached for the resolved package name would
+    lose the distinction the moment a dependency is aliased, which is the case this pins.
+    """
+    evidence = produced(manifest_bytes(), ["Cargo.toml"], true)
+    if len(evidence.build_slots) != 1:
+        fail(f"exactly one build slot was declared, got {len(evidence.build_slots)}")
+    slot = evidence.build_slots[0]
+    if slot.alias != "cc":
+        fail(f"the slot keeps the authored alias, got {slot.alias}")
+    if slot.host_unit != "x86_64-unknown-linux-gnu":
+        fail(f"a build dependency activates against the context's host triple, got {slot.host_unit}")
+
+
+pub def test_build_unit_presence_is_carried_not_inferred_from_the_slots() -> None:
+    """
+    `build_unit_present` comes from the checked source-unit inventory, never from the slot list.
+
+    They are different facts and usually agree, which is the danger: a package can declare build dependencies
+    and have no build unit. This manifest declares one and the context says there is no build unit, so a
+    producer that inferred presence from the slots would disagree with the inventory here and nowhere else.
+    """
+    evidence = produced(manifest_bytes(), ["Cargo.toml", "src/lib.rs"], false)
+    if evidence.build_unit_present:
+        fail("presence must follow the inventory, not the fact that a build dependency was declared")
+    if len(evidence.build_slots) != 1:
+        fail(f"the declared build slot is still recorded, got {len(evidence.build_slots)}")
+
+
+pub def test_inconsistent_evidence_is_refused_rather_than_repaired() -> None:
+    """
+    Evidence whose digest disagrees with its own bytes is refused, not silently re-digested.
+
+    Repairing it here would be the reconstruction the gate exists to prevent: the producer would be asserting a
+    digest it computed rather than one the authority retained, and the record would prove nothing.
+    """
+    raw = manifest_bytes()
+    catalog, activation = catalog_and_activation(raw, true)
+    tampered = ManifestEvidence(
+        path="Cargo.toml",
+        raw_bytes=raw,
+        source=decoded(raw),
+        sha256_digest=sha256.digest(b"not the manifest"),
+    )
+    match provider_intake_evidence(
+        "incan-oven", "packages/probe", tampered, ["Cargo.toml"], catalog, host_context(true), activation
+    ):
+        Ok(_) => fail("evidence that disagrees with its own bytes must be refused")
+        Err(error) =>
+            if error.kind != IntakeErrorKind.Invalid:
+                fail(f"the refusal should be an Invalid intake error, got {error.kind}")


### PR DESCRIPTION
## Summary

Gate 5 of RFC 119: one companion evidence record per selected unit, carrying what the retained source authority already holds and **deriving nothing**. Its five tests now execute and pass.

`provider_intake_evidence(owner, package_root, manifest, members, catalog, context, activation)` returns a `ProviderIntakeEvidence` carrying: owner identity; the package root under that owner; the typed manifest path, its exact retained bytes and their digest; the package-member inventory with the manifest removed; the original `build-dependencies` slots by declaration index, authored alias and host unit; `build_unit_present`; and the effective feature set.

**The gate is what it must not do.** None of that may come from the selected graph, from Cargo metadata, from a filesystem scan, or from a fresh dependency parse. `OvenSelectedRustFacetUnit` deliberately has no manifest slot and no inventory; `RustDependencyCatalog` in `rust_source.incn` is the authority. An implementation that satisfied the shape by reconstructing the data would pass a value-checking test and fail the gate, so the tests assert provenance:

- the carried digest is the digest of the **carried bytes**, not of a re-read of the file — a digest from a fresh read would agree with the file and say nothing about the snapshot;
- a build slot keeps its **declaration index and authored alias**, which a producer reaching for the resolved package name would lose the moment a dependency is aliased;
- evidence whose digest disagrees with its own bytes is **refused, not re-digested** — repairing it is the reconstruction the gate exists to prevent;
- an activation slot with no declaration in the retained catalog is refused.

`ProviderIntakeEvidence` deliberately does not derive `Eq`: two records are not interchangeable because their values match.

## What changed since this went up as a draft

`build_unit_present` is carried from the checked source-unit inventory, never inferred. The first implementation still leaked the inference through the back door: it read each build slot's presence off its *activation* outcome, and activation marks a build-role slot `BuildUnitAbsent` when the context says there is no build unit. So `build_slots` came out empty exactly when `build_unit_present` was false — one field mirroring the other, and the disagreement the record exists to capture quietly gone. A package can declare build dependencies and have no build unit; that is the case the evidence has to be able to state.

A build-role slot is now carried when it activated, or when its only exclusion is `BuildUnitAbsent`. Every other reason — an unselected optional, a target condition that does not hold — is a genuine deselection, and those stay out. `InactiveReason` already documents that an original declaration's source request is never deleted.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: none yet. This is the production source producer Gate 6 consumes; no command surfaces it.
- **Internals**: `workspaces/oven/src/provider_intake.incn`, authored in Incan against `rust_source` and `rust_activation`. The one refusal vocabulary is the existing `IntakeError`.
- **Risks**: the producer refuses rather than repairs, so a caller holding inconsistent evidence now gets an error where it previously got nothing at all. That is the intent.

## Testing / verification

- [x] `incan test` in `workspaces/oven` — **111 passed** (106 control plane + 5 here)
- [x] `incan oven bake --project workspaces/oven` — exit 0
- [x] `test_build_unit_presence_is_carried_not_inferred_from_the_slots` verified red before the fix: `the declared build slot is still recorded, got 0`

Running these needs [#1531](https://github.com/encero-systems/incan/pull/1531), which is what lets the control plane typecheck at all, and [#1532](https://github.com/encero-systems/incan/pull/1532) for a green baseline. This branch is additive and merges independently of both.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

RFC 119's progress checklist is updated when the gate sequence completes, not per gate.
