### PR TITLE
bugfix - #1494 keep a type application's arguments on its receiver

### DIFF
--- a/src/frontend/typechecker/check_expr/access.rs
+++ b/src/frontend/typechecker/check_expr/access.rs
@@ -3646,14 +3646,60 @@ impl TypeChecker {
     /// and recorded no identity for the call. Lowering then had nothing to project with and emitted the source
     /// spelling, while the declaration was emitted under its projection. Keeping the nominal type gives the
     /// subscripted spelling the same receiver the bare `FactoryBox.make(...)` form already has.
-    fn resolve_type_index_expression(&self, base_ty: &ResolvedType, base: &Spanned<Expr>) -> Option<ResolvedType> {
-        let ResolvedType::Named(_) = base_ty else {
+    fn resolve_type_index_expression(
+        &self,
+        base_ty: &ResolvedType,
+        base: &Spanned<Expr>,
+        index: &Spanned<Expr>,
+    ) -> Option<ResolvedType> {
+        let ResolvedType::Named(name) = base_ty else {
             return None;
         };
         if !matches!(self.type_info.ident_kind(base.span), Some(IdentKind::TypeName)) {
             return None;
         }
-        Some(base_ty.clone())
+        // `Deque[str]` applies a type argument; dropping it here left the receiver generic over nothing, so a
+        // classmethod returning `Self` produced `Deque[Unknown]` and every later substitution carried the
+        // unknown forward. See #1494, where it surfaced as a string literal reaching a `String` parameter
+        // unconverted -- the literal was correct for the element type it had been given.
+        match self.type_arguments_from_index_expression(index) {
+            Some(args) if !args.is_empty() => Some(ResolvedType::Generic(name.clone(), args)),
+            _ => Some(base_ty.clone()),
+        }
+    }
+
+    /// Read one type application's arguments out of the expression the parser produced for its brackets.
+    ///
+    /// A type application and a subscript are the same syntax, so the arguments arrive as an expression rather
+    /// than as types: `Deque[str]` is an index whose index is an identifier, and `Dict[str, int]` one whose index
+    /// is a tuple. Only identifiers and nested applications are read; anything else is a genuine subscript and
+    /// returns `None` so the caller keeps its existing behaviour rather than inventing a type from a value.
+    fn type_arguments_from_index_expression(&self, index: &Spanned<Expr>) -> Option<Vec<ResolvedType>> {
+        let elements: Vec<&Spanned<Expr>> = match &index.node {
+            Expr::Tuple(items) => items.iter().collect(),
+            _ => vec![index],
+        };
+        let mut args = Vec::new();
+        for element in elements {
+            args.push(self.type_argument_from_expression(element)?);
+        }
+        Some(args)
+    }
+
+    /// Resolve one type argument spelled as an expression, including a nested application such as `list[str]`.
+    fn type_argument_from_expression(&self, expr: &Spanned<Expr>) -> Option<ResolvedType> {
+        match &expr.node {
+            Expr::Ident(name) => Some(resolve_type(&Type::Simple(name.clone()), &self.symbols)),
+            Expr::Paren(inner) => self.type_argument_from_expression(inner),
+            Expr::Index(base, index) => {
+                let Expr::Ident(name) = &base.node else {
+                    return None;
+                };
+                let args = self.type_arguments_from_index_expression(index)?;
+                Some(ResolvedType::Generic(name.clone(), args))
+            }
+            _ => None,
+        }
     }
 
     /// Return whether `ty` is the compiler-owned `std.json.JsonValue` wrapper over the raw runtime carrier.
@@ -3688,7 +3734,7 @@ impl TypeChecker {
         span: Span,
     ) -> ResolvedType {
         let base_ty = self.check_type_receiver_expr(base);
-        if let Some(ty) = self.resolve_type_index_expression(&base_ty, base) {
+        if let Some(ty) = self.resolve_type_index_expression(&base_ty, base, index) {
             return ty;
         }
         let index_ty = self.check_expr(index);

--- a/tests/codegen_snapshot_tests.rs
+++ b/tests/codegen_snapshot_tests.rs
@@ -1733,6 +1733,11 @@ def main() -> None:
         // type arguments. The subscripted receiver used to resolve to `Unknown`, so method resolution matched no
         // declaration and recorded no identity, and lowering emitted the source spelling against a declaration that
         // was emitted under its projection.
+        //
+        // The subscript now also reaches the generated Rust, as a turbofish: resolving it to `Named` kept the
+        // projection but discarded the argument, which is what made `Deque[str].from_iter(...)` produce
+        // `Deque[Unknown]` in #1494. So the assertion pins the instantiation as well as the projection, and
+        // whitespace is collapsed first because prettyplease wraps the turbofish across lines.
         let rust_code = generate_registry_rust(
             r#"
 @derive(Clone)
@@ -1750,9 +1755,12 @@ def main() -> None:
             "app.main",
         );
 
+        let collapsed = rust_code.split_whitespace().collect::<Vec<_>>().join("");
         assert!(
-            rust_code.contains("FactoryBox::__incan_v1_"),
-            "an explicitly instantiated type-owned call must name its declaration's projection:\n{rust_code}"
+            collapsed.contains("FactoryBox::<i64,>::__incan_v1_")
+                || collapsed.contains("FactoryBox::<i64>::__incan_v1_"),
+            "an explicitly instantiated type-owned call must name its declaration's projection and carry its type \
+             argument:\n{rust_code}"
         );
         assert!(
             !rust_code.contains("FactoryBox::make("),


### PR DESCRIPTION
## Summary

`Deque[str].from_iter(...)` produced `Deque[Unknown]`. `resolve_type_index_expression` never read the index — it confirmed the base named a type, then returned that bare `Named` and dropped the argument:

```rust
let ResolvedType::Named(_) = base_ty else { return None; };
if !matches!(self.type_info.ident_kind(base.span), Some(IdentKind::TypeName)) { return None; }
Some(base_ty.clone())     // the index is never read
```

**This unblocks the Oven control plane.** `incan oven bake --project workspaces/oven` failed on the dev line, and since #1522 gave that project a library root, every `incan check` there demands a passing bake — so it blocked all Incan-side gate work, not one project. The bake now completes, exit 0, across all library and executable targets.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC

## Area(s)

- [ ] Incan Language
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling
- [ ] Editor integration
- [ ] Runtime / Core crates
- [ ] Documentation

## Key details

**The reported symptom was three steps downstream.** #1494 is filed as "a string literal passed to a `Deque[str]` method is not converted to String". The literal was correct for the element type it had been given. Instrumenting the emitter:

```
PROBE append recv=NamedGeneric("Deque", [Unknown])     before
PROBE append recv=NamedGeneric("Deque", [String])      after
```

Signature lookup and method specialization both worked correctly throughout — they were substituting `T := Unknown`, leaving `determine_conversion` no target to convert toward. Patching the conversion would have papered over a receiver that was already wrong.

**Why it was invisible to the existing test.** `a_string_literal_converts_for_a_generic_stdlib_method_issue1494` runs in-process through `IrCodegen::try_generate`, where stdlib symbols carry `SymbolOrigin::Module`. A real `incan build --lib` against a compiled provider store gives `SymbolOrigin::Package`, and the two disagree here. I had recorded this issue as no longer reproducing on that basis; it was reproducing the whole time.

**Reading the index.** A type application and a subscript share their syntax, so the arguments arrive as an expression rather than as types: `Deque[str]` is an index whose index is an identifier, `Dict[str, int]` one whose index is a tuple. Only identifiers and nested applications are read; anything else is a genuine subscript and the caller keeps its existing behaviour rather than inventing a type out of a value.

**Risks.** This changes `TypeName[...]` from `Named` to `Generic` wherever it appears as a receiver, which is a broad surface. It is covered below by a failing-name comparison rather than by a count.

## Testing / verification

- [x] `cargo +nightly fmt`
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `python3 scripts/check_changed_rustdocs.py --base origin/0.6.0-dev.4` — passed
- [x] `cargo test --lib -- typechecker` — 1099 passed
- [x] `cargo test --test codegen_snapshot_tests` — 266 passed
- [x] `incan oven bake --project workspaces/oven` — **exit 0**, where it previously failed to compile
- [x] `cargo test --lib` — same **32 failing test names** with and without this change, compared as a set; all are the documented standing set for a run without the prewarm environment

One snapshot assertion changed. `a_type_owned_call_with_explicit_type_arguments_projects_like_its_declaration` checked the projection by exact substring; the instantiation now also reaches the generated Rust as a turbofish — `FactoryBox::<i64>::__incan_v1_…` — so the assertion pins the type argument alongside the projection rather than matching a spelling that no longer occurs. That is the fix being visible at the call site, not the test being relaxed.

## Docs impact

- [x] No docs changes needed

Closes #1494. Unblocks #1528.