### PR TITLE
bugfix - take the last two drifted spellings from their registries (#1037)

### DIFF
--- a/src/backend/ir/emit/types.rs
+++ b/src/backend/ir/emit/types.rs
@@ -646,10 +646,15 @@ mod tests {
         let registry = FunctionRegistry::new();
         let mut emitter = IrEmitter::new(&registry);
         emitter.set_qualify_union_types_from_crate(true);
+        // A prelude constructor is unqualified on both sides, so it names the same registry spelling twice.
+        let bare_none = incan_core::lang::surface::constructors::as_str(
+            incan_core::lang::surface::constructors::ConstructorId::None,
+        )
+        .to_string();
         for (variant, expected) in [
             ("__IncanUnion123::V0", "crate :: __IncanUnion123 :: V0"),
             ("Shape::Circle", "Shape :: Circle"),
-            ("None", "None"),
+            (bare_none.as_str(), bare_none.as_str()),
         ] {
             let pattern = Pattern::Enum {
                 name: String::new(),

--- a/src/frontend/typechecker/tests/sdk_module_derives.rs
+++ b/src/frontend/typechecker/tests/sdk_module_derives.rs
@@ -8,23 +8,28 @@ use crate::frontend::api_metadata::{
 use crate::frontend::typechecker::TypeChecker;
 use crate::frontend::{lexer, parser};
 use crate::library_manifest::LibraryManifest;
+use incan_core::lang::traits::{self as core_traits, TraitId};
 
 type TestResult = Result<(), Box<dyn std::error::Error>>;
 
 /// Publish a synthetic module with no source-stdlib fallback and a deliberately excluded derivable trait.
 fn provider_metadata() -> Result<CheckedApiMetadata, Box<dyn std::error::Error>> {
-    let source = r#"
+    let source = format!(
+        r#"
 const __derives__ = [Included]
 
-@rust.derive("Debug")
+@rust.derive("{included}")
 pub trait Included:
     pass
 
-@rust.derive("Clone")
+@rust.derive("{omitted}")
 pub trait Omitted:
     pass
-"#;
-    metadata_from_source(source, &["bundle_probe".into()])
+"#,
+        included = core_traits::as_str(TraitId::Debug),
+        omitted = core_traits::as_str(TraitId::Clone),
+    );
+    metadata_from_source(&source, &["bundle_probe".into()])
 }
 
 /// Collect the same checked module representation used by SDK publishers.
@@ -98,7 +103,7 @@ fn sdk_module_derives_imports_and_aliases_preserve_backend_requirements() -> Tes
             info.derivations
                 .trait_rust_derive_paths
                 .get("std.bundle_probe.Included"),
-            Some(&vec!["Debug".into()])
+            Some(&vec![core_traits::as_str(TraitId::Debug).to_string()])
         );
         let mut generator = IrCodegen::new();
         generator.set_prechecked_type_info(info.clone(), Default::default());
@@ -107,7 +112,8 @@ fn sdk_module_derives_imports_and_aliases_preserve_backend_requirements() -> Tes
             .map_err(|error| format!("codegen: {error:?}"))?;
         assert!(
             rust.lines()
-                .any(|line| line.trim_start().starts_with("#[derive(") && line.contains("Debug")),
+                .any(|line| line.trim_start().starts_with("#[derive(")
+                    && line.contains(core_traits::as_str(TraitId::Debug))),
             "{rust}"
         );
         assert!(rust.contains("Included for Record"), "{rust}");
@@ -190,7 +196,7 @@ fn sdk_module_derives_trait_alias_retains_target_macro() -> TestResult {
             .derivations
             .trait_rust_derive_paths
             .get("std.bundle_facade.Exported"),
-        Some(&vec!["Debug".into()])
+        Some(&vec![core_traits::as_str(TraitId::Debug).to_string()])
     );
     let mut generator = IrCodegen::new();
     generator.set_prechecked_type_info(checker.type_info().clone(), Default::default());
@@ -198,8 +204,9 @@ fn sdk_module_derives_trait_alias_retains_target_macro() -> TestResult {
         .try_generate(&ast)
         .map_err(|error| format!("codegen: {error:?}"))?;
     assert!(
-        rust.lines()
-            .any(|line| line.trim_start().starts_with("#[derive(") && line.contains("Debug")),
+        rust.lines().any(
+            |line| line.trim_start().starts_with("#[derive(") && line.contains(core_traits::as_str(TraitId::Debug))
+        ),
         "{rust}"
     );
     Ok(())


### PR DESCRIPTION
## Summary

`crates/incan_core/tests/lang_registry_guardrails.rs` has two failures on the dev line — they show up on Oven replay shard 2 — and both are the same shape: a canonical spelling written as a string literal where a registry owns it.

**`src/backend/ir/emit/types.rs`** spells the `None` constructor twice in a pattern-qualification table. It reads as a fixture rather than a claim about the language, but it is exactly what the guardrail exists to catch: rename the constructor and this test keeps passing against a spelling that no longer exists. It now names `constructors::ConstructorId::None`, and because a prelude constructor is unqualified on both sides of that table, one binding serves as both input and expectation.

**`src/frontend/typechecker/tests/sdk_module_derives.rs`** spells `Debug` and `Clone` six times: twice inside the `@rust.derive(...)` fixture source, twice in the expected derive paths, and twice in assertions about the emitted `#[derive(...)]` line. All six now come from `core_traits::as_str(TraitId::…)`, which is how `stdlib_loader`'s own tests already do it. The fixture source becomes a `format!` over the same two names, so the source and the expectation cannot drift apart from each other either.

Both are test-local. Nothing in production behaviour changes.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [x] Compiler (frontend/backend/codegen)
- [ ] Incan Language (syntax/semantics)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: none.
- **Internals**: two test files take their canonical spellings from `incan_core::lang::surface::constructors` and `incan_core::lang::traits` instead of literals.
- **Risks**: none beyond the tests themselves, which still assert the same behaviour and still pass.

## Testing / verification

- [x] `cargo test -p incan_core --test lang_registry_guardrails` — 19 passed / 2 failed becomes **21 passed**
- [x] `cargo test --lib --features lsp sdk_module_derives` — 5 passed
- [x] `cargo test --lib --features lsp backend::ir::emit::types::tests::relative_enum_patterns` — passed
- [x] `cargo clippy --all-targets --features lsp -- -D warnings` — clean
- [x] `cargo +nightly fmt -- --check` — clean
- [x] `python3 scripts/check_changed_rustdocs.py --base origin/0.6.0-dev.4` — passed

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

Part of #1037. Two of the five failures still on replay shard 2; the other three are separate.
