### PR TITLE
chore - #1037 let the shadow-comparison lane find the compiler it was handed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -514,6 +514,10 @@ jobs:
       - name: Restore executable permissions
         run: chmod +x target/debug/incan
       - uses: ./.github/actions/consume-sdk-provider-store
+      # Cargo builds test dependencies in a separate target so it cannot replace the handoff CLI. The Makefile's
+      # own `TARGET_DIR` defaults to `CARGO_TARGET_DIR`, so it has to be told where the handoff binary actually
+      # is -- the same compensation the platform ABI job makes with `CARGO_BIN_EXE_incan`. Without it the recipe
+      # looks for the compiler in the empty scratch target and the lane cannot pass at all.
       - name: Prove the source-observable comparison ran and agreed
         env:
           CARGO_NET_OFFLINE: "true"
@@ -521,14 +525,16 @@ jobs:
           INCAN_TEST_COMPILER_ALREADY_BUILT: "1"
         run: |
           sha256sum target/debug/incan > "$RUNNER_TEMP/compiler-handoff.sha256"
-          make -s shadow-comparison-evidence
+          make -s shadow-comparison-evidence TARGET_DIR="$GITHUB_WORKSPACE/target"
           sha256sum --check "$RUNNER_TEMP/compiler-handoff.sha256"
+      # The corpus summary follows `CARGO_TARGET_DIR`, not the Makefile's `TARGET_DIR`, because the test writes it
+      # from inside the cargo run. It therefore lands in the scratch target above.
       - name: Upload the parity corpus summary
         if: always()
         uses: actions/upload-artifact@v5
         with:
           name: shadow-comparison-parity-summary
-          path: target/parity-corpus/summary.json
+          path: ${{ runner.temp }}/incan-shadow-test-target/parity-corpus/summary.json
           if-no-files-found: warn
 
   oven-linux-replay:


### PR DESCRIPTION
## Summary

The #1146 source-observable comparison is the parity instrument Gate 8's acceptance depends on — a release archive with zero `legacy-cargo` invocations *whose contents are byte-comparable against a legacy-produced archive*. Its CI lane cannot pass as configured, and fails with a bare `make: *** [Makefile:403: test-prewarm-sdk] Error 1` and no diagnostic.

**Two mismatches, one cause.**

The step redirects `CARGO_TARGET_DIR` to a scratch directory so Cargo cannot overwrite the handoff CLI. That is right, and it is what the platform ABI job does. But the Makefile derives its own `TARGET_DIR` from `CARGO_TARGET_DIR` (`Makefile:9`), and the handoff binary is downloaded to the workspace `target/debug`. Every `$(TARGET_DIR)/debug/incan` in the recipe therefore pointed into the empty scratch target, and `test -x` failed before anything ran. The platform job makes the same redirect and compensates with `CARGO_BIN_EXE_incan`; this one had no equivalent, so it now passes `TARGET_DIR` explicitly.

The second follows from the first. `parity_corpus_tests::summary_output_path` writes under `CARGO_TARGET_DIR`, because it runs inside the cargo invocation, while the upload step looked under the workspace `target`. Even a passing run would have uploaded nothing, and the failing log says exactly that: `No files were found with the provided path: target/parity-corpus/summary.json`.

**Why it was invisible.** The lane runs only for a pull request into `main` or a release branch, or one labelled `full-ci`. It is skipped on every dev-line push and on every dev-line pull request. Adding `full-ci` to [#1531](https://github.com/encero-systems/incan/pull/1531) today is what surfaced it.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [x] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: none. CI only.
- **Internals**: a `TARGET_DIR=` make override and a corrected artifact path. The Cargo isolation the step was written for is kept exactly as it was — this only tells the two halves where each other's files are.
- **Risks**: the lane has never completed, so this is the first run that reaches the comparison itself. It may then fail on the comparison rather than on its setup, which would be a real result and a different issue. That is the point of running it.

## Testing / verification

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — parses
- [ ] The lane itself — this PR carries the `full-ci` label so it runs here. Its result is the verification, and I will report what it says rather than assume.

A workflow change cannot be proven locally; the run on this PR is the evidence.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

Part of #1037.
