### PR TITLE
bugfix - #1037 green the five checks the heavy lane was hiding

### DIFF
--- a/src/oven/rustc.rs
+++ b/src/oven/rustc.rs
@@ -8988,9 +8988,17 @@ mod tests {
             compiler_version,
         )?;
         assert_eq!(loaded.identity(), authority.identity);
+        // Both sides are canonicalized before comparison. The loader resolves its root through the filesystem and
+        // the store hands back the path it was given, so on a host where the temporary directory sits behind a
+        // symlink -- `/var` to `/private/var` on macOS -- the two spell the same directory differently and the
+        // assertion fails for a reason that has nothing to do with selection.
         assert_eq!(
-            loaded.artifact_root(),
-            store.select(&authority.identity)?.0.materialized_root()
+            loaded.artifact_root().canonicalize()?,
+            store
+                .select(&authority.identity)?
+                .0
+                .materialized_root()
+                .canonicalize()?
         );
         assert_eq!(loaded.payload, authority_payload);
         Ok(())
@@ -9098,7 +9106,7 @@ mod tests {
         let result = load_project_inspection_authority(
             &store,
             &OvenProjectInspectionAuthorityRef {
-                identity: requested.identity,
+                identity: requested.identity.clone(),
                 receipt_identity: receipt.identity,
                 build_unit_identity: receipt.build_unit_identity,
             },
@@ -9106,10 +9114,23 @@ mod tests {
             source_authority_digest,
             compiler_version,
         );
-        assert!(matches!(
-            result,
-            Err(OvenRustcError::InvalidStoredPlan { identity, .. }) if identity == substitute.identity
-        ));
+        let refusal = match result {
+            Ok(_) => return Err("a substituted entry must not satisfy the requested authority".into()),
+            Err(error) => error.to_string(),
+        };
+        // The refusal moved down a layer and got stronger. It used to surface as `InvalidStoredPlan` from the
+        // authority loader, which noticed the payload disagreed after reading it. The store now refuses the
+        // substituted directory by its immutable coordinate before the loader sees it, so the assertion is on the
+        // property the test is named for -- the requested identity is what could not be selected -- rather than on
+        // which layer happened to say so.
+        assert!(
+            refusal.contains(&requested.identity),
+            "the refusal must name the authority that was requested: {refusal}"
+        );
+        assert!(
+            refusal.contains("entry directory and manifest names do not match"),
+            "a substituted entry must be refused on its immutable coordinate: {refusal}"
+        );
         Ok(())
     }
 

--- a/tests/fixtures/cli_layering/cli_compiler_reach_in.json
+++ b/tests/fixtures/cli_layering/cli_compiler_reach_in.json
@@ -20,6 +20,7 @@
         "crate::frontend::body_ir",
         "crate::frontend::contract_metadata",
         "crate::frontend::diagnostics",
+        "crate::frontend::executable_resolution",
         "crate::frontend::lexer",
         "crate::frontend::library_exports",
         "crate::frontend::library_manifest_index",

--- a/tests/fixtures/cli_layering/cli_compiler_reach_in.json
+++ b/tests/fixtures/cli_layering/cli_compiler_reach_in.json
@@ -37,15 +37,6 @@
       ]
     },
     {
-      "path": "src/cli/commands/codegraph.rs",
-      "reaches": [
-        "crate::frontend::ast",
-        "crate::frontend::diagnostics",
-        "crate::frontend::registry_metadata",
-        "crate::frontend::typechecker"
-      ]
-    },
-    {
       "path": "src/cli/commands/common.rs",
       "reaches": [
         "crate::backend::c_abi",
@@ -117,7 +108,7 @@
     {
       "path": "src/cli/prelude.rs",
       "reaches": [
-        "crate::frontend::ast"
+        "crate::frontend::parsed_module"
       ]
     },
     {

--- a/tests/nested_list_loop_tests.rs
+++ b/tests/nested_list_loop_tests.rs
@@ -107,6 +107,11 @@ fn nested_list_all_empty_leaves_remain_unknown() -> TestResult {
 }
 
 /// Existing checked lowering must carry the inferred leaf into owned-string collection emission.
+///
+/// The empty leaf is asserted as `Vec::<String>::new()` rather than as a bare `vec![]`. #1493 gave an empty list
+/// literal its element type, because as a comparison operand nothing else supplies one and `rustc` reported an
+/// ambiguous `PartialEq`. That strengthened exactly the property this test is here for -- the first empty list must
+/// not erase the later string element type -- so the assertion follows it rather than pinning the older spelling.
 #[test]
 fn nested_list_loop_emits_owned_strings_without_caller_annotation() -> TestResult {
     let source = include_str!("fixtures/nested_list_loop_1471.incn");
@@ -114,7 +119,10 @@ fn nested_list_loop_emits_owned_strings_without_caller_annotation() -> TestResul
     let program = parser::parse(&tokens).map_err(|errors| format!("{errors:?}"))?;
     let rust = IrCodegen::new().try_generate(&program)?;
     let compact: String = rust.chars().filter(|character| !character.is_whitespace()).collect();
-    assert!(compact.contains("vec![vec![],vec![\"x\".to_string()]]"), "{rust}");
+    assert!(
+        compact.contains("vec![Vec::<String>::new(),vec![\"x\".to_string()]]"),
+        "{rust}"
+    );
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Labelling a dev-line pull request `full-ci` today ran the four Oven replay shards for the first time, and **`0.6.0-dev.4` is not green.** Every failure below reproduces on an unmodified checkout of the dev line — verified by running each one there, not inferred — so none is caused by the change that surfaced them.

Five checks were failing. This greens all five — the last one on your call, recorded below.

| Check | Why it failed | What this does |
| --- | --- | --- |
| `nested_list_loop_emits_owned_strings_without_caller_annotation` | Pinned the older spelling of an empty list literal | #1493 gave such a literal its element type — as a comparison operand nothing else supplies one, and rustc reported an ambiguous `PartialEq`. That **strengthened** exactly the property this test exists for, so the assertion follows it to `Vec::<String>::new()` and records why |
| `project_inspection_authority_binds_the_requested_store_identity` | Expected `InvalidStoredPlan` from the authority loader | The store now refuses a swapped directory by its immutable coordinate *before* the loader reads the payload — a stronger refusal one layer down. The assertion moves to the property the test is named for: the requested identity is what could not be selected |
| `project_inspection_authority_reuses_a_compatible_direct_plan_across_receipts` | `/var` vs `/private/var` | It compares a loader-resolved path with one the store returns unresolved. Where the temporary directory sits behind a symlink the two spell one directory differently. Both sides canonicalized. Host-specific: this one would not fail on the Linux shard |
| `the_cli_layering_baseline_records_no_stale_entries` | Four reach-ins for `src/cli/commands/codegraph.rs` that #1502 removed, and `crate::frontend::ast` for the prelude where `ParsedModule` now lives in `crate::frontend::parsed_module` | One removal and one rename. The recorded surface shrinks by four |

## The fifth, settled

`src/cli/commands/build.rs` reaching `crate::frontend::executable_resolution` is **recorded rather than refactored away**, on your call.

The reasoning, so it is written down rather than re-derived next time someone hits this: the call at `build.rs:2741` is one `resolve_executable_requirements` whose result feeds `build_body_ir_module_v0_with_executable_context` two lines later, and `crate::frontend::body_ir` is already recorded for this file. That is orchestration of two frontend steps, which the guardrail's own preamble says is the CLI's job — the reimplementation it was written against is #1293's case, where a manifest export projection in the CLI disagreed with the validator about the same rule. Nothing here can disagree with anything.

Across this branch the recorded surface still shrinks: four reach-ins removed with `codegraph.rs`, one renamed in the prelude, one added here.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: none. Three test assertions and one guardrail baseline.
- **Internals**: no production code changes.
- **Risks**: two of these re-point an assertion at behavior that moved, which can launder a regression. Each is argued above from the commit that moved it — #1493 for the list literal, the store's coordinate check for the authority — rather than accepted because the new output looked plausible.

## Testing / verification

- [x] `cargo test --features cli --lib oven::rustc::tests::project_inspection_authority` — 3 passed (was 1 passed, 2 failed)
- [x] `cargo test --features cli --test nested_list_loop_tests` — 5 passed (was 4 passed, 1 failed)
- [x] `cargo test --features cli --test cli_layering_guardrails` — 2 passed (was 0 passed, 2 failed)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `python3 scripts/check_changed_rustdocs.py --base origin/0.6.0-dev.4` — passed
- [x] Each failure reproduced on clean `origin/0.6.0-dev.4` first

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

Part of #1037. Companions: [#1538](https://github.com/encero-systems/incan/pull/1538) (the shadow lane could not start) and [#1539](https://github.com/encero-systems/incan/pull/1539) (the semantic string audit).
