### PR TITLE
chore - let the Cargo guard name the invocations it caught (#1037)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -384,7 +384,11 @@ test-oven-replay:
 				--store "$(INCAN_TEST_OVEN_COMPILER_SUITE_STORE)" \
 				$(INCAN_TEST_OVEN_COMPILER_SUITE_PARTITION_ARGS) \
 				--format text; \
-		test ! -s "$$suite_output/cargo-guard/invocations.log"; \
+		if [ -s "$$suite_output/cargo-guard/invocations.log" ]; then \
+			echo "\033[31mThe Oven suite must run without Cargo, and these invocations reached the guard:\033[0m" >&2; \
+			sed "s/^/  /" "$$suite_output/cargo-guard/invocations.log" >&2; \
+			exit 1; \
+		fi; \
 		suite_succeeded=true
 
 .PHONY: test-oven-case-timings  ## test - Run the complete Oven suite once and retain its measured-duration report
@@ -753,7 +757,11 @@ test-one: test-prewarm-oven-loafs
 				--feature lsp --target "$(TEST_ROOT)" $(if $(TEST_EXACT),--exact "$(TEST_EXACT)") \
 				--output "$$root_output" --store "$(INCAN_TEST_OVEN_COMPILER_SUITE_STORE)" \
 				--format text; \
-		test ! -s "$$root_output/cargo-guard/invocations.log"; \
+		if [ -s "$$root_output/cargo-guard/invocations.log" ]; then \
+			echo "\033[31mThe Oven suite must run without Cargo, and these invocations reached the guard:\033[0m" >&2; \
+			sed "s/^/  /" "$$root_output/cargo-guard/invocations.log" >&2; \
+			exit 1; \
+		fi; \
 		root_succeeded=true
 
 # =============================================================================


### PR DESCRIPTION
## Summary

The Oven replay recipes install a PATH shim that records any `cargo` a run reaches for, then assert the log is empty:

```make
test ! -s "$suite_output/cargo-guard/invocations.log"
```

`test -s` reports nothing. When the assert fires, the lane prints `Error 1` after an otherwise green suite, and the run gives no indication of what invoked Cargo — the recorded lines sit in a file nothing reads, inside retained output whose path scrolled past far above.

This is no longer hypothetical. On the #1543 run, shard 1 reported:

```
ROOT OK    tests/integration_tests.rs (283 passed, 0 failed, 0 ignored in 2964.7s)
Oven executed 9 selected complete compiler-suite root(s): 291 native test(s),
with 291 passed, 0 failed, and 0 ignored
...
FAILED     suite wrapper (3050.253s, exit 1)
```

Every test passed and the shard still failed, with nothing in the log explaining why. Shard 1 had never reached this assert before — every earlier run failed inside the suite, so the trap ran first and the assert never executed. The gap only surfaced once the tests went green.

So print the recorded invocations, indented, and fail. Both recipes carry the same shim and both get the same treatment.

Zero Cargo invocations is #1037's north star. The one instrument that proves it has to be able to say what it saw.

## What is already ruled out

Chasing it by reading rather than waiting for this PR narrowed the field, and the notes are here so the next run's output is quick to interpret. Shard 1's eight reported roots were `integration_tests`, `string_len_semantics`, `fallible_entrypoint_codegen_tests`, `lowering_error_propagation`, `script_target_diagnostics`, `lsp`, `generate_feature_inventory` and `generate_replacement_compatibility_inventory`, plus one doctest target.

- **The `cargo --version` probe in `cli::commands::tools`** returns `unavailable_for_oven_compiler_suite()` when `INCAN_OVEN_COMPILER_SUITE_RUSTC` is set, so it never launches anything under the suite.
- **The doctest target** runs through `run_trusted_rustdoc_test`, which launches an absolute `rustdoc` resolved by `rustdoc_for_rustc` — `trusted_rustdoc_runs_a_receipt_bound_doctest_without_cargo` exists to pin exactly that.
- **`generate_feature_inventory`'s PATH fallback** is in `main`, which libtest never runs; that root reports one passing unit test.
- **A plain project with `CARGO` unset** reaches no Cargo at all: baking a trivial project under the same PATH shim the suite installs, with `CARGO` removed, exits 0 with an empty guard log.

What that leaves is a compiler-owned path with a bare-name fallback reached by something more specific than a trivial project — `run_cargo_lock_projection` in `backend::project::runner` takes `env::var_os("CARGO").unwrap_or_else(|| "cargo".into())` and runs `generate-lockfile`, and `integration_tests` deliberately strips `CARGO` from normal commands so they cannot inherit the suite's baker proxy. That is a candidate, not a conclusion, and guessing further without the log is how the last two theories died. Hence this PR.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [x] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [x] Tooling (CLI/formatter/test runner)
- [ ] Incan Language (syntax/semantics)
- [ ] Compiler (frontend/backend/codegen)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: none. A lane that passes the guard behaves identically; a lane that fails it now says which invocations it caught.
- **Internals**: `test ! -s …` becomes an `if [ -s … ]` that echoes the file through `sed` before exiting 1, in both `test-oven-replay` and `test-one`.
- **Risks**: none to the assertion itself — an empty log still passes, a non-empty log still fails.

## Testing / verification

- [x] The shell fragment exercised both ways: an empty log passes silently, a two-line log prints both invocations indented and exits 1
- [x] `make -n test-oven-partition INCAN_TEST_OVEN_PARTITION_INDEX=0 INCAN_TEST_OVEN_PARTITION_COUNT=4` — the Makefile parses and the recipe expands

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

Part of #1037. Needed to diagnose what shard 1 is now reaching for.
