### PR TITLE
bugfix - #1037 refuse an unsupported plan schema before reading the envelope it does not use

### DIFF
--- a/workspaces/oven/src/plan_json.incn
+++ b/workspaces/oven/src/plan_json.incn
@@ -79,6 +79,15 @@ pub def evaluate(source: str) -> JsonValue:
 pub def decode_request(source: str) -> Result[SelectionRequest, SelectionError]:
     """Decode every required wire field; model defaults never supply omitted protocol intent."""
     document = parse(source).map_err((_) => SelectionError(kind=SelectionErrorKind.InvalidInput, fields=[]))?
+    # An unsupported version is refused before the envelope's shape is read. Every other field's meaning is
+    # version-specific, so a document from a sibling schema — a native-compilation request reaching the shared
+    # dispatcher, say — must be refused on `schema` and not on whichever keys that other schema happens to carry.
+    # This peeks rather than decodes, so a document that is not an object, or whose `schema` is not a string, still
+    # falls through to the checks below that own those faults.
+    if let Some(declared) = document.get("schema"):
+        if let Some(declared_name) = declared.as_str():
+            if declared_name != SCHEMA and declared_name != SCHEMA_V2:
+                return Err(SelectionError(kind=SelectionErrorKind.InvalidInput, fields=["schema"]))
     exact_object(document, ["schema", "request"], [])?
     schema = text_field(document, "schema", [])?
     if schema != SCHEMA and schema != SCHEMA_V2:

--- a/workspaces/oven/src/test_rust_activation.incn
+++ b/workspaces/oven/src/test_rust_activation.incn
@@ -275,7 +275,7 @@ pub def test_inactive_invalid_version_and_malformed_cfg_refuse() -> None:
 
 
 pub def test_duplicate_requests_and_shared_feature_paths_keep_sorted_demands() -> None:
-    """Duplicate queue arrivals and roots produce one sorted demand without mutating authored features."""
+    """Duplicate queue arrivals and roots produce one sorted demand, and activation leaves the catalog alone."""
     source = "\n    [dependencies]\n    cache={version='1', optional=true, features=['base','base'], default-features=false}\n    [features]\n    default=['right','left','right']\n    left=['dep:cache','leaf','cache?/serde','cache?/serde']\n    right=['leaf','left']\n    leaf=[]\n    "
     catalog = require_ok(read_dependency_catalog(source, "Cargo.toml"))
     for requested in [["right", "left", "right"], ["left", "right"]]:
@@ -291,4 +291,6 @@ pub def test_duplicate_requests_and_shared_feature_paths_keep_sorted_demands() -
                 assert not defaults
                 assert domain == DependencyDomain.Target
             _ => fail("duplicate feature paths lost the active optional dependency")
-        assert catalog.dependencies[0].features == ["base", "base"]
+        # Intake already collapsed the authored `['base','base']` into one sorted demand. Re-reading it after each
+        # activation proves activation does not fold `cache?/serde` back into the declaration it was resolved from.
+        assert catalog.dependencies[0].features == ["base"]


### PR DESCRIPTION
## Summary

`workspaces/oven`'s test suite now reports **106 passed**. It had never executed before — [#1530](https://github.com/encero-systems/incan/issues/1530) stopped it at the typechecker — so both expectations this PR touches were written blind against a control plane nobody could run.

**A sibling schema was refused on the wrong field.** `decode_request` validated the envelope's key set before reading the version that decides what those keys *mean*. A native-compilation request reaching the shared dispatcher was therefore refused on whichever keys that schema carries, rather than on `schema`. The version check further down already produced `fields: ["schema"]` — it was simply unreachable for anything whose shape was not the selection envelope's.

The version is now peeked first. The peek short-circuits only when the document has a string `schema` naming an unsupported version, so the existing refusals are untouched: `null` is still refused with no field, and an integer `schema` is still refused on `schema`. `test_malformed_json_and_schema_refuse` covers both and passes unchanged.

**One test expectation was wrong.** `test_duplicate_requests_and_shared_feature_paths_keep_sorted_demands` expected a dependency's authored `features = ['base','base']` to survive intake verbatim. It does not: `read_catalog` collapses declared features into one sorted set as it reads them. That is deliberate — `RustDependencyDeclaration` documents what it preserves verbatim (absent flags stay absent, path spelling is kept) and makes no claim about feature order or duplicates. The test now reads the normalized `['base']`, which still proves what it was written for: activation resolves `cache?/serde` without folding it back into the declaration it came from.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: an unsupported plan-JSON schema version is refused on `schema`, which is the field that is actually wrong. Nothing else changes.
- **Internals**: the peek uses `document.get("schema")` / `as_str()` — the same pair the dispatcher above it already uses to route — so there is one spelling of "what version is this" in the file.
- **Risks**: the early return fires before `exact_object`, so a document that is both an unsupported version *and* structurally malformed now reports the version rather than the structure. That is the intended order: the structure cannot be judged until the version is known.

## Testing / verification

- [x] `incan test` in `workspaces/oven` — **106 passed**
- [x] `incan oven bake --project workspaces/oven` — exit 0, six plans
- [ ] `make test` — unchanged by this PR; no Rust source touched

Verification needs [#1531](https://github.com/encero-systems/incan/pull/1531) applied, because without it the suite cannot reach a single assertion. This branch is cut from `0.6.0-dev.4` and does not depend on it to build, so it can merge in either order.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable
