### PR TITLE
bugfix - #1530 let the Oven project graph load: declare the sysroot, and keep the sealed authority the judge of the target closure

### DIFF
--- a/crates/rust_inspect/src/loader.rs
+++ b/crates/rust_inspect/src/loader.rs
@@ -43,6 +43,28 @@ pub struct RustWorkspace {
 /// tree or in Cargo's cache.
 static OVEN_PROJECT_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
+/// Resolve the active toolchain's sysroot, for declaring it in a build-system-neutral project graph.
+///
+/// A `rust-project.json` graph contains exactly the crates it lists. Unlike the Cargo loader, nothing discovers
+/// the sysroot for it, so omitting these fields leaves `std`, `core` and `alloc` absent and every `rust::std::…`
+/// or `rust::core::…` lookup fails with `CrateNotFound`. That failure is then persisted as a negative cache
+/// entry, so one unanswerable query poisons the item for the life of the workspace. See #1530.
+fn active_sysroot() -> Option<PathBuf> {
+    let rustc = std::env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
+    let output = std::process::Command::new(rustc)
+        .args(["--print", "sysroot"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let sysroot = std::str::from_utf8(&output.stdout).ok()?.trim();
+    if sysroot.is_empty() {
+        return None;
+    }
+    Some(PathBuf::from(sysroot))
+}
+
 /// Resolve the proc-macro server installed beside the active Rust compiler.
 fn active_proc_macro_server() -> ProcMacroServerChoice {
     let rustc = std::env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
@@ -1122,10 +1144,17 @@ impl RustWorkspace {
                 })
             })
             .collect::<Vec<_>>();
-        serde_json::to_vec(&serde_json::json!({
-            "crates": crates,
-        }))
-        .map_err(|error| RustMetadataError::LoadWorkspace {
+        // Declare the sysroot so `std`, `core` and `alloc` are in the graph. Their absence is not a property of
+        // this project: a `rust-project.json` contains exactly what it lists, and nothing discovers them for it.
+        let mut graph = serde_json::json!({ "crates": crates });
+        if let Some(sysroot) = active_sysroot() {
+            let sysroot_src = sysroot.join("lib/rustlib/src/rust/library");
+            graph["sysroot"] = serde_json::json!(sysroot.to_string_lossy());
+            if sysroot_src.is_dir() {
+                graph["sysroot_src"] = serde_json::json!(sysroot_src.to_string_lossy());
+            }
+        }
+        serde_json::to_vec(&graph).map_err(|error| RustMetadataError::LoadWorkspace {
             path: manifest_dir.to_path_buf(),
             message: format!("failed to encode direct Oven rust-project graph: {error}"),
         })

--- a/crates/rust_inspect/src/loader.rs
+++ b/crates/rust_inspect/src/loader.rs
@@ -385,6 +385,22 @@ struct OvenDependencyDeclaration {
     path: Option<PathBuf>,
     version: Option<String>,
     features: Vec<String>,
+    /// Whether the declaration came from a `[target.'cfg(...)'.dependencies]` table rather than `[dependencies]`.
+    target_conditional: bool,
+    /// Whether the declaration is `optional = true`, so a feature selection decides if the edge exists at all.
+    optional: bool,
+}
+
+impl OvenDependencyDeclaration {
+    /// Whether this edge must appear in the sealed source authority for the authority to be considered complete.
+    ///
+    /// The lockfile is platform- and feature-independent: it retains every edge any resolve could take. The sealed
+    /// authority is the opposite — it records the one closure the bake actually resolved for one target and feature
+    /// selection. So a target-conditional or optional edge is legitimately absent, and demanding a source for it
+    /// fails the whole workspace load over a dependency this build never had.
+    fn requires_sealed_source(&self) -> bool {
+        !self.target_conditional && !self.optional
+    }
 }
 
 /// A package entry from the already-resolved lockfile for a direct Oven project.
@@ -566,6 +582,7 @@ impl RustWorkspace {
             fn collect(
                 table: Option<&toml::Value>,
                 manifest_dir: &Path,
+                target_conditional: bool,
                 dependencies: &mut Vec<OvenDependencyDeclaration>,
             ) {
                 let Some(table) = table.and_then(toml::Value::as_table) else {
@@ -588,6 +605,10 @@ impl RustWorkspace {
                             .and_then(toml::Value::as_str)
                             .map(str::to_string)
                     });
+                    let optional = declaration
+                        .get("optional")
+                        .and_then(toml::Value::as_bool)
+                        .unwrap_or(false);
                     let mut features = declaration
                         .get("features")
                         .and_then(toml::Value::as_array)
@@ -611,6 +632,8 @@ impl RustWorkspace {
                         path,
                         version,
                         features,
+                        target_conditional,
+                        optional,
                     });
                 }
             }
@@ -618,20 +641,38 @@ impl RustWorkspace {
             let mut dependencies = Vec::new();
             // Direct inspection needs the runtime crate graph. Dev-only and build-script dependencies are neither
             // linked into the sealed Loaf nor available through this no-Cargo projection.
-            collect(manifest.get("dependencies"), manifest_dir, &mut dependencies);
+            collect(manifest.get("dependencies"), manifest_dir, false, &mut dependencies);
+            // Every `[target.'cfg(...)']` table is collected because this projection does not evaluate cfg
+            // predicates; the sealed source authority already encodes which of those edges the bake resolved for
+            // the target being inspected. They are marked conditional so an edge this target does not have is
+            // skipped rather than demanded.
             if let Some(targets) = manifest.get("target").and_then(toml::Value::as_table) {
                 for target in targets.values() {
-                    collect(target.get("dependencies"), manifest_dir, &mut dependencies);
+                    collect(target.get("dependencies"), manifest_dir, true, &mut dependencies);
                 }
             }
+            // The conditionality flags sort last and `false` sorts first, so a package declared both unconditionally
+            // and under a cfg or a feature keeps its unconditional record. Collapsing that the other way round would
+            // let a genuinely required source go missing without a refusal.
             dependencies.sort_by(|left, right| {
-                (&left.name, &left.package, &left.path, &left.version, &left.features).cmp(&(
-                    &right.name,
-                    &right.package,
-                    &right.path,
-                    &right.version,
-                    &right.features,
-                ))
+                (
+                    &left.name,
+                    &left.package,
+                    &left.path,
+                    &left.version,
+                    &left.features,
+                    left.target_conditional,
+                    left.optional,
+                )
+                    .cmp(&(
+                        &right.name,
+                        &right.package,
+                        &right.path,
+                        &right.version,
+                        &right.features,
+                        right.target_conditional,
+                        right.optional,
+                    ))
             });
             dependencies.dedup_by(|left, right| {
                 left.name == right.name
@@ -788,9 +829,13 @@ impl RustWorkspace {
         }
 
         /// Locate the source with the same package, registry, checksum, and version as one locked package.
+        ///
+        /// `required` comes from [`OvenDependencyDeclaration::requires_sealed_source`] and decides whether a locked
+        /// edge with no sealed source is a refusal or a skip.
         fn registry_source(
             authority: &OvenInspectionSourceAuthority,
             package: &OvenLockedPackage,
+            required: bool,
         ) -> Result<Option<(PathBuf, Vec<String>)>, RustMetadataError> {
             let Some(registry) = package
                 .source
@@ -816,6 +861,16 @@ impl RustWorkspace {
                     && source.checksum == checksum
             });
             let Some(source) = matches.next() else {
+                if !required || !authority.sources.iter().any(|source| source.package == package.name) {
+                    // Either the edge is conditional, or the authority names no version of this package at all. The
+                    // second case is how an unlinked crate looks from here: a proc-macro or build-script package is
+                    // in the lock and in a crate's `[dependencies]`, but it is never part of the target closure the
+                    // authority sealed, and this projection has no manifest to recognize it by. Refusing would fail
+                    // every query against the workspace over a crate the direct-rustc graph does not link.
+                    return Ok(None);
+                }
+                // The authority does know this package, at some other version or checksum. That is a stale or
+                // tampered authority rather than an unlinked crate, and it stays a refusal.
                 return Err(RustMetadataError::LoadWorkspace {
                     path: PathBuf::from(OVEN_DIRECT_INSPECTION_AUTHORITY_FILE),
                     message: format!(
@@ -981,7 +1036,9 @@ impl RustWorkspace {
                             is_local_path: true,
                             features: declaration.features.clone(),
                         });
-                    } else if let Some((source_dir, features)) = registry_source(authority, dependency)? {
+                    } else if let Some((source_dir, features)) =
+                        registry_source(authority, dependency, declaration.requires_sealed_source())?
+                    {
                         dependencies.push(OvenProjectDependency {
                             name: declaration.name.clone(),
                             source_dir,
@@ -1642,6 +1699,140 @@ mod tests {
             "the root and its one directly authorized registry source must be present"
         );
         assert_eq!(crates[1]["display_name"], "direct");
+        Ok(())
+    }
+
+    /// Build a workspace whose lock names one registry package the sealed authority never carries.
+    ///
+    /// The three unsealed spellings — a `[target.'cfg(...)']` edge, an `optional` edge, and an edge whose package
+    /// the authority does not name at any version — are the three ways Cargo's platform- and feature-independent
+    /// lock can hold a dependency that one target's resolved closure does not.
+    fn oven_workspace_with_unsealed_dependency(
+        workspace: &std::path::Path,
+        sealed_root: &std::path::Path,
+        root_dependency_table: &str,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        fs::create_dir_all(workspace.join("src"))?;
+        fs::write(
+            workspace.join("Cargo.toml"),
+            format!(
+                "[package]\nname = \"root\"\nversion = \"0.1.0\"\n\n[dependencies]\nsealed = \"1\"\n{root_dependency_table}"
+            ),
+        )?;
+        fs::write(workspace.join("src/main.rs"), "fn main() {}\n")?;
+        fs::write(
+            workspace.join("Cargo.lock"),
+            "version = 4\n\n[[package]]\nname = \"root\"\nversion = \"0.1.0\"\ndependencies = [\"sealed\", \"unsealed\"]\n\n[[package]]\nname = \"sealed\"\nversion = \"1.0.0\"\nsource = \"registry+https://example.invalid/index\"\nchecksum = \"sealed-checksum\"\n\n[[package]]\nname = \"unsealed\"\nversion = \"1.0.0\"\nsource = \"registry+https://example.invalid/index\"\nchecksum = \"unsealed-checksum\"\n",
+        )?;
+        fs::create_dir_all(sealed_root.join("src"))?;
+        fs::write(
+            sealed_root.join("Cargo.toml"),
+            "[package]\nname = \"sealed\"\nversion = \"1.0.0\"\n",
+        )?;
+        fs::write(sealed_root.join("src/lib.rs"), "pub fn sealed() {}\n")?;
+        let source_digest = digest_oven_source_tree(sealed_root)?;
+        write_oven_inspection_source_authority(
+            workspace,
+            vec![OvenInspectionRegistrySource {
+                package: "sealed".to_string(),
+                version: "1.0.0".to_string(),
+                registry: "registry+https://example.invalid/index".to_string(),
+                checksum: "sealed-checksum".to_string(),
+                features: Vec::new(),
+                source_root: sealed_root.to_path_buf(),
+                source_digest,
+            }],
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn direct_oven_project_skips_locked_edges_outside_the_sealed_target_closure()
+    -> Result<(), Box<dyn std::error::Error>> {
+        for root_dependency_table in [
+            // Target-conditional: the predicate admits some platforms, and the authority sealed one of them.
+            "\n[target.'cfg(target_arch = \"x86_64\")'.dependencies]\nunsealed = \"1\"\n",
+            // Optional: a feature selection decides whether the edge exists, and this one did not take it.
+            "\n[dependencies.unsealed]\nversion = \"1\"\noptional = true\n",
+            // Unlinked: a proc-macro or build-script package is in the lock and in `[dependencies]`, but never in
+            // the target closure, and the authority names no version of it.
+            "\n[dependencies.unsealed]\nversion = \"1\"\n",
+        ] {
+            let workspace = tempdir()?;
+            let sealed = tempdir()?;
+            oven_workspace_with_unsealed_dependency(workspace.path(), sealed.path(), root_dependency_table)?;
+            let payload = RustWorkspace::oven_project_json_payload(workspace.path())
+                .map_err(|error| format!("`{root_dependency_table}` must load: {error}"))?;
+            let graph: serde_json::Value = serde_json::from_slice(&payload)?;
+            let crates = graph["crates"].as_array().ok_or("direct Oven graph omitted crates")?;
+            let names = crates
+                .iter()
+                .map(|entry| entry["display_name"].as_str().unwrap_or_default().to_string())
+                .collect::<Vec<_>>();
+            assert!(
+                names.iter().any(|name| name == "sealed"),
+                "`{root_dependency_table}` must keep the sealed edge, got {names:?}"
+            );
+            assert!(
+                !names.iter().any(|name| name == "unsealed"),
+                "`{root_dependency_table}` must not invent an unsealed crate, got {names:?}"
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn direct_oven_project_refuses_a_locked_edge_the_authority_knows_at_another_version()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let workspace = tempdir()?;
+        let sealed = tempdir()?;
+        let stale = tempdir()?;
+        oven_workspace_with_unsealed_dependency(
+            workspace.path(),
+            sealed.path(),
+            "\n[dependencies.unsealed]\nversion = \"1\"\n",
+        )?;
+        // Seal `unsealed` at a version the lock does not name. An authority that knows the package but disagrees on
+        // its identity is stale or tampered with, not an unlinked crate, so it must still be refused.
+        fs::create_dir_all(stale.path().join("src"))?;
+        fs::write(
+            stale.path().join("Cargo.toml"),
+            "[package]\nname = \"unsealed\"\nversion = \"0.9.0\"\n",
+        )?;
+        fs::write(stale.path().join("src/lib.rs"), "pub fn unsealed() {}\n")?;
+        let sealed_digest = digest_oven_source_tree(sealed.path())?;
+        let stale_digest = digest_oven_source_tree(stale.path())?;
+        write_oven_inspection_source_authority(
+            workspace.path(),
+            vec![
+                OvenInspectionRegistrySource {
+                    package: "sealed".to_string(),
+                    version: "1.0.0".to_string(),
+                    registry: "registry+https://example.invalid/index".to_string(),
+                    checksum: "sealed-checksum".to_string(),
+                    features: Vec::new(),
+                    source_root: sealed.path().to_path_buf(),
+                    source_digest: sealed_digest,
+                },
+                OvenInspectionRegistrySource {
+                    package: "unsealed".to_string(),
+                    version: "0.9.0".to_string(),
+                    registry: "registry+https://example.invalid/index".to_string(),
+                    checksum: "stale-checksum".to_string(),
+                    features: Vec::new(),
+                    source_root: stale.path().to_path_buf(),
+                    source_digest: stale_digest,
+                },
+            ],
+        )?;
+        let error = match RustWorkspace::oven_project_json_payload(workspace.path()) {
+            Ok(_) => return Err("an authority that knows the package at another version must refuse".into()),
+            Err(error) => error,
+        };
+        assert!(
+            error.to_string().contains("no sealed Oven source matches"),
+            "unexpected refusal: {error}"
+        );
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

`workspaces/oven`'s control plane could not run a single test: all 106 failed with `Cannot use '?' on type '?'` at `intake.incn:152`, pointing at the author's own `from_utf8(raw)` call. The cause was two layers away — the direct-rustc project graph the typechecker inspects through was failing to load at all, so every `rust::std::*` query returned Unknown.

Two independent defects were doing that. Both are in the build-system-neutral Oven project loader.

**1. The project graph declared no sysroot.** `load_oven_project` emitted `{"crates": [...]}` with no `sysroot` key, so rust-analyzer had no `std`/`core`/`alloc` to resolve against and reported `CrateNotFound: std`. It now discovers the active sysroot the same way the Cargo loader already does, and adds `sysroot_src` when the source component is installed.

**2. The loader read the Cargo lock as the authority on the target's crate closure.** A lock is platform- and feature-independent: it retains every dependency edge any resolve could take, including build-script and proc-macro closures. The sealed Oven source authority is the opposite — it records the one closure a bake actually resolved for one target and feature selection. The loader demanded a sealed source for every locked edge that matched a `[dependencies]` declaration by name, and any mismatch failed the entire workspace load.

In this project 21 of 74 locked registry packages are legitimately outside the sealed closure, in four spellings:

| Spelling | Example here |
| --- | --- |
| `[target.'cfg(...)']` predicate this target does not satisfy | `blake3` declares `cpufeatures` only for `x86`/`x86_64`; the arm64 bake correctly never resolved `cpufeatures 0.3.1` |
| `optional` edge whose feature was not selected | `encoding_rs`'s optional `rustversion` |
| build-only package whose name also appears in `[dependencies]` | `rustversion` again, declared both ways |
| proc-macro crate, never linked into the target graph | `multiversion_no_op`, an unconditional `[dependencies]` entry that is `[lib] proc-macro = true` |

Declarations now carry whether they are target-conditional or optional, and a locked edge with no exact sealed match is skipped when it is conditional, or when the authority names no version of that package at all — the shape an unlinked crate has from a projection that cannot read its manifest. It stays a refusal when the authority *does* know the package at another version or checksum: that is a stale or tampered authority, not an unlinked crate, and the existing checksum-mismatch test still proves it.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: a project whose Rust dependency graph contains proc-macro, build-only, optional or target-gated packages can now be inspected at all. Before this, one such package anywhere in the lock made every `rust::` import in the project resolve to Unknown, and the diagnostic pointed at the author's source rather than the missing authority.
- **Internals**: `OvenDependencyDeclaration` gains `target_conditional` and `optional`, and a `requires_sealed_source()` predicate. Sort/dedup put the unconditional, non-optional record first so a package declared both ways keeps its strict form. `registry_source` takes that as `required`.
- **Risks**: the strict refusal is narrower than it was. It no longer fires for a package the authority does not name at all — which is exactly the unlinked-crate case, and is the only way this projection can recognize one. Integrity for packages the authority *does* carry is unchanged: a version or checksum disagreement is still a hard refusal.

## Testing / verification

- [x] `cargo test -p rust_inspect --lib loader::` — 14 passed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `python3 scripts/check_changed_rustdocs.py --base origin/0.6.0-dev.4` — passed
- [x] Manual verification described below

**Tests added:**

- `direct_oven_project_skips_locked_edges_outside_the_sealed_target_closure` — all three unsealed spellings load, keep the sealed edge, and do not invent the unsealed crate. Verified red before the fix: the first case failed with `no sealed Oven source matches locked registry package 'unsealed' 1.0.0`.
- `direct_oven_project_refuses_a_locked_edge_the_authority_knows_at_another_version` — the narrowing does not reach a stale authority.

**End-to-end:** `incan oven bake --project workspaces/oven` bakes all six plans, and `incan test` in `workspaces/oven` goes from **106 failed** to **104 passed, 2 failed**. The two remaining failures are assertion failures in the control plane's own Incan logic (`test_native_compilation.incn`, `test_rust_activation.incn`), not inspection failures, and are being handled separately.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

Rustdoc on the changed items carries the contract; there is no user-facing surface change to document.

Closes #1530
