### PR TITLE
feature - #573 take a reference's language from the identity it resolved to

### DIFF
--- a/src/inspect/codegraph.rs
+++ b/src/inspect/codegraph.rs
@@ -2214,7 +2214,7 @@ impl CodegraphBuilder {
         let stable_identity = self.stable_identity_for(canonical_identity.as_ref());
         self.records.push(CodegraphRecord::Reference(CodegraphReferenceRecord {
             id: id.clone(),
-            language: CodegraphLanguage::Incan,
+            language: reference_language(canonical_identity.as_ref()),
             module_id: module_id.to_string(),
             owner_id: owner_id.clone(),
             name: name.to_string(),
@@ -3002,6 +3002,20 @@ const fn checked_registry_subject_kind(kind: CheckedRegistrySubjectKind) -> &'st
         CheckedRegistrySubjectKind::Method => "method",
         CheckedRegistrySubjectKind::CompilationUnit => "compilation_unit",
         CheckedRegistrySubjectKind::Package => "package",
+    }
+}
+
+/// Return the language a body fact belongs to, taken from the identity the compiler gave what it resolved to.
+///
+/// RFC 106 keeps one graph across both languages and makes `language` an attribute of a fact rather than a separate
+/// node kind, so a reference the compiler resolved to a Rust crate item is a Rust fact even though the source that
+/// wrote it is Incan. Only a checked identity decides this. Where nothing was proven the fact stays Incan, the
+/// language of the module that wrote it: matching a name against the module's Rust imports would infer origin from
+/// a spelling, which is the mistake RFC 120 exists to prevent and which an alias defeats immediately.
+fn reference_language(identity: Option<&CanonicalSymbolId>) -> CodegraphLanguage {
+    match identity.map(|identity| &identity.origin) {
+        Some(SymbolOrigin::RustCrate(_)) => CodegraphLanguage::Rust,
+        _ => CodegraphLanguage::Incan,
     }
 }
 
@@ -4241,6 +4255,85 @@ pub def pick(value: int, fallback: int) -> int:
             CodegraphLanguage::Incan,
             "an ordinary Incan import must not be relabelled by this change"
         );
+        Ok(())
+    }
+
+    /// A reference the compiler resolved into a Rust crate is a Rust fact, whatever the source that wrote it.
+    ///
+    /// The import records from `a_module_records_every_rust_item_it_reaches` say which items a module *reaches*.
+    /// They do not say which declaration *uses* one, and that is the question a build-invalidation or navigation
+    /// consumer actually asks. Every use site was emitted as `language: "incan"` regardless of what it resolved
+    /// to, so the graph could not distinguish a call into a Rust crate from a call to a local function.
+    ///
+    /// The identity decides it, not the spelling. An alias makes the spelling useless — `Predicate as Pred` reads
+    /// as an ordinary local name at the call site — and inferring origin from a name is the mistake RFC 120 exists
+    /// to prevent. A reference with no checked identity therefore stays Incan: absence of proof is not proof.
+    #[test]
+    fn a_reference_resolved_into_a_rust_crate_is_a_rust_fact() -> Result<(), Box<dyn std::error::Error>> {
+        fn identity(origin: SymbolOrigin, name: &str) -> CanonicalSymbolId {
+            CanonicalSymbolId {
+                namespace: incan_semantics_core::SymbolNamespace::OrdinaryLexical,
+                origin,
+                declaration_name: name.to_string(),
+                kind: incan_semantics_core::SemanticSourceTargetKind::Function,
+                scope_discriminant: None,
+                declaration_span: incan_semantics_core::HirSourceSpan::new(0, 1),
+            }
+        }
+
+        let source = "def probe() -> None:\n    pass\n";
+        let tokens = lexer::lex(source).map_err(|errors| format!("{errors:?}"))?;
+        let program = parser::parse(&tokens).map_err(|errors| format!("{errors:?}"))?;
+        let module = ParsedModule {
+            name: "probe".to_string(),
+            path_segments: vec!["probe".to_string()],
+            file_path: PathBuf::from("probe.incn"),
+            source: source.to_string(),
+            ast: program,
+        };
+
+        let cases = [
+            (
+                "rust_call",
+                Some(identity(
+                    SymbolOrigin::RustCrate(vec!["cfg_expr".to_string(), "Predicate".to_string()]),
+                    "Predicate",
+                )),
+                CodegraphLanguage::Rust,
+            ),
+            (
+                "incan_call",
+                Some(identity(SymbolOrigin::Module(vec!["probe".to_string()]), "helper")),
+                CodegraphLanguage::Incan,
+            ),
+            ("unresolved_call", None, CodegraphLanguage::Incan),
+        ];
+
+        for (name, checked, expected) in cases {
+            let mut collector = CodegraphBuilder::new(Path::new("."), None, false);
+            collector.push_reference_with_checked(
+                &module,
+                "file:probe",
+                None,
+                name,
+                "call",
+                Span::new(0, 1),
+                false,
+                checked.map(|identity| (identity, None)),
+            );
+            let language = collector
+                .records
+                .iter()
+                .find_map(|record| match record {
+                    CodegraphRecord::Reference(reference) if reference.name == name => Some(reference.language),
+                    _ => None,
+                })
+                .ok_or_else(|| format!("`{name}` should produce a reference record"))?;
+            assert_eq!(
+                language, expected,
+                "`{name}` must take its language from the identity the compiler resolved, not from the module"
+            );
+        }
         Ok(())
     }
 

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -3297,6 +3297,11 @@ def main() -> None:
     Ok(())
 }
 
+/// Assert the record contract every codegraph export owes a consumer, over an Incan-only fixture.
+///
+/// The language assertion is a property of *these fixtures*, which import nothing from Rust, not of the export
+/// format: RFC 106 keeps one graph across both languages and makes `language` an attribute of each fact, so a
+/// fixture that reaches a Rust item legitimately yields `"rust"` records and must not be checked with this helper.
 fn assert_codegraph_record_contract(records: &[serde_json::Value]) {
     assert!(!records.is_empty(), "codegraph export should include a header record");
     assert_eq!(records[0]["record"], serde_json::json!("header"));
@@ -3312,7 +3317,7 @@ fn assert_codegraph_record_contract(records: &[serde_json::Value]) {
         assert_eq!(
             record["language"],
             serde_json::json!("incan"),
-            "v0.5 codegraph fact records should be explicitly Incan-language facts: {record}"
+            "every fact from an Incan-only fixture should be an Incan-language fact: {record}"
         );
         assert!(
             record["provenance"].is_string(),
@@ -3330,14 +3335,6 @@ fn assert_codegraph_record_contract(records: &[serde_json::Value]) {
             assert_source_span_shape(span, record);
         }
     }
-
-    assert!(
-        records
-            .iter()
-            .skip(1)
-            .all(|record| record["language"] != serde_json::json!("rust")),
-        "v0.4 should not emit Rust codegraph facts before first-class Rust support lands"
-    );
 }
 
 fn assert_source_span_shape(span: &serde_json::Value, record: &serde_json::Value) {


### PR DESCRIPTION
## Summary

[#1524](https://github.com/encero-systems/incan/pull/1524) gave the codegraph the Rust items a module *reaches*, recorded at the import statement. It did not say which declaration *uses* one — and that is the question a build-invalidation or navigation consumer actually asks. Every use site was emitted as `language: "incan"` whatever it resolved to, so a call into a Rust crate and a call to a local function were indistinguishable facts.

RFC 106 keeps one graph across both languages and makes `language` an attribute of a fact rather than a separate node kind — it explicitly retires `rust_item` and `uses_rust_item` for "encoding the distinction `language` exists to dissolve". So the change is not new vocabulary; it is making the existing attribute tell the truth. `push_reference_with_checked` now takes the language from the canonical identity's origin: a `SymbolOrigin::RustCrate` resolution is a Rust fact.

**Only a checked identity decides it.** A reference with no identity stays Incan, the language of the module that wrote it. Matching a name against the module's Rust imports would infer origin from a spelling — the mistake RFC 120 exists to prevent — and `Predicate as Pred` defeats it at the first alias.

Toward #777, which needs an Oven-supported mixed project to expose where an Incan `rust::` boundary is crossed. This is the use-site half of that; the Rust package/target records and their provenance vocabulary are a schema change and are not here.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: a `codegraph` reference record whose target the compiler resolved into a Rust crate now reports `"language": "rust"`. Nothing else about the record changes, and no record kind is added or removed.
- **Internals**: one helper, `reference_language`, beside the existing `provenance_for_identity` — both answer "what does this fact's identity tell us", so they sit together.
- **Risks**: a consumer that filtered records by `language == "incan"` to mean "every body fact" now sees fewer. That filter was already wrong after #1524, which emitted Rust references at imports; this widens where it shows. The export's `languages` header already declares both.

## Testing / verification

- [x] `cargo test --features cli --lib codegraph` — 12 passed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `python3 scripts/check_changed_rustdocs.py --base origin/0.6.0-dev.4` — passed

**Test added:** `a_reference_resolved_into_a_rust_crate_is_a_rust_fact` drives `push_reference_with_checked` with three identities — a `RustCrate` origin, a `Module` origin, and none — and asserts the resulting record's language. Verified red before the change: `` `rust_call` must take its language from the identity the compiler resolved, not from the module ``.

**Boy Scout:** `assert_codegraph_record_contract` claimed "v0.4 should not emit Rust codegraph facts before first-class Rust support lands", which #1524 made false, and separately asserted every record was Incan. That is a property of the Incan-only fixtures it runs over, not of the export format, and it now says so — otherwise the first `rust::` import added to one of those fixtures fails on a stale claim rather than on a real contract.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

The codegraph reference already documents `language` as a per-fact attribute spanning both languages; this makes the producer match it.

Part of #573.
