### PR TITLE
chore - #1037 reclassify the semantic string audit the heavy lane has been failing on

### DIFF
--- a/tests/fixtures/vocab_guardrails/semantic_string_audit.json
+++ b/tests/fixtures/vocab_guardrails/semantic_string_audit.json
@@ -37,6 +37,12 @@
       "expected_fingerprint": "0xdc8309b97ee19675"
     },
     {
+      "path": "crates/rust_inspect/src/digest_tokens.rs",
+      "category": "Rust attribute and macro keywords the declaration digest excludes",
+      "expected_count": 2,
+      "expected_fingerprint": "0x4b52d4b8a76f66fd"
+    },
+    {
       "path": "crates/rust_inspect/src/extractor.rs",
       "category": "rust-inspect display-shape normalization",
       "expected_count": 11,
@@ -70,7 +76,7 @@
       "path": "src/backend/ir/codegen/capability_bridge.rs",
       "category": "serialized trait capability argument matching",
       "expected_count": 1,
-      "expected_fingerprint": "0xaa404d9a8890213a"
+      "expected_fingerprint": "0x55a833df26b069fe"
     },
     {
       "path": "src/backend/ir/codegen/dependency_metadata.rs",
@@ -163,6 +169,12 @@
       "expected_fingerprint": "0x24e1c86b39837a62"
     },
     {
+      "path": "src/backend/ir/emit/native_unions.rs",
+      "category": "`pub::` import-root segment in native union owner paths",
+      "expected_count": 2,
+      "expected_fingerprint": "0xf88a5f38a2f57053"
+    },
+    {
       "path": "src/backend/ir/emit/program.rs",
       "category": "callable source-name metadata use analysis",
       "expected_count": 2,
@@ -201,8 +213,8 @@
     {
       "path": "src/backend/ir/lower/expr/calls.rs",
       "category": "public dependency call, checked C string construction, default lowering, and assert-raises policy",
-      "expected_count": 7,
-      "expected_fingerprint": "0xdad31d3b8cc3bb76"
+      "expected_count": 8,
+      "expected_fingerprint": "0xd7fbb13ceabbe8ed"
     },
     {
       "path": "src/backend/ir/lower/expr/mod.rs",
@@ -351,8 +363,8 @@
     {
       "path": "src/frontend/typechecker/mod.rs",
       "category": "Rust display type parsing, provider ABI lookup, shared nominal String canonicalization, source type-name validation, stdlib derive compatibility, and dependency registry owner paths",
-      "expected_count": 42,
-      "expected_fingerprint": "0x1b2bbba180ba3e3d"
+      "expected_count": 43,
+      "expected_fingerprint": "0x1a1160a72917c035"
     },
     {
       "path": "src/frontend/typechecker/stdlib_loader.rs",


### PR DESCRIPTION
## Summary

`semantic_string_checks_are_classified` fails on **clean `0.6.0-dev.4`**, and has been failing for four merges. It runs only inside the Oven replay shards, which are skipped for every dev-line push and every dev-line pull request, so nothing reported it until a `full-ci` label went on a dev-line PR today.

Verified pre-existing rather than assumed: `cargo test --test vocab_guardrails` on a checkout of `origin/0.6.0-dev.4` with no Rust changes produces the byte-identical five-entry failure that [#1531](https://github.com/encero-systems/incan/pull/1531)'s CI reported.

**Two files had no classification at all.**

- `crates/rust_inspect/src/digest_tokens.rs` matches `doc` and `macro_rules`. Those are names in Rust's own grammar, not Incan vocabulary, and no registry can own them — the declaration digest has to know which attributes it drops and which macro bodies it keeps. Classified as *Rust attribute and macro keywords the declaration digest excludes*.
- `src/backend/ir/emit/native_unions.rs` matches the `pub::` import root twice. That is the same audited exception `lower/expr/calls.rs` and `lower/expr/mod.rs` already carry for the same segment, so it gets the same treatment rather than a new rationale.

**Three had drifted**, and in each case the existing category still describes what is there:

| File | Was | Now | What changed |
| --- | --- | --- | --- |
| `capability_bridge.rs` | 1 site | 1 site | Same single check, reworded |
| `lower/expr/calls.rs` | 7 sites | 8 | One more `pub::` root check — "public dependency call" already covers it |
| `typechecker/mod.rs` | 42 sites | 43 | One more Rust display-type parse — "Rust display type parsing" already covers it |

The drift came from #1426, #1499, #1504 and #1438. None of them could have seen it.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: none. A test fixture.
- **Internals**: no code changes at all — every one of these is an existing string check that the audit had not been told about.
- **Risks**: re-baselining a guardrail can launder a real regression. Each new site is named above and read individually rather than accepted as a hash: the guardrail's own instruction is "move behavior behind a registry when possible; otherwise classify the file", and none of the five is registry-ownable — two are Rust's own grammar, three are the `pub::` root and Rust display types, all of which the fixture already audits elsewhere for exactly that reason.

## Testing / verification

- [x] `cargo test --test vocab_guardrails` — **3 passed** (was 2 passed, 1 failed)
- [x] The same command on clean `origin/0.6.0-dev.4` — reproduces the failure this fixes

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

Part of #1037. Companion to [#1538](https://github.com/encero-systems/incan/pull/1538), which fixes the other thing the heavy lane could not get past.
