### PR TITLE
bugfix - let the #1458 fixture force the portable entry it claims to (#1037)

### DIFF
--- a/tests/package_boundary_facade_tests.rs
+++ b/tests/package_boundary_facade_tests.rs
@@ -236,13 +236,17 @@ fn source_free_native_diamond_preserves_published_store_inventory_issue1458() ->
     write_fixture_file(
         &catalog,
         "loaf.toml",
-        "[project]\nname = \"immutable_catalog\"\nversion = \"0.1.0\"\n\n[rust-dependencies]\nuuid = { version = \"=1.18.1\", features = [\"v4\"] }\n",
+        "[project]\nname = \"immutable_catalog\"\nversion = \"0.1.0\"\n\n[rust-dependencies]\nuuid = { version = \"1.0\", features = [\"v4\"] }\n",
     )?;
     // The named Rust dependency forces a portable project entry, rather than an empty package store whose entire
     // native closure happens to be supplied by the compiler's release envelope — but only while the emitted Rust
     // actually reaches it. A dependency nothing in the generated crate calls is not in the closure, so the bake
     // resolves the plain stdlib Loaf and packages no entry at all, and this regression's precondition quietly
     // stops holding. `answer` therefore calls into the crate rather than merely naming it.
+    //
+    // The requirement is spelled the way `tests/fixtures/oven_loaf_dependencies/Cargo.toml` spells it, because
+    // that manifest is the locked source inventory the lane pre-fetches. An exact pin on whatever version happens
+    // to sit in a local registry forces a re-resolve the offline publisher refuses.
     write_fixture_file(
         &catalog,
         "src/lib.incn",

--- a/tests/package_boundary_facade_tests.rs
+++ b/tests/package_boundary_facade_tests.rs
@@ -236,14 +236,17 @@ fn source_free_native_diamond_preserves_published_store_inventory_issue1458() ->
     write_fixture_file(
         &catalog,
         "loaf.toml",
-        "[project]\nname = \"immutable_catalog\"\nversion = \"0.1.0\"\n\n[rust-dependencies]\nbitflags = \"=1.3.2\"\n",
+        "[project]\nname = \"immutable_catalog\"\nversion = \"0.1.0\"\n\n[rust-dependencies]\nuuid = { version = \"=1.18.1\", features = [\"v4\"] }\n",
     )?;
     // The named Rust dependency forces a portable project entry, rather than an empty package store whose entire
-    // native closure happens to be supplied by the compiler's release envelope.
+    // native closure happens to be supplied by the compiler's release envelope — but only while the emitted Rust
+    // actually reaches it. A dependency nothing in the generated crate calls is not in the closure, so the bake
+    // resolves the plain stdlib Loaf and packages no entry at all, and this regression's precondition quietly
+    // stops holding. `answer` therefore calls into the crate rather than merely naming it.
     write_fixture_file(
         &catalog,
         "src/lib.incn",
-        "rust.module(\"bitflags\")\n\npub def answer() -> int:\n    return 42\n",
+        "from rust::uuid import Uuid\n\npub def answer() -> int:\n    return 42\n\npub def fresh_id() -> str:\n    return Uuid.new_v4().to_string()\n",
     )?;
     write_fixture_file(
         &pricing,


### PR DESCRIPTION
## Summary

`source_free_native_diamond_preserves_published_store_inventory_issue1458` fails on the replay lane at its own precondition — *"the regression requires actual packaged store entries"* — while the bake immediately before it succeeds. The catalog's `target/lib` holds no `oven/loafs/entries/**/loaf.json` at all.

The fixture states its own premise in a comment:

> The named Rust dependency forces a portable project entry, rather than an empty package store whose entire native closure happens to be supplied by the compiler's release envelope.

That premise stopped holding. It declared `bitflags` and referenced it through `rust.module("bitflags")` with no `@rust.extern` item — which the compiler warns has no effect — and a dependency nothing in the emitted Rust reaches is not in the closure.

Baked three ways against a warm store:

| project | selected debug plan | packaged entries |
| --- | --- | --- |
| the fixture as written | `loaf:sha256:6e7efcd8…` | 0 |
| no dependency at all | `loaf:sha256:6e7efcd8…` | 0 |
| the fixture plus a private `@rust.extern` anchor | `loaf:sha256:6e7efcd8…` | 0 |

The same plan as an empty project in all three, and the generated `src/lib.rs` mentioned the crate in none of them. One plan for one closure is unit identity working correctly — the fixture simply stopped establishing what it asserts.

## The change

Give it a dependency the emitted Rust actually reaches, through the `from rust::<crate> import <item>` spelling that `examples/advanced/using_rust_crates.incn` uses. `bitflags` is a poor choice for this — almost entirely macros, with no convenient callable item — so this uses `uuid`, whose `Uuid::new_v4()` lowers to a real call.

`answer` keeps returning 42. The diamond consumer asserts `answer() + quote()` prints `84`, and my first attempt returned the UUID string's length and printed `72`. The crate is reached from a second public function instead, so every existing assertion is untouched.

## Verification

- [x] End to end against a warm store: the catalog bake now packages an entry (`entries: 1` where it was `0`), and **the test passes in 200 s**
- [x] `cargo +nightly fmt -- --check` — clean
- [x] `python3 scripts/check_changed_rustdocs.py --base origin/0.6.0-dev.4` — passed
- [ ] Replay lane

The file's other two tests fail in that borrowed environment, both at the same shared helper on line 73, and both are green on the lane — the same limit that makes a deriving fixture unbuildable locally. Only the one this PR targets is red in CI, and it now passes.

## Worth deciding separately

Nothing states whether an unreferenced `[rust-dependencies]` entry silently leaving the closure is the intended contract. It is defensible and it is what unit identity implies, but this test was written assuming the opposite, and the compiler's `rust.module()` warning is the only thing that hints at it. Recorded on #1550.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling
- [ ] RFC (adds/updates `docs/RFCs/*`)

## Area(s)

- [x] Compiler (frontend/backend/codegen)
- [ ] Incan Language (syntax/semantics)
- [ ] Tooling (CLI/formatter/test runner)
- [ ] Editor integration (LSP/VS Code extension)
- [ ] Runtime / Core crates (stdlib/core/derive)
- [ ] Documentation

## Key details

- **User-facing behavior**: none. Test fixture only.
- **Internals**: the catalog fixture declares `uuid` instead of `bitflags` and calls into it from a second public function.
- **Risks**: none beyond the test. Every existing assertion, including the `84`, is unchanged.

## Docs impact

- [x] No docs changes needed
- [ ] Docs updated
- [ ] Docs follow Divio intent (tutorial/how-to/reference/explanation) where applicable

Closes the fixture half of #1550. Part of #1037.
