### PR TITLE
chore - verify each store manifest once per run instead of once per visit (#1037)

### DIFF
--- a/src/oven/store.rs
+++ b/src/oven/store.rs
@@ -4,11 +4,12 @@
 //! logical artifact bytes and measured physical file allocation separately, and refuses publication when its active
 //! leases leave no safe way to satisfy capacity policy.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs::{self, File, OpenOptions, TryLockError};
 use std::io::{self, Read, Write};
 use std::path::{Component, Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
@@ -2495,9 +2496,43 @@ fn verify_entry(root: &Path) -> Result<OvenStoreEntry, OvenStoreError> {
     })
 }
 
+/// Identity of one manifest file as seen on disk, used to key the verified-manifest memo.
+///
+/// Length and modification time together are what a rewritten file changes, so a staging manifest replaced in place
+/// misses the memo and is verified again. An admitted entry never changes at all: its directory name is the digest.
+type ManifestFileStamp = (PathBuf, u64, Option<SystemTime>);
+
+/// Process-local memo of manifests already verified in this run.
+///
+/// Verification is a pure function of the file's bytes — parse, schema check, then recompute the identity digest and
+/// compare it to the one recorded. Nothing about it depends on when it runs, and a single bake reaches the same
+/// admitted entries from many directions: resolving the plan, taking leases, and answering each dependency query all
+/// land back on the same `loaf.json`. Measured on one no-op bake of a trivial project, that was 1,454 reads of 61
+/// distinct manifests — every one of them parsed and re-digested twenty-six times.
+fn verified_manifest_memo() -> &'static Mutex<HashMap<ManifestFileStamp, OvenArtifactManifest>> {
+    static MEMO: OnceLock<Mutex<HashMap<ManifestFileStamp, OvenArtifactManifest>>> = OnceLock::new();
+    MEMO.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Describe one manifest file well enough to notice it being rewritten underneath us.
+///
+/// A manifest that cannot be stated — it has just been removed, or the filesystem reports no modification time — is
+/// simply not memoized: the caller falls through to a full read, which produces the honest error.
+fn manifest_file_stamp(manifest_path: &Path) -> Option<ManifestFileStamp> {
+    let metadata = fs::metadata(manifest_path).ok()?;
+    Some((manifest_path.to_path_buf(), metadata.len(), metadata.modified().ok()))
+}
+
 /// Verify immutable manifest structure and identity without traversing the materialized compiler closure.
 fn verify_entry_manifest(root: &Path) -> Result<OvenArtifactManifest, OvenStoreError> {
     let manifest_path = manifest_path_for_entry(root);
+    let stamp = manifest_file_stamp(&manifest_path);
+    if let Some(stamp) = stamp.as_ref()
+        && let Ok(memo) = verified_manifest_memo().lock()
+        && let Some(manifest) = memo.get(stamp)
+    {
+        return Ok(manifest.clone());
+    }
     let content = fs::read(&manifest_path).map_err(|source| OvenStoreError::Io {
         path: manifest_path.clone(),
         source,
@@ -2519,6 +2554,11 @@ fn verify_entry_manifest(root: &Path) -> Result<OvenArtifactManifest, OvenStoreE
             identity: manifest.identity,
             message: "manifest identity does not match its immutable content".to_string(),
         });
+    }
+    if let Some(stamp) = stamp
+        && let Ok(mut memo) = verified_manifest_memo().lock()
+    {
+        memo.insert(stamp, manifest.clone());
     }
     Ok(manifest)
 }
@@ -3954,6 +3994,37 @@ mod tests {
             assert!(matches!(result, Err(OvenStoreError::Integrity { .. })));
             assert_eq!(published_inventory(temp.path())?, before);
         }
+        Ok(())
+    }
+
+    #[test]
+    fn a_verified_manifest_is_reverified_once_its_file_changes() -> Result<(), Box<dyn std::error::Error>> {
+        // Repeated verification of one admitted entry must answer identically, and must stop answering from the memo
+        // the moment the file behind it is no longer the file that was verified.
+        let temp = tempfile::tempdir()?;
+        let project = tempfile::tempdir()?;
+        write_project(project.path())?;
+        let store = OvenStore::new(temp.path(), OvenStoreLimits::new(1_000_000, 1_000_000, 1_000_000));
+        let published = store.publish(&request(project.path(), "memo-entry", b"memo payload")?)?;
+        let entry = store.entry_root(&published.identity);
+
+        let first = super::verify_entry_manifest(&entry)?;
+        let second = super::verify_entry_manifest(&entry)?;
+        assert_eq!(first, second);
+        assert_eq!(first.identity, published.identity);
+
+        // Publication seals the manifest read-only; replacing this test-owned entry models external corruption.
+        let manifest_path = super::manifest_path_for_entry(&entry);
+        let tampered = format!(
+            "{}   ",
+            fs::read_to_string(&manifest_path)?.replace("memo-entry", "other-name")
+        );
+        fs::remove_file(&manifest_path)?;
+        fs::write(&manifest_path, tampered)?;
+        assert!(
+            super::verify_entry_manifest(&entry).is_err(),
+            "a rewritten manifest must be verified again rather than served from the memo"
+        );
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

A single explicit bake of a trivial project that compiles **nothing** — it reports `action: "toolchain_loaf"`, so every unit it needs is already in the store — was reading and verifying store manifests **1,454 times**. There are **61** distinct manifests behind those reads. Each one was parsed, schema-checked and re-digested **twenty-six times** in one process.

Nothing about that verification depends on when it runs: it reads a file, deserializes it, checks the schema version, recomputes the identity digest from the content, and compares it to the one recorded. Given the same bytes it gives the same answer. A bake reaches the same admitted entries from many directions — resolving the plan, taking leases, and answering each dependency query all land back on the same `loaf.json`.

So memoize it for the life of the process, keyed by the manifest's path together with its length and modification time. An admitted entry cannot change at all: its directory name *is* its digest. The stamp covers the case that can — a staging manifest rewritten in place misses the memo and is verified again.

## Measured

Same warm store, three fresh projects per binary, each binary pre-warmed once first, `INCAN_OVEN_BAKE_PROFILES=debug`:

| | run 1 | run 2 | run 3 |
| --- | --- | --- | --- |
| before | 7.16 s | 6.97 s | 6.94 s |
| after | 3.29 s | 3.30 s | 3.31 s |

**53% off every explicit bake**, and it compounds with #1542: a fresh bake that materialized both profiles and re-verified everything 26 times was 14.10 s; with both changes it is 3.3 s.

## What this does not fix

This is the within-process half. Each bake is a new process that re-establishes the same 61 immutable manifests from cold, so a test file running fifty bakes still pays that fifty times. The store already names every entry by its own sha256 and the SDK provider store is a sha256 directory — nothing in either can change without changing its name — so the verification result is a pure function of a name that is already a digest, and it should be written down once rather than re-derived per process. That is separate work and it is the larger half.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [x] Runtime / Core crates (stdlib/core/derive)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Documentation

## Key details

- **User-facing behavior**: every `incan oven bake`, `build`, `run` and `test` against a warm store gets faster. No observable change otherwise — the memo returns the identical verified manifest.
- **Internals**: `verify_entry_manifest` consults a process-local `HashMap` keyed by `(path, len, mtime)` before reading.
- **Risks**: the stamp cannot distinguish a rewrite that preserves both length and modification time. That is not reachable for an admitted entry, whose directory name is the digest of its own content, and a store that could be edited in place under a running process has already lost the integrity this verification exists to check. A test covers the reachable case.

## Testing / verification

- [x] `a_verified_manifest_is_reverified_once_its_file_changes` — repeated verification agrees, and a manifest rewritten behind the memo is verified again rather than served stale
- [x] `cargo clippy --all-targets --features lsp -- -D warnings` — clean
- [x] `cargo +nightly fmt -- --check` — clean
- [x] `python3 scripts/check_changed_rustdocs.py --base origin/0.6.0-dev.4` — passed
- [x] Four Oven replay shards under `full-ci` — shard 3 fails only on `vocab_guardrails::semantic_string_checks_are_classified`, which is what #1539 fixes and which is red on plain `0.6.0-dev.4`. No new failure from this change.

**On the CI timings:** shard 3 came in at 4m25s here against 6m55s on #1541. That is the lowest of four runs, but #1543 carries no performance change at all and came in at 5m26s, so the lane has real run-to-run variance and one sample cannot carry an attribution. The controlled evidence is the local table above — same store, same fixture, each binary pre-warmed, three runs each.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

Part of #1037.
