### PR TITLE
chore - read the sealed SDK once per run instead of once per reading (#1037)

### DIFF
--- a/src/provider/plan.rs
+++ b/src/provider/plan.rs
@@ -1481,7 +1481,71 @@ fn project_dependency_records(
 }
 
 /// Normalize every known SDK provider, including disabled and unavailable component records, into the shared catalog.
+/// Name the exact SDK reading these records were built from.
+///
+/// Everything the records depend on is already stated by the inventory the SDK shipped: its release identity, the
+/// codegen revision that emitted the providers, the digest recorded for each one, and which components this
+/// invocation enabled. The provider store is itself a content-addressed directory, so two readings agreeing on this
+/// key cannot be looking at different bytes.
+fn sdk_provider_records_key(inventory: &SdkInventory, resolved: Option<&ResolvedSdkComponents>) -> String {
+    let mut key = format!(
+        "{}\u{1f}{}\u{1f}{}\u{1f}{}",
+        inventory.root.display(),
+        inventory.sdk_id,
+        inventory.sdk_version,
+        inventory.provider_codegen_revision
+    );
+    for (id, component) in &inventory.components {
+        key.push('\u{1e}');
+        key.push_str(id);
+        for descriptor in &component.providers {
+            key.push('\u{1d}');
+            key.push_str(&descriptor.digest);
+        }
+    }
+    if let Some(resolved) = resolved {
+        key.push('\u{1c}');
+        for enabled in &resolved.enabled {
+            key.push('\u{1d}');
+            key.push_str(enabled);
+        }
+    }
+    key
+}
+
+/// Build the provider records for one SDK reading, reusing the last identical reading in this process.
+///
+/// The SDK reaches the baker prebuilt and sealed: the publisher wrote the inventory and the `.incnlib` descriptors
+/// together, and nothing between then and now can move one without moving the other. Yet a single explicit bake
+/// rebuilt these records four times — six when it materializes both profiles, twice in a plain `incan build` — and
+/// each rebuild re-read and re-deserialized the whole 6.6 MB provider surface and re-validated all ten descriptors
+/// against the inventory that shipped with them. Measured on one profile of a bake that compiles nothing, that was
+/// about thirty percent of the run.
+///
+/// `ProviderRecord` keeps its manifest behind an `Arc`, so serving a repeat reading costs a handful of small clones
+/// rather than another parse.
 fn sdk_provider_records(
+    inventory: &SdkInventory,
+    resolved: Option<&ResolvedSdkComponents>,
+) -> Result<Vec<ProviderRecord>, ProviderPlanError> {
+    let key = sdk_provider_records_key(inventory, resolved);
+    static READINGS: std::sync::OnceLock<std::sync::Mutex<std::collections::HashMap<String, Vec<ProviderRecord>>>> =
+        std::sync::OnceLock::new();
+    let readings = READINGS.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+    if let Ok(cached) = readings.lock()
+        && let Some(records) = cached.get(&key)
+    {
+        return Ok(records.clone());
+    }
+    let records = build_sdk_provider_records(inventory, resolved)?;
+    if let Ok(mut cached) = readings.lock() {
+        cached.insert(key, records.clone());
+    }
+    Ok(records)
+}
+
+/// Read every enabled SDK provider's sealed manifest and artifact into one catalog record per provider.
+fn build_sdk_provider_records(
     inventory: &SdkInventory,
     resolved: Option<&ResolvedSdkComponents>,
 ) -> Result<Vec<ProviderRecord>, ProviderPlanError> {
@@ -2435,6 +2499,54 @@ mod tests {
 
     fn set_paths(values: &[&[&str]]) -> BTreeSet<Vec<String>> {
         values.iter().map(|value| path(value)).collect()
+    }
+
+    /// Build one resolved selection enabling exactly the named components.
+    fn resolved_components(enabled: &[&str]) -> super::super::ResolvedSdkComponents {
+        super::super::ResolvedSdkComponents {
+            sdk_identity: "incan@0.5.0".to_string(),
+            profile: "default".to_string(),
+            enabled: enabled.iter().map(|id| (*id).to_string()).collect(),
+            unavailable: BTreeSet::new(),
+            reasons: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn the_sdk_reading_key_moves_with_everything_the_records_depend_on() {
+        // The records are reused whenever this key repeats, so anything that would change them has to change it.
+        let root = Path::new("/sdk/root");
+        let manifest = Path::new("/sdk/root/core.incnlib");
+        let inventory = sdk_inventory(root, manifest, "sha256:aaa".to_string());
+        let enabled = resolved_components(&["stdlib-core"]);
+
+        let key = super::sdk_provider_records_key(&inventory, Some(&enabled));
+        assert_eq!(key, super::sdk_provider_records_key(&inventory, Some(&enabled)));
+
+        let republished = sdk_inventory(root, manifest, "sha256:bbb".to_string());
+        assert_ne!(
+            key,
+            super::sdk_provider_records_key(&republished, Some(&enabled)),
+            "a provider republished at a different digest must not reuse the earlier reading"
+        );
+
+        let elsewhere = sdk_inventory(Path::new("/other/root"), manifest, "sha256:aaa".to_string());
+        assert_ne!(
+            key,
+            super::sdk_provider_records_key(&elsewhere, Some(&enabled)),
+            "the same SDK installed at a second root is a separate reading"
+        );
+
+        assert_ne!(
+            key,
+            super::sdk_provider_records_key(&inventory, Some(&resolved_components(&[]))),
+            "enabling a different component set must not reuse the earlier reading"
+        );
+        assert_ne!(
+            key,
+            super::sdk_provider_records_key(&inventory, None),
+            "an unresolved selection is not the same reading as an explicitly enabled one"
+        );
     }
 
     fn sdk_inventory(root: &Path, manifest_path: &Path, digest: String) -> SdkInventory {


### PR DESCRIPTION
## Summary

The SDK reaches the baker prebuilt. Its publisher wrote `sdk-inventory.json` and the ten `.incnlib` provider descriptors together, recorded a `sha256:` digest for each provider in the inventory, and placed the whole thing in a content-addressed directory whose name *is* that content's digest. Nothing between then and the bake can move one of those without moving the name.

The baker was treating it as an input to be rediscovered. One explicit bake rebuilt the SDK provider records **four times** — six when it materializes both profiles, and twice in a plain `incan build`. Every rebuild re-read and re-deserialized the whole **6.6 MB** provider surface and re-validated all ten descriptors against the inventory that shipped with them.

Sampling one profile of a bake that compiles nothing (`action: "toolchain_loaf"` — every unit already in the store) put that at roughly **30% of the run**: `sdk_provider_records` at 20%, split between `validate_sdk_descriptor` (15%) and deserializing the `api_metadata` surface out of the `.incnlib` files (14%).

So keep the reading for the life of the process, keyed by everything the records actually depend on: the installation root, the SDK release identity, the codegen revision that emitted the providers, each provider's recorded digest, and the component set this invocation enabled. A republished provider, a second installation root, or a different enabled set is a different key. `ProviderRecord` already holds its manifest behind an `Arc`, so serving a repeat reading costs a handful of small clones rather than another parse.

## Measured

One warm store, three fresh projects per configuration, each binary pre-warmed once first:

| Bake | before | after |
| --- | --- | --- |
| `INCAN_OVEN_BAKE_PROFILES=debug` | 7.0 s | **5.4 s** |
| same, with #1544 also applied | 7.0 s | **2.26 s** |
| both profiles, with #1544 | 14.1 s | **3.19 s** |

The suite's configuration after #1542 is the debug-only row. 14.1 s to 2.26 s across the three changes is **6.2×**.

## What this does not fix

This is the within-process half, the same boundary #1544 stops at. Each bake is a new process that reads the sealed SDK once from cold, so a test file running fifty bakes still reads it fifty times, and `make` with no code changes still re-establishes it rather than passing straight through. Treating Incan's own compiler and SDK as a constant the baker never scans — rather than as an input it rescans efficiently — is the larger change and is separate work.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [ ] Incan Language (syntax/semantics)
- [x] Compiler (frontend/backend/codegen)
- [x] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: every command that resolves SDK providers gets faster. Nothing observable changes — a repeat reading is the same records.
- **Internals**: `sdk_provider_records` becomes a memo in front of `build_sdk_provider_records`, keyed by `sdk_provider_records_key`.
- **Risks**: all of it is in the key. If the key missed something the records depend on, a stale reading would be served. It carries the installation root, SDK id and version, codegen revision, every provider digest, and the enabled component set — and a test asserts it moves when each of those moves. Digests are what the inventory itself uses to identify a provider, so a key that agrees implies bytes that agree.

## Testing / verification

- [x] `the_sdk_reading_key_moves_with_everything_the_records_depend_on` — stable for one reading; distinct for a republished digest, a second root, a different enabled set, and an unresolved selection
- [x] `cargo clippy --all-targets --features lsp -- -D warnings` — clean
- [x] `cargo +nightly fmt -- --check` — clean
- [x] `python3 scripts/check_changed_rustdocs.py --base origin/0.6.0-dev.4` — passed
- [ ] Four Oven replay shards under `full-ci`

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

Part of #1037. Independent of #1544 — different file, different cost, and the measurements above show each one separately and together.
