### PR TITLE
chore - verification only: is the heavy lane green with #1538, #1539 and #1540

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -514,6 +514,10 @@ jobs:
       - name: Restore executable permissions
         run: chmod +x target/debug/incan
       - uses: ./.github/actions/consume-sdk-provider-store
+      # Cargo builds test dependencies in a separate target so it cannot replace the handoff CLI. The Makefile's
+      # own `TARGET_DIR` defaults to `CARGO_TARGET_DIR`, so it has to be told where the handoff binary actually
+      # is -- the same compensation the platform ABI job makes with `CARGO_BIN_EXE_incan`. Without it the recipe
+      # looks for the compiler in the empty scratch target and the lane cannot pass at all.
       - name: Prove the source-observable comparison ran and agreed
         env:
           CARGO_NET_OFFLINE: "true"
@@ -521,14 +525,16 @@ jobs:
           INCAN_TEST_COMPILER_ALREADY_BUILT: "1"
         run: |
           sha256sum target/debug/incan > "$RUNNER_TEMP/compiler-handoff.sha256"
-          make -s shadow-comparison-evidence
+          make -s shadow-comparison-evidence TARGET_DIR="$GITHUB_WORKSPACE/target"
           sha256sum --check "$RUNNER_TEMP/compiler-handoff.sha256"
+      # The corpus summary follows `CARGO_TARGET_DIR`, not the Makefile's `TARGET_DIR`, because the test writes it
+      # from inside the cargo run. It therefore lands in the scratch target above.
       - name: Upload the parity corpus summary
         if: always()
         uses: actions/upload-artifact@v5
         with:
           name: shadow-comparison-parity-summary
-          path: target/parity-corpus/summary.json
+          path: ${{ runner.temp }}/incan-shadow-test-target/parity-corpus/summary.json
           if-no-files-found: warn
 
   oven-linux-replay:

--- a/src/oven/rustc.rs
+++ b/src/oven/rustc.rs
@@ -8988,9 +8988,17 @@ mod tests {
             compiler_version,
         )?;
         assert_eq!(loaded.identity(), authority.identity);
+        // Both sides are canonicalized before comparison. The loader resolves its root through the filesystem and
+        // the store hands back the path it was given, so on a host where the temporary directory sits behind a
+        // symlink -- `/var` to `/private/var` on macOS -- the two spell the same directory differently and the
+        // assertion fails for a reason that has nothing to do with selection.
         assert_eq!(
-            loaded.artifact_root(),
-            store.select(&authority.identity)?.0.materialized_root()
+            loaded.artifact_root().canonicalize()?,
+            store
+                .select(&authority.identity)?
+                .0
+                .materialized_root()
+                .canonicalize()?
         );
         assert_eq!(loaded.payload, authority_payload);
         Ok(())
@@ -9098,7 +9106,7 @@ mod tests {
         let result = load_project_inspection_authority(
             &store,
             &OvenProjectInspectionAuthorityRef {
-                identity: requested.identity,
+                identity: requested.identity.clone(),
                 receipt_identity: receipt.identity,
                 build_unit_identity: receipt.build_unit_identity,
             },
@@ -9106,10 +9114,23 @@ mod tests {
             source_authority_digest,
             compiler_version,
         );
-        assert!(matches!(
-            result,
-            Err(OvenRustcError::InvalidStoredPlan { identity, .. }) if identity == substitute.identity
-        ));
+        let refusal = match result {
+            Ok(_) => return Err("a substituted entry must not satisfy the requested authority".into()),
+            Err(error) => error.to_string(),
+        };
+        // The refusal moved down a layer and got stronger. It used to surface as `InvalidStoredPlan` from the
+        // authority loader, which noticed the payload disagreed after reading it. The store now refuses the
+        // substituted directory by its immutable coordinate before the loader sees it, so the assertion is on the
+        // property the test is named for -- the requested identity is what could not be selected -- rather than on
+        // which layer happened to say so.
+        assert!(
+            refusal.contains(&requested.identity),
+            "the refusal must name the authority that was requested: {refusal}"
+        );
+        assert!(
+            refusal.contains("entry directory and manifest names do not match"),
+            "a substituted entry must be refused on its immutable coordinate: {refusal}"
+        );
         Ok(())
     }
 

--- a/tests/fixtures/cli_layering/cli_compiler_reach_in.json
+++ b/tests/fixtures/cli_layering/cli_compiler_reach_in.json
@@ -20,6 +20,7 @@
         "crate::frontend::body_ir",
         "crate::frontend::contract_metadata",
         "crate::frontend::diagnostics",
+        "crate::frontend::executable_resolution",
         "crate::frontend::lexer",
         "crate::frontend::library_exports",
         "crate::frontend::library_manifest_index",

--- a/tests/fixtures/cli_layering/cli_compiler_reach_in.json
+++ b/tests/fixtures/cli_layering/cli_compiler_reach_in.json
@@ -37,15 +37,6 @@
       ]
     },
     {
-      "path": "src/cli/commands/codegraph.rs",
-      "reaches": [
-        "crate::frontend::ast",
-        "crate::frontend::diagnostics",
-        "crate::frontend::registry_metadata",
-        "crate::frontend::typechecker"
-      ]
-    },
-    {
       "path": "src/cli/commands/common.rs",
       "reaches": [
         "crate::backend::c_abi",
@@ -117,7 +108,7 @@
     {
       "path": "src/cli/prelude.rs",
       "reaches": [
-        "crate::frontend::ast"
+        "crate::frontend::parsed_module"
       ]
     },
     {

--- a/tests/fixtures/vocab_guardrails/semantic_string_audit.json
+++ b/tests/fixtures/vocab_guardrails/semantic_string_audit.json
@@ -37,6 +37,12 @@
       "expected_fingerprint": "0xdc8309b97ee19675"
     },
     {
+      "path": "crates/rust_inspect/src/digest_tokens.rs",
+      "category": "Rust attribute and macro keywords the declaration digest excludes",
+      "expected_count": 2,
+      "expected_fingerprint": "0x4b52d4b8a76f66fd"
+    },
+    {
       "path": "crates/rust_inspect/src/extractor.rs",
       "category": "rust-inspect display-shape normalization",
       "expected_count": 11,
@@ -70,7 +76,7 @@
       "path": "src/backend/ir/codegen/capability_bridge.rs",
       "category": "serialized trait capability argument matching",
       "expected_count": 1,
-      "expected_fingerprint": "0xaa404d9a8890213a"
+      "expected_fingerprint": "0x55a833df26b069fe"
     },
     {
       "path": "src/backend/ir/codegen/dependency_metadata.rs",
@@ -163,6 +169,12 @@
       "expected_fingerprint": "0x24e1c86b39837a62"
     },
     {
+      "path": "src/backend/ir/emit/native_unions.rs",
+      "category": "`pub::` import-root segment in native union owner paths",
+      "expected_count": 2,
+      "expected_fingerprint": "0xf88a5f38a2f57053"
+    },
+    {
       "path": "src/backend/ir/emit/program.rs",
       "category": "callable source-name metadata use analysis",
       "expected_count": 2,
@@ -201,8 +213,8 @@
     {
       "path": "src/backend/ir/lower/expr/calls.rs",
       "category": "public dependency call, checked C string construction, default lowering, and assert-raises policy",
-      "expected_count": 7,
-      "expected_fingerprint": "0xdad31d3b8cc3bb76"
+      "expected_count": 8,
+      "expected_fingerprint": "0xd7fbb13ceabbe8ed"
     },
     {
       "path": "src/backend/ir/lower/expr/mod.rs",
@@ -351,8 +363,8 @@
     {
       "path": "src/frontend/typechecker/mod.rs",
       "category": "Rust display type parsing, provider ABI lookup, shared nominal String canonicalization, source type-name validation, stdlib derive compatibility, and dependency registry owner paths",
-      "expected_count": 42,
-      "expected_fingerprint": "0x1b2bbba180ba3e3d"
+      "expected_count": 43,
+      "expected_fingerprint": "0x1a1160a72917c035"
     },
     {
       "path": "src/frontend/typechecker/stdlib_loader.rs",

--- a/tests/nested_list_loop_tests.rs
+++ b/tests/nested_list_loop_tests.rs
@@ -107,6 +107,11 @@ fn nested_list_all_empty_leaves_remain_unknown() -> TestResult {
 }
 
 /// Existing checked lowering must carry the inferred leaf into owned-string collection emission.
+///
+/// The empty leaf is asserted as `Vec::<String>::new()` rather than as a bare `vec![]`. #1493 gave an empty list
+/// literal its element type, because as a comparison operand nothing else supplies one and `rustc` reported an
+/// ambiguous `PartialEq`. That strengthened exactly the property this test is here for -- the first empty list must
+/// not erase the later string element type -- so the assertion follows it rather than pinning the older spelling.
 #[test]
 fn nested_list_loop_emits_owned_strings_without_caller_annotation() -> TestResult {
     let source = include_str!("fixtures/nested_list_loop_1471.incn");
@@ -114,7 +119,10 @@ fn nested_list_loop_emits_owned_strings_without_caller_annotation() -> TestResul
     let program = parser::parse(&tokens).map_err(|errors| format!("{errors:?}"))?;
     let rust = IrCodegen::new().try_generate(&program)?;
     let compact: String = rust.chars().filter(|character| !character.is_whitespace()).collect();
-    assert!(compact.contains("vec![vec![],vec![\"x\".to_string()]]"), "{rust}");
+    assert!(
+        compact.contains("vec![Vec::<String>::new(),vec![\"x\".to_string()]]"),
+        "{rust}"
+    );
     Ok(())
 }
 


### PR DESCRIPTION
## Not for merge

This branch exists to answer one question: **is the heavy CI lane green on the dev line once [#1538](https://github.com/encero-systems/incan/pull/1538), [#1539](https://github.com/encero-systems/incan/pull/1539) and [#1540](https://github.com/encero-systems/incan/pull/1540) land?** It is those three merged onto `0.6.0-dev.4` and nothing else. Close it once they are in.

I tried to answer this without a pull request, by dispatching the workflow with `heavy=true` on the pushed branch. That does not work, and the reason is worth recording: all four Oven replay shards failed in *Verify prepared suite handoff* with

```
Event Validation Error: The event type workflow_dispatch is not supported because it's not tied to a branch or tag ref.
```

The shards consume artifacts produced by an earlier job in the same run, and that cross-job download is rejected for `workflow_dispatch`. So `workflow_dispatch` with `heavy=true` cannot exercise the replay lane at all — only a pull request or a push to a dev line can. Worth knowing before anyone reaches for it as the cheap way to run the heavy suite.

Carrying `full-ci` so the lane actually runs here.

## What the lane found, for context

The heavy lane runs only for a pull request into `main` or a release branch, or one labelled `full-ci` — never for a dev-line push or a dev-line pull request. Labelling one today was the first time, and `0.6.0-dev.4` is not green: the #1146 parity instrument cannot start at all, and six checks fail on an unmodified checkout. The three PRs above address all of them.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [x] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [x] Tooling (CLI/formatter/test runner)

## Testing / verification

The run on this pull request *is* the verification. I will report what it says rather than assume.
