### PR TITLE
bugfix - merge a union wrapper's per-module captures instead of comparing them (#1426)

### DIFF
--- a/src/backend/ir/codegen.rs
+++ b/src/backend/ir/codegen.rs
@@ -599,6 +599,53 @@ pub struct IrCodegen<'a> {
     rust_inspect_manifest_dir: Option<PathBuf>,
 }
 
+/// Fold one module's capture of an emitted union wrapper into the record already held for that wrapper.
+///
+/// A wrapper is captured once per module that mentions it, and each capture only sees what that module can:
+/// `local_nominals` comes from the module's own checked declarations, so the module declaring the payload models
+/// contributes every leaf binding while a module that merely accepts the union in a signature contributes none.
+/// The bindings are therefore merged rather than compared — the published record has to name every leaf, not the
+/// subset whichever module happened to be emitted first could see.
+///
+/// What must agree across modules is the wrapper's representation: its owner, and the payload members in producer
+/// order, because consumers index the emitted `V0`, `V1`, ... variants by that order and may not recompute it. Two
+/// captures disagreeing there, or binding one leaf name to two canonical identities, is a genuine defect and stays
+/// an error — named precisely, so the next occurrence does not need an instrumented build to diagnose.
+fn merge_native_union_capture(
+    existing: &mut crate::library_manifest::NativeUnionExport,
+    captured: crate::library_manifest::NativeUnionExport,
+) -> Result<(), EmitError> {
+    if existing.owner != captured.owner {
+        return Err(EmitError::InternalInvariant(format!(
+            "emitted union {} was captured under two owners",
+            captured.rust_name
+        )));
+    }
+    if existing.members != captured.members {
+        return Err(EmitError::InternalInvariant(format!(
+            "emitted union {} was captured with two different payload orders",
+            captured.rust_name
+        )));
+    }
+    for (name, canonical) in captured.local_nominals {
+        match existing.local_nominals.entry(name) {
+            std::collections::btree_map::Entry::Vacant(slot) => {
+                slot.insert(canonical);
+            }
+            std::collections::btree_map::Entry::Occupied(slot) => {
+                if slot.get() != &canonical {
+                    return Err(EmitError::InternalInvariant(format!(
+                        "emitted union {} binds {} to two canonical identities",
+                        captured.rust_name,
+                        slot.key()
+                    )));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 impl<'a> IrCodegen<'a> {
     /// Create a new IR-based code generator
     pub fn new() -> Self {
@@ -718,20 +765,15 @@ impl<'a> IrCodegen<'a> {
         );
         self.emitted_declaration_types.extend(declarations);
         for definition in definitions {
-            if let Some(existing) = self
+            let Some(existing) = self
                 .native_unions
-                .iter()
+                .iter_mut()
                 .find(|existing| existing.rust_name == definition.rust_name)
-            {
-                if existing != &definition {
-                    return Err(EmitError::InternalInvariant(format!(
-                        "emitted union {} has incompatible source-module identities",
-                        definition.rust_name
-                    )));
-                }
-            } else {
+            else {
                 self.native_unions.push(definition);
-            }
+                continue;
+            };
+            merge_native_union_capture(existing, definition)?;
         }
         self.native_unions
             .sort_by(|left, right| left.rust_name.cmp(&right.rust_name));
@@ -8274,6 +8316,93 @@ pub def observe(item: Item) -> Item:
             checker.type_info().rust.receiver_contracts
         );
         assert!(!generated.contains("child.clone()"), "{generated}");
+        Ok(())
+    }
+
+    /// Build one producer-local nominal binding for the union-capture merge tests.
+    fn nominal_binding(name: &str, module: &str) -> crate::library_manifest::CanonicalIdentityExport {
+        crate::library_manifest::CanonicalIdentityExport {
+            namespace: crate::library_manifest::CanonicalIdentityNamespaceExport::OrdinaryLexical,
+            origin: crate::library_manifest::CanonicalIdentityOriginExport::Package {
+                library: "provider".to_string(),
+                module_path: vec![module.to_string()],
+            },
+            declaration_name: name.to_string(),
+            kind: "model".to_string(),
+            declaration_span: crate::library_manifest::CanonicalIdentitySpanExport { start: 0, end: 1 },
+        }
+    }
+
+    /// Build one capture of the same emitted wrapper as seen from a single module.
+    fn union_capture(members: &[&str], nominals: &[(&str, &str)]) -> crate::library_manifest::NativeUnionExport {
+        crate::library_manifest::NativeUnionExport {
+            owner: crate::library_manifest::NativeUnionOwnerExport::ContainingArtifact,
+            rust_name: "__IncanUnionTest".to_string(),
+            members: members
+                .iter()
+                .map(|name| crate::library_manifest::TypeRef::Named {
+                    name: (*name).to_string(),
+                    origin: None,
+                })
+                .collect(),
+            local_nominals: nominals
+                .iter()
+                .map(|(name, module)| ((*name).to_string(), nominal_binding(name, module)))
+                .collect(),
+            checked_projection: None,
+        }
+    }
+
+    #[test]
+    fn a_wrapper_captured_from_two_modules_keeps_every_module_s_nominal_bindings()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // The module declaring the payload models sees every leaf; a module that only accepts the union in a
+        // signature sees none. Both are honest partial views of one wrapper, so the merge has to keep the union.
+        let mut declaring = union_capture(&["Left", "Right"], &[("Left", "shapes"), ("Right", "shapes")]);
+        let accepting = union_capture(&["Left", "Right"], &[]);
+        merge_native_union_capture(&mut declaring, accepting)?;
+        assert_eq!(
+            declaring.local_nominals.keys().cloned().collect::<Vec<_>>(),
+            vec!["Left".to_string(), "Right".to_string()]
+        );
+
+        let mut accepting = union_capture(&["Left", "Right"], &[]);
+        let declaring = union_capture(&["Left", "Right"], &[("Left", "shapes"), ("Right", "shapes")]);
+        merge_native_union_capture(&mut accepting, declaring)?;
+        assert_eq!(
+            accepting.local_nominals.keys().cloned().collect::<Vec<_>>(),
+            vec!["Left".to_string(), "Right".to_string()]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn a_wrapper_captured_with_two_payload_orders_is_refused() -> Result<(), Box<dyn std::error::Error>> {
+        // Consumers index the emitted `V0`, `V1`, ... variants by producer order, so disagreement here is a defect
+        // rather than a partial view, and must not be merged away.
+        let mut first = union_capture(&["Left", "Right"], &[]);
+        let reordered = union_capture(&["Right", "Left"], &[]);
+        let Err(error) = merge_native_union_capture(&mut first, reordered) else {
+            return Err("a reordered payload list must not merge".into());
+        };
+        assert!(
+            format!("{error:?}").contains("two different payload orders"),
+            "the refusal must name the payload order: {error:?}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn a_leaf_bound_to_two_canonical_identities_is_refused() -> Result<(), Box<dyn std::error::Error>> {
+        let mut first = union_capture(&["Left"], &[("Left", "shapes")]);
+        let conflicting = union_capture(&["Left"], &[("Left", "other_module")]);
+        let Err(error) = merge_native_union_capture(&mut first, conflicting) else {
+            return Err("one leaf name bound to two identities must not merge".into());
+        };
+        assert!(
+            format!("{error:?}").contains("two canonical identities"),
+            "the refusal must name the conflicting binding: {error:?}"
+        );
         Ok(())
     }
 }

--- a/src/provider/plan.rs
+++ b/src/provider/plan.rs
@@ -525,10 +525,28 @@ impl ProviderPlan {
             });
             Ok(ty)
         };
-        let requested = normalize(native)?;
         let mut matched = None;
         for candidate in candidates {
-            if normalize(&candidate)? == requested {
+            // Both sides are captures of one producer's wrapper, and each carries only the nominal bindings the
+            // module it was captured in could see. The published record is captured from every module that
+            // mentions the wrapper; the requested side comes from one declaration's type, and a module that
+            // accepts the union in a signature without declaring its payload models contributes no bindings at
+            // all. Comparing them as they stand compares how much each module happened to know.
+            //
+            // So complete the requested view from the published record before comparing, filling only bindings it
+            // does not already carry: a spelling it binds differently still disagrees and still fails to match,
+            // and every filled binding is validated against the owner's public surface by
+            // `bind_native_union_local_nominals` exactly as the candidate's own are. What the comparison is left
+            // deciding is the wrapper's representation — its owner, and its payload members in producer order,
+            // which is what consumers index the emitted `V0`, `V1`, ... variants by.
+            let mut completed = native.clone();
+            for (spelling, canonical) in &candidate.local_nominals {
+                completed
+                    .local_nominals
+                    .entry(spelling.clone())
+                    .or_insert_with(|| canonical.clone());
+            }
+            if normalize(&candidate)? == normalize(&completed)? {
                 matched = Some(candidate);
                 break;
             }


### PR DESCRIPTION
## Summary

`external_pub_consumer_uses_flattened_nested_union_variant_index_issue1198` has been failing on Oven replay shard 1 since #1426 landed yesterday, with `emitted union __IncanUnion60eb06ef6f070724 has incompatible source-module identities`. Both the `local_nominals` field and the invariant that compares it arrived in that PR, and dev-line pushes do not run the replay lane, so it was invisible on the branch it landed on.

An emitted anonymous-union wrapper is captured once per module that mentions it, and each capture only sees what that module can. `local_nominals` is built from the module's own checked declarations, so the module declaring the payload models contributes every leaf binding while a module that merely accepts the union in a signature contributes none. `capture_native_union_metadata` compared whole captures for equality, so the second module to mention a wrapper always disagreed with the first.

The two captures on the committed fixture, dumped from an instrumented build: identical `owner`, identical thirteen `members` in identical order, `local_nominals` of thirteen entries versus zero.

So merge the bindings rather than compare them. The published record has to name every leaf, not the subset whichever module happened to be emitted first could see — today, if the first capture came from a module declaring none of them, the manifest would publish an empty set.

What must still agree is the wrapper's representation: `owner`, and the payload `members` in producer order, because consumers index the emitted `V0`, `V1`, … variants by that order and may not recompute it. That, and one leaf name bound to two different canonical identities, stay errors. Each now names what disagreed, so the next occurrence does not need an instrumented build to read.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: a library whose public surface mentions one anonymous-union wrapper from more than one module bakes again instead of failing with an internal invariant. The published `local_nominals` for such a wrapper is now the union of every module's bindings rather than the first module's view.
- **Internals**: `merge_native_union_capture` replaces the whole-record equality check in `IrCodegen::capture_native_union_metadata`.
- **Risks**: the merge is narrower than it looks — it only folds `local_nominals`. Owner and member order remain strictly compared, which is the property RFC 123 relies on for variant indexing.

## Two stages, and the second was found by CI

CI is the honest report here. On replay shard 1 the `incompatible source-module identities` error is **gone** (zero occurrences in the log), both provider bakes now succeed, and `external_pub_consumer_uses_flattened_nested_union_variant_index_issue1198` fails one stage later, at the consumer bake:

```
type error: compiled library `issue1198_union_provider` has an invalid native union representation:
native union `__IncanUnion60eb06ef6f070724` has no matching emitted representation in
issue1198_union_provider@0.1.0#sha256:19f0f095…
```

It is the same partial-view assumption, now on the comparison rather than the capture. `select_native_union_route` matches a requested union against the published candidates by normalizing both through `bind_native_union_local_nominals`, which sets each member's `origin` from that record's `local_nominals`, after which `normalize` rewrites every bound member's name to `origin.binding_key()`. A record that knows all thirteen leaves therefore normalizes to something different from a record that knows none — so now that the published side is complete, a partial requested side no longer matches it.

Before this change the two sides could never disagree, because publication refused outright whenever they did. Removing that refusal is what exposes the comparison.

**The second commit completes it.** Tracing where each side comes from settles what the match is over, so this did not need a guess after all. Both sides are captures of the same producer's wrapper: `candidates` come from the artifact's published `native_unions`, and the requested `native` comes from one declaration's type — `Frame.filter(predicate: ColumnExpr)` is declared in `dataset`, which declares none of the payload models and therefore contributes no bindings. Each side carries only what its own module could see, so comparing them as they stand compares how much each module happened to know.

So the requested view is completed from the published record before comparing, filling only bindings it does not already carry. A spelling it binds differently still disagrees and still fails to match; every filled binding is validated against the owner's public surface by `bind_native_union_local_nominals` exactly as the candidate's own are. What the comparison is left deciding is the wrapper's representation — owner, and payload members in producer order — which is what consumers index the emitted `V0`, `V1`, … variants by, and which this function's own rustdoc already names as the thing that must agree.

**Verified.** On the `full-ci` run after the second commit, shard 1 reports:

```
ROOT OK    tests/integration_tests.rs (283 passed, 0 failed, 0 ignored in 2964.7s)
Oven executed 9 selected complete compiler-suite root(s): 291 native test(s),
with 291 passed, 0 failed, and 0 ignored
```

Both error strings are gone from the log entirely — zero occurrences of `incompatible source-module identities` and zero of `has no matching emitted representation` — and `external_pub_consumer_uses_flattened_nested_union_variant_index_issue1198` passes along with every other test in the shard.

The shard job still exits 1, and that is a separate thing this run uncovered: the wrapper's Cargo guard fires *after* the suite, and `test ! -s` prints nothing, so a green suite ends in a bare `Error 1`. Shard 1 had never reached that assert before, because every earlier run failed inside the suite first. #1552 makes the guard name what it caught so the next run can be read.

## Testing / verification

- [x] Three unit tests on the merge itself: two partial views combine, a reordered payload list is refused, one leaf bound to two identities is refused
- [x] A/B on the committed fixture, same environment, same project: the pre-fix binary reports the invariant, the post-fix binary generates and stops at the expected "dependencies have not been compiled yet"
- [x] `cargo clippy --all-targets --features lsp -- -D warnings` — clean
- [x] `cargo +nightly fmt -- --check` — clean
- [x] `python3 scripts/check_changed_rustdocs.py --base origin/0.6.0-dev.4` — passed
- [x] Oven replay shard 1 under `full-ci` — **283 passed, 0 failed** in `integration_tests.rs`, 291 passed 0 failed across the shard, and both union error strings absent from the log

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

The behavior is internal to emission; the rustdoc on the merge states the contract.
